### PR TITLE
[UI] Add runtime API URL host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN apt-get update &&\
     apt-get install -y build-essential &&\
     apt-get install -y git
 
-# Install Node@v12
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - &&\
+# Install Node@v16
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - &&\
     apt-get install -y nodejs &&\
     npm update &&\
     npm i -g yarn@1.22.17

--- a/ui/app/models/pipeline.js
+++ b/ui/app/models/pipeline.js
@@ -10,6 +10,8 @@ const STATUS_MAP = {
   STATUS_RUNNING: 'running',
 };
 
+const API_URL = config.conduitAPIURL ? config.conduitAPIURL : '';
+
 export default class PipelineModel extends Model {
   @attr()
   config;
@@ -64,11 +66,11 @@ export default class PipelineModel extends Model {
   }
 
   async startPipeline() {
-    await axios.post(`${config.conduitAPIURL}/v1/pipelines/${this.id}/start`);
+    await axios.post(`${API_URL}/v1/pipelines/${this.id}/start`);
   }
 
   async stopPipeline() {
-    await axios.post(`${config.conduitAPIURL}/v1/pipelines/${this.id}/stop`);
+    await axios.post(`${API_URL}/v1/pipelines/${this.id}/stop`);
   }
 
   @task

--- a/ui/config/environment.js
+++ b/ui/config/environment.js
@@ -1,12 +1,16 @@
 'use strict';
 
 module.exports = function (environment) {
+  const conduitAPIURL =
+    environment === 'production'
+      ? null
+      : process.env.CONDUIT_API_URL || 'http://localhost:8080';
   let ENV = {
     modulePrefix: 'conduit-ui',
     environment,
     rootURL: '/ui/',
     locationType: 'auto',
-    conduitAPIURL: process.env.CONDUIT_API_URL || 'http://localhost:8080',
+    conduitAPIURL,
     isDevMirageEnabled: process.env.ENABLE_DEV_MIRAGE === 'true' || false,
     EmberENV: {
       FEATURES: {


### PR DESCRIPTION
### Description
Generally, API hosts (and other environment variables) are written at build time if not using the same host. Since we build the conduit UI into the conduit binary, we do not know at build time what the API host is, so we fallback to ember-data and axios with no host. 

There is some further work slated to further define and optimize our configurations for enabling/disabling the UI (and other configurations). See #32 

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.