### PR TITLE
[UI] Add synchronous start/stop pipeline error notifications

### DIFF
--- a/ui/app/adapters/application.js
+++ b/ui/app/adapters/application.js
@@ -37,6 +37,7 @@ export default class ApplicationAdapter extends RESTAdapter {
       this.flashMessages.add({
         type: 'error',
         message: payload.message || 'Server Error',
+        sticky: true,
       });
     }
     return handledResponse;


### PR DESCRIPTION
### Description
We wrote an error system around handling asynchronous pipeline errors, but it doesnt handle synchronous pipeline errors 😅  

This PR addresses that

Fixes #127 

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.