### PR TITLE
[UI] Fix ghost connectors

### DIFF
--- a/ui/app/components/pipeline-editor.js
+++ b/ui/app/components/pipeline-editor.js
@@ -175,6 +175,9 @@ export default class PipelineEditorComponent extends Component {
 
   @action
   cancelCreateConnectorModal() {
+    if (this.connectorModalModel) {
+      this.connectorModalModel.data.unloadRecord();
+    }
     this.connectorModalModel = null;
     this.isShowingNewConnectorModal = false;
   }
@@ -283,5 +286,11 @@ export default class PipelineEditorComponent extends Component {
     run(() => {
       this.pipelineNodeManager.regeneratePaths();
     });
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+
+    this.cancelCreateConnectorModal();
   }
 }

--- a/ui/app/components/pipelines/list.hbs
+++ b/ui/app/components/pipelines/list.hbs
@@ -49,7 +49,12 @@
       {{#each @pipelines as |pipeline|}}
         <tr class="border-b border-gray-300">
           <td class="p-4 border-gray-300">
-            <LinkTo class="font-medium text-sm" @route="pipeline" @model={{pipeline.id}}>
+            <LinkTo
+              class="font-medium text-sm"
+              @route="pipeline"
+              @model={{pipeline.id}}
+              data-test-pipeline-list-item={{pipeline.id}}
+            >
               {{truncate pipeline.name}}
             </LinkTo>
             <div class="text-xs text-gray-500">

--- a/ui/mirage/factories/pipeline.js
+++ b/ui/mirage/factories/pipeline.js
@@ -24,6 +24,10 @@ export default Factory.extend({
     },
   }),
 
+  connector_ids() {
+    return [];
+  },
+
   withFileConnectors: trait({
     afterCreate(pipeline, server) {
       let fileSourcePlugin = server.db.connectorPlugins.findBy({

--- a/ui/tests/acceptance/pipeline/index-test.js
+++ b/ui/tests/acceptance/pipeline/index-test.js
@@ -122,6 +122,7 @@ module('Acceptance | pipeline/index', function (hooks) {
   module('adding a connector to a pipeline', function (hooks) {
     hooks.beforeEach(async function () {
       const pipeline = this.server.create('pipeline');
+      this.pipeline = pipeline;
 
       await visit(`/pipelines/${pipeline.id}`);
     });
@@ -142,6 +143,24 @@ module('Acceptance | pipeline/index', function (hooks) {
       await click(page.pipelineAddNewSourceButton);
       await click(page.newConnectorModalCancelButton);
       assert.dom(page.newConnectorModal).doesNotExist();
+    });
+
+    module('canceling adding a connector', function (hooks) {
+      hooks.beforeEach(async function () {
+        await click(page.pipelineAddNewNodeButton);
+        await click(page.pipelineAddNewSourceButton);
+        await click(page.newConnectorModalCancelButton);
+
+        await click(page.pipelineAddNewNodeButton);
+        await click(page.pipelineAddNewSourceButton);
+        await click(page.newConnectorModalCancelButton);
+      });
+
+      test('unloads the new record and doesnt leave ghost connectors in the pipeline', async function (assert) {
+        await click(page.pipelineTopNavIndexLink);
+        await click(`[data-test-pipeline-list-item='${this.pipeline.id}']`);
+        assert.dom(page.pipelineEditorZeroState).exists();
+      });
     });
   });
 


### PR DESCRIPTION
### Description
Platform UI had this same issue where connectors need to be explicitly unloaded thanks to the nature of new ember-data records. Implements the same type of fix and adds tests for this case. 

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.