### PR TITLE
Fix: nightly build running every hour

### DIFF
--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # * is a special character in YAML, so you have to quote this string
     # we want the nightly builds only on work days
-    - cron:  '0 * * * 1-5'
+    - cron:  '0 0 * * 1-5'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Description

By mistake, the current nightly build trigger goes off on top of each hour.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.