### PR TITLE
use builtin plugins in UI

### DIFF
--- a/ui/app/utils/connector-plugins/file/destination.js
+++ b/ui/app/utils/connector-plugins/file/destination.js
@@ -6,7 +6,7 @@ export default class FileDestination extends ConnectorPlugin {
 
   static name = 'File Destination';
   static connectorType = 'destination';
-  static pluginPath = 'pkg/plugins/file/file';
+  static pluginPath = 'builtin:file';
 
   static get blueprint() {
     const requiredString = generateBlueprint(

--- a/ui/app/utils/connector-plugins/file/source.js
+++ b/ui/app/utils/connector-plugins/file/source.js
@@ -6,7 +6,7 @@ export default class FileSource extends ConnectorPlugin {
 
   static name = 'File Source';
   static connectorType = 'source';
-  static pluginPath = 'pkg/plugins/file/file';
+  static pluginPath = 'builtin:file';
 
   static get blueprint() {
     const requiredString = generateBlueprint(

--- a/ui/app/utils/connector-plugins/kafka/destination.js
+++ b/ui/app/utils/connector-plugins/kafka/destination.js
@@ -6,7 +6,7 @@ export default class KafkaDestination extends ConnectorPlugin {
 
   static name = 'Kafka Destination';
   static connectorType = 'destination';
-  static pluginPath = 'pkg/plugins/kafka/kafka';
+  static pluginPath = 'builtin:kafka';
 
   static get blueprint() {
     return [

--- a/ui/app/utils/connector-plugins/kafka/source.js
+++ b/ui/app/utils/connector-plugins/kafka/source.js
@@ -6,7 +6,7 @@ export default class KafkaSource extends ConnectorPlugin {
 
   static name = 'Kafka Source';
   static connectorType = 'source';
-  static pluginPath = 'pkg/plugins/kafka/kafka';
+  static pluginPath = 'builtin:kafka';
 
   static get blueprint() {
     return [

--- a/ui/app/utils/connector-plugins/postgres/destination.js
+++ b/ui/app/utils/connector-plugins/postgres/destination.js
@@ -6,7 +6,7 @@ export default class PostgresDestination extends ConnectorPlugin {
 
   static name = 'Postgres Destination';
   static connectorType = 'destination';
-  static pluginPath = 'pkg/plugins/pg/pg';
+  static pluginPath = 'builtin:pg';
 
   static get blueprint() {
     const requiredURL = generateBlueprint(

--- a/ui/app/utils/connector-plugins/postgres/destination.js
+++ b/ui/app/utils/connector-plugins/postgres/destination.js
@@ -6,7 +6,7 @@ export default class PostgresDestination extends ConnectorPlugin {
 
   static name = 'Postgres Destination';
   static connectorType = 'destination';
-  static pluginPath = 'builtin:pg';
+  static pluginPath = 'builtin:postgres';
 
   static get blueprint() {
     const requiredURL = generateBlueprint(

--- a/ui/app/utils/connector-plugins/postgres/source.js
+++ b/ui/app/utils/connector-plugins/postgres/source.js
@@ -6,7 +6,7 @@ export default class PostgresSource extends ConnectorPlugin {
 
   static name = 'Postgres Source';
   static connectorType = 'source';
-  static pluginPath = 'builtin:pg';
+  static pluginPath = 'builtin:postgres';
 
   static get blueprint() {
     const requiredURL = generateBlueprint(

--- a/ui/app/utils/connector-plugins/postgres/source.js
+++ b/ui/app/utils/connector-plugins/postgres/source.js
@@ -6,7 +6,7 @@ export default class PostgresSource extends ConnectorPlugin {
 
   static name = 'Postgres Source';
   static connectorType = 'source';
-  static pluginPath = 'pkg/plugins/pg/pg';
+  static pluginPath = 'builtin:pg';
 
   static get blueprint() {
     const requiredURL = generateBlueprint(

--- a/ui/app/utils/connector-plugins/s3/destination.js
+++ b/ui/app/utils/connector-plugins/s3/destination.js
@@ -6,7 +6,7 @@ export default class S3Destination extends ConnectorPlugin {
 
   static name = 'S3 Destination';
   static connectorType = 'destination';
-  static pluginPath = 'pkg/plugins/s3/s3';
+  static pluginPath = 'builtin:s3';
 
   static get blueprint() {
     return [

--- a/ui/app/utils/connector-plugins/s3/source.js
+++ b/ui/app/utils/connector-plugins/s3/source.js
@@ -6,7 +6,7 @@ export default class S3Source extends ConnectorPlugin {
 
   static name = 'S3 Source';
   static connectorType = 'source';
-  static pluginPath = 'pkg/plugins/s3/s3';
+  static pluginPath = 'builtin:s3';
 
   static get blueprint() {
     return [

--- a/ui/mirage/factories/connector.js
+++ b/ui/mirage/factories/connector.js
@@ -5,7 +5,7 @@ export default Factory.extend({
     return { name: 'Some Source Connector', settings: {} };
   },
 
-  plugin: 'pkg/plugins/file/file',
+  plugin: 'builtin:file',
 
   state() {
     return { position: '' };

--- a/ui/mirage/factories/pipeline.js
+++ b/ui/mirage/factories/pipeline.js
@@ -41,7 +41,7 @@ export default Factory.extend({
       if (!fileSourcePlugin) {
         fileSourcePlugin = server.create('connector-plugin', 'source', {
           name: 'File Source',
-          pluginPath: 'pkg/plugins/file/file',
+          pluginPath: 'builtin:file',
         });
       }
 
@@ -51,7 +51,7 @@ export default Factory.extend({
           'destination',
           {
             name: 'File Destination',
-            pluginPath: 'pkg/plugins/file/file',
+            pluginPath: 'builtin:file',
           }
         );
       }

--- a/ui/tests/acceptance/pipeline/index/connectors/kafka-test.js
+++ b/ui/tests/acceptance/pipeline/index/connectors/kafka-test.js
@@ -75,7 +75,7 @@ module('Acceptance | pipeline/index/connectors/kafka', function (hooks) {
                 },
               },
               pipeline_id: pipelineID,
-              plugin: 'pkg/plugins/kafka/kafka',
+              plugin: 'builtin:kafka',
               type: 'TYPE_SOURCE',
             },
             'it calls the API with the correct protocol'
@@ -155,7 +155,7 @@ module('Acceptance | pipeline/index/connectors/kafka', function (hooks) {
                 },
               },
               pipeline_id: pipelineID,
-              plugin: 'pkg/plugins/kafka/kafka',
+              plugin: 'builtin:kafka',
               type: 'TYPE_DESTINATION',
             },
             'it calls the API with the correct protocol'

--- a/ui/tests/acceptance/pipeline/index/connectors/s3-test.js
+++ b/ui/tests/acceptance/pipeline/index/connectors/s3-test.js
@@ -87,7 +87,7 @@ module('Acceptance | pipeline/index/connectors/s3', function (hooks) {
                 },
               },
               pipeline_id: pipelineID,
-              plugin: 'pkg/plugins/s3/s3',
+              plugin: 'builtin:s3',
               type: 'TYPE_SOURCE',
             },
             'it calls the API with the correct protocol'
@@ -186,7 +186,7 @@ module('Acceptance | pipeline/index/connectors/s3', function (hooks) {
                 },
               },
               pipeline_id: pipelineID,
-              plugin: 'pkg/plugins/s3/s3',
+              plugin: 'builtin:s3',
               type: 'TYPE_DESTINATION',
             },
             'it calls the API with the correct protocol'


### PR DESCRIPTION
### Description

Changed plugins' paths in the UI to point to the builtin plugins instead.

Relates to #218 

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.