### PR TITLE
Support for passing flags to go test via make

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,17 +9,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.17
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
 
-    - name: Test
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_REGION: us-east-1
-        AWS_S3_BUCKET: conduit-s3-testing
-      run: make test-integration
+      - name: Test
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-east-1
+          AWS_S3_BUCKET: conduit-s3-testing
+        run: make test-integration GOTEST_FLAGS="-v -count=1"

--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,12 @@ build-generator-plugin:
 	go build -o pkg/plugins/generator/generator pkg/plugins/generator/cmd/generator/main.go
 
 test: build-file-plugin
-	go test -v -race ./...
+	go test $(GOTEST_FLAGS) -race ./...
 
 test-integration: build-file-plugin
 	# run required docker containers, execute integration tests, stop containers after tests
 	docker-compose -f test/docker-compose-postgres.yml -f test/docker-compose-kafka.yml up -d
-	go test -v -race --tags=integration ./...; ret=$$?; \
+	go test $(GOTEST_FLAGS) -race --tags=integration ./...; ret=$$?; \
 		docker-compose -f test/docker-compose-postgres.yml -f test/docker-compose-kafka.yml down; \
 		exit $$ret
 

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@ test: build-file-plugin
 
 test-integration: build-file-plugin
 	# run required docker containers, execute integration tests, stop containers after tests
-	docker-compose -f test/docker-compose-postgres.yml -f test/docker-compose-kafka.yml up -d --wait
+	docker compose -f test/docker-compose-postgres.yml -f test/docker-compose-kafka.yml up -d --wait
 	go test $(GOTEST_FLAGS) -race --tags=integration ./...; ret=$$?; \
-		docker-compose -f test/docker-compose-postgres.yml -f test/docker-compose-kafka.yml down; \
+		docker compose -f test/docker-compose-postgres.yml -f test/docker-compose-kafka.yml down; \
 		exit $$ret
 
 build-server: build-plugins

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test: build-file-plugin
 
 test-integration: build-file-plugin
 	# run required docker containers, execute integration tests, stop containers after tests
-	docker compose -f test/docker-compose-postgres.yml -f test/docker-compose-kafka.yml up -d --wait
+	docker compose -f test/docker-compose-postgres.yml -f test/docker-compose-kafka.yml up --quiet-pull -d --wait
 	go test $(GOTEST_FLAGS) -race --tags=integration ./...; ret=$$?; \
 		docker compose -f test/docker-compose-postgres.yml -f test/docker-compose-kafka.yml down; \
 		exit $$ret

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test: build-file-plugin
 
 test-integration: build-file-plugin
 	# run required docker containers, execute integration tests, stop containers after tests
-	docker-compose -f test/docker-compose-postgres.yml -f test/docker-compose-kafka.yml up -d
+	docker-compose -f test/docker-compose-postgres.yml -f test/docker-compose-kafka.yml up -d --wait
 	go test $(GOTEST_FLAGS) -race --tags=integration ./...; ret=$$?; \
 		docker-compose -f test/docker-compose-postgres.yml -f test/docker-compose-kafka.yml down; \
 		exit $$ret

--- a/pkg/plugins/kafka/destination_integration_test.go
+++ b/pkg/plugins/kafka/destination_integration_test.go
@@ -48,7 +48,7 @@ func TestDestination_Write_Simple(t *testing.T) {
 	assert.Ok(t, writeErr)
 	assert.Equal(t, record.Position, result)
 
-	message, err := waitForReaderMessage(cfg.Settings[kafka.Topic], 10*time.Second)
+	message, err := waitForReaderMessage(cfg.Settings[kafka.Topic], 15*time.Second)
 	assert.Ok(t, err)
 	assert.Equal(t, record.Payload.Bytes(), message.Value)
 }

--- a/test/docker-compose-kafka.yml
+++ b/test/docker-compose-kafka.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.4'
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:7.0.0
@@ -8,6 +8,14 @@ services:
 
   kafka:
     image: confluentinc/cp-kafka:7.0.0
+    healthcheck:
+      test: kafka-topics --list --bootstrap-server localhost:9092
+      # healthchecks happen every 10s, failures in the first 30s are not counted toward the maximum number of retries,
+      # after 3 failed healthchecks the service is marked as unhealthy
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     depends_on:
       - zookeeper
     ports:


### PR DESCRIPTION
### Description

This change removes the `-v` flag from go test by default, which makes for a nicer output in the CLI that makes it easier to spot which test failed. It also allows you to set the variable `GOTEST_FLAGS` when calling `make test` or `make test-integration` and supplying additional flags to `go test`. The Github action is adjusted to pass `-v -count=1` which enables verbose logging (same as it was before) and disables test caching (caching is not happening anyway on the CI, but just to be sure).