### PR TITLE
Kafka plugin: Support TLS

### DIFF
--- a/pkg/plugins/kafka/config.go
+++ b/pkg/plugins/kafka/config.go
@@ -30,9 +30,9 @@ const (
 	Acks               = "acks"
 	DeliveryTimeout    = "deliveryTimeout"
 	ReadFromBeginning  = "readFromBeginning"
-	ClientCertFile     = "clientCertFile"
-	ClientKeyFile      = "clientKeyFile"
-	CACertFile         = "caCertFile"
+	ClientCert         = "clientCert"
+	ClientKey          = "clientKey"
+	CACert             = "caCert"
 	InsecureSkipVerify = "insecureSkipVerify"
 )
 
@@ -52,9 +52,9 @@ type Config struct {
 	// Default value: false (only new messages are read)
 	ReadFromBeginning bool
 	// TLS
-	ClientCertFile     string
-	ClientKeyFile      string
-	CACertFile         string
+	ClientCert         string
+	ClientKey          string
+	CACert             string
 	InsecureSkipVerify bool
 }
 
@@ -108,14 +108,14 @@ func Parse(cfg map[string]string) (Config, error) {
 func setTLSConfigs(parsed *Config, cfg map[string]string) error {
 	// All three values should be set so that TLS works
 	// If none of the three values are set, then TLS should not be used.
-	tlsCfgOk := (cfg[ClientCertFile] == "") == (cfg[ClientKeyFile] == "")
-	tlsCfgOk = tlsCfgOk && (cfg[ClientKeyFile] == "") == (cfg[CACertFile] == "")
+	tlsCfgOk := (cfg[ClientCert] == "") == (cfg[ClientKey] == "")
+	tlsCfgOk = tlsCfgOk && (cfg[ClientKey] == "") == (cfg[CACert] == "")
 	if !tlsCfgOk {
 		return cerrors.New("TLS config not OK (all values need to be set or all values need to be unset)")
 	}
-	parsed.ClientCertFile = cfg[ClientCertFile]
-	parsed.ClientKeyFile = cfg[ClientKeyFile]
-	parsed.CACertFile = cfg[CACertFile]
+	parsed.ClientCert = cfg[ClientCert]
+	parsed.ClientKey = cfg[ClientKey]
+	parsed.CACert = cfg[CACert]
 	// Parse InsecureSkipVerify, default is 'false'
 	insecureString, ok := cfg[InsecureSkipVerify]
 	if ok {

--- a/pkg/plugins/kafka/config_test.go
+++ b/pkg/plugins/kafka/config_test.go
@@ -105,7 +105,7 @@ func TestParse_TLSConfig(t *testing.T) {
 			cfg: map[string]string{
 				Servers:    "localhost:9092",
 				Topic:      "hello-world-topic",
-				ClientCert: "/path/ClientCert",
+				ClientCert: "ClientCert",
 			},
 			assertFn: func(t *testing.T, config Config, err error) {
 				assert.Error(t, err)
@@ -116,9 +116,9 @@ func TestParse_TLSConfig(t *testing.T) {
 			cfg: map[string]string{
 				Servers:    "localhost:9092",
 				Topic:      "hello-world-topic",
-				ClientCert: "/path/ClientCert",
-				ClientKey:  "/path/ClientKey",
-				CACert:     "/path/CACert",
+				ClientCert: "ClientCert",
+				ClientKey:  "ClientKey",
+				CACert:     "CACert",
 			},
 			assertFn: func(t *testing.T, config Config, err error) {
 				assert.Ok(t, err)
@@ -130,9 +130,9 @@ func TestParse_TLSConfig(t *testing.T) {
 			cfg: map[string]string{
 				Servers:            "localhost:9092",
 				Topic:              "hello-world-topic",
-				ClientCert:         "/path/ClientCert",
-				ClientKey:          "/path/ClientKey",
-				CACert:             "/path/CACert",
+				ClientCert:         "ClientCert",
+				ClientKey:          "ClientKey",
+				CACert:             "CACert",
 				InsecureSkipVerify: "true",
 			},
 			assertFn: func(t *testing.T, config Config, err error) {
@@ -145,9 +145,9 @@ func TestParse_TLSConfig(t *testing.T) {
 			cfg: map[string]string{
 				Servers:            "localhost:9092",
 				Topic:              "hello-world-topic",
-				ClientCert:         "/path/ClientCert",
-				ClientKey:          "/path/ClientKey",
-				CACert:             "/path/CACert",
+				ClientCert:         "ClientCert",
+				ClientKey:          "ClientKey",
+				CACert:             "CACert",
 				InsecureSkipVerify: "     false",
 			},
 			assertFn: func(t *testing.T, config Config, err error) {
@@ -202,9 +202,9 @@ func TestParse_Full(t *testing.T) {
 		Acks:              "all",
 		DeliveryTimeout:   "1s2ms",
 		ReadFromBeginning: "true",
-		ClientCert:        "/path/ClientCert",
-		ClientKey:         "/path/ClientKey",
-		CACert:            "/path/CACert",
+		ClientCert:        "ClientCert",
+		ClientKey:         "ClientKey",
+		CACert:            "CACert",
 	})
 
 	assert.Ok(t, err)
@@ -213,9 +213,9 @@ func TestParse_Full(t *testing.T) {
 	assert.Equal(t, kafka.RequireAll, parsed.Acks)
 	assert.Equal(t, int64(1002), parsed.DeliveryTimeout.Milliseconds())
 	assert.Equal(t, true, parsed.ReadFromBeginning)
-	assert.Equal(t, "/path/ClientCert", parsed.ClientCert)
-	assert.Equal(t, "/path/ClientKey", parsed.ClientKey)
-	assert.Equal(t, "/path/CACert", parsed.CACert)
+	assert.Equal(t, "ClientCert", parsed.ClientCert)
+	assert.Equal(t, "ClientKey", parsed.ClientKey)
+	assert.Equal(t, "CACert", parsed.CACert)
 }
 
 func TestParse_Ack(t *testing.T) {

--- a/pkg/plugins/kafka/config_test.go
+++ b/pkg/plugins/kafka/config_test.go
@@ -103,9 +103,9 @@ func TestParse_TLSConfig(t *testing.T) {
 		{
 			name: "TLS config incomplete",
 			cfg: map[string]string{
-				Servers:        "localhost:9092",
-				Topic:          "hello-world-topic",
-				ClientCertFile: "/path/ClientCertFile",
+				Servers:    "localhost:9092",
+				Topic:      "hello-world-topic",
+				ClientCert: "/path/ClientCert",
 			},
 			assertFn: func(t *testing.T, config Config, err error) {
 				assert.Error(t, err)
@@ -114,11 +114,11 @@ func TestParse_TLSConfig(t *testing.T) {
 		{
 			name: "InsecureSkipVerify is false by default",
 			cfg: map[string]string{
-				Servers:        "localhost:9092",
-				Topic:          "hello-world-topic",
-				ClientCertFile: "/path/ClientCertFile",
-				ClientKeyFile:  "/path/ClientKeyFile",
-				CACertFile:     "/path/CACertFile",
+				Servers:    "localhost:9092",
+				Topic:      "hello-world-topic",
+				ClientCert: "/path/ClientCert",
+				ClientKey:  "/path/ClientKey",
+				CACert:     "/path/CACert",
 			},
 			assertFn: func(t *testing.T, config Config, err error) {
 				assert.Ok(t, err)
@@ -130,9 +130,9 @@ func TestParse_TLSConfig(t *testing.T) {
 			cfg: map[string]string{
 				Servers:            "localhost:9092",
 				Topic:              "hello-world-topic",
-				ClientCertFile:     "/path/ClientCertFile",
-				ClientKeyFile:      "/path/ClientKeyFile",
-				CACertFile:         "/path/CACertFile",
+				ClientCert:         "/path/ClientCert",
+				ClientKey:          "/path/ClientKey",
+				CACert:             "/path/CACert",
 				InsecureSkipVerify: "true",
 			},
 			assertFn: func(t *testing.T, config Config, err error) {
@@ -145,9 +145,9 @@ func TestParse_TLSConfig(t *testing.T) {
 			cfg: map[string]string{
 				Servers:            "localhost:9092",
 				Topic:              "hello-world-topic",
-				ClientCertFile:     "/path/ClientCertFile",
-				ClientKeyFile:      "/path/ClientKeyFile",
-				CACertFile:         "/path/CACertFile",
+				ClientCert:         "/path/ClientCert",
+				ClientKey:          "/path/ClientKey",
+				CACert:             "/path/CACert",
 				InsecureSkipVerify: "     false",
 			},
 			assertFn: func(t *testing.T, config Config, err error) {
@@ -202,9 +202,9 @@ func TestParse_Full(t *testing.T) {
 		Acks:              "all",
 		DeliveryTimeout:   "1s2ms",
 		ReadFromBeginning: "true",
-		ClientCertFile:    "/path/ClientCertFile",
-		ClientKeyFile:     "/path/ClientKeyFile",
-		CACertFile:        "/path/CACertFile",
+		ClientCert:        "/path/ClientCert",
+		ClientKey:         "/path/ClientKey",
+		CACert:            "/path/CACert",
 	})
 
 	assert.Ok(t, err)
@@ -213,9 +213,9 @@ func TestParse_Full(t *testing.T) {
 	assert.Equal(t, kafka.RequireAll, parsed.Acks)
 	assert.Equal(t, int64(1002), parsed.DeliveryTimeout.Milliseconds())
 	assert.Equal(t, true, parsed.ReadFromBeginning)
-	assert.Equal(t, "/path/ClientCertFile", parsed.ClientCertFile)
-	assert.Equal(t, "/path/ClientKeyFile", parsed.ClientKeyFile)
-	assert.Equal(t, "/path/CACertFile", parsed.CACertFile)
+	assert.Equal(t, "/path/ClientCert", parsed.ClientCert)
+	assert.Equal(t, "/path/ClientKey", parsed.ClientKey)
+	assert.Equal(t, "/path/CACert", parsed.CACert)
 }
 
 func TestParse_Ack(t *testing.T) {

--- a/pkg/plugins/kafka/consumer.go
+++ b/pkg/plugins/kafka/consumer.go
@@ -95,7 +95,7 @@ func newReader(cfg Config, groupID string) (*kafka.Reader, error) {
 		readerCfg.StartOffset = kafka.LastOffset
 	}
 	// TLS config
-	if cfg.ClientCertFile != "" {
+	if cfg.ClientCert != "" {
 		dialer, err := newTLSDialer(cfg)
 		if err != nil {
 			return nil, cerrors.Errorf("couldn't create dialer: %w", err)
@@ -106,7 +106,7 @@ func newReader(cfg Config, groupID string) (*kafka.Reader, error) {
 }
 
 func newTLSDialer(cfg Config) (*kafka.Dialer, error) {
-	tlsCfg, err := newTLSConfig(cfg.ClientCertFile, cfg.ClientKeyFile, cfg.CACertFile, cfg.InsecureSkipVerify)
+	tlsCfg, err := newTLSConfig(cfg.ClientCert, cfg.ClientKey, cfg.CACert, cfg.InsecureSkipVerify)
 	if err != nil {
 		return nil, cerrors.Errorf("invalid TLS config: %w", err)
 	}

--- a/pkg/plugins/kafka/consumer.go
+++ b/pkg/plugins/kafka/consumer.go
@@ -119,7 +119,7 @@ func newTLSDialer(cfg Config) (*kafka.Dialer, error) {
 }
 
 func newTLSConfig(clientCertFile, clientKeyFile, caCertFile string, serverNoVerify bool) (*tls.Config, error) {
-	tlsConfig := tls.Config{}
+	tlsConfig := tls.Config{MinVersion: tls.VersionTLS12}
 
 	// Load client cert
 	cert, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
@@ -137,7 +137,7 @@ func newTLSConfig(clientCertFile, clientKeyFile, caCertFile string, serverNoVeri
 	caCertPool.AppendCertsFromPEM(caCert)
 	tlsConfig.RootCAs = caCertPool
 
-	tlsConfig.InsecureSkipVerify = true
+	tlsConfig.InsecureSkipVerify = serverNoVerify
 	return &tlsConfig, err
 }
 

--- a/pkg/plugins/kafka/consumer.go
+++ b/pkg/plugins/kafka/consumer.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/google/uuid"
@@ -118,23 +117,18 @@ func newTLSDialer(cfg Config) (*kafka.Dialer, error) {
 	}, nil
 }
 
-func newTLSConfig(clientCertFile, clientKeyFile, caCertFile string, serverNoVerify bool) (*tls.Config, error) {
+func newTLSConfig(clientCert, clientKey, caCert string, serverNoVerify bool) (*tls.Config, error) {
 	tlsConfig := tls.Config{MinVersion: tls.VersionTLS12}
 
 	// Load client cert
-	cert, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
+	cert, err := tls.X509KeyPair([]byte(clientCert), []byte(clientKey))
 	if err != nil {
 		return nil, err
 	}
 	tlsConfig.Certificates = []tls.Certificate{cert}
 
-	// Load CA cert
-	caCert, err := ioutil.ReadFile(caCertFile)
-	if err != nil {
-		return nil, err
-	}
 	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(caCert)
+	caCertPool.AppendCertsFromPEM([]byte(caCert))
 	tlsConfig.RootCAs = caCertPool
 
 	tlsConfig.InsecureSkipVerify = serverNoVerify

--- a/pkg/plugins/kafka/producer.go
+++ b/pkg/plugins/kafka/producer.go
@@ -55,8 +55,8 @@ func NewProducer(cfg Config) (Producer, error) {
 		MaxAttempts:  3,
 	}
 	// TLS config
-	if cfg.ClientCertFile != "" {
-		tlsCfg, err := newTLSConfig(cfg.ClientCertFile, cfg.ClientKeyFile, cfg.CACertFile, cfg.InsecureSkipVerify)
+	if cfg.ClientCert != "" {
+		tlsCfg, err := newTLSConfig(cfg.ClientCert, cfg.ClientKey, cfg.CACert, cfg.InsecureSkipVerify)
 		if err != nil {
 			return nil, cerrors.Errorf("invalid TLS config: %w", err)
 		}


### PR DESCRIPTION
### Description

Adds TLS support in the Kafka plugin. The changes (as they are now) expect the needed files to be present on the machine where Conduit is running.

Fixes #141 

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.