### PR TITLE
Set version tag in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,8 @@ builds:
       - CGO_ENABLED=0
     tags:
       - ui
+    ldflags:
+      - "-s -w -X 'github.com/conduitio/conduit/pkg/conduit.version={{ .Tag }}'"
 archives:
   - builds:
       - conduit

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VERSION=`./scripts/get-tag.sh`
 
 # The build target should stay at the top since we want it to be the default target.
 build: pkg/web/ui/dist
-	go build -ldflags "-X github.com/conduitio/conduit/pkg/conduit.version=${VERSION}" -o conduit -tags ui ./cmd/conduit/main.go
+	go build -ldflags "-X 'github.com/conduitio/conduit/pkg/conduit.version=${VERSION}'" -o conduit -tags ui ./cmd/conduit/main.go
 	@echo "\nBuild complete. Enjoy using Conduit!"
 	@echo "Get started by running:"
 	@echo " ./conduit"


### PR DESCRIPTION
### Description

Makes sure that the version tag is set when goreleaser builds the binary. We'll see if it works once we merge it and the next nightly is built.

Fixes #162