### PR TITLE
Fix container cleanup

### DIFF
--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -41,7 +41,7 @@ jobs:
           image-names: conduit
           cut-off: 1 week ago UTC
           account-type: org
-          org-name: conduitio
+          org-name: ConduitIO
           keep-at-least: 5
           token: ${{ secrets.NIGHTLY_BUILD_GH_TOKEN }}
           filter-tags: '*-nightly*'

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # * is a special character in YAML, so you have to quote this string
     # we want the nightly builds only on work days
-    - cron:  '0 0 * * 1-5'
+    - cron:  '0 0 * * 2-6'
   workflow_dispatch:
 
 jobs:
@@ -41,7 +41,7 @@ jobs:
           image-names: conduit
           cut-off: 1 week ago UTC
           account-type: org
-          org-name: ConduitIO
+          org-name: conduitio
           keep-at-least: 5
           token: ${{ secrets.NIGHTLY_BUILD_GH_TOKEN }}
           filter-tags: '*-nightly*'


### PR DESCRIPTION
### Description

This hopefully fixes the issue with the container cleanup. In the [package](https://github.com/ConduitIO/conduit/pkgs/container/conduit) the install command looks like this:
```
docker pull ghcr.io/conduitio/conduit:latest-nightly
```

Notice that the organization is all lower case. I have a _hunch_ this might be the reason for the cleanup job to fail.

This PR also changes the schedule of when the nightly job runs (Tue-Sat), I think it makes more sense since it now happens after each workday.

Fixes #291