### PR TITLE
Ignore github action updates in release changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,6 +37,7 @@ changelog:
       - '^test:'
       - '^npm:'
       - '^go.mod:'
+      - '^.github:'
       - Merge branch
 release:
   prerelease: auto


### PR DESCRIPTION
Ignore updates of github actions like [this one](https://github.com/ConduitIO/conduit/pull/273) for example.