### PR TITLE
Pin postgres image to version 11

### DIFF
--- a/test/docker-compose-postgres.yml
+++ b/test/docker-compose-postgres.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   pg-0:
-    image: docker.io/bitnami/postgresql-repmgr:latest
+    image: docker.io/bitnami/postgresql-repmgr:11
     ports:
       - 5432:5432
     volumes:
@@ -21,7 +21,7 @@ services:
       - REPMGR_NODE_NETWORK_NAME=pg-0
       - REPMGR_PORT_NUMBER=5432
   pg-1:
-    image: docker.io/bitnami/postgresql-repmgr:latest
+    image: docker.io/bitnami/postgresql-repmgr:11
     ports:
       - 5433:5432
     volumes:


### PR DESCRIPTION
### Description

Lately tests have started failing because we are using the docker image `docker.io/bitnami/postgresql-repmgr:latest` and the `latest` tag was moved from version 11 to version 14. This PR pins the version of the image back to 11.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.