### PR TITLE
Enable Javascript Transform

### DIFF
--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -59,6 +59,7 @@ import (
 
 	// NB: anonymous import triggers transform registry creation
 	_ "github.com/conduitio/conduit/pkg/processor/transform/txfbuiltin"
+	_ "github.com/conduitio/conduit/pkg/processor/transform/txfjs"
 )
 
 const (


### PR DESCRIPTION
### Description

The first step towards a JS transform. This PR enables the transform under the name `js` and lets people use it at their own risk.

Related to https://github.com/ConduitIO/conduit/issues/19