### PR TITLE
Display plugin name with builtin prefix

### DIFF
--- a/pkg/web/api/plugin_v1.go
+++ b/pkg/web/api/plugin_v1.go
@@ -66,11 +66,11 @@ func (p *PluginAPIv1) ListPlugins(
 	}
 	var plist []*apiv1.PluginSpecifications
 
-	for k, v := range mp {
-		if nameFilter != nil && !nameFilter.MatchString(v.Name) {
+	for name, v := range mp {
+		if nameFilter != nil && !nameFilter.MatchString(name) {
 			continue // don't add to result list, filter didn't match
 		}
-		plist = append(plist, toproto.Plugin(mp[k]))
+		plist = append(plist, toproto.Plugin(name, v))
 	}
 
 	return &apiv1.ListPluginsResponse{Plugins: plist}, nil

--- a/pkg/web/api/toproto/plugin.go
+++ b/pkg/web/api/toproto/plugin.go
@@ -30,9 +30,9 @@ func _() {
 	_ = vTypes[int(plugin.ValidationTypeRegex)-int(apiv1.PluginSpecifications_Parameter_Validation_TYPE_REGEX)]
 }
 
-func Plugin(in plugin.Specification) *apiv1.PluginSpecifications {
+func Plugin(name string, in plugin.Specification) *apiv1.PluginSpecifications {
 	return &apiv1.PluginSpecifications{
-		Name:              in.Name,
+		Name:              name,
 		Summary:           in.Summary,
 		Description:       in.Description,
 		Version:           in.Version,


### PR DESCRIPTION
### Description

This makes sure that builtin plugins are returned in the API as `builtin:plugin-name` and not just `plugin-name`.