### PR TITLE
Log error which made a node stop

### DIFF
--- a/pkg/pipeline/lifecycle.go
+++ b/pkg/pipeline/lifecycle.go
@@ -365,6 +365,7 @@ func (s *Service) runPipeline(ctx context.Context, pl *Instance) error {
 				return nil
 			}
 			if err != nil {
+				s.logger.Err(ctx, err).Msgf("node %s stopped", node.ID())
 				return cerrors.Errorf("node %s stopped with error: %w", node.ID(), err)
 			}
 			return nil

--- a/pkg/pipeline/lifecycle.go
+++ b/pkg/pipeline/lifecycle.go
@@ -192,8 +192,10 @@ func (s *Service) buildNodes(
 	nodes = append(nodes, destinationNodes...)
 
 	// set up logger for all nodes that need it
+	nodeLogger := s.logger
+	nodeLogger.Logger = nodeLogger.Logger.With().Str(log.PipelineIDField, pl.ID).Logger()
 	for _, n := range nodes {
-		stream.SetLogger(n, s.logger)
+		stream.SetLogger(n, nodeLogger)
 	}
 
 	return nodes, nil


### PR DESCRIPTION
### Description

Logs the error which made a node stop. 

Fixes part of https://github.com/ConduitIO/conduit-connector-kafka/issues/15.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests. -- Only logging added.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.