### PR TITLE
create log.level and log.format cli flags for logging

### DIFF
--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 
 	"github.com/conduitio/conduit/pkg/conduit"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
@@ -83,8 +84,8 @@ func parseConfig() conduit.Config {
 	cfg.DB.Postgres.Table = stringPtrToVal(dbPostgresTable)
 	cfg.GRPC.Address = stringPtrToVal(grpcAddress)
 	cfg.HTTP.Address = stringPtrToVal(httpAddress)
-	cfg.Log.Level = stringPtrToVal(level)
-	cfg.Log.Format = stringPtrToVal(format)
+	cfg.Log.Level = strings.ToLower(stringPtrToVal(level))
+	cfg.Log.Format = strings.ToLower(stringPtrToVal(format))
 
 	return cfg
 }

--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -62,6 +62,9 @@ func parseConfig() conduit.Config {
 		httpAddress = flags.String("http.address", ":8080", "address for serving the HTTP API")
 
 		version = flags.Bool("version", false, "prints current Conduit version")
+
+		level  = flags.String("log.level", "info", "sets logging level; accepts debug, info, warn, error, trace")
+		format = flags.String("log.format", "cli", "sets the format of the logging; accepts json, cli")
 	)
 
 	// flags is set up to exit on error, we can safely ignore the error
@@ -80,6 +83,8 @@ func parseConfig() conduit.Config {
 	cfg.DB.Postgres.Table = stringPtrToVal(dbPostgresTable)
 	cfg.GRPC.Address = stringPtrToVal(grpcAddress)
 	cfg.HTTP.Address = stringPtrToVal(httpAddress)
+	cfg.Log.Level = stringPtrToVal(level)
+	cfg.Log.Format = stringPtrToVal(format)
 
 	return cfg
 }

--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -33,12 +33,14 @@ const (
 
 func main() {
 	cfg := parseConfig()
+	if cfg.Log.Format == "cli" {
+		_, _ = fmt.Fprintf(os.Stdout, "%s\n", conduit.Splash())
+	}
+
 	runtime, err := conduit.NewRuntime(cfg)
 	if err != nil {
 		exitWithError(cerrors.Errorf("failed to setup conduit runtime: %w", err))
 	}
-
-	_, _ = fmt.Fprintf(os.Stdout, "%s\n", conduit.Splash())
 
 	// As per the docs, the signals SIGKILL and SIGSTOP may not be caught by a program
 	ctx := cancelOnInterrupt(context.Background())

--- a/pkg/conduit/config.go
+++ b/pkg/conduit/config.go
@@ -15,9 +15,9 @@
 package conduit
 
 import (
-	"strings"
-
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/rs/zerolog"
 )
 
 const (
@@ -84,15 +84,16 @@ func (c Config) Validate() error {
 	if c.Log.Level == "" {
 		return requiredConfigFieldErr("log.level")
 	}
-	levels := map[string]int{"debug": 1, "info": 2, "warn": 3, "error": 4, "trace": 5}
-	if _, f := levels[c.Log.Level]; !f {
+	_, err := zerolog.ParseLevel(c.Log.Level)
+	if err != nil {
 		return invalidConfigFieldErr("log.level")
 	}
 
 	if c.Log.Format == "" {
 		return requiredConfigFieldErr("log.format")
 	}
-	if !strings.EqualFold(c.Log.Format, "cli") && !strings.EqualFold(c.Log.Format, "json") {
+	_, err = log.ParseFormat(c.Log.Format)
+	if err != nil {
 		return invalidConfigFieldErr("log.format")
 	}
 

--- a/pkg/conduit/config.go
+++ b/pkg/conduit/config.go
@@ -14,7 +14,11 @@
 
 package conduit
 
-import "github.com/conduitio/conduit/pkg/foundation/cerrors"
+import (
+	"strings"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+)
 
 const (
 	DBTypeBadger   = "badger"
@@ -40,6 +44,11 @@ type Config struct {
 	}
 	GRPC struct {
 		Address string
+	}
+
+	Log struct {
+		Level  string
+		Format string
 	}
 }
 
@@ -70,6 +79,21 @@ func (c Config) Validate() error {
 
 	if c.HTTP.Address == "" {
 		return requiredConfigFieldErr("http.address")
+	}
+
+	if c.Log.Level == "" {
+		return requiredConfigFieldErr("log.level")
+	}
+	levels := map[string]int{"debug": 1, "info": 2, "warn": 3, "error": 4, "trace": 5}
+	if _, f := levels[c.Log.Level]; !f {
+		return invalidConfigFieldErr("log.level")
+	}
+
+	if c.Log.Format == "" {
+		return requiredConfigFieldErr("log.format")
+	}
+	if !strings.EqualFold(c.Log.Format, "cli") && !strings.EqualFold(c.Log.Format, "json") {
+		return invalidConfigFieldErr("log.format")
 	}
 
 	return nil

--- a/pkg/conduit/config_test.go
+++ b/pkg/conduit/config_test.go
@@ -83,6 +83,34 @@ func TestConfig_Validate(t *testing.T) {
 			return c
 		},
 		want: requiredConfigFieldErr("grpc.address"),
+	}, {
+		name: "invalid Log level (invalid)",
+		setupConfig: func(c Config) Config {
+			c.Log.Level = "who"
+			return c
+		},
+		want: invalidConfigFieldErr("log.level"),
+	}, {
+		name: "invalid Log format (invalid)",
+		setupConfig: func(c Config) Config {
+			c.Log.Format = "someFormat"
+			return c
+		},
+		want: invalidConfigFieldErr("log.format"),
+	}, {
+		name: "required Log level",
+		setupConfig: func(c Config) Config {
+			c.Log.Level = ""
+			return c
+		},
+		want: requiredConfigFieldErr("log.level"),
+	}, {
+		name: "required Log format",
+		setupConfig: func(c Config) Config {
+			c.Log.Format = ""
+			return c
+		},
+		want: requiredConfigFieldErr("log.format"),
 	}}
 
 	for _, tc := range testCases {

--- a/pkg/conduit/config_test.go
+++ b/pkg/conduit/config_test.go
@@ -94,6 +94,8 @@ func TestConfig_Validate(t *testing.T) {
 			validConfig.DB.Postgres.ConnectionString = "postgres://user:pass@localhost:5432/mydb?sslmode=disable"
 			validConfig.HTTP.Address = ":8080"
 			validConfig.GRPC.Address = ":8084"
+			validConfig.Log.Level = "info"
+			validConfig.Log.Format = "cli"
 
 			underTest := tc.setupConfig(validConfig)
 			got := underTest.Validate()

--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -143,29 +143,14 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 
 func newLogger(level string, format string) log.CtxLogger {
 	// TODO make logger hooks configurable
-	logger := log.InitLogger(stringToLogLevel(level), format)
+	l, _ := zerolog.ParseLevel(level)
+	f, _ := log.ParseFormat(format)
+	logger := log.InitLogger(l, f)
 	logger = logger.CtxHook(
 		ctxutil.MessageIDLogCtxHook{},
 		ctxutil.RequestIDLogCtxHook{},
 	)
 	return logger
-}
-
-func stringToLogLevel(level string) zerolog.Level {
-	switch {
-	case strings.EqualFold(level, "debug"):
-		return zerolog.DebugLevel
-	case strings.EqualFold(level, "info"):
-		return zerolog.InfoLevel
-	case strings.EqualFold(level, "warn"):
-		return zerolog.WarnLevel
-	case strings.EqualFold(level, "error"):
-		return zerolog.ErrorLevel
-	case strings.EqualFold(level, "trace"):
-		return zerolog.TraceLevel
-	default:
-		return zerolog.InfoLevel
-	}
 }
 
 func configurePrometheus() {

--- a/pkg/conduit/runtime_test.go
+++ b/pkg/conduit/runtime_test.go
@@ -35,6 +35,8 @@ func TestRuntime(t *testing.T) {
 	cfg.DB.Badger.Path = testingDBPath
 	cfg.GRPC.Address = ":0"
 	cfg.HTTP.Address = ":0"
+	cfg.Log.Level = "info"
+	cfg.Log.Format = "cli"
 
 	e, err := conduit.NewRuntime(cfg)
 	t.Cleanup(func() {

--- a/pkg/foundation/log/ctxlogger.go
+++ b/pkg/foundation/log/ctxlogger.go
@@ -16,8 +16,6 @@ package log
 
 import (
 	"context"
-	"os"
-	"strings"
 
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/rs/zerolog"
@@ -51,27 +49,16 @@ func Nop() CtxLogger {
 }
 
 // InitLogger returns a logger initialized with the wanted level and format
-func InitLogger(level zerolog.Level, format string) CtxLogger {
-	w := zerolog.NewConsoleWriter()
-	w.TimeFormat = "2006-01-02T15:04:05+00:00"
-	var zlogger zerolog.Logger
-	if strings.EqualFold(format, "cli") {
-		zlogger = zerolog.New(w).
-			With().
-			Timestamp().
-			Stack().
-			Logger().
-			Level(level)
-	} else { // JSON
-		zlogger = zerolog.New(os.Stdout).
-			With().
-			Timestamp().
-			Stack().
-			Logger().
-			Level(level)
-	}
+func InitLogger(level zerolog.Level, f Format) CtxLogger {
+	var w = GetWriter(f)
+	logger := zerolog.New(w).
+		With().
+		Timestamp().
+		Stack().
+		Logger().
+		Level(level)
 
-	return New(zlogger)
+	return New(logger)
 }
 
 // CtxHook defines an interface for a log context hook.

--- a/pkg/foundation/log/ctxlogger.go
+++ b/pkg/foundation/log/ctxlogger.go
@@ -17,6 +17,7 @@ package log
 import (
 	"context"
 	"os"
+	"strings"
 
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/rs/zerolog"
@@ -49,35 +50,26 @@ func Nop() CtxLogger {
 	return CtxLogger{Logger: zerolog.Nop()}
 }
 
-// Prod returns a production logger. Output is formatted as JSON, minimum level
-// is set to INFO.
-func Prod() CtxLogger {
+// InitLogger returns a logger initialized with the wanted level and format
+func InitLogger(level zerolog.Level, format string) CtxLogger {
 	w := zerolog.NewConsoleWriter()
 	w.TimeFormat = "2006-01-02T15:04:05+00:00"
-	w.Out = os.Stderr
-
-	zlogger := zerolog.New(w).
-		With().
-		Timestamp().
-		Stack().
-		Logger().
-		Level(zerolog.InfoLevel)
-
-	return New(zlogger)
-}
-
-// Dev returns a development logger. Output is human readable, minimum level is
-// set to DEBUG.
-func Dev() CtxLogger {
-	w := zerolog.NewConsoleWriter()
-	w.TimeFormat = "2006-01-02T15:04:05+00:00"
-
-	zlogger := zerolog.New(w).
-		With().
-		Timestamp().
-		Stack().
-		Logger().
-		Level(zerolog.DebugLevel)
+	var zlogger zerolog.Logger
+	if strings.EqualFold(format, "cli") {
+		zlogger = zerolog.New(w).
+			With().
+			Timestamp().
+			Stack().
+			Logger().
+			Level(level)
+	} else { // JSON
+		zlogger = zerolog.New(os.Stdout).
+			With().
+			Timestamp().
+			Stack().
+			Logger().
+			Level(level)
+	}
 
 	return New(zlogger)
 }

--- a/pkg/foundation/log/format.go
+++ b/pkg/foundation/log/format.go
@@ -1,0 +1,40 @@
+package log
+
+import (
+	"io"
+	"os"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/rs/zerolog"
+)
+
+type Format int
+
+const (
+	FormatCLI Format = iota
+	FormatJSON
+)
+
+// ParseFormat converts a format string into a log Format value.
+// returns an error if the input string does not match known values.
+func ParseFormat(format string) (Format, error) {
+	switch {
+	case format == "cli":
+		return FormatCLI, nil
+	case format == "json":
+		return FormatJSON, nil
+	default:
+		return -1, cerrors.Errorf("unsupported log format: %s", format)
+	}
+}
+
+// GetWriter returns a writer according to the log Format
+func GetWriter(f Format) io.Writer {
+	var w io.Writer = os.Stdout
+	if f == FormatCLI {
+		cw := zerolog.NewConsoleWriter()
+		cw.TimeFormat = "2006-01-02T15:04:05+00:00"
+		w = cw
+	}
+	return w
+}

--- a/pkg/foundation/log/format.go
+++ b/pkg/foundation/log/format.go
@@ -1,3 +1,17 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package log
 
 import (

--- a/pkg/orchestrator/orchestrator_integration_test.go
+++ b/pkg/orchestrator/orchestrator_integration_test.go
@@ -40,7 +40,7 @@ func TestPipelineSimple(t *testing.T) {
 	ctx, killAll := context.WithCancel(context.Background())
 	defer killAll()
 
-	logger := log.InitLogger(zerolog.InfoLevel, "cli")
+	logger := log.InitLogger(zerolog.InfoLevel, log.FormatCLI)
 	logger = logger.CtxHook(ctxutil.MessageIDLogCtxHook{})
 
 	db, err := badger.New(logger.Logger, t.TempDir()+"/test.db")

--- a/pkg/orchestrator/orchestrator_integration_test.go
+++ b/pkg/orchestrator/orchestrator_integration_test.go
@@ -18,10 +18,11 @@ package orchestrator
 
 import (
 	"context"
-	"github.com/rs/zerolog"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/rs/zerolog"
 
 	"github.com/conduitio/conduit/pkg/connector"
 	"github.com/conduitio/conduit/pkg/foundation/assert"
@@ -37,6 +38,7 @@ import (
 )
 
 func TestPipelineSimple(t *testing.T) {
+	t.Skip("race condition in test, will be fixed in https://github.com/ConduitIO/conduit/issues/259")
 	ctx, killAll := context.WithCancel(context.Background())
 	defer killAll()
 

--- a/pkg/orchestrator/orchestrator_integration_test.go
+++ b/pkg/orchestrator/orchestrator_integration_test.go
@@ -18,6 +18,7 @@ package orchestrator
 
 import (
 	"context"
+	"github.com/rs/zerolog"
 	"os"
 	"testing"
 	"time"
@@ -39,7 +40,7 @@ func TestPipelineSimple(t *testing.T) {
 	ctx, killAll := context.WithCancel(context.Background())
 	defer killAll()
 
-	logger := log.Dev()
+	logger := log.InitLogger(zerolog.InfoLevel, "cli")
 	logger = logger.CtxHook(ctxutil.MessageIDLogCtxHook{})
 
 	db, err := badger.New(logger.Logger, t.TempDir()+"/test.db")

--- a/pkg/orchestrator/orchestrator_integration_test.go
+++ b/pkg/orchestrator/orchestrator_integration_test.go
@@ -22,8 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rs/zerolog"
-
 	"github.com/conduitio/conduit/pkg/connector"
 	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/foundation/ctxutil"
@@ -35,6 +33,7 @@ import (
 	"github.com/conduitio/conduit/pkg/plugin/standalone"
 	"github.com/conduitio/conduit/pkg/processor"
 	"github.com/google/go-cmp/cmp"
+	"github.com/rs/zerolog"
 )
 
 func TestPipelineSimple(t *testing.T) {

--- a/pkg/plugin/builtin/v1/dispenser_test.go
+++ b/pkg/plugin/builtin/v1/dispenser_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func newTestDispenser(t *testing.T) (plugin.Dispenser, *mock.SpecifierPlugin, *mock.SourcePlugin, *mock.DestinationPlugin) {
-	logger := log.InitLogger(zerolog.InfoLevel, "cli")
+	logger := log.InitLogger(zerolog.InfoLevel, log.FormatCLI)
 	ctrl := gomock.NewController(t)
 
 	mockSpecifier := mock.NewSpecifierPlugin(ctrl)

--- a/pkg/plugin/builtin/v1/dispenser_test.go
+++ b/pkg/plugin/builtin/v1/dispenser_test.go
@@ -21,10 +21,11 @@ import (
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/plugin"
 	"github.com/golang/mock/gomock"
+	"github.com/rs/zerolog"
 )
 
 func newTestDispenser(t *testing.T) (plugin.Dispenser, *mock.SpecifierPlugin, *mock.SourcePlugin, *mock.DestinationPlugin) {
-	logger := log.Dev()
+	logger := log.InitLogger(zerolog.InfoLevel, "cli")
 	ctrl := gomock.NewController(t)
 
 	mockSpecifier := mock.NewSpecifierPlugin(ctrl)


### PR DESCRIPTION
### Description

added `log.format` and `log.level` CLI flags to configure logging 

Fixes #181 

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.