### PR TITLE
dynamically determine minor version for nightly builds

### DIFF
--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -19,12 +19,14 @@ jobs:
           token: ${{ secrets.NIGHTLY_BUILD_GH_TOKEN }}
       -
         name: 'Push new tag'
-        # TODO determine nightly version based on latest minor version
         run: |
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
-          TAG=v0.2.0-nightly.$(date +'%Y%m%d')
+          DESCRIBE=`git describe --match "v[0-9].[0-9].[0-9]" --abbrev=0`
+          MINOR_VERSION=`echo $DESCRIBE | awk '{split($0,a,"."); print a[2]}'`
+          MINOR_VERSION="$((${MINOR_VERSION} + 1))"
+          TAG="v0.${MINOR_VERSION}.0-nightly.$(date +'%Y%m%d')"
           git tag -a $TAG -m "$TAG: nightly build"
           git push origin $TAG
       - name: 'Clean up nightly releases'


### PR DESCRIPTION
### Description

this PR gets the last minor version released.. to determine the nightly version dynamically 

Fixes #186 

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.