### PR TITLE
docs: Update Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ as a simple backend service.
 
 ### Docker
 
-Our Docker images are hosted on GitHub's Container Registry. To pull the latest tag, you should run the following command:
+Our Docker images are hosted on GitHub's Container Registry. To run the latest Conduit version, you should run the following commands:
 
 ```
-docker pull ghcr.io/conduitio/conduit:latest
+docker run -p 8080:8080 ghcr.io/conduitio/conduit:latest
 ```
 
-The Docker images include the [UI](#ui).
+The Docker image includes the [UI](#ui), it is accessible if you navigate to `http://localhost:8080/ui`.
 
 ## Connectors
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ as a simple backend service.
 
 ### Docker
 
-Our Docker images are hosted on GitHub's Container Registry. To run the latest Conduit version, you should run the following commands:
+Our Docker images are hosted on GitHub's Container Registry. To run the latest Conduit version, you should run the following command:
 
 ```
 docker run -p 8080:8080 ghcr.io/conduitio/conduit:latest

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Our Docker images are hosted on GitHub's Container Registry. To run the latest C
 docker run -p 8080:8080 ghcr.io/conduitio/conduit:latest
 ```
 
-The Docker image includes the [UI](#ui), it is accessible if you navigate to `http://localhost:8080/ui`.
+The Docker image includes the [UI](#ui), you can access it by navigating to `http://localhost:8080/ui`.
 
 ## Connectors
 


### PR DESCRIPTION
### Description

Updates the Docker instructions so it explains how to run the container and not how to pull it (pull happens automatically).