### PR TITLE
Reduce healthcheck logging

### DIFF
--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -319,7 +319,7 @@ func (r *Runtime) serveHTTPAPI(
 		grpcruntime.WithOutgoingHeaderMatcher(grpcutil.HeaderMatcher),
 		grpcutil.WithErrorHandler(r.logger),
 		grpcutil.WithPrettyJSONMarshaler(),
-		grpcutil.WithHealthzEndpoint(conn),
+		grpcruntime.WithHealthzEndpoint(grpc_health_v1.NewHealthClient(conn)),
 	)
 
 	err = apiv1.RegisterPipelineServiceHandler(ctx, gwmux, conn)

--- a/pkg/foundation/grpcutil/interceptor.go
+++ b/pkg/foundation/grpcutil/interceptor.go
@@ -90,6 +90,11 @@ func LoggerUnaryServerInterceptor(logger log.CtxLogger) grpc.UnaryServerIntercep
 		defer func() {
 			duration := time.Since(start)
 			e := logger.Err(ctx, err)
+			// set logger level to trace if it's a healthcheck request and has no error
+			if info.FullMethod == "/grpc.health.v1.Health/Check" && err == nil {
+				e = logger.Trace(ctx)
+			}
+
 			if httpEndpoint != "" {
 				// request was forwarded by GRPC gateway, output the endpoint
 				e = e.Str(log.HTTPEndpointField, httpEndpoint)


### PR DESCRIPTION
### Description

Used `WithHealthzEndpoint` method after getting merged to `grpc-gateway` https://github.com/grpc-ecosystem/grpc-gateway/pull/2319

Set the log level to `trace` when `/healthz` is called and has no error.

Fixes #182 

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.