### PR TITLE
Ensure acker node stops correctly

### DIFF
--- a/pkg/pipeline/stream/acker_test.go
+++ b/pkg/pipeline/stream/acker_test.go
@@ -52,12 +52,12 @@ func TestAckerNode_Run_StopAfterWait(t *testing.T) {
 	dest.EXPECT().Ack(gomock.Any()).Return(nil, plugin.ErrStreamNotOpen)
 
 	// give the test 1 second to finish
-	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
-	node.Wait(ctx)
+	node.Wait(waitCtx)
 
 	select {
-	case <-ctx.Done():
+	case <-waitCtx.Done():
 		is.Fail() // expected node to stop running
 	case <-nodeDone:
 		// all good
@@ -97,11 +97,11 @@ func TestAckerNode_Run_StopAfterExpectAck(t *testing.T) {
 	is.NoErr(err)
 
 	// give the test 1 second to finish
-	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 
 	select {
-	case <-ctx.Done():
+	case <-waitCtx.Done():
 		is.Fail() // expected node to stop running
 	case <-nodeDone:
 		// all good

--- a/pkg/pipeline/stream/acker_test.go
+++ b/pkg/pipeline/stream/acker_test.go
@@ -1,0 +1,109 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stream
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit/pkg/connector/mock"
+	"github.com/conduitio/conduit/pkg/plugin"
+	"github.com/conduitio/conduit/pkg/record"
+	"github.com/golang/mock/gomock"
+	"github.com/matryer/is"
+)
+
+func TestAckerNode_Run_StopAfterWait(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	dest := mock.NewDestination(ctrl)
+
+	node := &AckerNode{
+		Name:        "acker-node",
+		Destination: dest,
+	}
+
+	nodeDone := make(chan struct{})
+	go func() {
+		defer close(nodeDone)
+		err := node.Run(ctx)
+		is.NoErr(err)
+	}()
+
+	// give Go a chance to run the node
+	time.Sleep(time.Millisecond)
+
+	// up to this point there should have been no calls to the destination
+	// only after the call to Wait should the node try to fetch any acks
+	dest.EXPECT().Ack(gomock.Any()).Return(nil, plugin.ErrStreamNotOpen)
+
+	// give the test 1 second to finish
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	node.Wait(ctx)
+
+	select {
+	case <-ctx.Done():
+		is.Fail() // expected node to stop running
+	case <-nodeDone:
+		// all good
+	}
+}
+
+func TestAckerNode_Run_StopAfterExpectAck(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	dest := mock.NewDestination(ctrl)
+
+	node := &AckerNode{
+		Name:        "acker-node",
+		Destination: dest,
+	}
+
+	nodeDone := make(chan struct{})
+	go func() {
+		defer close(nodeDone)
+		err := node.Run(ctx)
+		is.NoErr(err)
+	}()
+
+	// give Go a chance to run the node
+	time.Sleep(time.Millisecond)
+
+	// up to this point there should have been no calls to the destination
+	// only after the call to ExpectAck should the node try to fetch any acks
+	msg := &Message{
+		Record: record.Record{Position: record.Position("test-position")},
+	}
+	c1 := dest.EXPECT().Ack(gomock.Any()).Return(msg.Record.Position, nil)         // first return position
+	dest.EXPECT().Ack(gomock.Any()).Return(nil, plugin.ErrStreamNotOpen).After(c1) // second return closed stream
+
+	err := node.ExpectAck(msg)
+	is.NoErr(err)
+
+	// give the test 1 second to finish
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		is.Fail() // expected node to stop running
+	case <-nodeDone:
+		// all good
+	}
+}

--- a/pkg/pipeline/stream/source.go
+++ b/pkg/pipeline/stream/source.go
@@ -57,7 +57,9 @@ func (n *SourceNode) Run(ctx context.Context) (err error) {
 	var wgOpenMessages sync.WaitGroup
 	defer func() {
 		// wait for open messages before tearing down connector
+		n.logger.Trace(ctx).Msg("waiting for open messages to be processed")
 		wgOpenMessages.Wait()
+		n.logger.Trace(ctx).Msg("all messages processed, tearing down source")
 		tdErr := n.Source.Teardown(connectorCtx)
 		if tdErr != nil {
 			if err == nil {


### PR DESCRIPTION
### Description

This fixes the issue of stopping an empty pipeline that didn't process any messages.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.