### PR TITLE
Ensure built-in dispenser doesn't reuse plugins

### DIFF
--- a/pkg/plugin/builtin/registry.go
+++ b/pkg/plugin/builtin/registry.go
@@ -21,6 +21,7 @@ import (
 	postgres "github.com/conduitio/conduit-connector-postgres"
 	pgdest "github.com/conduitio/conduit-connector-postgres/destination"
 	pgsource "github.com/conduitio/conduit-connector-postgres/source"
+	"github.com/conduitio/conduit-connector-protocol/cpluginv1"
 	s3 "github.com/conduitio/conduit-connector-s3"
 	s3destination "github.com/conduitio/conduit-connector-s3/destination"
 	s3source "github.com/conduitio/conduit-connector-s3/source"
@@ -65,9 +66,9 @@ func sdkDispenserFactory(
 		return builtinv1.NewDispenser(
 			name,
 			logger,
-			sdk.NewSpecifierPlugin(specFactory()),
-			sdk.NewSourcePlugin(sourceFactory()),
-			sdk.NewDestinationPlugin(destinationFactory()),
+			func() cpluginv1.SpecifierPlugin { return sdk.NewSpecifierPlugin(specFactory()) },
+			func() cpluginv1.SourcePlugin { return sdk.NewSourcePlugin(sourceFactory()) },
+			func() cpluginv1.DestinationPlugin { return sdk.NewDestinationPlugin(destinationFactory()) },
 		)
 	}
 }

--- a/pkg/plugin/builtin/v1/dispenser.go
+++ b/pkg/plugin/builtin/v1/dispenser.go
@@ -23,17 +23,17 @@ import (
 type Dispenser struct {
 	name              string
 	logger            log.CtxLogger
-	specifierPlugin   cpluginv1.SpecifierPlugin
-	sourcePlugin      cpluginv1.SourcePlugin
-	destinationPlugin cpluginv1.DestinationPlugin
+	specifierPlugin   func() cpluginv1.SpecifierPlugin
+	sourcePlugin      func() cpluginv1.SourcePlugin
+	destinationPlugin func() cpluginv1.DestinationPlugin
 }
 
 func NewDispenser(
 	name string,
 	logger log.CtxLogger,
-	specifierPlugin cpluginv1.SpecifierPlugin,
-	sourcePlugin cpluginv1.SourcePlugin,
-	destinationPlugin cpluginv1.DestinationPlugin,
+	specifierPlugin func() cpluginv1.SpecifierPlugin,
+	sourcePlugin func() cpluginv1.SourcePlugin,
+	destinationPlugin func() cpluginv1.DestinationPlugin,
 ) *Dispenser {
 	return &Dispenser{
 		name:              name,
@@ -45,15 +45,15 @@ func NewDispenser(
 }
 
 func (d *Dispenser) DispenseSpecifier() (plugin.SpecifierPlugin, error) {
-	return newSpecifierPluginAdapter(d.specifierPlugin), nil
+	return newSpecifierPluginAdapter(d.specifierPlugin()), nil
 }
 
 func (d *Dispenser) DispenseSource() (plugin.SourcePlugin, error) {
-	return newSourcePluginAdapter(d.sourcePlugin, d.pluginLogger("source")), nil
+	return newSourcePluginAdapter(d.sourcePlugin(), d.pluginLogger("source")), nil
 }
 
 func (d *Dispenser) DispenseDestination() (plugin.DestinationPlugin, error) {
-	return newDestinationPluginAdapter(d.destinationPlugin, d.pluginLogger("destination")), nil
+	return newDestinationPluginAdapter(d.destinationPlugin(), d.pluginLogger("destination")), nil
 }
 
 func (d *Dispenser) pluginLogger(pluginType string) log.CtxLogger {

--- a/pkg/plugin/builtin/v1/dispenser_test.go
+++ b/pkg/plugin/builtin/v1/dispenser_test.go
@@ -17,6 +17,7 @@ package builtinv1
 import (
 	"testing"
 
+	"github.com/conduitio/conduit-connector-protocol/cpluginv1"
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1/mock"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/plugin"
@@ -32,7 +33,12 @@ func newTestDispenser(t *testing.T) (plugin.Dispenser, *mock.SpecifierPlugin, *m
 	mockSource := mock.NewSourcePlugin(ctrl)
 	mockDestination := mock.NewDestinationPlugin(ctrl)
 
-	dispenser := NewDispenser("mockPlugin", logger, mockSpecifier, mockSource, mockDestination)
-
+	dispenser := NewDispenser(
+		"mockPlugin",
+		logger,
+		func() cpluginv1.SpecifierPlugin { return mockSpecifier },
+		func() cpluginv1.SourcePlugin { return mockSource },
+		func() cpluginv1.DestinationPlugin { return mockDestination },
+	)
 	return dispenser, mockSpecifier, mockSource, mockDestination
 }


### PR DESCRIPTION
### Description

This PR changes the behavior of the built-in dispenser so that it creates a new plugin instance every time it dispenses a plugin. Previously a dispenser held the same plugin in memory even after it wasn't used anymore which created a memory leak as well as issues with restarting pipelines, as the plugin didn't start from scratch but already contained the state from the previous run.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.