### PR TITLE
Fix acker node test and nil pointer

### DIFF
--- a/pkg/pipeline/stream/acker.go
+++ b/pkg/pipeline/stream/acker.go
@@ -232,11 +232,11 @@ type positionMessageMap struct {
 // The loaded result reports whether the key was present.
 func (m *positionMessageMap) LoadAndDelete(pos record.Position) (msg *Message, loaded bool) {
 	val, loaded := m.m.LoadAndDelete(m.key(pos))
-	if loaded {
-		atomic.AddUint32(&m.length, ^uint32(0)) // decrement
-		return val.(*Message), loaded
+	if !loaded {
+		return nil, false
 	}
-	return nil, false
+	atomic.AddUint32(&m.length, ^uint32(0)) // decrement
+	return val.(*Message), loaded
 }
 
 // LoadOrStore returns the existing value for the key if present.

--- a/pkg/pipeline/stream/acker.go
+++ b/pkg/pipeline/stream/acker.go
@@ -234,8 +234,9 @@ func (m *positionMessageMap) LoadAndDelete(pos record.Position) (msg *Message, l
 	val, loaded := m.m.LoadAndDelete(m.key(pos))
 	if loaded {
 		atomic.AddUint32(&m.length, ^uint32(0)) // decrement
+		return val.(*Message), loaded
 	}
-	return val.(*Message), loaded
+	return nil, false
 }
 
 // LoadOrStore returns the existing value for the key if present.


### PR DESCRIPTION
### Description

This [failed run](https://github.com/ConduitIO/conduit/actions/runs/2110239882/attempts/1) exposed a race condition in the test as well as an interface conversion error if the message is somehow not in the acker cache.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.