### PR TITLE
Fix internal race conditions

### DIFF
--- a/pkg/connector/persister.go
+++ b/pkg/connector/persister.go
@@ -81,6 +81,8 @@ func (p *Persister) ConnectorStarted() {
 // connectors this persister is persisting. Once all connectors are stopped the
 // Wait function stops blocking.
 func (p *Persister) ConnectorStopped() {
+	p.m.Lock()
+	defer p.m.Unlock()
 	p.triggerFlush(context.Background())
 	p.connWg.Done()
 }

--- a/pkg/connector/source.go
+++ b/pkg/connector/source.go
@@ -39,20 +39,23 @@ type source struct {
 	// persister is used for persisting the connector state when it changes.
 	persister *Persister
 
-	// pluginDispenser TODO
+	// pluginDispenser is used to dispense the plugin.
 	pluginDispenser plugin.Dispenser
 
 	// errs is used to signal the node that the connector experienced an error
 	// when it was processing something asynchronously (e.g. persisting state).
 	errs chan error
 
-	// below fields are nil when source is created and are managed by source
-	// internally.
+	// plugin is the running instance of the source plugin.
 	plugin plugin.SourcePlugin
 
-	// m can lock a source from concurrent access (e.g. in connector persister)
+	// m can lock a source from concurrent access (e.g. in connector persister).
 	m sync.Mutex
+	// wg tracks the number of in flight calls to the plugin.
+	wg sync.WaitGroup
 }
+
+// not running -> running -> stopping -> not running
 
 func (s *source) ID() string {
 	return s.XID
@@ -79,6 +82,8 @@ func (s *source) SetState(state SourceState) {
 }
 
 func (s *source) IsRunning() bool {
+	s.m.Lock()
+	defer s.m.Unlock()
 	return s.plugin != nil
 }
 
@@ -103,7 +108,10 @@ func (s *source) Validate(ctx context.Context, settings map[string]string) error
 }
 
 func (s *source) Open(ctx context.Context) error {
-	if s.IsRunning() {
+	// lock source as we are about to mutate the plugin field
+	s.m.Lock()
+	defer s.m.Unlock()
+	if s.plugin != nil {
 		return plugin.ErrPluginRunning
 	}
 
@@ -134,6 +142,9 @@ func (s *source) Open(ctx context.Context) error {
 }
 
 func (s *source) Stop(ctx context.Context) error {
+	// increase wait group so Teardown knows a call to the plugin is running
+	s.wg.Add(1)
+	defer s.wg.Done()
 	if !s.IsRunning() {
 		return plugin.ErrPluginNotRunning
 	}
@@ -149,9 +160,15 @@ func (s *source) Stop(ctx context.Context) error {
 }
 
 func (s *source) Teardown(ctx context.Context) error {
-	if !s.IsRunning() {
+	// lock source as we are about to mutate the plugin field
+	s.m.Lock()
+	defer s.m.Unlock()
+	if s.plugin == nil {
 		return plugin.ErrPluginNotRunning
 	}
+
+	// wait for any calls to the plugin to stop running first (e.g. Stop, Ack or Read)
+	s.wg.Wait()
 
 	s.logger.Debug(ctx).Msg("tearing down source connector plugin")
 
@@ -169,6 +186,9 @@ func (s *source) Teardown(ctx context.Context) error {
 }
 
 func (s *source) Read(ctx context.Context) (record.Record, error) {
+	// increase wait group so Teardown knows a call to the plugin is running
+	s.wg.Add(1)
+	defer s.wg.Done()
 	if !s.IsRunning() {
 		return record.Record{}, plugin.ErrPluginNotRunning
 	}
@@ -191,6 +211,9 @@ func (s *source) Read(ctx context.Context) (record.Record, error) {
 }
 
 func (s *source) Ack(ctx context.Context, p record.Position) error {
+	// increase wait group so Teardown knows a call to the plugin is running
+	s.wg.Add(1)
+	defer s.wg.Done()
 	if !s.IsRunning() {
 		return plugin.ErrPluginNotRunning
 	}

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -51,7 +51,6 @@ func newMockServices(t *testing.T) (*mock.PipelineService, *mock.ConnectorServic
 }
 
 func TestPipelineSimple(t *testing.T) {
-	t.Skip("race condition in test, will be fixed in https://github.com/ConduitIO/conduit/issues/259")
 	ctx, killAll := context.WithCancel(context.Background())
 	defer killAll()
 

--- a/pkg/pipeline/stream/acker_test.go
+++ b/pkg/pipeline/stream/acker_test.go
@@ -47,9 +47,8 @@ func TestAckerNode_Run_StopAfterWait(t *testing.T) {
 	// give Go a chance to run the node
 	time.Sleep(time.Millisecond)
 
-	// up to this point there should have been no calls to the destination
-	// only after the call to Wait should the node try to fetch any acks
-	dest.EXPECT().Ack(gomock.Any()).Return(nil, plugin.ErrStreamNotOpen)
+	// note that there should be no calls to the destination at all if we didn't
+	// receive any ExpectedAck call
 
 	// give the test 1 second to finish
 	waitCtx, cancel := context.WithTimeout(ctx, time.Second)


### PR DESCRIPTION
### Description

This PR fixes three race conditions:
- a race condition in the connector persister when calling `ConnectorStopped`
- race condition when calling `Terminate` on `connector.source` (a call to `Read` or `Ack` could still be in flight)
- same race condition in `connector.destination`

All these were previously reported in `orchestrator.TestPipelineSimple`, which was enabled again and should now work fine.

Additionally it makes the `AckerNode` stop flow a bit more explicit in case no messages flowed through the pipeline. In that case the node won't even try to fetch acks from the plugin. This also fixes another race condition that might occur in case the plugin was closed before `AckerNode` could ask the plugin to return acks.

Fixes #259

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.