### PR TITLE
Catch panic in built-in connectors

### DIFF
--- a/pkg/plugin/builtin/v1/destination.go
+++ b/pkg/plugin/builtin/v1/destination.go
@@ -64,7 +64,7 @@ func (s *destinationPluginAdapter) Configure(ctx context.Context, cfg map[string
 		return err
 	}
 	s.logger.Trace(ctx).Msg("calling Configure")
-	resp, err := s.impl.Configure(s.withLogger(ctx), req)
+	resp, err := runSandbox(s.impl.Configure, s.withLogger(ctx), req)
 	if err != nil {
 		// TODO create new errors as strings, this happens when they are
 		//  transmitted through gRPC and we don't want to falsely rely on types
@@ -82,7 +82,7 @@ func (s *destinationPluginAdapter) Start(ctx context.Context) error {
 
 	req := toplugin.DestinationStartRequest()
 	s.logger.Trace(ctx).Msg("calling Start")
-	resp, err := s.impl.Start(s.withLogger(ctx), req)
+	resp, err := runSandbox(s.impl.Start, s.withLogger(ctx), req)
 	if err != nil {
 		return err
 	}
@@ -91,7 +91,7 @@ func (s *destinationPluginAdapter) Start(ctx context.Context) error {
 	s.stream = newDestinationRunStream(ctx)
 	go func() {
 		s.logger.Trace(ctx).Msg("calling Run")
-		err := s.impl.Run(s.withLogger(ctx), s.stream)
+		err := runSandboxNoResp(s.impl.Run, s.withLogger(ctx), cpluginv1.DestinationRunStream(s.stream)) // TODO sandbox
 		if err != nil {
 			s.stream.stopAll(cerrors.Errorf("error in run: %w", err))
 		} else {
@@ -149,7 +149,7 @@ func (s *destinationPluginAdapter) Stop(ctx context.Context) error {
 	s.stream.stopSend()
 
 	s.logger.Trace(ctx).Msg("calling Stop")
-	resp, err := s.impl.Stop(s.withLogger(ctx), toplugin.DestinationStopRequest())
+	resp, err := runSandbox(s.impl.Stop, s.withLogger(ctx), toplugin.DestinationStopRequest())
 	if err != nil {
 		return err
 	}
@@ -160,7 +160,7 @@ func (s *destinationPluginAdapter) Stop(ctx context.Context) error {
 
 func (s *destinationPluginAdapter) Teardown(ctx context.Context) error {
 	s.logger.Trace(ctx).Msg("calling Teardown")
-	resp, err := s.impl.Teardown(s.withLogger(ctx), toplugin.DestinationTeardownRequest())
+	resp, err := runSandbox(s.impl.Teardown, s.withLogger(ctx), toplugin.DestinationTeardownRequest())
 	if err != nil {
 		return err
 	}

--- a/pkg/plugin/builtin/v1/destination.go
+++ b/pkg/plugin/builtin/v1/destination.go
@@ -34,7 +34,6 @@ import (
 // conduit-connector-protocol (cpluginv1). This adapter needs to make sure it behaves in the
 // same way as the standalone plugin adapter, which communicates with the plugin
 // through gRPC, so that the caller can use both of them interchangeably.
-// TODO make sure a panic in a plugin doesn't crash Conduit
 type destinationPluginAdapter struct {
 	impl cpluginv1.DestinationPlugin
 	// logger is used as the internal logger of destinationPluginAdapter.

--- a/pkg/plugin/builtin/v1/destination.go
+++ b/pkg/plugin/builtin/v1/destination.go
@@ -91,7 +91,7 @@ func (s *destinationPluginAdapter) Start(ctx context.Context) error {
 	s.stream = newDestinationRunStream(ctx)
 	go func() {
 		s.logger.Trace(ctx).Msg("calling Run")
-		err := runSandboxNoResp(s.impl.Run, s.withLogger(ctx), cpluginv1.DestinationRunStream(s.stream)) // TODO sandbox
+		err := runSandboxNoResp(s.impl.Run, s.withLogger(ctx), cpluginv1.DestinationRunStream(s.stream))
 		if err != nil {
 			s.stream.stopAll(cerrors.Errorf("error in run: %w", err))
 		} else {

--- a/pkg/plugin/builtin/v1/sandbox.go
+++ b/pkg/plugin/builtin/v1/sandbox.go
@@ -14,11 +14,21 @@
 
 package builtinv1
 
-import "github.com/conduitio/conduit/pkg/foundation/cerrors"
+import (
+	"context"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+)
 
 // runSandbox takes a function and runs it in a sandboxed mode that catches
 // panics and converts them into an error instead.
-func runSandbox(f func() error) (err error) {
+// It is specifically designed to run functions that take a context and a
+// request and return a response and an error (i.e. plugin calls).
+func runSandbox[REQ any, RES any](
+	ctx context.Context,
+	req REQ,
+	f func(context.Context, REQ) (RES, error),
+) (res RES, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			panicErr, ok := r.(error)
@@ -28,5 +38,5 @@ func runSandbox(f func() error) (err error) {
 			err = panicErr
 		}
 	}()
-	return f()
+	return f(ctx, req)
 }

--- a/pkg/plugin/builtin/v1/sandbox.go
+++ b/pkg/plugin/builtin/v1/sandbox.go
@@ -25,9 +25,9 @@ import (
 // It is specifically designed to run functions that take a context and a
 // request and return a response and an error (i.e. plugin calls).
 func runSandbox[REQ any, RES any](
-	ctx context.Context,
-	req REQ,
 	f func(context.Context, REQ) (RES, error),
+	ctx context.Context, // context is the second parameter on purpose
+	req REQ,
 ) (res RES, err error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -39,4 +39,16 @@ func runSandbox[REQ any, RES any](
 		}
 	}()
 	return f(ctx, req)
+}
+
+func runSandboxNoResp[REQ any](
+	f func(context.Context, REQ) error,
+	ctx context.Context, // context is the second parameter on purpose
+	req REQ,
+) error {
+	_, err := runSandbox(func(ctx context.Context, req REQ) (any, error) {
+		err := f(ctx, req)
+		return nil, err
+	}, ctx, req)
+	return err
 }

--- a/pkg/plugin/builtin/v1/sandbox.go
+++ b/pkg/plugin/builtin/v1/sandbox.go
@@ -1,0 +1,32 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builtinv1
+
+import "github.com/conduitio/conduit/pkg/foundation/cerrors"
+
+// runSandbox takes a function and runs it in a sandboxed mode that catches
+// panics and converts them into an error instead.
+func runSandbox(f func() error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			panicErr, ok := r.(error)
+			if !ok {
+				panicErr = cerrors.Errorf("panic: %v", r)
+			}
+			err = panicErr
+		}
+	}()
+	return f()
+}

--- a/pkg/plugin/builtin/v1/sandbox_test.go
+++ b/pkg/plugin/builtin/v1/sandbox_test.go
@@ -84,7 +84,7 @@ func TestRunSandbox(t *testing.T) {
 
 	for _, td := range testData {
 		t.Run(td.name, func(t *testing.T) {
-			gotResp, gotErr := runSandbox(ctx, td.req, td.f)
+			gotResp, gotErr := runSandbox(td.f, ctx, td.req)
 			is.Equal(gotResp, td.resp)
 			if td.strict {
 				// strict mode means we expect a very specific error
@@ -95,4 +95,12 @@ func TestRunSandbox(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRunSandboxNoResp(t *testing.T) {
+	ctx := context.Background()
+	is := is.New(t)
+	wantErr := cerrors.New("test error")
+	gotErr := runSandboxNoResp(func(context.Context, any) error { panic(wantErr) }, ctx, nil)
+	is.Equal(gotErr, wantErr)
 }

--- a/pkg/plugin/builtin/v1/sandbox_test.go
+++ b/pkg/plugin/builtin/v1/sandbox_test.go
@@ -1,0 +1,77 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builtinv1
+
+import (
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/matryer/is"
+)
+
+func TestRunSandbox(t *testing.T) {
+	is := is.New(t)
+	haveErr := cerrors.New("test error")
+
+	testData := []struct {
+		name    string
+		f       func() error
+		wantErr error
+		strict  bool
+	}{{
+		name:    "func returns nil",
+		f:       func() error { return nil },
+		wantErr: nil,
+		strict:  true,
+	}, {
+		name:    "nil func",
+		f:       nil,
+		wantErr: cerrors.New("runtime error: invalid memory address or nil pointer dereference"),
+		strict:  false,
+	}, {
+		name:    "func returns error",
+		f:       func() error { return haveErr },
+		wantErr: haveErr,
+		strict:  true,
+	}, {
+		name:    "func returns error in panic",
+		f:       func() error { panic(haveErr) },
+		wantErr: haveErr,
+		strict:  true,
+	}, {
+		name:    "func returns string in panic",
+		f:       func() error { panic("oh noes something went bad") },
+		wantErr: cerrors.New("panic: oh noes something went bad"),
+		strict:  false,
+	}, {
+		name:    "func returns number in panic",
+		f:       func() error { panic(1) },
+		wantErr: cerrors.New("panic: 1"),
+		strict:  false,
+	}}
+
+	for _, td := range testData {
+		t.Run(td.name, func(t *testing.T) {
+			gotErr := runSandbox(td.f)
+			if td.strict {
+				// strict mode means we expect a very specific error
+				is.Equal(gotErr, td.wantErr)
+			} else {
+				// relaxed mode only compares error strings
+				is.Equal(gotErr.Error(), td.wantErr.Error())
+			}
+		})
+	}
+}

--- a/pkg/plugin/builtin/v1/source.go
+++ b/pkg/plugin/builtin/v1/source.go
@@ -65,7 +65,7 @@ func (s *sourcePluginAdapter) Configure(ctx context.Context, cfg map[string]stri
 		return err
 	}
 	s.logger.Trace(ctx).Msg("calling Configure")
-	resp, err := s.impl.Configure(s.withLogger(ctx), req)
+	resp, err := runSandbox(s.impl.Configure, s.withLogger(ctx), req)
 	if err != nil {
 		// TODO create new errors as strings, this happens when they are
 		//  transmitted through gRPC and we don't want to falsely rely on types
@@ -87,7 +87,7 @@ func (s *sourcePluginAdapter) Start(ctx context.Context, p record.Position) erro
 	}
 
 	s.logger.Trace(ctx).Msg("calling Start")
-	resp, err := s.impl.Start(s.withLogger(ctx), req)
+	resp, err := runSandbox(s.impl.Start, s.withLogger(ctx), req)
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func (s *sourcePluginAdapter) Start(ctx context.Context, p record.Position) erro
 	s.stream = newSourceRunStream(ctx)
 	go func() {
 		s.logger.Trace(ctx).Msg("calling Run")
-		err := s.impl.Run(s.withLogger(ctx), s.stream)
+		err := runSandboxNoResp(s.impl.Run, s.withLogger(ctx), cpluginv1.SourceRunStream(s.stream))
 		if err != nil {
 			s.stream.stop(cerrors.Errorf("error in run: %w", err))
 		} else {
@@ -152,7 +152,7 @@ func (s *sourcePluginAdapter) Stop(ctx context.Context) error {
 	}
 
 	s.logger.Trace(ctx).Msg("calling Stop")
-	resp, err := s.impl.Stop(s.withLogger(ctx), toplugin.SourceStopRequest())
+	resp, err := runSandbox(s.impl.Stop, s.withLogger(ctx), toplugin.SourceStopRequest())
 	if err != nil {
 		return err
 	}
@@ -163,7 +163,7 @@ func (s *sourcePluginAdapter) Stop(ctx context.Context) error {
 
 func (s *sourcePluginAdapter) Teardown(ctx context.Context) error {
 	s.logger.Trace(ctx).Msg("calling Teardown")
-	resp, err := s.impl.Teardown(s.withLogger(ctx), toplugin.SourceTeardownRequest())
+	resp, err := runSandbox(s.impl.Teardown, s.withLogger(ctx), toplugin.SourceTeardownRequest())
 	if err != nil {
 		return err
 	}

--- a/pkg/plugin/builtin/v1/source.go
+++ b/pkg/plugin/builtin/v1/source.go
@@ -34,7 +34,6 @@ import (
 // conduit-connector-protocol (cpluginv1). This adapter needs to make sure it behaves in the
 // same way as the standalone plugin adapter, which communicates with the plugin
 // through gRPC, so that the caller can use both of them interchangeably.
-// TODO make sure a panic in a plugin doesn't crash Conduit
 type sourcePluginAdapter struct {
 	impl cpluginv1.SourcePlugin
 	// logger is used as the internal logger of sourcePluginAdapter.

--- a/pkg/plugin/builtin/v1/specifier.go
+++ b/pkg/plugin/builtin/v1/specifier.go
@@ -38,7 +38,7 @@ func newSpecifierPluginAdapter(impl cpluginv1.SpecifierPlugin) *specifierPluginA
 
 func (s *specifierPluginAdapter) Specify() (plugin.Specification, error) {
 	req := toplugin.SpecifierSpecifyRequest()
-	resp, err := s.impl.Specify(context.Background(), req)
+	resp, err := runSandbox(s.impl.Specify, context.Background(), req)
 	if err != nil {
 		return plugin.Specification{}, err
 	}


### PR DESCRIPTION
### Description

This PR makes sure explicit calls to builtin plugins can't crash Conduit. If the plugin spawns a goroutine that panics it can still bring down Conduit, there's no way to catch those panics (if there is, let me know!).

First use of generics in Conduit! 😁 

Fixes #220

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.