### PR TITLE
[UI] Update connector config labels to be more readable

### DIFF
--- a/ui/app/components/pipeline-editor/connector-modal.js
+++ b/ui/app/components/pipeline-editor/connector-modal.js
@@ -152,6 +152,7 @@ export default class PipelineEditorNewConnectorModal extends Component {
         this.connector
       );
     }
+    this.isShowingRequiredTab = true;
   }
 
   @action

--- a/ui/app/utils/blueprints/generate-blueprint-fields.js
+++ b/ui/app/utils/blueprints/generate-blueprint-fields.js
@@ -7,6 +7,7 @@ import {
   validateExclusion,
   validateFormat,
 } from 'ember-changeset-validations/validators';
+import { underscore } from '@ember/string';
 
 const ConfigValidationMap = {
   TYPE_REQUIRED: function () {
@@ -51,7 +52,7 @@ export default function generateBlueprintFields(blueprint, configurable) {
 
     const fieldModel = {
       id: fieldName,
-      label: fieldName,
+      label: underscore(fieldName).replace('.', '_').split('_').join(' '),
       description: fieldOpts.description,
       type: fieldOpts.type,
       isRequired: !!fieldOpts.validations.findBy('type', 'TYPE_REQUIRED'),


### PR DESCRIPTION
### Description
+ Makes plugin config labels more human friendly by inserting spaces
+ Fixes a UI bug that didn't show required plugin fields when switching from another plugin with optional fields

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.

<img width="471" alt="Screen Shot 2022-06-13 at 8 05 54 AM" src="https://user-images.githubusercontent.com/4818826/173349940-2d59d5f6-b638-4afd-a4a9-bdd637abf129.png">
<img width="460" alt="Screen Shot 2022-06-13 at 8 06 02 AM" src="https://user-images.githubusercontent.com/4818826/173349959-79926962-487b-48fd-919e-27db0535b951.png">
