### PR TITLE
ci(lint): add linter task to ui CI workflow

### DIFF
--- a/.github/workflows/ui-lint.yml
+++ b/.github/workflows/ui-lint.yml
@@ -1,0 +1,35 @@
+name: UI Lint
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - main
+    paths:
+      - 'ui/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'ui/**'
+
+jobs:
+  lint-app:
+    name: Run linter
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Use Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: make ui-dependencies
+
+      - name: lint
+        run: cd ui/ && npm run lint

--- a/ui/app/components/pipeline-editor.hbs
+++ b/ui/app/components/pipeline-editor.hbs
@@ -36,12 +36,14 @@
 
                 <dd.Content class="bg-white rounded-md border border-gray-200 shadow-md text-sm">
                   <ul>
+                    {{!-- template-lint-disable no-invalid-interactive --}}
                     <li
                       class="py-4 pr-16 pl-4 cursor-pointer flex items-center font-medium hover:bg-gray-100"
                       data-test-pipeline-editor-add-node-source
                       {{on "click" (fn this.showCreateConnectorModal "source")}}
                       {{on "click" dd.actions.close}}
                     >
+                    {{!-- template-lint-enable no-invalid-interactive --}}
                       <svg class="fill-current h-4 w-4 mr-2">
                         <use xlink:href="/ui/svg-defs.svg#source-16"></use>
                       </svg>

--- a/ui/app/components/pipeline-editor/connector-modal.hbs
+++ b/ui/app/components/pipeline-editor/connector-modal.hbs
@@ -59,6 +59,7 @@
     <div class="flex text-center mb-2 border-b border-gray-300">
 
       {{#if this.optionalFields}}
+        {{!-- template-lint-disable no-invalid-interactive --}}
         <div
           class="w-1/2 flex-auto pb-2
             {{if this.isShowingRequiredTab 'border-b-2'}}
@@ -74,15 +75,18 @@
           {{on "click" (fn (mut this.isShowingRequiredTab) false)}}
           data-test-connector-modal-optional-tab
         >
+        {{!-- template-lint-enable no-invalid-interactive --}}
           Optional
         </div>
       {{else}}
+        {{!-- template-lint-disable no-invalid-interactive --}}
         <div
           class="w-full flex-auto pb-2
             {{if this.isShowingRequiredTab 'border-b-2'}}
             border-teal-900 uppercase text-xs cursor-pointer"
           {{on "click" (fn (mut this.isShowingRequiredTab) true)}}
         >
+        {{!-- template-lint-enable no-invalid-interactive --}}
           Configure
         </div>
       {{/if}}

--- a/ui/app/components/pipeline-editor/connector-overview.hbs
+++ b/ui/app/components/pipeline-editor/connector-overview.hbs
@@ -1,5 +1,6 @@
 <ul data-test-connector-overview-list>
   {{#each @sourceConnectors as |connector|}}
+    {{!-- template-lint-disable no-invalid-interactive --}}
     <li
       class="mb-2 py-2 px-4 hover:bg-purple-100 cursor-pointer
         {{if
@@ -10,6 +11,7 @@
       data-test-connector-overview-list-item
       {{on "click" (fn @selectNode connector)}}
     >
+    {{!-- template-lint-enable no-invalid-interactive --}}
       <div class="flex items-center justify-between">
         <div class="text-xs font-medium">
           {{connector.name}}
@@ -31,6 +33,7 @@
     </li>
   {{/each}}
   {{#each @destinationConnectors as |connector|}}
+    {{!-- template-lint-disable no-invalid-interactive --}}
     <li
       class="mb-2 py-2 px-4 hover:bg-purple-100 cursor-pointer
         {{if
@@ -41,6 +44,7 @@
       data-test-connector-overview-list-item
       {{on "click" (fn @selectNode connector)}}
     >
+    {{!-- template-lint-enable no-invalid-interactive --}}
       <div class="flex items-center justify-between mb-1">
         <div class="text-xs font-medium">
           {{connector.name}}

--- a/ui/app/components/pipeline-editor/connector-slide-panel.hbs
+++ b/ui/app/components/pipeline-editor/connector-slide-panel.hbs
@@ -37,23 +37,27 @@
               </dd.Trigger>
               <dd.Content class="bg-white rounded-md border border-gray-200 shadow-md text-sm">
                 <ul class="font-semibold">
+                  {{!-- template-lint-disable no-invalid-interactive --}}
                   <li
                     class="cursor-pointer pl-2 pr-16 py-4 hover:bg-gray-100 flex items-center"
                     data-test-dropdown-button="connector-panel-edit"
                     {{on "click" @showEditConnectorModal}}
                     {{on "click" dd.actions.close}}
                   >
+                  {{!-- template-lint-enable no-invalid-interactive --}}
                     <svg class="fill-current h-4 w-4 mr-2">
                       <use xlink:href="/ui/svg-defs.svg#settings-16"></use>
                     </svg>
                     Edit Connector
                   </li>
+                  {{!-- template-lint-disable no-invalid-interactive --}}
                   <li
                     class="cursor-pointer text-orange-700 pl-2 pr-16 py-4 hover:bg-gray-100 flex items-center"
                     data-test-dropdown-button="connector-panel-delete"
                     {{on "click" @showDeleteConnectorModal}}
                     {{on "click" dd.actions.close}}
                   >
+                  {{!-- template-lint-enable no-invalid-interactive --}}
                     <svg class="fill-current text-orange-700 h-4 w-4 mr-2">
                       <use xlink:href="/ui/svg-defs.svg#delete-16"></use>
                     </svg>
@@ -163,12 +167,14 @@
                           </div>
                         </div>
                       </div>
+                      {{!-- template-lint-disable no-invalid-interactive --}}
                       <svg
                         class="text-gray-500 stroke-current h-4 w-4 cursor-pointer"
                         fill="none"
                         {{on "click" (fn this.showEditTransformPanel connectorTransform)}}
                         data-test-button="edit-transform"
                       >
+                      {{!-- template-lint-enable no-invalid-interactive --}}
                         <use xlink:href="/ui/svg-defs.svg#pencil-16"></use>
                       </svg>
                     </div>

--- a/ui/app/components/pipeline-editor/connector-slide-panel/available-transforms-panel.hbs
+++ b/ui/app/components/pipeline-editor/connector-slide-panel/available-transforms-panel.hbs
@@ -16,11 +16,13 @@
     </div>
     <ul>
       {{#each this.availableFilteredTransforms as |availableTransform|}}
+        {{!-- template-lint-disable no-invalid-interactive --}}
         <li
           class="border border-gray-300 p-4 flex items-center justify-between rounded-md mb-2 cursor-pointer"
           {{on "click" (fn @showNewTransformPanel availableTransform)}}
           data-test-available-transform={{dasherize availableTransform.label}}
         >
+        {{!-- template-lint-enable no-invalid-interactive --}}
           <div class="w-5/6">
             <div class="text-sm">
               {{availableTransform.label}}

--- a/ui/app/components/pipeline-editor/connector-slide-panel/transform-panel.hbs
+++ b/ui/app/components/pipeline-editor/connector-slide-panel/transform-panel.hbs
@@ -17,21 +17,25 @@
 
           <dd.Content class="bg-white rounded-md border border-gray-200 shadow-md p-4 text-sm">
             <ul>
+              {{!-- template-lint-disable no-invalid-interactive --}}
               <li
                 class="cursor-pointer mb-4"
                 {{on "click" (fn @duplicateTransform @connectorTransform)}}
                 {{on "click" dd.actions.close}}
                 data-test-dropdown-button="duplicate-connector-transform"
               >
+              {{!-- template-lint-enable no-invalid-interactive --}}
                 Duplicate
               </li>
 
+              {{!-- template-lint-disable no-invalid-interactive --}}
               <li
                 {{on "click" (fn @removeTransform @connectorTransform)}}
                 {{on "click" dd.actions.close}}
                 class="cursor-pointer text-orange-700"
                 data-test-dropdown-button="delete-connector-transform"
               >
+              {{!-- template-lint-enable no-invalid-interactive --}}
                 Delete
               </li>
             </ul>

--- a/ui/app/components/pipeline/status.hbs
+++ b/ui/app/components/pipeline/status.hbs
@@ -22,24 +22,28 @@
     <dd.Content class="bg-white rounded-md border border-gray-200 shadow-md text-sm">
       <ul>
         {{#if (or (eq @status "paused") (eq @status "degraded"))}}
+          {{!-- template-lint-disable no-invalid-interactive --}}
           <li
             data-test-pipeline-status-action="start"
             class="p-4 cursor-pointer flex items-center hover:bg-gray-100"
             {{on "click" @startPipeline}}
             {{on "click" dd.actions.close}}
           >
+          {{!-- template-lint-enable no-invalid-interactive --}}
             <svg class="text-teal-600 stroke-current h-4 w-4 mr-2">
               <use xlink:href="/ui/svg-defs.svg#play-24"></use>
             </svg>
             Start Pipeline
           </li>
         {{else}}
+          {{!-- template-lint-disable no-invalid-interactive --}}
           <li
             data-test-pipeline-status-action="stop"
             class="p-4 cursor-pointer flex items-center hover:bg-gray-100"
             {{on "click" @stopPipeline}}
             {{on "click" dd.actions.close}}
           >
+          {{!-- template-lint-enable no-invalid-interactive --}}
             <svg class="text-gray-500 stroke-current h-4 w-4 mr-2">
               <use xlink:href="/ui/svg-defs.svg#pause-24"></use>
             </svg>

--- a/ui/app/components/pipelines/list.hbs
+++ b/ui/app/components/pipelines/list.hbs
@@ -111,11 +111,13 @@
                           Settings
                         </LinkTo>
                       </li>
+                      {{!-- template-lint-disable no-invalid-interactive --}}
                       <li
                         class="text-orange-700 font-medium pr-16 cursor-pointer flex items-center"
                         {{on "click" (fn @onDeletePipeline pipeline)}}
                         {{on "click" dd.actions.close}}
                       >
+                      {{!-- template-lint-enable no-invalid-interactive --}}
                         <svg class="fill-current text-orange-700 h-4 w-4 mr-2">
                           <use xlink:href="/ui/svg-defs.svg#delete-16"></use>
                         </svg>

--- a/ui/app/templates/pipeline.hbs
+++ b/ui/app/templates/pipeline.hbs
@@ -33,6 +33,7 @@
                     Pipeline settings
                   </LinkTo>
                 </li>
+                {{!-- template-lint-disable no-invalid-interactive --}}
                 <li
                   class="text-orange-700 font-medium flex items-center cursor-select hover:bg-gray-100 pr-16 pl-4 pb-4 pt-2"
                   data-test-pipeline-menu-item="delete"
@@ -42,6 +43,7 @@
                   }}
                   {{on "click" dd.actions.close}}
                 >
+                {{!-- template-lint-enable no-invalid-interactive --}}
                   <svg class="fill-current text-orange-700 h-4 w-4 mr-2">
                     <use xlink:href="/ui/svg-defs.svg#delete-16"></use>
                   </svg>


### PR DESCRIPTION
### Description

This adds a CI linter task for the ui project that will be run on any open pull requests, as well as commits to the `main` branch of the project.

This change is motivated by the recent dependabot upgrade of the template linter dependency. Right now, it is not possible, when reviewing a dependabot PR related to UI linter utilities, to infer if the version upgrade will cause any issues for our linter workflow

After merging this PR, we would now see the CI failing if linter upgrades either surface new linting errors or break our linting flow all together.

Follow-up to https://github.com/ConduitIO/conduit/pull/421
Reference: https://github.com/ConduitIO/conduit/pull/421#issuecomment-1156316979

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests. (not applicable)
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.