### PR TITLE
Linter is king at Conduit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45.2
+          version: v1.46.2
 
   buf-lint:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,14 @@ linters-settings:
   goheader:
     template-path: '.golangci.goheader.template'
 
+issues:
+  exclude-rules:
+    - path: '(.+)acceptance_testing\.go'
+      linters:
+        - stylecheck
+      text: "ST1003: should not use underscores in Go names"
+
+
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.
   # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint

--- a/pkg/foundation/cerrors/cerrors.go
+++ b/pkg/foundation/cerrors/cerrors.go
@@ -31,8 +31,9 @@ import (
 )
 
 var (
+	// xerrors is used, since it provides the stack traces too
 	New    = xerrors.New    //nolint:forbidigo // xerrors.New is allowed here, but not anywhere else
-	Errorf = xerrors.Errorf //nolint:forbidigo // xerrors.Errorf is allowed here, but not anywhere else
+	Errorf = xerrors.Errorf //nolint:forbidigo,staticcheck // xerrors.Errorf is allowed here, but not anywhere else
 	Is     = errors.Is
 	As     = errors.As
 	Unwrap = errors.Unwrap

--- a/pkg/foundation/metrics/prometheus/prometheus_example_test.go
+++ b/pkg/foundation/metrics/prometheus/prometheus_example_test.go
@@ -28,7 +28,7 @@ import (
 var (
 	testCounter = metrics.NewCounter("prom_example_counter", "example")
 	testTimer   = metrics.NewTimer("prom_example_timer", "example")
-	// nolint:deadcode,varcheck // the whole point of this is to show that even unused gauges show up in prometheus
+	// nolint:unused,deadcode,varcheck // the whole point of this is to show that even unused gauges show up in prometheus
 	testGauge = metrics.NewGauge("prom_example_gauge", "example")
 )
 

--- a/pkg/pipeline/lifecycle.go
+++ b/pkg/pipeline/lifecycle.go
@@ -358,6 +358,7 @@ func (s *Service) runPipeline(ctx context.Context, pl *Instance) error {
 			// If any of the nodes stops, the nodesTomb will be put into a dying state
 			// and ctx will be cancelled.
 			// This way, the other nodes will be notified that they need to stop too.
+			//nolint: staticcheck // nil used to use the default (parent provided via WithContext)
 			ctx := nodesTomb.Context(nil)
 			s.logger.Trace(ctx).Str(log.NodeIDField, node.ID()).Msg("running node")
 			defer func() {
@@ -405,6 +406,7 @@ func (s *Service) runPipeline(ctx context.Context, pl *Instance) error {
 	// before declaring the pipeline as stopped.
 	pl.t = &tomb.Tomb{}
 	pl.t.Go(func() error {
+		//nolint: staticcheck // nil used to use the default (parent provided via WithContext)
 		ctx := pl.t.Context(nil)
 		err := nodesTomb.Wait()
 

--- a/pkg/plugin/acceptance_testing.go
+++ b/pkg/plugin/acceptance_testing.go
@@ -45,8 +45,8 @@ import (
 //
 func AcceptanceTestV1(t *testing.T, tdf testDispenserFunc) {
 	// specifier tests
-	run(t, tdf, testSpecifier_Specify_Success)
-	run(t, tdf, testSpecifier_Specify_Fail)
+	run(t, tdf, testSpecifierSpecifySuccess)
+	run(t, tdf, testSpecifierSpecifyFail)
 
 	// source tests
 	run(t, tdf, testSource_Configure_Success)
@@ -89,7 +89,7 @@ type testDispenserFunc func(*testing.T) (Dispenser, *mock.SpecifierPlugin, *mock
 // -- SPECIFIER --
 // ---------------
 
-func testSpecifier_Specify_Success(t *testing.T, tdf testDispenserFunc) {
+func testSpecifierSpecifySuccess(t *testing.T, tdf testDispenserFunc) {
 	dispenser, mockSpecifier, _, _ := tdf(t)
 
 	want := Specification{
@@ -141,7 +141,7 @@ func testSpecifier_Specify_Success(t *testing.T, tdf testDispenserFunc) {
 	}
 }
 
-func testSpecifier_Specify_Fail(t *testing.T, tdf testDispenserFunc) {
+func testSpecifierSpecifyFail(t *testing.T, tdf testDispenserFunc) {
 	dispenser, mockSpecifier, _, _ := tdf(t)
 
 	want := cerrors.New("specify error")

--- a/pkg/plugin/acceptance_testing.go
+++ b/pkg/plugin/acceptance_testing.go
@@ -45,8 +45,8 @@ import (
 //
 func AcceptanceTestV1(t *testing.T, tdf testDispenserFunc) {
 	// specifier tests
-	run(t, tdf, testSpecifierSpecifySuccess)
-	run(t, tdf, testSpecifierSpecifyFail)
+	run(t, tdf, testSpecifier_Specify_Success)
+	run(t, tdf, testSpecifier_Specify_Fail)
 
 	// source tests
 	run(t, tdf, testSource_Configure_Success)
@@ -89,7 +89,7 @@ type testDispenserFunc func(*testing.T) (Dispenser, *mock.SpecifierPlugin, *mock
 // -- SPECIFIER --
 // ---------------
 
-func testSpecifierSpecifySuccess(t *testing.T, tdf testDispenserFunc) {
+func testSpecifier_Specify_Success(t *testing.T, tdf testDispenserFunc) {
 	dispenser, mockSpecifier, _, _ := tdf(t)
 
 	want := Specification{
@@ -141,7 +141,7 @@ func testSpecifierSpecifySuccess(t *testing.T, tdf testDispenserFunc) {
 	}
 }
 
-func testSpecifierSpecifyFail(t *testing.T, tdf testDispenserFunc) {
+func testSpecifier_Specify_Fail(t *testing.T, tdf testDispenserFunc) {
 	dispenser, mockSpecifier, _, _ := tdf(t)
 
 	want := cerrors.New("specify error")


### PR DESCRIPTION
### Description

Upgrades golangci-lint to 1.46.2.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.