### PR TITLE
Utility: Log or replace

### DIFF
--- a/pkg/connector/source.go
+++ b/pkg/connector/source.go
@@ -72,8 +72,8 @@ func (s *source) Config() Config {
 	return s.XConfig
 }
 
-func (s *source) SetConfig(d Config) {
-	s.XConfig = d
+func (s *source) SetConfig(c Config) {
+	s.XConfig = c
 }
 
 func (s *source) CreatedAt() time.Time {

--- a/pkg/connector/source.go
+++ b/pkg/connector/source.go
@@ -106,13 +106,16 @@ func (s *source) Errors() <-chan error {
 	return s.errs
 }
 
-func (s *source) Validate(ctx context.Context, settings map[string]string) error {
+func (s *source) Validate(ctx context.Context, settings map[string]string) (err error) {
 	src, err := s.pluginDispenser.DispenseSource()
 	if err != nil {
 		return err
 	}
 	defer func() {
-		_ = src.Teardown(ctx)
+		tmpErr := src.Teardown(ctx)
+		err = cerrors.LogOrReplace(err, tmpErr, func() {
+			s.logger.Err(ctx, tmpErr).Msg("could not teardown source")
+		})
 	}()
 
 	err = src.Configure(ctx, settings)

--- a/pkg/foundation/cerrors/cerrors_test.go
+++ b/pkg/foundation/cerrors/cerrors_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/matryer/is"
 )
 
 var _, testFileLocation, _, _ = runtime.Caller(0)
@@ -142,6 +143,55 @@ func TestGetStackTrace(t *testing.T) {
 			act, ok := res.([]cerrors.Frame)
 			assert.True(t, ok, "expected []cerrors.Frame")
 			assert.Equal(t, tc.expected, act)
+		})
+	}
+}
+
+func TestLogOrReplace(t *testing.T) {
+	is := is.New(t)
+
+	errFoo := cerrors.New("foo")
+	errBar := cerrors.New("bar")
+
+	testCases := map[string]struct {
+		oldErr        error
+		newErr        error
+		wantErr       error
+		wantLogCalled bool
+	}{
+		"both nil": {
+			oldErr:        nil,
+			newErr:        nil,
+			wantErr:       nil,
+			wantLogCalled: false,
+		},
+		"oldErr exists, newErr nil": {
+			oldErr:        errFoo,
+			newErr:        nil,
+			wantErr:       errFoo,
+			wantLogCalled: false,
+		},
+		"oldErr nil, newErr exists": {
+			oldErr:        nil,
+			newErr:        errFoo,
+			wantErr:       errFoo,
+			wantLogCalled: false,
+		},
+		"both exist": {
+			oldErr:        errFoo,
+			newErr:        errBar,
+			wantErr:       errFoo,
+			wantLogCalled: true,
+		}}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			logCalled := false
+			gotErr := cerrors.LogOrReplace(tc.oldErr, tc.newErr, func() {
+				logCalled = true
+			})
+			is.Equal(tc.wantErr, gotErr)
+			is.Equal(tc.wantLogCalled, logCalled)
 		})
 	}
 }

--- a/pkg/foundation/cerrors/cerrors_test.go
+++ b/pkg/foundation/cerrors/cerrors_test.go
@@ -60,7 +60,7 @@ func TestErrorf(t *testing.T) {
 	assert.Equal(
 		t,
 		"caused by:\n    github.com/conduitio/conduit/pkg/foundation/cerrors_test.TestErrorf\n        "+
-			testFileLocation+":57\n  - "+
+			testFileLocation+":58\n  - "+
 			"foobar:\n    github.com/conduitio/conduit/pkg/foundation/cerrors_test.newError\n        "+
 			helperFilePath+":26",
 		s,
@@ -90,7 +90,7 @@ func TestGetStackTrace(t *testing.T) {
 				{
 					Func: "github.com/conduitio/conduit/pkg/foundation/cerrors_test.TestGetStackTrace",
 					File: testFileLocation,
-					Line: 87,
+					Line: 88,
 				},
 			},
 		},


### PR DESCRIPTION
### Description

Adds a utility function `cerrors.LogOrReplace` (see godoc for more info). The PR only changes the case in the `source` and `destination` connectors to use this utility, but we have these cases all throughout the codebase (e.g. [1](https://github.com/ConduitIO/conduit/blob/8c534b14679f2f1bb5a726e9fb7ca7249ee4f3bf/pkg/pipeline/stream/destination.go#L75-L80), [2](https://github.com/ConduitIO/conduit/blob/8c534b14679f2f1bb5a726e9fb7ca7249ee4f3bf/pkg/pipeline/stream/destination_acker.go#L70-L75), [3](https://github.com/ConduitIO/conduit/blob/8c534b14679f2f1bb5a726e9fb7ca7249ee4f3bf/pkg/pipeline/stream/source.go#L69-L75)). I didn't change the other cases though because it would create a conflict with existing PRs, we can change those later.

Fixes #224

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.