### PR TITLE
Use "create" instead of "insert"

### DIFF
--- a/docs/design-documents/20220309-opencdc.md
+++ b/docs/design-documents/20220309-opencdc.md
@@ -9,7 +9,7 @@ The main goal is to ensure compatibility between any combination of source/desti
 Define a format that fulfills the following criteria:
 - A record can be associated to a schema that describes the payload or key
 - The payload/key schema can be included in the record or pointing to a schema stored in a schema registry
-- Be able to represent an inserted, updated and deleted record
+- Be able to represent an created, updated and deleted record
 - Be able to represent a record created in a snapshot
 - Support for splitting big records into multiple parts
 - Define standard metadata fields
@@ -22,7 +22,7 @@ Besides the format itself, we want to roughly define how Conduit will work with 
 ### Questions
 
 - **Should we have a separate field announcing the record was created as part of a snapshot?**
-  - No, this information will be stored in the action (insert, update, delete, snapshot).
+  - No, this information will be stored in the action (create, update, delete, snapshot).
 - **Should the record support sending a schema only (e.g. we transmit a CREATE TABLE statement)? This might be useful for setting up the target structure even if the source is still empty.**
   - No, this kind of data would only make sense in straight replication between two systems without any transforms. Connectors should rather detect differences in schemas lazily based on each record (more info: https://github.com/ConduitIO/conduit/pull/326#discussion_r835596003).
 - **Should the specification of a plugin include the info about what data a plugin can work with? More specifically, the plugin could announce if it can handle raw data or not (e.g. postgres right now needs structured data). If we had this info we could let the user know in advance that a pipeline config is invalid or that a schema needs to be added to records so that they can be converted to structured data.**
@@ -51,8 +51,8 @@ The record that Conduit receives could look something like this (note that the r
     "kafka.offset": 123, // kafka offset of message
   },
   "position": "my-topic:123", // internal position
-  "operation": "insert", // all records coming from kafka have the operation insert
-  "before": null, // insert operation has no before state
+  "operation": "create", // all records coming from kafka have the operation create
+  "before": null, // create operation has no before state
   "after": {
     "key": {
       "schema": null, // no schema
@@ -83,7 +83,7 @@ Example record that Conduit receives in this case:
     "webhook.endpoint": "/demo", // endpoint where on which the request was received
   },
   "position": "/demo:5", // internal position
-  "operation": "insert",
+  "operation": "create",
   "before": null,
   "after": {
     "key": null // no key
@@ -112,7 +112,7 @@ Example record that Conduit receives in this case:
     "opencdc.readAt": 1647216000123456789, // unix nano timestamp when the record was read by the connector
   },
   "position": "protobuf-record:5", // internal position
-  "operation": "insert",
+  "operation": "create",
   "before": null,
   "after": {
     "key": null // no key
@@ -229,7 +229,7 @@ type Record struct {
 	Position Position
 	// Metadata contains additional information regarding the record.
 	Metadata map[string]string
-+	// Operation defines if this record contains data related to an insert,
++	// Operation defines if this record contains data related to a create,
 +	// update, delete or snapshot.
 +	Operation Operation
 -	// CreatedAt represents the time when the change occurred in the source
@@ -252,7 +252,7 @@ type Record struct {
 +		Payload DataWithSchema
 +	}
 +	// After holds the key and payload data that is valid after the change.
-+	// This field is only populated if the operation is insert, update or snapshot.
++	// This field is only populated if the operation is create, update or snapshot.
 +	After struct {
 +		// Key contains the data and schema of the key after the change.
 +		Key DataWithSchema
@@ -265,7 +265,7 @@ type Record struct {
 + type Operation string
 +
 + const (
-+ 	OperationInsert Operation = "insert"
++ 	OperationCreate Operation = "create"
 + 	OperationUpdate Operation = "update"
 + 	OperationDelete Operation = "delete"
 + 	OperationSnapshot Operation = "snapshot"


### PR DESCRIPTION
### Description

Changes the term "insert" to "create" in the OpenCDC design doc.

Related to https://github.com/ConduitIO/conduit-connector-protocol/pull/8#discussion_r915014729.