### PR TITLE
Update dependabot to check npm weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,6 @@ updates:
   - package-ecosystem: "npm"
     directory: "/ui"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     commit-message:
       prefix: "npm:"


### PR DESCRIPTION
### Description
Updates dependabot's interval from `daily` to `weekly` to cut down on some of the noise. Since we are in a good spot currently with a lot of the latest dep versions (except ember 4 and related deps), this is a good time to update the interval. 

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.