### PR TITLE
[UI] Fix supporting dots in key names

### DIFF
--- a/ui/app/serializers/application.js
+++ b/ui/app/serializers/application.js
@@ -1,3 +1,12 @@
 import JSONSerializer from '@ember-data/serializer/json';
 
-export default class ApplicationSerializer extends JSONSerializer {}
+export default class ApplicationSerializer extends JSONSerializer {
+  _replaceKeys(obj, replace, replaceWith) {
+    return Object.keys(obj).reduce((acc, key) => {
+      const replacedKey = key.replace(replace, replaceWith);
+      acc[replacedKey] = obj[key];
+
+      return acc;
+    }, {});
+  }
+}

--- a/ui/app/serializers/connector.js
+++ b/ui/app/serializers/connector.js
@@ -7,9 +7,9 @@ const CONNECTOR_TYPE_MAP = {
 
 export default class ConnectorSerializer extends ApplicationSerializer {
   serialize(snapshot) {
-    const configSettings = this._replaceKeys(
+    const configSettings = super._replaceKeys(
       snapshot.record.config.settings,
-      '_',
+      '@@',
       '.'
     );
 
@@ -38,7 +38,11 @@ export default class ConnectorSerializer extends ApplicationSerializer {
 
   normalize(typeClass, hash) {
     if (hash.config?.settings) {
-      const configSettings = this._replaceKeys(hash.config?.settings, '.', '_');
+      const configSettings = super._replaceKeys(
+        hash.config?.settings,
+        '.',
+        '@@'
+      );
       hash.config.settings = configSettings;
     }
 
@@ -46,14 +50,5 @@ export default class ConnectorSerializer extends ApplicationSerializer {
     normalized.data.attributes.type =
       CONNECTOR_TYPE_MAP[normalized.data.attributes.type];
     return normalized;
-  }
-
-  _replaceKeys(obj, replace, replaceWith) {
-    return Object.keys(obj).reduce((acc, key) => {
-      const replacedKey = key.replace(replace, replaceWith);
-      acc[replacedKey] = obj[key];
-
-      return acc;
-    }, {});
   }
 }

--- a/ui/app/serializers/plugin.js
+++ b/ui/app/serializers/plugin.js
@@ -2,4 +2,15 @@ import ApplicationSerializer from './application';
 
 export default class ConnectorPluginSerializer extends ApplicationSerializer {
   primaryKey = 'name';
+
+  normalize(typeClass, hash) {
+    hash.sourceParams = super._replaceKeys(hash.sourceParams, '.', '@@');
+    hash.destinationParams = super._replaceKeys(
+      hash.destinationParams,
+      '.',
+      '@@'
+    );
+
+    return super.normalize(typeClass, hash);
+  }
 }

--- a/ui/app/serializers/processor.js
+++ b/ui/app/serializers/processor.js
@@ -18,7 +18,7 @@ export default class ProcessorSerializer extends ApplicationSerializer {
     const serializedConfigSettings = Object.keys(
       serialized.config.settings
     ).reduce((acc, settingsKey) => {
-      acc[settingsKey.replace(':', '.')] =
+      acc[settingsKey.replace('@@', '.')] =
         serialized.config.settings[settingsKey];
       return acc;
     }, {});
@@ -32,7 +32,7 @@ export default class ProcessorSerializer extends ApplicationSerializer {
     if (hash.config?.settings) {
       hash.config.settings = Object.keys(hash.config.settings).reduce(
         (acc, settingsKey) => {
-          acc[settingsKey.replace('.', ':')] =
+          acc[settingsKey.replace('.', '@@')] =
             hash.config.settings[settingsKey];
           return acc;
         },

--- a/ui/app/serializers/transform.js
+++ b/ui/app/serializers/transform.js
@@ -22,7 +22,7 @@ export default class TransformSerializer extends ApplicationSerializer {
 
   normalize(typeClass, hash) {
     hash.blueprint = Object.keys(hash.blueprint).reduce((acc, item) => {
-      const replaced = item.replace('.', ':');
+      const replaced = item.replace('.', '@@');
       acc[replaced] = hash.blueprint[item];
 
       return acc;

--- a/ui/app/utils/blueprints/generate-blueprint-fields.js
+++ b/ui/app/utils/blueprints/generate-blueprint-fields.js
@@ -52,7 +52,7 @@ export default function generateBlueprintFields(blueprint, configurable) {
 
     const fieldModel = {
       id: fieldName,
-      label: underscore(fieldName).replace('.', '_').split('_').join(' '),
+      label: underscore(fieldName).replace('@@', '_').split('_').join(' '),
       description: fieldOpts.description,
       type: fieldOpts.type,
       isRequired: !!fieldOpts.validations.findBy('type', 'TYPE_REQUIRED'),

--- a/ui/mirage/factories/connector.js
+++ b/ui/mirage/factories/connector.js
@@ -16,9 +16,9 @@ export default Factory.extend({
       const config = {
         name: connector.config.name,
         settings: {
-          'titan:name': 'eren jaeger',
+          titanName: 'eren jaeger',
           'titan:height': 50,
-          'titan:type': 'attack',
+          'titan.type': 'attack',
         },
       };
 

--- a/ui/mirage/factories/plugin.js
+++ b/ui/mirage/factories/plugin.js
@@ -53,7 +53,7 @@ export default Factory.extend({
     name: 'builtin:generic',
     blueprint() {
       const requiredText = generateBlueprint(
-        'titan:name',
+        'titanName',
         'Titan Name',
         'Enter Titan Name',
         'TYPE_STRING',
@@ -67,7 +67,7 @@ export default Factory.extend({
         { isRequired: true }
       );
       const requiredSelect = generateBlueprint(
-        'titan:type',
+        'titan.type',
         'Titan Type',
         'Enter Titan Type',
         'TYPE_STRING',

--- a/ui/tests/acceptance/pipeline/index/connector-modal-test.js
+++ b/ui/tests/acceptance/pipeline/index/connector-modal-test.js
@@ -47,9 +47,9 @@ module('Acceptance | pipeline/index/connector-modal-test', function (hooks) {
       await click(page.connectorModalPluginSelect.sourceOption);
     });
     test('shows the connectors required fields', function (assert) {
-      assert.dom('[data-test-config-field="titan:name"]').exists();
+      assert.dom('[data-test-config-field="titanName"]').exists();
       assert
-        .dom('[data-test-config-field="titan:name"]')
+        .dom('[data-test-config-field="titanName"]')
         .hasAttribute('type', 'text');
 
       assert.dom('[data-test-config-field="titan:height"]').exists();
@@ -57,9 +57,9 @@ module('Acceptance | pipeline/index/connector-modal-test', function (hooks) {
         .dom('[data-test-config-field="titan:height"]')
         .hasAttribute('type', 'number');
 
-      assert.dom('[data-test-config-field="titan:type"]').exists();
+      assert.dom('[data-test-config-field="titan@@type"]').exists();
       assert
-        .dom('[data-test-config-field="titan:type"]')
+        .dom('[data-test-config-field="titan@@type"]')
         .hasAttribute('type', 'text');
     });
 
@@ -86,9 +86,9 @@ module('Acceptance | pipeline/index/connector-modal-test', function (hooks) {
               config: {
                 name: 'My Connector',
                 settings: {
-                  'titan:name': 'sleep',
+                  titanName: 'sleep',
                   'titan:height': '100',
-                  'titan:type': 'attack',
+                  'titan.type': 'attack',
                 },
               },
               pipeline_id: pipelineID,
@@ -139,9 +139,9 @@ module('Acceptance | pipeline/index/connector-modal-test', function (hooks) {
       await click(page.connectorModalPluginSelect.destinationOption);
     });
     test('shows the connectors required fields', function (assert) {
-      assert.dom('[data-test-config-field="titan:name"]').exists();
+      assert.dom('[data-test-config-field="titanName"]').exists();
       assert
-        .dom('[data-test-config-field="titan:name"]')
+        .dom('[data-test-config-field="titanName"]')
         .hasAttribute('type', 'text');
 
       assert.dom('[data-test-config-field="titan:height"]').exists();
@@ -149,9 +149,9 @@ module('Acceptance | pipeline/index/connector-modal-test', function (hooks) {
         .dom('[data-test-config-field="titan:height"]')
         .hasAttribute('type', 'number');
 
-      assert.dom('[data-test-config-field="titan:type"]').exists();
+      assert.dom('[data-test-config-field="titan@@type"]').exists();
       assert
-        .dom('[data-test-config-field="titan:type"]')
+        .dom('[data-test-config-field="titan@@type"]')
         .hasAttribute('type', 'text');
     });
 
@@ -178,9 +178,9 @@ module('Acceptance | pipeline/index/connector-modal-test', function (hooks) {
               config: {
                 name: 'My Connector',
                 settings: {
-                  'titan:name': 'sleep',
+                  titanName: 'sleep',
                   'titan:height': '100',
-                  'titan:type': 'attack',
+                  'titan.type': 'attack',
                 },
               },
               pipeline_id: pipelineID,

--- a/ui/tests/integration/components/pipeline-editor/config-field-test.js
+++ b/ui/tests/integration/components/pipeline-editor/config-field-test.js
@@ -15,7 +15,7 @@ module(
         function (hooks) {
           hooks.beforeEach(async function () {
             const field = generateBlankBlueprintField(
-              'titan:name',
+              'titanName',
               'Titan Name',
               'Enter Titan Name',
               'TYPE_STRING'
@@ -40,7 +40,7 @@ module(
         function (hooks) {
           hooks.beforeEach(async function () {
             const field = generateBlankBlueprintField(
-              'titan:name',
+              'titanName',
               'Titan Name',
               'Enter Titan Name',
               'TYPE_STRING',
@@ -172,7 +172,7 @@ module(
         function (hooks) {
           hooks.beforeEach(async function () {
             const field = generateBlankBlueprintField(
-              'titan:type',
+              'titan.type',
               'Titan Type',
               'Pick titan type',
               'TYPE_STRING',


### PR DESCRIPTION
Fixes our normalization/serialization to handle plugin key names with periods. Fixes s3 connector config from UI. 

### Description
Most of our built-in plugins use camel casing for the key names and they work just fine. But the s3 built in connector uses periods for the key names, which confuses changesets under the hood when a users goes to create an s3 connector, resulting in an exception. 

In the interest of supporting different variations of key names with casing separators, we normalize/serialize key names at the boundary using `@@` and consistently use this in other places where this might occur (plugins api, processors, etc)

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.