### PR TITLE
Revert "When only docs change, don't run build and lint workflows"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,11 +3,7 @@ name: build
 on:
   push:
     branches: [ main ]
-    paths-ignore:
-      - '**.md'
   pull_request:
-    paths-ignore:
-      - '**.md'
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,11 +3,7 @@ name: lint
 on:
   push:
     branches: [ main ]
-    paths-ignore:
-      - '**.md'
   pull_request:
-    paths-ignore:
-      - '**.md'
 
 jobs:
   golangci-lint:


### PR DESCRIPTION
Reverts ConduitIO/conduit#527.

Even though build and lint can be ignored for docs-only PRs, GitHub still expects them to run if they are required checks. I didn't notice this in my fork, because I didn't have the same protection rules after forking.

Also related: https://github.com/actions/virtual-environments/issues/1281