### PR TITLE
Fix a deadlock in source connectors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.46.2
+          version: v1.47.3
 
   buf-lint:
     runs-on: ubuntu-latest

--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -401,12 +401,17 @@ func (r *Runtime) serveHTTPAPI(
 		return nil, cerrors.Errorf("failed to register metrics handler: %w", err)
 	}
 
-	return r.serveHTTP(ctx, t, &http.Server{
-		Addr: r.Config.HTTP.Address,
-		Handler: grpcutil.WithDefaultGatewayMiddleware(
-			r.logger, allowCORS(gwmux, "http://localhost:4200"),
-		),
-	})
+	return r.serveHTTP(
+		ctx,
+		t,
+		&http.Server{
+			Addr: r.Config.HTTP.Address,
+			Handler: grpcutil.WithDefaultGatewayMiddleware(
+				r.logger, allowCORS(gwmux, "http://localhost:4200"),
+			),
+			ReadHeaderTimeout: 10 * time.Second,
+		},
+	)
 }
 
 func preflightHandler(w http.ResponseWriter) {

--- a/pkg/connector/source.go
+++ b/pkg/connector/source.go
@@ -260,9 +260,9 @@ func (s *source) Ack(ctx context.Context, p record.Position) error {
 
 	// lock to prevent race condition with connector persister
 	s.m.Lock()
-	defer s.m.Unlock()
-
 	s.XState.Position = p
+	s.m.Unlock()
+
 	s.persister.Persist(ctx, s, func(err error) {
 		if err != nil {
 			s.errs <- err

--- a/pkg/connector/source_test.go
+++ b/pkg/connector/source_test.go
@@ -16,6 +16,10 @@ package connector
 
 import (
 	"context"
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/conduitio/conduit/pkg/foundation/database/inmemory"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/plugin"
@@ -24,9 +28,6 @@ import (
 	"github.com/conduitio/conduit/pkg/record"
 	"github.com/google/uuid"
 	"github.com/matryer/is"
-	"sync"
-	"testing"
-	"time"
 )
 
 func TestSource_Ack_Deadlock(t *testing.T) {

--- a/pkg/connector/source_test.go
+++ b/pkg/connector/source_test.go
@@ -1,0 +1,104 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connector
+
+import (
+	"context"
+	"github.com/conduitio/conduit/pkg/foundation/database/inmemory"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/plugin"
+	"github.com/conduitio/conduit/pkg/plugin/builtin"
+	"github.com/conduitio/conduit/pkg/plugin/standalone"
+	"github.com/conduitio/conduit/pkg/record"
+	"github.com/google/uuid"
+	"github.com/matryer/is"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestSource_Ack_Deadlock(t *testing.T) {
+	is := is.New(t)
+
+	logger := log.Nop()
+	persister := NewPersister(
+		logger,
+		&inmemory.DB{},
+		DefaultPersisterDelayThreshold,
+		1,
+	)
+	pluginService := plugin.NewService(
+		builtin.NewRegistry(logger, builtin.DefaultDispenserFactories...),
+		standalone.NewRegistry(logger),
+	)
+	builder := NewDefaultBuilder(
+		logger,
+		persister,
+		pluginService,
+	)
+	c, err := builder.Build(TypeSource, ProvisionTypeAPI)
+	is.NoErr(err)
+
+	err = builder.Init(
+		c,
+		"test-source-id",
+		Config{
+			Name: "test-source",
+			Settings: map[string]string{
+				"recordCount":    "-1",
+				"readTime":       "0ms",
+				"format.options": "id:int",
+				"format.type":    "raw",
+			},
+			Plugin:     "builtin:generator",
+			PipelineID: uuid.NewString(),
+		},
+	)
+	is.NoErr(err)
+	s := c.(Source)
+
+	err = s.Open(context.Background())
+	is.NoErr(err)
+
+	msgs := 5
+	var wg sync.WaitGroup
+	wg.Add(msgs)
+	for i := 0; i < msgs; i++ {
+		go func() {
+			err := s.Ack(context.Background(), record.Position("test-pos"))
+			wg.Done()
+			is.NoErr(err)
+		}()
+	}
+
+	if waitTimeout(&wg, 100*time.Millisecond) {
+		is.Fail() // timeout reached
+	}
+}
+
+// waitTimeout was copied from pkg/pipeline/stream/stream_test.go
+func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+	select {
+	case <-c:
+		return false // completed normally
+	case <-time.After(timeout):
+		return true // timed out
+	}
+}

--- a/pkg/processor/procbuiltin/httprequest.go
+++ b/pkg/processor/procbuiltin/httprequest.go
@@ -84,8 +84,9 @@ func httpRequest(
 		return nil, cerrors.Errorf("%s: error trying to create HTTP request: %w", processorName, err)
 	}
 
-	procFn := func(_ context.Context, r record.Record) (record.Record, error) {
-		req, err := http.NewRequest(
+	procFn := func(ctx context.Context, r record.Record) (record.Record, error) {
+		req, err := http.NewRequestWithContext(
+			ctx,
 			method,
 			rawURL,
 			bytes.NewReader(r.Payload.After.Bytes()),


### PR DESCRIPTION
### Description

Fixes a deadlock in the source connector. Also upgrade golangci and fixes two new reported issues.

**Cause of the deadlock**:
Here's a simplified representation of how the source connector ack's records:
```
source.Ack()
    lock connector
    defer unlock connector
  
    update position in connector
    connectorPersister.Persist()
```
Here's how Persist() works:
```
Persist()
    if batch is full
        triggerFlush()

triggerFlush()
    wait for any running flusher to finish
    // trigger a flush in a separate goroutine
    go flushNow()    

flushNow()
    start new DB transaction
    serialize connector -> requires locking the connector
    persist connector state
```
If the source is acking really fast, then it's possible that, while `flushNow()` is still running (starting a new DB txn, but didn't lock the connector yet), another flush needs to be triggered. 

`Ack()` locks the connector, calls `triggerFlush()` (indirectly), which is waiting for the `flushNow()` from previous batch. `flushNow()` tries to acquire a lock, but cannot since `Ack()` is actually waiting on it to be done with the flush, to trigger a new one. 

Fixes #570.

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.