### PR TITLE
[UI] Rollback pipeline delete if error

### DIFF
--- a/ui/app/components/pipelines/list.hbs
+++ b/ui/app/components/pipelines/list.hbs
@@ -78,7 +78,7 @@
             <div class="flex items-center justify-center w-full space-x-4">
               <div>
                 <BasicDropdown @horizontalPosition="auto-right" as |dd|>
-                  <dd.Trigger>
+                  <dd.Trigger data-test-dropdown-trigger="pipeline-list-item">
                     <svg class="text-gray-500 fill-current h-5 w-5">
                       <use xlink:href="/ui/svg-defs.svg#action-menu-16"></use>
                     </svg>
@@ -108,16 +108,16 @@
                           <svg class="fill-current h-4 w-4 mr-2">
                             <use xlink:href="/ui/svg-defs.svg#settings-16"></use>
                           </svg>
-                          Settings
                         </LinkTo>
                       </li>
-                      {{!-- template-lint-disable no-invalid-interactive --}}
+                      {{! template-lint-disable no-invalid-interactive }}
                       <li
                         class="text-orange-700 font-medium pr-16 cursor-pointer flex items-center"
                         {{on "click" (fn @onDeletePipeline pipeline)}}
                         {{on "click" dd.actions.close}}
+                        data-test-dropdown-button="delete-pipeline"
                       >
-                      {{!-- template-lint-enable no-invalid-interactive --}}
+                        {{! template-lint-enable no-invalid-interactive }}
                         <svg class="fill-current text-orange-700 h-4 w-4 mr-2">
                           <use xlink:href="/ui/svg-defs.svg#delete-16"></use>
                         </svg>

--- a/ui/app/controllers/pipelines.js
+++ b/ui/app/controllers/pipelines.js
@@ -25,7 +25,11 @@ export default class PipelinesController extends Controller {
 
   @action
   async destroyPipeline(pipeline) {
-    await pipeline.destroyRecord();
+    try {
+      await pipeline.destroyRecord();
+    } catch (e) {
+      pipeline.rollbackAttributes();
+    }
     this.setConfirmDeletePipeline(null);
     this.router.transitionTo('pipelines');
   }

--- a/ui/tests/acceptance/pipelines/index-test.js
+++ b/ui/tests/acceptance/pipelines/index-test.js
@@ -1,0 +1,53 @@
+import { assert, module, test } from 'qunit';
+import { visit, click, fillIn, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { Response } from 'ember-cli-mirage';
+
+const page = {
+  pipelineDropdownTrigger: '[data-test-dropdown-trigger="pipeline-list-item"]',
+  pipelineDropdownDeleteButton: '[data-test-dropdown-button="delete-pipeline"]',
+
+  pipelineListItem: '[data-test-pipeline-list-item]',
+
+  confirmInput: '[data-test-confirm-input]',
+  confirmSubmit: '[data-test-confirm-submit-button]',
+};
+
+module('Acceptance | pipelines/index', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('deleting a pipeline that is running', function (hooks) {
+    hooks.beforeEach(async function () {
+      this.pipeline = this.server.create(
+        'pipeline',
+        { state: { status: 'STATUS_RUNNING' } },
+        'withFileConnectors'
+      );
+
+      this.server.delete('/pipelines/:id', function () {
+        return new Response(
+          400,
+          {},
+          {
+            code: 9,
+            message: 'failed to delete pipeline: pipeline is running',
+            details: [],
+          }
+        );
+      });
+
+      await visit(`/pipelines`);
+      await click(page.pipelineDropdownTrigger);
+      await click(page.pipelineDropdownDeleteButton);
+      await fillIn(page.confirmInput, 'My Conduit Pipeline 1');
+      await click(page.confirmSubmit);
+    });
+
+    test('fails to delete and still allows the user to view the pipeline', async function () {
+      await click(page.pipelineListItem);
+      assert.strictEqual(currentURL(), `/pipelines/${this.pipeline.id}`);
+    });
+  });
+});


### PR DESCRIPTION
### Description
We don't explicitly catch on pipeline destroy when the API errors, so the pipeline itself was going into a deleted state and was causing issues with ember refetching the model. Now we catch on pipeline destroy and do a rollback, which appropriately resets the state. 

Fixes https://github.com/ConduitIO/conduit/issues/592

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.