### PR TITLE
[UI] Pipeline/Connector name length handling

### DIFF
--- a/ui/app/components/pipeline-editor.hbs
+++ b/ui/app/components/pipeline-editor.hbs
@@ -203,17 +203,22 @@
   <Mxa::ConfirmModal
     @onDismiss={{this.hideDeleteConnectorModal}}
     @confirmableActionName="Delete"
-    @entityName={{this.selectedNode.name}}
+    @entityName={{truncate this.selectedNode.name}}
     @confirmedAction={{fn this.destroyConnector this.selectedNode}}
-    @isTextInputRequired={{true}}
+    @isTextInputRequired={{not this.isLongConnectorName}}
     as |entityName|
   >
-    Deleting a connector cannot be undone. Please input your connector's name
-    <code>
-      (
-      {{entityName}}
-      )
-    </code>
-    below to confirm you would like to delete this connector
+
+    {{#if (not this.isLongConnectorName)}}
+      Deleting a connector cannot be undone. Please input your connector's name
+      <code>
+        (
+        {{entityName}}
+        )
+      </code>
+      below to confirm you would like to delete this connector
+    {{else}}
+      Deleting a connector cannot be undone. Confirm you would like to delete this connector.
+    {{/if}}
   </Mxa::ConfirmModal>
 {{/if}}

--- a/ui/app/components/pipeline-editor.js
+++ b/ui/app/components/pipeline-editor.js
@@ -144,6 +144,10 @@ export default class PipelineEditorComponent extends Component {
     );
   }
 
+  get isLongConnectorName() {
+    return this.selectedNode?.name.length > 32;
+  }
+
   @action
   showCreateConnectorModal(connectorType) {
     this.newConnectorType = connectorType;

--- a/ui/app/components/pipeline-editor/connector-modal.hbs
+++ b/ui/app/components/pipeline-editor/connector-modal.hbs
@@ -18,6 +18,7 @@
         @onInput={{fn this.setConnectorName this.connector}}
         class="mt-1 mb-2"
         data-test-connector-modal-input="name"
+        maxlength="32"
       />
       {{#if (not this.isConnectorNameValid)}}
         <div class="text-orange-700 text-xs">
@@ -59,7 +60,7 @@
     <div class="flex text-center mb-2 border-b border-gray-300">
 
       {{#if this.optionalFields}}
-        {{!-- template-lint-disable no-invalid-interactive --}}
+        {{! template-lint-disable no-invalid-interactive }}
         <div
           class="w-1/2 flex-auto pb-2
             {{if this.isShowingRequiredTab 'border-b-2'}}
@@ -75,18 +76,18 @@
           {{on "click" (fn (mut this.isShowingRequiredTab) false)}}
           data-test-connector-modal-optional-tab
         >
-        {{!-- template-lint-enable no-invalid-interactive --}}
+          {{! template-lint-enable no-invalid-interactive }}
           Optional
         </div>
       {{else}}
-        {{!-- template-lint-disable no-invalid-interactive --}}
+        {{! template-lint-disable no-invalid-interactive }}
         <div
           class="w-full flex-auto pb-2
             {{if this.isShowingRequiredTab 'border-b-2'}}
             border-teal-900 uppercase text-xs cursor-pointer"
           {{on "click" (fn (mut this.isShowingRequiredTab) true)}}
         >
-        {{!-- template-lint-enable no-invalid-interactive --}}
+          {{! template-lint-enable no-invalid-interactive }}
           Configure
         </div>
       {{/if}}

--- a/ui/app/components/pipeline-editor/connector-overview.hbs
+++ b/ui/app/components/pipeline-editor/connector-overview.hbs
@@ -13,7 +13,7 @@
     >
       {{! template-lint-enable no-invalid-interactive }}
       <div class="flex items-center justify-between">
-        <div class="text-xs font-medium">
+        <div class="text-xs font-medium w-full overflow-hidden text-ellipsis">
           {{connector.name}}
         </div>
         <div class="text-gray-500 text-xs">
@@ -46,7 +46,7 @@
     >
       {{! template-lint-enable no-invalid-interactive }}
       <div class="flex items-center justify-between mb-1">
-        <div class="text-xs font-medium">
+        <div class="text-xs font-medium w-full overflow-hidden text-ellipsis">
           {{connector.name}}
         </div>
         <div class="text-gray-500 text-xs">

--- a/ui/app/components/pipeline-editor/connector-slide-panel.hbs
+++ b/ui/app/components/pipeline-editor/connector-slide-panel.hbs
@@ -13,7 +13,10 @@
   >
     <div class="flex flex-col w-76">
       <div class="flex justify-between items-center bg-white px-6 py-6">
-        <span class="slide-panel-header font-semibold" data-test-connector-slide-panel-node-name>
+        <span
+          class="slide-panel-header font-semibold w-3/4 overflow-hidden text-ellipsis"
+          data-test-connector-slide-panel-node-name
+        >
           {{@selectedNode.name}}
         </span>
         <div>
@@ -37,27 +40,27 @@
               </dd.Trigger>
               <dd.Content class="bg-white rounded-md border border-gray-200 shadow-md text-sm">
                 <ul class="font-semibold">
-                  {{!-- template-lint-disable no-invalid-interactive --}}
+                  {{! template-lint-disable no-invalid-interactive }}
                   <li
                     class="cursor-pointer pl-2 pr-16 py-4 hover:bg-gray-100 flex items-center"
                     data-test-dropdown-button="connector-panel-edit"
                     {{on "click" @showEditConnectorModal}}
                     {{on "click" dd.actions.close}}
                   >
-                  {{!-- template-lint-enable no-invalid-interactive --}}
+                    {{! template-lint-enable no-invalid-interactive }}
                     <svg class="fill-current h-4 w-4 mr-2">
                       <use xlink:href="/ui/svg-defs.svg#settings-16"></use>
                     </svg>
                     Edit Connector
                   </li>
-                  {{!-- template-lint-disable no-invalid-interactive --}}
+                  {{! template-lint-disable no-invalid-interactive }}
                   <li
                     class="cursor-pointer text-orange-700 pl-2 pr-16 py-4 hover:bg-gray-100 flex items-center"
                     data-test-dropdown-button="connector-panel-delete"
                     {{on "click" @showDeleteConnectorModal}}
                     {{on "click" dd.actions.close}}
                   >
-                  {{!-- template-lint-enable no-invalid-interactive --}}
+                    {{! template-lint-enable no-invalid-interactive }}
                     <svg class="fill-current text-orange-700 h-4 w-4 mr-2">
                       <use xlink:href="/ui/svg-defs.svg#delete-16"></use>
                     </svg>
@@ -167,14 +170,14 @@
                           </div>
                         </div>
                       </div>
-                      {{!-- template-lint-disable no-invalid-interactive --}}
+                      {{! template-lint-disable no-invalid-interactive }}
                       <svg
                         class="text-gray-500 stroke-current h-4 w-4 cursor-pointer"
                         fill="none"
                         {{on "click" (fn this.showEditTransformPanel connectorTransform)}}
                         data-test-button="edit-transform"
                       >
-                      {{!-- template-lint-enable no-invalid-interactive --}}
+                        {{! template-lint-enable no-invalid-interactive }}
                         <use xlink:href="/ui/svg-defs.svg#pencil-16"></use>
                       </svg>
                     </div>

--- a/ui/app/components/pipeline-editor/nodes/connector-node.hbs
+++ b/ui/app/components/pipeline-editor/nodes/connector-node.hbs
@@ -12,7 +12,10 @@
     role="button"
   >
     <div class="flex items-center justify-between mb-1">
-      <div class="text-xs font-medium" data-test-connector-node-name>
+      <div
+        class="text-xs font-medium w-1/2 overflow-hidden text-ellipsis"
+        data-test-connector-node-name
+      >
         {{@connector.name}}
       </div>
       <div class="text-gray-500 text-xs" data-test-connector-node-plugin-name>

--- a/ui/app/components/pipeline/form.hbs
+++ b/ui/app/components/pipeline/form.hbs
@@ -12,6 +12,7 @@
         @isValid={{this.isPipelineNameValid}}
         @onInput={{fn this.setPipelineName @pipeline}}
         disabled={{and (not @pipeline.isNew) @pipeline.isRunning}}
+        maxlength="32"
         data-test-pipeline-form-name-input
       />
     </div>

--- a/ui/app/components/pipelines/list.hbs
+++ b/ui/app/components/pipelines/list.hbs
@@ -108,6 +108,7 @@
                           <svg class="fill-current h-4 w-4 mr-2">
                             <use xlink:href="/ui/svg-defs.svg#settings-16"></use>
                           </svg>
+                          Settings
                         </LinkTo>
                       </li>
                       {{! template-lint-disable no-invalid-interactive }}

--- a/ui/app/controllers/pipelines.js
+++ b/ui/app/controllers/pipelines.js
@@ -13,6 +13,10 @@ export default class PipelinesController extends Controller {
   @tracked
   pipelineRunningError = null;
 
+  get isLongPipelineName() {
+    return this.confirmDeletePipeline?.name.length > 32;
+  }
+
   @action
   setConfirmDeletePipeline(value) {
     this.confirmDeletePipeline = value;

--- a/ui/app/templates/pipeline.hbs
+++ b/ui/app/templates/pipeline.hbs
@@ -4,7 +4,10 @@
 <div class="pl-9 pr-6 py-6 max-h-26 bg-white border-b border-gray-200 -mx-9 -mt-9 mb-10">
   {{#if @model.pipeline.name}}
     <div class="flex items-center">
-      <div class="font-medium text-2xl" data-test-pipeline-subheader-name>
+      <div
+        class="font-medium text-2xl overflow-hidden text-ellipsis w-64"
+        data-test-pipeline-subheader-name
+      >
         {{@model.pipeline.name}}
       </div>
       {{#if @model.pipeline.id}}

--- a/ui/app/templates/pipelines.hbs
+++ b/ui/app/templates/pipelines.hbs
@@ -4,14 +4,18 @@
   <Mxa::ConfirmModal
     @onDismiss={{fn (mut this.confirmDeletePipeline) null}}
     @confirmableActionName="Delete"
-    @entityName={{this.confirmDeletePipeline.name}}
+    @entityName={{truncate this.confirmDeletePipeline.name}}
     @confirmedAction={{fn this.destroyPipeline this.confirmDeletePipeline}}
-    @isTextInputRequired={{true}}
+    @isTextInputRequired={{not this.isLongPipelineName}}
     as |entityName|
   >
-    Deleting a pipeline cannot be undone. Please input your pipelines's name
-    <code>({{entityName}})</code>
-    below to confirm you would like to delete this pipeline
+    {{#if (not this.isLongPipelineName)}}
+      Deleting a pipeline cannot be undone. Please input your pipelines's name
+      <code>({{entityName}})</code>
+      below to confirm you would like to delete this pipeline
+    {{else}}
+      Deleting a pipeline cannot be undone. Please confirm you would like to delete this pipeline.
+    {{/if}}
   </Mxa::ConfirmModal>
 {{/if}}
 


### PR DESCRIPTION
### Description
Best effort character limit handling since we do not have backend validations (but do have client side validations)
+ Adds ellipsis to areas where titles can overflow from long names (Connector overview, connector nodes, connector slide panel, pipeline title, confirm delete)
+ Handles confirm deletes to not ask user for text input if title is long

Fixes #597 

### Screenshots
<img width="1014" alt="Screen Shot 2022-09-26 at 12 34 30 PM" src="https://user-images.githubusercontent.com/4818826/192333950-9724c0d9-5228-463a-a93b-37164646505f.png">
<img width="494" alt="Screen Shot 2022-09-26 at 12 39 17 PM" src="https://user-images.githubusercontent.com/4818826/192333969-aa698368-a503-4908-ae90-4b635c04429b.png">

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.