### PR TITLE
[UI] Smooth out pipeline save / update

### DIFF
--- a/ui/app/controllers/pipeline/settings.js
+++ b/ui/app/controllers/pipeline/settings.js
@@ -1,16 +1,27 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+import { isEmpty } from '@ember/utils';
+import { inject as service } from '@ember/service';
 
 export default class PipelineSettingsController extends Controller {
+  @service
+  router;
+
+  get isPipelineUpdateDisabled() {
+    const pipeline = this.model;
+    return (
+      !pipeline.isValid ||
+      isEmpty(pipeline.changes) ||
+      (!pipeline.isNew && pipeline.isRunning)
+    );
+  }
   @action
   async savePipeline(changeset) {
-    const pipeline = changeset.save();
-
     try {
-      await pipeline;
+      const pipeline = await changeset.save();
+      this.router.transitionTo('pipeline.index', pipeline.id);
     } catch (error) {
       return;
     }
-    this.replaceRoute('pipeline', pipeline.id);
   }
 }

--- a/ui/app/templates/pipeline.hbs
+++ b/ui/app/templates/pipeline.hbs
@@ -5,7 +5,7 @@
   {{#if @model.pipeline.name}}
     <div class="flex items-center">
       <div
-        class="font-medium text-2xl overflow-hidden text-ellipsis w-64"
+        class="font-medium text-2xl overflow-hidden text-ellipsis max-w-64"
         data-test-pipeline-subheader-name
       >
         {{@model.pipeline.name}}

--- a/ui/app/templates/pipeline/settings.hbs
+++ b/ui/app/templates/pipeline/settings.hbs
@@ -8,7 +8,7 @@
     <Mxa::Button
       {{on "click" (fn this.savePipeline pipeline)}}
       data-test-button="create-pipeline"
-      disabled={{or (not pipeline.isValid) (and (not pipeline.isNew) pipeline.isRunning)}}
+      disabled={{this.isPipelineUpdateDisabled}}
     >
       Save Changes
     </Mxa::Button>

--- a/ui/tests/acceptance/pipeline/index-test.js
+++ b/ui/tests/acceptance/pipeline/index-test.js
@@ -1,5 +1,5 @@
 import { assert, module, test } from 'qunit';
-import { find, visit, click, waitUntil } from '@ember/test-helpers';
+import { find, visit, click, waitUntil, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { Response } from 'ember-cli-mirage';
@@ -33,6 +33,7 @@ const page = {
 
   pipelineSettingsSaveButton: '[data-test-button="create-pipeline"]',
   pipelineSettingsDisabledMessage: '[data-test-pipeline-settings-disabled]',
+  pipelineSettingsNameInput: '[data-test-pipeline-form-name-input]',
 
   connectorOverviewListItem: '[data-test-connector-overview-list-item]',
   connectorOverviewButton: '[data-test-connector-overview-button]',
@@ -109,6 +110,22 @@ module('Acceptance | pipeline/index', function (hooks) {
 
     test('it shows the pipeline zero state', function (assert) {
       assert.dom(page.pipelineEditorZeroState).exists();
+    });
+  });
+
+  module('updating a pipelines title or description', function (hooks) {
+    hooks.beforeEach(async function () {
+      const pipeline = this.server.create('pipeline');
+      await visit(`/pipelines/${pipeline.id}/settings`);
+    });
+
+    test('it shows the button as disabled when there are no changes', function (assert) {
+      assert.dom(page.pipelineSettingsSaveButton).isDisabled();
+    });
+
+    test('it shows the button as enabled when there are changes', async function (assert) {
+      await fillIn(page.pipelineSettingsNameInput, 'anewname');
+      assert.dom(page.pipelineSettingsSaveButton).isNotDisabled();
     });
   });
 


### PR DESCRIPTION
### Description
+ Fixes a bug that prevents a user from transitioning to the pipeline after updating pipeline name/description
+ Disables save button when there are no changes
+ Fixes pipeline title ellipsis to be max-w due to chevron icon

Fixes #579

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.