### PR TITLE
[UI] Plugin lookup logic

### DIFF
--- a/ui/app/routes/pipeline.js
+++ b/ui/app/routes/pipeline.js
@@ -29,6 +29,7 @@ export default class PipelineRoute extends Route {
       pipeline = await this.store.findRecord('pipeline', params.pipeline_id, {
         reload: true,
       });
+      await this.store.findAll('plugin');
       await pipeline.hasMany('connectors').reload();
 
       const connectorIDs = pipeline.connectors.mapBy('id');

--- a/ui/app/routes/pipeline/index.js
+++ b/ui/app/routes/pipeline/index.js
@@ -13,7 +13,7 @@ export default class PipelineIndexRoute extends Route {
     } else {
       allPipelines = null;
 
-      connectorPlugins = await this.store.findAll('plugin');
+      connectorPlugins = this.store.peekAll('plugin');
 
       this.store.pushPayload('transform', Transforms);
       transforms = this.store.peekAll('transform');

--- a/ui/app/serializers/connector.js
+++ b/ui/app/serializers/connector.js
@@ -27,8 +27,86 @@ export default class ConnectorSerializer extends ApplicationSerializer {
 
   extractRelationship(modelName, value) {
     if (modelName === 'plugin' && value) {
+      const pluginNames = this.store.peekAll('plugin').mapBy('name');
+
+      const hasOnlyType = /^(any|builtin|standalone):[\w-]+$/.test(value);
+      const hasOnlyVersion = /^[\w-]+@v\S+$/.test(value);
+      const hasTypeAndVersion = /(any|builtin|standalone):[\w-]+@v\S+$/.test(
+        value
+      );
+
+      let pluginName = value;
+      let pluginType = 'any';
+      let pluginVersion = 'latest';
+
+      if (hasOnlyType) {
+        pluginType = value.split(':')[0];
+        pluginName = value.split(':')[1];
+      }
+
+      if (hasOnlyVersion) {
+        pluginName = value.split('@')[0];
+        pluginVersion = value.split('@')[1];
+      }
+
+      if (hasTypeAndVersion) {
+        const split = value
+          .replaceAll(':', '@@')
+          .replaceAll('@v', '@@')
+          .split('@@');
+
+        pluginType = split[0];
+        pluginName = split[1];
+        pluginVersion = split[2];
+      }
+
+      const filtered = pluginNames.filter((name) => {
+        return name.indexOf(pluginName) !== -1;
+      });
+
+      if (filtered.length === 1) {
+        return {
+          id: filtered[0],
+          type: modelName,
+        };
+      }
+
+      const latestVersion = filtered.reduce((acc, name) => {
+        const accVersion = acc.split('@v')[1];
+        const version = name.split('@v')[1];
+        if (accVersion > version) {
+          return accVersion;
+        } else {
+          return version;
+        }
+      }, '');
+
+      let pluginMatch;
+
+      if (pluginType === 'any') {
+        pluginType = 'standalone';
+      }
+
+      if (pluginVersion === 'latest') {
+        pluginVersion = latestVersion;
+      }
+
+      pluginMatch =
+        filtered.find((name) => {
+          return (
+            name.indexOf(`${pluginType}:${pluginName}@${latestVersion}`) !== -1
+          );
+        }) ||
+        filtered.find((name) => {
+          return name.indexOf(`builtin:${pluginName}@${latestVersion}`) !== -1;
+        });
+
+      if (!pluginMatch) {
+        return super.extractRelationship(modelName, value);
+      }
+
       return {
-        id: value,
+        id: pluginMatch,
         type: modelName,
       };
     }


### PR DESCRIPTION
### Description
A bug came up at the end of last week that I discussed with @lovromazgon due to the changes outlined here https://github.com/ConduitIO/conduit/issues/427#issuecomment-1227396725 (see also https://github.com/ConduitIO/conduit/pull/609)

While this isn't a show stopping bug, it does limit the functionality of the UI when setting relationships between connectors and plugins using the new format.

As a nice-to-have and a temporary fix, I duplicate lookup logic outlined in the above comment/PR to allow for connectors to use the shortened names or special tags (`any`, `latest`) to match the right plugins.

Fixes #644 

BEFORE
<img width="1437" alt="Screen Shot 2022-09-26 at 6 36 12 PM" src="https://user-images.githubusercontent.com/4818826/192392905-236ee165-7e4f-4b28-9ea6-359ca3818647.png">

AFTER
<img width="1495" alt="Screen Shot 2022-09-26 at 6 37 14 PM" src="https://user-images.githubusercontent.com/4818826/192392912-a942a71a-1365-4303-a9b3-349ffa1bfe30.png">


### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.