### PR TITLE
latest buf schema registry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.37.0
 	github.com/rs/zerolog v1.28.0
-	go.buf.build/conduitio/conduit/conduitio/conduit v1.1.2
+	go.buf.build/conduitio/conduit/conduitio/conduit v1.1.3
 	go.buf.build/grpc/go/conduitio/conduit-connector-protocol v1.4.3
 	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91
 	golang.org/x/tools v0.1.12

--- a/go.sum
+++ b/go.sum
@@ -623,8 +623,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
-go.buf.build/conduitio/conduit/conduitio/conduit v1.1.2 h1:NA+g6oUk77nDXDtwJ1rYiWkio7k0s0sTgRPR3seAkCE=
-go.buf.build/conduitio/conduit/conduitio/conduit v1.1.2/go.mod h1:ttn+ikX+/7BBbxm1wzW1o82vwC/eC4jB6OYw0VZSoLc=
+go.buf.build/conduitio/conduit/conduitio/conduit v1.1.3 h1:HdGbCSFjTNno8iM01C5IDP/KFVKLbvvA1DsYlkjj7BE=
+go.buf.build/conduitio/conduit/conduitio/conduit v1.1.3/go.mod h1:ttn+ikX+/7BBbxm1wzW1o82vwC/eC4jB6OYw0VZSoLc=
 go.buf.build/conduitio/conduit/grpc-ecosystem/grpc-gateway v1.1.46 h1:z+PbmyLgVOUJRtiikFqTGHOabL9Qsf7v7PUHLLIffqI=
 go.buf.build/conduitio/conduit/grpc-ecosystem/grpc-gateway v1.1.46/go.mod h1:tnSMjRFryUW1a4VsSD9t6mRsfUvTLrPONDVTlHHHJV4=
 go.buf.build/grpc/go/conduitio/conduit-connector-protocol v1.4.3 h1:6xmHosBGMcHQFboRbi9rNoqrKtePhTxL239ZfftVWMY=

--- a/pkg/foundation/metrics/measure/measure.go
+++ b/pkg/foundation/metrics/measure/measure.go
@@ -33,7 +33,7 @@ var (
 		[]string{"type"})
 	ProcessorsGauge = metrics.NewLabeledGauge("conduit_processors",
 		"Number of processors by type.",
-		[]string{"processor", "type"})
+		[]string{"type"})
 
 	ConnectorBytesHistogram = metrics.NewLabeledHistogram("conduit_connector_bytes",
 		"Number of bytes a connector processed by pipeline name, plugin and type (source, destination).",

--- a/pkg/web/api/processor_v1.go
+++ b/pkg/web/api/processor_v1.go
@@ -100,7 +100,7 @@ func (p *ProcessorAPIv1) CreateProcessor(
 ) (*apiv1.CreateProcessorResponse, error) {
 	created, err := p.ps.Create(
 		ctx,
-		req.Name,
+		req.Type,
 		fromproto.ProcessorParent(req.Parent),
 		fromproto.ProcessorConfig(req.Config),
 	)

--- a/pkg/web/api/processor_v1_test.go
+++ b/pkg/web/api/processor_v1_test.go
@@ -187,7 +187,7 @@ func TestProcessorAPIv1_ListProcessorsByParents(t *testing.T) {
 	want := &apiv1.ListProcessorsResponse{Processors: []*apiv1.Processor{
 		{
 			Id:   prs[0].ID,
-			Name: prs[0].Type,
+			Type: prs[0].Type,
 			Config: &apiv1.Processor_Config{
 				Settings: prs[0].Config.Settings,
 			},
@@ -201,7 +201,7 @@ func TestProcessorAPIv1_ListProcessorsByParents(t *testing.T) {
 
 		{
 			Id:   prs[2].ID,
-			Name: prs[2].Type,
+			Type: prs[2].Type,
 			Config: &apiv1.Processor_Config{
 				Settings: prs[2].Config.Settings,
 			},
@@ -214,7 +214,7 @@ func TestProcessorAPIv1_ListProcessorsByParents(t *testing.T) {
 		},
 		{
 			Id:   prs[3].ID,
-			Name: prs[3].Type,
+			Type: prs[3].Type,
 			Config: &apiv1.Processor_Config{
 				Settings: prs[3].Config.Settings,
 			},
@@ -264,7 +264,7 @@ func TestProcessorAPIv1_CreateProcessor(t *testing.T) {
 
 	want := &apiv1.CreateProcessorResponse{Processor: &apiv1.Processor{
 		Id:   pr.ID,
-		Name: pr.Type,
+		Type: pr.Type,
 		Config: &apiv1.Processor_Config{
 			Settings: pr.Config.Settings,
 		},
@@ -316,7 +316,7 @@ func TestProcessorAPIv1_GetProcessor(t *testing.T) {
 
 	want := &apiv1.GetProcessorResponse{Processor: &apiv1.Processor{
 		Id:   pr.ID,
-		Name: pr.Type,
+		Type: pr.Type,
 		Config: &apiv1.Processor_Config{
 			Settings: pr.Config.Settings,
 		},
@@ -367,7 +367,7 @@ func TestProcessorAPIv1_UpdateProcessor(t *testing.T) {
 
 	want := &apiv1.UpdateProcessorResponse{Processor: &apiv1.Processor{
 		Id:   pr.ID,
-		Name: pr.Type,
+		Type: pr.Type,
 		Config: &apiv1.Processor_Config{
 			Settings: pr.Config.Settings,
 		},

--- a/pkg/web/api/processor_v1_test.go
+++ b/pkg/web/api/processor_v1_test.go
@@ -77,7 +77,7 @@ func TestProcessorAPIv1_ListProcessors(t *testing.T) {
 	want := &apiv1.ListProcessorsResponse{Processors: []*apiv1.Processor{
 		{
 			Id:   prs[0].ID,
-			Name: prs[0].Type,
+			Type: prs[0].Type,
 			Config: &apiv1.Processor_Config{
 				Settings: prs[0].Config.Settings,
 			},
@@ -91,7 +91,7 @@ func TestProcessorAPIv1_ListProcessors(t *testing.T) {
 
 		{
 			Id:   prs[1].ID,
-			Name: prs[1].Type,
+			Type: prs[1].Type,
 			Config: &apiv1.Processor_Config{
 				Settings: prs[1].Config.Settings,
 			},
@@ -279,7 +279,7 @@ func TestProcessorAPIv1_CreateProcessor(t *testing.T) {
 	got, err := api.CreateProcessor(
 		ctx,
 		&apiv1.CreateProcessorRequest{
-			Name:   want.Processor.Name,
+			Type:   want.Processor.Type,
 			Parent: want.Processor.Parent,
 			Config: want.Processor.Config,
 		},

--- a/pkg/web/api/toproto/processor.go
+++ b/pkg/web/api/toproto/processor.go
@@ -30,7 +30,7 @@ func _() {
 func Processor(in *processor.Instance) *apiv1.Processor {
 	return &apiv1.Processor{
 		Id:        in.ID,
-		Name:      in.Type,
+		Type:      in.Type,
 		CreatedAt: timestamppb.New(in.CreatedAt),
 		UpdatedAt: timestamppb.New(in.UpdatedAt),
 		Config:    ProcessorConfig(in.Config),

--- a/pkg/web/openapi/swagger-ui/api/v1/api.swagger.json
+++ b/pkg/web/openapi/swagger-ui/api/v1/api.swagger.json
@@ -1485,7 +1485,7 @@
     "v1CreateProcessorRequest": {
       "type": "object",
       "properties": {
-        "name": {
+        "type": {
           "type": "string"
         },
         "parent": {
@@ -1706,7 +1706,7 @@
         "config": {
           "$ref": "#/definitions/v1ProcessorConfig"
         },
-        "name": {
+        "type": {
           "type": "string"
         },
         "parent": {

--- a/ui/app/components/pipeline-editor/connector-slide-panel.js
+++ b/ui/app/components/pipeline-editor/connector-slide-panel.js
@@ -45,7 +45,7 @@ export default class PipelineEditorConnectorSlidePanel extends Component {
         lookupValidator(ConnectorTransformValidations),
         ConnectorTransformValidations,
         {
-          changesetKeys: ['name', 'type', 'config', 'parent'],
+          changesetKeys: ['type', 'config', 'parent'],
         }
       );
     });
@@ -54,7 +54,7 @@ export default class PipelineEditorConnectorSlidePanel extends Component {
   @action
   showNewTransformPanel(transform) {
     const newConnectorTransform = this.store.createRecord('processor', {
-      name: `${transform.id}${transform.onOptions.firstObject}`,
+      type: `${transform.id}${transform.onOptions.firstObject}`,
       parent: {
         type: 'TYPE_CONNECTOR',
         id: this.args.selectedNode.id,
@@ -67,7 +67,7 @@ export default class PipelineEditorConnectorSlidePanel extends Component {
       lookupValidator(ConnectorTransformValidations),
       ConnectorTransformValidations,
       {
-        changesetKeys: ['name', 'type', 'config', 'parent', 'transform'],
+        changesetKeys: ['type', 'config', 'parent', 'transform'],
       }
     );
 
@@ -125,7 +125,7 @@ export default class PipelineEditorConnectorSlidePanel extends Component {
   @action
   duplicateTransform(connectorTransform) {
     const duplicated = this.store.createRecord('processor', {
-      name: connectorTransform.name,
+      type: connectorTransform.type,
       parent: connectorTransform.data.parent,
       config: connectorTransform.data.config,
     });
@@ -135,7 +135,7 @@ export default class PipelineEditorConnectorSlidePanel extends Component {
       lookupValidator(ConnectorTransformValidations),
       ConnectorTransformValidations,
       {
-        changesetKeys: ['name', 'type', 'config', 'parent', 'transform'],
+        changesetKeys: ['type', 'config', 'parent', 'transform'],
       }
     );
 

--- a/ui/app/components/pipeline-editor/connector-slide-panel/transform-panel.js
+++ b/ui/app/components/pipeline-editor/connector-slide-panel/transform-panel.js
@@ -24,7 +24,7 @@ export default class PipelineEditorConnectorSlidePanelTransformPanel extends Com
 
     this.selectedTransformOnOption = this.transformOnOptions.findBy(
       'value',
-      this.connectorTransform.name
+      this.connectorTransform.type
     );
   }
 
@@ -49,7 +49,7 @@ export default class PipelineEditorConnectorSlidePanelTransformPanel extends Com
 
   @action
   setTransformOnOption(option) {
-    this.connectorTransform.name = option.value;
+    this.connectorTransform.type = option.value;
     this.selectedTransformOnOption = this.transformOnOptions.findBy(
       'value',
       option.value

--- a/ui/app/models/processor.js
+++ b/ui/app/models/processor.js
@@ -2,13 +2,10 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class ProcessorModel extends Model {
   @attr()
-  name;
+  type;
 
   @attr()
   config;
-
-  @attr('string', { defaultValue: 'TYPE_TRANSFORM' })
-  type;
 
   @attr()
   parent;
@@ -17,10 +14,10 @@ export default class ProcessorModel extends Model {
   connector;
 
   get transform() {
-    if (this.name) {
+    if (this.type) {
       return this.store.peekAll('transform').find((transform) => {
         return transform.onOptions.find((onOption) => {
-          return `${transform.id}${onOption}` === this.name;
+          return `${transform.id}${onOption}` === this.type;
         });
       });
     } else {
@@ -31,7 +28,7 @@ export default class ProcessorModel extends Model {
   get onOption() {
     if (this.transform) {
       return this.transform.onOptions.find((onOption) => {
-        return `${this.transform.id}${onOption}` === this.name;
+        return `${this.transform.id}${onOption}` === this.type;
       });
     } else {
       return null;

--- a/ui/mirage/factories/processor.js
+++ b/ui/mirage/factories/processor.js
@@ -1,7 +1,7 @@
 import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
-  name: 'maskfieldkey',
+  type: 'maskfieldkey',
 
   config() {
     return {
@@ -11,8 +11,6 @@ export default Factory.extend({
       },
     };
   },
-
-  type: 'TYPE_TRANSFORM',
 
   parent() {
     return {};


### PR DESCRIPTION
### Description

after merging the proto file changes for renaming processors' name to type, a new schema for conduit was pushed to the Buf schema registry, and this PR uses the latest version.

Fixes #498 

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.