### PR TITLE
fix bug: Pipeline is run before being deprovisioned

### DIFF
--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -237,7 +237,7 @@ func (r *Runtime) Run(ctx context.Context) (err error) {
 		}
 	}
 
-	err = r.pipelineService.InitStatus(ctx, r.connectorService, r.processorService)
+	err = r.pipelineService.Run(ctx, r.connectorService, r.processorService)
 	if err != nil {
 		return cerrors.Errorf("failed to init pipeline statuses: %w", err)
 	}

--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -220,7 +220,7 @@ func (r *Runtime) Run(ctx context.Context) (err error) {
 	if err != nil {
 		return cerrors.Errorf("failed to init connector service: %w", err)
 	}
-	err = r.pipelineService.Init(ctx, r.connectorService, r.processorService)
+	err = r.pipelineService.Init(ctx)
 	if err != nil {
 		return cerrors.Errorf("failed to init pipeline service: %w", err)
 	}
@@ -235,6 +235,11 @@ func (r *Runtime) Run(ctx context.Context) (err error) {
 		} else {
 			r.logger.Err(ctx, err).Msg("provisioning failed")
 		}
+	}
+
+	err = r.pipelineService.InitStatus(ctx, r.connectorService, r.processorService)
+	if err != nil {
+		return cerrors.Errorf("failed to init pipeline statuses: %w", err)
 	}
 
 	// Serve grpc and http API

--- a/pkg/pipeline/service.go
+++ b/pkg/pipeline/service.go
@@ -72,8 +72,8 @@ func (s *Service) Init(ctx context.Context) error {
 	return err
 }
 
-// InitStatus run pipelines that had the running state in store.
-func (s *Service) InitStatus(
+// Run runs pipelines that had the running state in store.
+func (s *Service) Run(
 	ctx context.Context,
 	connFetcher ConnectorFetcher,
 	procFetcher ProcessorFetcher,

--- a/pkg/pipeline/service_test.go
+++ b/pkg/pipeline/service_test.go
@@ -173,7 +173,7 @@ func testServiceInit(t *testing.T, status Status, expected Status) {
 	service = NewService(logger, db)
 	err = service.Init(ctx)
 	is.NoErr(err)
-	err = service.InitStatus(
+	err = service.Run(
 		ctx,
 		testConnectorFetcher{
 			source.ID():      source,

--- a/pkg/pipeline/service_test.go
+++ b/pkg/pipeline/service_test.go
@@ -105,7 +105,7 @@ func TestService_Init_Simple(t *testing.T) {
 
 	// create a new pipeline service and initialize it
 	service = NewService(logger, db)
-	err = service.Init(ctx, nil, nil)
+	err = service.Init(ctx)
 	assert.Ok(t, err)
 
 	got := service.List(ctx)
@@ -171,7 +171,9 @@ func testServiceInit(t *testing.T, status Status, expected Status) {
 
 	// create a new pipeline service and initialize it
 	service = NewService(logger, db)
-	err = service.Init(
+	err = service.Init(ctx)
+	is.NoErr(err)
+	err = service.InitStatus(
 		ctx,
 		testConnectorFetcher{
 			source.ID():      source,

--- a/pkg/provisioning/service.go
+++ b/pkg/provisioning/service.go
@@ -60,6 +60,8 @@ func NewService(
 	}
 }
 
+// Init provision pipelines defined in pipelinePath directory. should initialize pipeline service
+// before calling this function, and all pipelines should be stopped.
 func (s *Service) Init(ctx context.Context) error {
 	s.logger.Debug(ctx).
 		Str("pipelines_path", s.pipelinesPath).


### PR DESCRIPTION
### Description

to fix this bug, pipeline service initializes the pipelines from store without running any of them, using the function `Init`. It marks the running pipelines with the status `systemStopped` so they can be identified after provisioning.

after provisioning is done, `InitStatus` function from pipeline service is called, to run the pipelines that had the running status in store.

Fixes #672 

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.