### PR TITLE
docs: spell out dead-letter-queue

### DIFF
--- a/docs/design-documents/20221028-dead-letter-queue.md
+++ b/docs/design-documents/20221028-dead-letter-queue.md
@@ -94,11 +94,12 @@ The user can also configure a stop window and stop threshold.
 
 - `window-size` defines how many last acks/nacks are monitored in the window
   that controls if the pipeline should stop. 0 disables the window.
-- `window-nack-threshold` defines the number of nacks in the window that would
-  cause the pipeline to stop.
+- `window-nack-threshold` defines the number of nacks in the window that are
+  tolerated. Crossing the threshold stops the pipeline. The threshold has to be
+  lower than the window size unless window size is 0.
 
 The default DLQ plugin should be `builtin:log` with a `window-size` of 1 and a
-`window-nack-threshold` of 1. This would result in the same behavior as before
+`window-nack-threshold` of 0. This would result in the same behavior as before
 the introduction of DLQs - the first nacked message would stop the pipeline.
 
 ### API
@@ -120,9 +121,9 @@ message DLQ {
   // that controls if the pipeline should stop (0 disables the window)
   // default = 1
   uint64 window_size = 3;
-  // window_nack_threshold defines the number of nacks in the window that would
-  // cause the pipeline to stop
-  // default = 1
+  // window_nack_threshold defines the number of nacks in the window that are
+  // tolerated. Crossing the threshold stops the pipeline.
+  // default = 0
   uint64 window_nack_threshold = 4;
 }
 
@@ -192,7 +193,7 @@ pipelines:
     connectors:
       [...]
     dead-letter-queue:
-      # stop when 30 of the last 100 messages are nacked
+      # stop when more than 30 of the last 100 messages are nacked
       window-size: 100
       window-nack-threshold: 30
 

--- a/docs/design-documents/20221028-dead-letter-queue.md
+++ b/docs/design-documents/20221028-dead-letter-queue.md
@@ -92,13 +92,13 @@ the plugin name and its settings.
 
 The user can also configure a stop window and stop threshold.
 
-- `window_size` defines how many last acks/nacks are monitored in the window
+- `window-size` defines how many last acks/nacks are monitored in the window
   that controls if the pipeline should stop. 0 disables the window.
-- `window_nack_threshold` defines the number of nacks in the window that would
+- `window-nack-threshold` defines the number of nacks in the window that would
   cause the pipeline to stop.
 
-The default DLQ plugin should be `builtin:log` with a `window_size` of 1 and a
-`window_nack_threshold` of 1. This would result in the same behavior as before
+The default DLQ plugin should be `builtin:log` with a `window-size` of 1 and a
+`window-nack-threshold` of 1. This would result in the same behavior as before
 the introduction of DLQs - the first nacked message would stop the pipeline.
 
 ### API
@@ -129,14 +129,14 @@ message DLQ {
 service PipelineService {
   rpc GetDLQ(GetDLQRequest) returns (GetDLQResponse) {
     option (google.api.http) = {
-      get: "/v1/pipelines/{id}/dlq"
+      get: "/v1/pipelines/{id}/dead-letter-queue"
       response_body: "dlq"
     };
   };
 
   rpc UpdateDLQ(UpdateDLQRequest) returns (UpdateDLQResponse) {
     option (google.api.http) = {
-      put: "/v1/pipelines/{id}/dlq"
+      put: "/v1/pipelines/{id}/dead-letter-queue"
       body: "dlq"
       response_body: "dlq"
     };
@@ -168,12 +168,12 @@ Example of a DLQ config that logs records and never stops.
 ```yaml
 version: 1.1
 pipelines:
-  dlq-example:
+  dlq-example-pipeline:
     connectors:
       [...]
-    dlq:
+    dead-letter-queue:
       # disable stop window
-      windowSize: 0
+      window-size: 0
 
       # the next 3 lines explicitly define the log plugin
       # removing this wouldn't change the behavior, it's the default DLQ config
@@ -188,13 +188,13 @@ least 30 of the last 100 records were nacked.
 ```yaml
 version: 1.1
 pipelines:
-  dlq-example:
+  dlq-example-pipeline:
     connectors:
       [...]
-    dlq:
+    dead-letter-queue:
       # stop when 30 of the last 100 messages are nacked
-      windowSize: 100
-      windowNackThreshold: 30
+      window-size: 100
+      window-nack-threshold: 30
 
       # define file plugin used for DLQ messages
       plugin: builtin:file


### PR DESCRIPTION
We are changing the user-facing naming of DLQ to `dead-letter-queue` (endpoints, config files).

I also updated the definition of the nack threshold. After starting to work with it I think it's more intuitive to define what is still tolerated rather than when the pipeline stops. For example, a threshold of `0` means no nacks are tolerated (first failed message brings the number of nacked messages to `1` which crosses the threshold and stops the pipeline).