### PR TITLE
Pipeline config changelog and linter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/conduitio/conduit-connector-protocol v0.4.0
 	github.com/conduitio/conduit-connector-s3 v0.3.0
 	github.com/conduitio/conduit-connector-sdk v0.4.0
-	github.com/conduitio/yaml/v3 v3.1.1
+	github.com/conduitio/yaml/v3 v3.2.0
 	github.com/dgraph-io/badger/v3 v3.2103.5
 	github.com/dop251/goja v0.0.0-20210225094849-f3cfc97811c0
 	github.com/gammazero/deque v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/conduitio/conduit-connector-s3 v0.3.0 h1:Zy+TYRnZKw09mks4qsXW43qnp0Pu
 github.com/conduitio/conduit-connector-s3 v0.3.0/go.mod h1:ims2iWZJcOSjEPY1nal/DQrxiqG+xHPYFV5nN1ia/Pk=
 github.com/conduitio/conduit-connector-sdk v0.4.0 h1:kQBhk+cy9npo5NXTPyqdeXvs7e1pJeYdKcHa0lMRHjo=
 github.com/conduitio/conduit-connector-sdk v0.4.0/go.mod h1:SNz/Sn4zNuJNMELlr+HVe8Br8SpDea0EB4Gmh+Ha0+k=
-github.com/conduitio/yaml/v3 v3.1.1 h1:3I6/pNhnXVGS6v77riPCGasBwI0RrnK1UTAUOD2/Nxg=
-github.com/conduitio/yaml/v3 v3.1.1/go.mod h1:JNgFMOX1t8W4YJuRZOh6GggVtSMsgP9XgTw+7dIenpc=
+github.com/conduitio/yaml/v3 v3.2.0 h1:itolFiK0dzUYG6PdlOpmCi1fcMYFoaWdZ1wbNNTEnlI=
+github.com/conduitio/yaml/v3 v3.2.0/go.mod h1:JNgFMOX1t8W4YJuRZOh6GggVtSMsgP9XgTw+7dIenpc=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/pkg/provisioning/changelog.go
+++ b/pkg/provisioning/changelog.go
@@ -1,0 +1,117 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioning
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// changelog should be adjusted every time we change the pipeline config and add
+// a new config version. Based on the changelog the parser will output warnings.
+var changelog = map[string][]change{
+	"1.0": {}, // no changes, initial version
+	"1.1": {{
+		field:      "pipelines.*.dead-letter-queue",
+		changeType: fieldIntroduced,
+		message:    "field dead-letter-queue was introduced in version 1.1, please update the pipeline config version",
+	}},
+}
+
+// change is a single change that was introduced in a specific version.
+type change struct {
+	// field contains the path to the field that was changed. Nested fields can
+	// be represented with dots (e.g. nested.field)
+	field      string
+	changeType changeType
+	// message is the log message that will be printed if a file is detected
+	// that uses this field with an unsupported version.
+	message string
+}
+
+// changeType defines the type of the change introduced in a specific version.
+type changeType int
+
+const (
+	fieldDeprecated changeType = iota
+	fieldIntroduced
+)
+
+// expandedChangelog is populated in init based on changelog. This map contains
+// the changelog in a structure that is useful for traversing in configLinter.
+var expandedChangelog map[string]map[string]interface{}
+
+func init() {
+	expandedChangelog = expand(changelog)
+}
+
+func expand(changelog map[string][]change) map[string]map[string]interface{} {
+	var versions semver.Collection
+	for k := range changelog {
+		versions = append(versions, semver.MustParse(k))
+	}
+	sort.Sort(versions)
+
+	knownChanges := make(map[string]map[string]interface{})
+	for _, v := range versions {
+		knownChanges[v.Original()] = make(map[string]interface{})
+	}
+
+	addChange := func(c change, m map[string]interface{}) {
+		tokens := strings.Split(c.field, ".")
+		curMap := m
+		for i, t := range tokens {
+			if i == len(tokens)-1 {
+				// last token, set it in the map
+				curMap[t] = c
+				break
+			}
+			raw, ok := curMap[t]
+			if !ok {
+				nextMap := make(map[string]interface{})
+				curMap[t] = nextMap
+				curMap = nextMap
+				continue
+			}
+			curMap, ok = raw.(map[string]interface{})
+			if !ok {
+				break
+			}
+		}
+	}
+
+	for _, v := range versions {
+		changes := changelog[v.Original()]
+		for _, v2 := range versions {
+			switch {
+			case !v.GreaterThan(v2):
+				for _, c := range changes {
+					if c.changeType == fieldDeprecated {
+						addChange(c, knownChanges[v2.Original()])
+					}
+				}
+			case v.GreaterThan(v2):
+				for _, c := range changes {
+					if c.changeType == fieldIntroduced {
+						addChange(c, knownChanges[v2.Original()])
+					}
+				}
+			}
+		}
+	}
+	return knownChanges
+}

--- a/pkg/provisioning/changelog.go
+++ b/pkg/provisioning/changelog.go
@@ -56,10 +56,10 @@ const (
 var expandedChangelog map[string]map[string]interface{}
 
 func init() {
-	expandedChangelog = expand(changelog)
+	expandedChangelog = expandChangelog(changelog)
 }
 
-func expand(changelog map[string][]change) map[string]map[string]interface{} {
+func expandChangelog(changelog map[string][]change) map[string]map[string]interface{} {
 	var versions semver.Collection
 	for k := range changelog {
 		versions = append(versions, semver.MustParse(k))

--- a/pkg/provisioning/changelog_test.go
+++ b/pkg/provisioning/changelog_test.go
@@ -1,0 +1,129 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioning
+
+import (
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+func TestExpandChangelog(t *testing.T) {
+	is := is.New(t)
+
+	have := map[string][]change{
+		"1.0": {}, // no changes, initial version
+		"1.1": {{
+			// introduced field should get a warning in all previous versions
+			field:      "pipelines.*.dead-letter-queue",
+			changeType: fieldIntroduced,
+			message:    "field dead-letter-queue was introduced in version 1.1, please update the pipeline config version",
+		}},
+		"1.2": {{
+			// introduced field should produce a warning in all previous
+			// versions except those where a parent field itself was introduced,
+			// in this case pipelines.*.dead-letter-queue takes precedence in 1.0
+			field:      "pipelines.*.dead-letter-queue.new-setting",
+			changeType: fieldIntroduced,
+			message:    "field new-setting was introduced in version 1.2, please update the pipeline config version",
+		}, {
+			field:      "pipelines.*.title",
+			changeType: fieldIntroduced,
+			message:    "field title was introduced in version 1.2, please update the pipeline config version",
+		}, {
+			// deprecated field should show up in this and all newer versions,
+			// except those that deprecate a parent field, in this case
+			// pipelines was deprecated in 1.4 so it takes precedence
+			field:      "pipelines.*.name",
+			changeType: fieldDeprecated,
+			message:    "field name was deprecated in version 1.2, please use \"title\" instead",
+		}},
+		"1.3": {}, // here just to test deprecated field
+		"1.4": {{
+			field:      "pipelines",
+			changeType: fieldDeprecated,
+			message:    "field pipelines was deprecated in version 1.4, please don't create pipelines anymore",
+		}},
+	}
+
+	want := map[string]map[string]interface{}{
+		"1.0": {
+			"pipelines": map[string]interface{}{
+				"*": map[string]interface{}{
+					"dead-letter-queue": change{
+						field:      "pipelines.*.dead-letter-queue",
+						changeType: fieldIntroduced,
+						message:    "field dead-letter-queue was introduced in version 1.1, please update the pipeline config version",
+					},
+					"title": change{
+						field:      "pipelines.*.title",
+						changeType: fieldIntroduced,
+						message:    "field title was introduced in version 1.2, please update the pipeline config version",
+					},
+				},
+			},
+		},
+		"1.1": {
+			"pipelines": map[string]interface{}{
+				"*": map[string]interface{}{
+					"dead-letter-queue": map[string]interface{}{
+						"new-setting": change{
+							field:      "pipelines.*.dead-letter-queue.new-setting",
+							changeType: fieldIntroduced,
+							message:    "field new-setting was introduced in version 1.2, please update the pipeline config version",
+						},
+					},
+					"title": change{
+						field:      "pipelines.*.title",
+						changeType: fieldIntroduced,
+						message:    "field title was introduced in version 1.2, please update the pipeline config version",
+					},
+				},
+			},
+		},
+		"1.2": {
+			"pipelines": map[string]interface{}{
+				"*": map[string]interface{}{
+					"name": change{
+						field:      "pipelines.*.name",
+						changeType: fieldDeprecated,
+						message:    "field name was deprecated in version 1.2, please use \"title\" instead",
+					},
+				},
+			},
+		},
+		"1.3": {
+			"pipelines": map[string]interface{}{
+				"*": map[string]interface{}{
+					"name": change{
+						field:      "pipelines.*.name",
+						changeType: fieldDeprecated,
+						message:    "field name was deprecated in version 1.2, please use \"title\" instead",
+					},
+				},
+			},
+		},
+		"1.4": {
+			"pipelines": change{
+				field:      "pipelines",
+				changeType: fieldDeprecated,
+				message:    "field pipelines was deprecated in version 1.4, please don't create pipelines anymore",
+			},
+		},
+	}
+
+	got := expandChangelog(have)
+	is.Equal(want, got)
+}

--- a/pkg/provisioning/linter.go
+++ b/pkg/provisioning/linter.go
@@ -93,13 +93,16 @@ func (cl *configLinter) addWarning(field string, node *yaml.Node, message string
 	})
 }
 
-func (cl *configLinter) LogWarnings(ctx context.Context, logger log.CtxLogger) {
+func (cl *configLinter) LogWarnings(ctx context.Context, logger log.CtxLogger, path string) {
 	for _, w := range cl.warnings {
-		logger.Warn(ctx).
+		e := logger.Warn(ctx).
 			Int("line", w.line).
 			Int("column", w.column).
 			Str("field", w.field).
-			Str("value", w.value).
-			Msg(w.message)
+			Str("value", w.value)
+		if path != "" {
+			e.Str("path", path)
+		}
+		e.Msg(w.message)
 	}
 }

--- a/pkg/provisioning/linter.go
+++ b/pkg/provisioning/linter.go
@@ -1,0 +1,105 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioning
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/yaml/v3"
+)
+
+type configLinter struct {
+	version  string
+	warnings []warning
+}
+
+type warning struct {
+	field   string
+	line    int
+	column  int
+	value   string
+	message string
+}
+
+func newConfigLinter() *configLinter {
+	cl := &configLinter{}
+	cl.init()
+	return cl
+}
+
+func (cl *configLinter) init() {
+	var versions semver.Collection
+	for k := range changelog {
+		versions = append(versions, semver.MustParse(k))
+	}
+	sort.Sort(versions)
+
+	// latest version is the default version
+	cl.version = versions[len(versions)-1].Original()
+}
+
+func (cl *configLinter) DecoderHook(path []string, node *yaml.Node) {
+	if len(path) == 1 && path[0] == "version" {
+		// version gets special treatment, it adjusts the warning we create
+		if _, ok := expandedChangelog[node.Value]; !ok {
+			cl.addWarning(path[0], node, fmt.Sprintf("unrecognized version, using parser version %v instead", cl.version))
+			return
+		}
+		cl.version = node.Value
+		return
+	}
+
+	curMap := expandedChangelog[cl.version]
+	for _, field := range path {
+		nextMap, ok := curMap[field]
+		if !ok {
+			nextMap, ok = curMap["*"]
+			if !ok {
+				break
+			}
+		}
+		switch v := nextMap.(type) {
+		case change:
+			cl.addWarning(field, node, v.message)
+		case map[string]interface{}:
+			curMap = v
+		}
+	}
+}
+
+func (cl *configLinter) addWarning(field string, node *yaml.Node, message string) {
+	cl.warnings = append(cl.warnings, warning{
+		field:   field,
+		line:    node.Line,
+		column:  node.Column,
+		value:   node.Value,
+		message: message,
+	})
+}
+
+func (cl *configLinter) LogWarnings(ctx context.Context, logger log.CtxLogger) {
+	for _, w := range cl.warnings {
+		logger.Warn(ctx).
+			Int("line", w.line).
+			Int("column", w.column).
+			Str("field", w.field).
+			Str("value", w.value).
+			Msg(w.message)
+	}
+}

--- a/pkg/provisioning/parse_test.go
+++ b/pkg/provisioning/parse_test.go
@@ -19,11 +19,13 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/matryer/is"
 )
 
 func TestParser_Success(t *testing.T) {
 	is := is.New(t)
+	parser := NewParser(log.Nop())
 	filename, err := filepath.Abs("./test/pipelines1-success.yml")
 	if err != nil {
 		t.Error(err)
@@ -108,13 +110,14 @@ func TestParser_Success(t *testing.T) {
 		t.Error(err)
 	}
 
-	got, err := Parse(data)
+	got, err := parser.Parse(data)
 	is.NoErr(err)
 	is.Equal(want, got)
 }
 
 func TestParser_DuplicatePipelineId(t *testing.T) {
 	is := is.New(t)
+	parser := NewParser(log.Nop())
 	filename, err := filepath.Abs("./test/pipelines2-duplicate-pipeline-id.yml")
 	if err != nil {
 		t.Error(err)
@@ -125,13 +128,14 @@ func TestParser_DuplicatePipelineId(t *testing.T) {
 		t.Error(err)
 	}
 
-	p, err := Parse(data)
+	p, err := parser.Parse(data)
 	is.True(err != nil)
 	is.Equal(p, nil)
 }
 
 func TestParser_EmptyFile(t *testing.T) {
 	is := is.New(t)
+	parser := NewParser(log.Nop())
 	filename, err := filepath.Abs("./test/pipelines5-empty.yml")
 	if err != nil {
 		t.Error(err)
@@ -142,13 +146,14 @@ func TestParser_EmptyFile(t *testing.T) {
 		t.Error(err)
 	}
 
-	p, err := Parse(data)
+	p, err := parser.Parse(data)
 	is.NoErr(err)
 	is.Equal(p, nil)
 }
 
 func TestParser_InvalidYaml(t *testing.T) {
 	is := is.New(t)
+	parser := NewParser(log.Nop())
 	filename, err := filepath.Abs("./test/pipelines6-invalid-yaml.yml")
 	if err != nil {
 		t.Error(err)
@@ -159,13 +164,14 @@ func TestParser_InvalidYaml(t *testing.T) {
 		t.Error(err)
 	}
 
-	p, err := Parse(data)
+	p, err := parser.Parse(data)
 	is.True(err != nil)
 	is.Equal(p, nil)
 }
 
 func TestParser_EnvVars(t *testing.T) {
 	is := is.New(t)
+	parser := NewParser(log.Nop())
 	filename, err := filepath.Abs("./test/pipelines7-env-vars.yml")
 	if err != nil {
 		t.Error(err)
@@ -211,7 +217,7 @@ func TestParser_EnvVars(t *testing.T) {
 		t.Error(err)
 	}
 
-	got, err := Parse(data)
+	got, err := parser.Parse(data)
 	is.NoErr(err)
 	is.Equal(want, got)
 }

--- a/pkg/provisioning/service.go
+++ b/pkg/provisioning/service.go
@@ -116,7 +116,7 @@ func (s *Service) provisionConfigFile(ctx context.Context, path string, alreadyP
 		return nil, nil, cerrors.Errorf("could not read the file %q: %w", path, err)
 	}
 
-	before, err := s.parser.Parse(data)
+	before, err := s.parser.Parse(ctx, path, data)
 	if err != nil {
 		return nil, nil, cerrors.Errorf("could not parse the file %q: %w", path, err)
 	}

--- a/pkg/provisioning/service.go
+++ b/pkg/provisioning/service.go
@@ -36,6 +36,7 @@ import (
 type Service struct {
 	db               database.DB
 	logger           log.CtxLogger
+	parser           *Parser
 	pipelineService  PipelineService
 	connectorService ConnectorService
 	processorService ProcessorService
@@ -53,6 +54,7 @@ func NewService(
 	return &Service{
 		db:               db,
 		logger:           logger.WithComponent("provisioning.Service"),
+		parser:           NewParser(logger),
 		pipelineService:  plService,
 		connectorService: connService,
 		processorService: procService,
@@ -114,7 +116,7 @@ func (s *Service) provisionConfigFile(ctx context.Context, path string, alreadyP
 		return nil, nil, cerrors.Errorf("could not read the file %q: %w", path, err)
 	}
 
-	before, err := Parse(data)
+	before, err := s.parser.Parse(data)
 	if err != nil {
 		return nil, nil, cerrors.Errorf("could not parse the file %q: %w", path, err)
 	}

--- a/pkg/provisioning/test/pipelines1-success.yml
+++ b/pkg/provisioning/test/pipelines1-success.yml
@@ -2,6 +2,7 @@
 version: 1.0
 pipelines:
   pipeline1:
+    unknownField: this triggers a warning
     status: running
     name: pipeline1
     description: desc1
@@ -25,6 +26,7 @@ pipelines:
         settings:
           additionalProp1: string
           additionalProp2: string
+    # dead letter queue is parsed even though version is 1.0, we warn the user
     dead-letter-queue:
       plugin: my-plugin
       settings:


### PR DESCRIPTION
### Description

This PR adds a way to define the changelog for the pipeline config file that is used in a linter that produces warnings based on deprecated fields and/or new fields that officially don't exist in that config version yet.

Right now the following warnings are produced:
- warn when version of file is unknown
- warn when a field is found that is unknown (field will be ignored)
- warn when a field is defined that was introduced in a higher version than what is specified in the file (even if parser knows how to use it)
- warn when a field is deprecated

Depends on https://github.com/ConduitIO/conduit/pull/771 ~and https://github.com/ConduitIO/yaml/pull/3 (tests won't pass until this is merged)~.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.