### PR TITLE
Add conduit-pipeline-check utility

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+.gitignore
+.golangci.goheader.template
+.golangci.yml
+.goreleaser.yml
+CONTRIBUTING.md
+LICENSE.md
+README.md
+conduit.db
+docs
+examples
+githooks

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ conduit.db
 
 # Binary, built with `make build`
 /conduit
+/conduit-pipeline-check
 
 ### Conduit UI ###
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,5 @@ EXPOSE 8080/tcp
 EXPOSE 8084/tcp
 WORKDIR /app
 COPY --from=base /app/conduit /app
+COPY --from=base /app/conduit-pipeline-check /app
 CMD ["/app/conduit"]

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ VERSION=`git describe --tags --dirty`
 GO_VERSION_CHECK=`./scripts/check-go-version.sh`
 
 # The build target should stay at the top since we want it to be the default target.
-build: check-go-version pkg/web/ui/dist
+build: check-go-version pkg/web/ui/dist build-pipeline-check
 	go build -ldflags "-X 'github.com/conduitio/conduit/pkg/conduit.version=${VERSION}'" -o conduit -tags ui ./cmd/conduit/main.go
 	@echo "\nBuild complete. Enjoy using Conduit!"
 	@echo "Get started by running:"
@@ -28,6 +28,9 @@ test-integration:
 build-server: check-go-version
 	go build -ldflags "-X 'github.com/conduitio/conduit/pkg/conduit.version=${VERSION}'" -o conduit ./cmd/conduit/main.go
 	@echo "build version: ${VERSION}"
+
+build-pipeline-check: check-go-version
+	go build -o conduit-pipeline-check ./cmd/conduit-pipeline-check/main.go
 
 run:
 	go run ./cmd/conduit/main.go

--- a/cmd/conduit-pipeline-check/main.go
+++ b/cmd/conduit-pipeline-check/main.go
@@ -1,0 +1,118 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	apiv1 "github.com/conduitio/conduit/proto/gen/api/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const (
+	exitCodeOk = iota
+	exitCodeErr
+	exitCodeInterrupt
+)
+
+func main() {
+	ctx := cancelOnInterrupt(context.Background())
+
+	exitcode, err := checkPipeline(ctx)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+	os.Exit(exitcode)
+}
+
+func checkPipeline(ctx context.Context) (int, error) {
+	flags := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	var (
+		grpcAddress  = flags.String("grpc.address", ":8084", "address of the Conduit server gRPC API")
+		pipelineName = flags.String("pipeline.name", "", "name of the target pipeline")
+		timeout      = flags.Duration("timeout", 10*time.Second, "timeout duration")
+		verbose      = flags.Bool("verbose", false, "return non-zero code on failure instead of logging")
+	)
+
+	_ = flags.Parse(os.Args[1:])
+
+	if pipelineName == nil || *pipelineName == "" {
+		return exitCodeErr, fmt.Errorf("pipeline.name is not set")
+	}
+
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+
+	dialCtx, dialCancel := context.WithTimeout(ctx, *timeout)
+	defer dialCancel()
+
+	c, err := grpc.DialContext(dialCtx, *grpcAddress, opts...)
+	if err != nil {
+		return exitCodeErr, fmt.Errorf("failed to connect to conduit grpc server: %v", err)
+	}
+	defer c.Close()
+
+	pipeline := apiv1.NewPipelineServiceClient(c)
+	p, err := pipeline.GetPipeline(
+		ctx,
+		&apiv1.GetPipelineRequest{
+			Id: *pipelineName,
+		})
+	if err != nil {
+		return exitCodeErr, fmt.Errorf("failed to find pipeline %q: %v", *pipelineName, err)
+	}
+
+	switch p.Pipeline.State.Status {
+	case apiv1.Pipeline_STATUS_RUNNING:
+		if *verbose {
+			fmt.Printf("pipeline %q is running", *pipelineName)
+		}
+		// success
+		return exitCodeOk, nil
+	default:
+		if *verbose {
+			fmt.Printf("pipeline %q is not running: %v", *pipelineName, p.Pipeline.State.Status)
+		}
+		return exitCodeErr, nil
+	}
+}
+
+// cancelOnInterrupt returns a context that is canceled when the interrupt
+// signal is received.
+// * After the first signal the function will continue to listen
+// * On the second signal executes a hard exit, without waiting for a graceful
+// shutdown.
+func cancelOnInterrupt(ctx context.Context) context.Context {
+	ctx, cancel := context.WithCancel(ctx)
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, os.Interrupt)
+	go func() {
+		select {
+		case <-signalChan: // first interrupt signal
+			cancel()
+		case <-ctx.Done():
+		}
+		<-signalChan // second interrupt signal
+		os.Exit(exitCodeInterrupt)
+	}()
+	return ctx
+}

--- a/cmd/conduit-pipeline-check/main.go
+++ b/cmd/conduit-pipeline-check/main.go
@@ -43,6 +43,11 @@ func main() {
 	os.Exit(exitcode)
 }
 
+// checkPipeline returns an exit code depending on the pipeline runtime status.
+// error is returned when an unexpected error is encountered.
+// * missing or invalid flags
+// * gRPC connection failures
+// * operation takes too long to execute
 func checkPipeline(ctx context.Context) (int, error) {
 	flags := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	var (
@@ -67,7 +72,7 @@ func checkPipeline(ctx context.Context) (int, error) {
 
 	c, err := grpc.DialContext(dialCtx, *grpcAddress, opts...)
 	if err != nil {
-		return exitCodeErr, fmt.Errorf("failed to connect to conduit grpc server: %v", err)
+		return exitCodeErr, fmt.Errorf("failed to connect to conduit grpc server: %w", err)
 	}
 	defer c.Close()
 
@@ -78,7 +83,7 @@ func checkPipeline(ctx context.Context) (int, error) {
 			Id: *pipelineName,
 		})
 	if err != nil {
-		return exitCodeErr, fmt.Errorf("failed to find pipeline %q: %v", *pipelineName, err)
+		return exitCodeErr, fmt.Errorf("failed to find pipeline %q: %w", *pipelineName, err)
 	}
 
 	switch p.Pipeline.State.Status {


### PR DESCRIPTION
### Description

The command line utility allows users or automation to request status of a pipeline and return a non-zero code when the pipeline is not running. The check happens over gRPC.

Additionally include a .dockerignore file to speed up docker builds.

Fixes #773 

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.