### PR TITLE
Skip connector validation when initializing connector service

### DIFF
--- a/pkg/connector/builder.go
+++ b/pkg/connector/builder.go
@@ -15,7 +15,6 @@
 package connector
 
 import (
-	"context"
 	"time"
 
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
@@ -101,5 +100,5 @@ func (b *DefaultBuilder) Init(c Connector, id string, config Config) error {
 		return ErrInvalidConnectorType
 	}
 
-	return c.Validate(context.Background(), c.Config().Settings)
+	return nil
 }

--- a/pkg/connector/mock/builder.go
+++ b/pkg/connector/mock/builder.go
@@ -24,6 +24,7 @@ type Builder struct {
 	Ctrl             *gomock.Controller
 	SetupSource      func(source *Source)
 	SetupDestination func(source *Destination)
+	SkipValidate     bool
 }
 
 func (b Builder) Build(t connector.Type) (connector.Connector, error) {
@@ -44,6 +45,9 @@ func (b Builder) Init(c connector.Connector, id string, cfg connector.Config) er
 		m.EXPECT().Type().Return(connector.TypeSource).AnyTimes()
 		m.EXPECT().ID().Return(id).AnyTimes()
 		m.EXPECT().Config().Return(cfg).AnyTimes()
+		if !b.SkipValidate {
+			m.EXPECT().Validate(gomock.Any(), cfg.Settings).Return(nil)
+		}
 		if b.SetupSource != nil {
 			b.SetupSource(m)
 		}
@@ -53,6 +57,9 @@ func (b Builder) Init(c connector.Connector, id string, cfg connector.Config) er
 		m.EXPECT().Type().Return(connector.TypeDestination).AnyTimes()
 		m.EXPECT().ID().Return(id).AnyTimes()
 		m.EXPECT().Config().Return(cfg).AnyTimes()
+		if !b.SkipValidate {
+			m.EXPECT().Validate(gomock.Any(), cfg.Settings).Return(nil)
+		}
 		if b.SetupDestination != nil {
 			b.SetupDestination(m)
 		}

--- a/pkg/connector/persister_test.go
+++ b/pkg/connector/persister_test.go
@@ -210,7 +210,7 @@ func initPersisterTest(
 ) (*connector.Persister, *connector.Store, mock.Builder) {
 	logger := log.New(zerolog.Nop())
 	db := &inmemory.DB{}
-	builder := mock.Builder{Ctrl: ctrl}
+	builder := mock.Builder{Ctrl: ctrl, SkipValidate: true}
 
 	persister := connector.NewPersister(logger, db, delayThreshold, bundleCountThreshold)
 	return persister, connector.NewStore(db, logger, builder), builder

--- a/pkg/connector/service.go
+++ b/pkg/connector/service.go
@@ -102,6 +102,11 @@ func (s *Service) Create(ctx context.Context, id string, t Type, cfg Config) (Co
 		return nil, cerrors.Errorf("could not init connector: %w", err)
 	}
 
+	err = conn.Validate(ctx, conn.Config().Settings)
+	if err != nil {
+		return nil, cerrors.Errorf("connector invalid: %w", err)
+	}
+
 	// persist instance
 	err = s.store.Set(ctx, id, conn)
 	if err != nil {

--- a/pkg/connector/service_test.go
+++ b/pkg/connector/service_test.go
@@ -56,6 +56,7 @@ func TestService_Init_Success(t *testing.T) {
 
 	want := service.List(ctx)
 
+	connBuilder.SkipValidate = true // in init we don't want the connector to be validated
 	// create a new connector service and initialize it
 	service = connector.NewService(logger, db, connBuilder)
 	err = service.Init(ctx)

--- a/pkg/connector/store_test.go
+++ b/pkg/connector/store_test.go
@@ -34,7 +34,7 @@ func TestConfigStore_SetGet(t *testing.T) {
 	logger := log.Nop()
 	db := &inmemory.DB{}
 	ctrl := gomock.NewController(t)
-	connBuilder := mock.Builder{Ctrl: ctrl}
+	connBuilder := mock.Builder{Ctrl: ctrl, SkipValidate: true}
 
 	s := connector.NewStore(db, logger, connBuilder)
 
@@ -53,7 +53,7 @@ func TestConfigStore_GetAll(t *testing.T) {
 	logger := log.Nop()
 	db := &inmemory.DB{}
 	ctrl := gomock.NewController(t)
-	connBuilder := mock.Builder{Ctrl: ctrl}
+	connBuilder := mock.Builder{Ctrl: ctrl, SkipValidate: true}
 
 	s := connector.NewStore(db, logger, connBuilder)
 


### PR DESCRIPTION
### Description

This fixes the bug where an invalid connector prevents Conduit from starting.

This is a backport to v0.2.1, a similar fix will be created for the latest version.