### PR TITLE
Fix for nightly builds after a lightweight tag

### DIFF
--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -24,7 +24,10 @@ jobs:
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
-          DESCRIBE=`git describe --match "v[0-9].[0-9].[0-9]" --abbrev=0`
+          # A previous release was created using a lightweight tag
+          # git describe by default includes only annotated tags
+          # git describe --tags includes lightweight tags as well
+          DESCRIBE=`git describe --tags --match "v[0-9].[0-9].[0-9]" --abbrev=0`
           MAJOR_VERSION=`echo $DESCRIBE | awk '{split($0,a,"."); print a[1]}'`
           MINOR_VERSION=`echo $DESCRIBE | awk '{split($0,a,"."); print a[2]}'`
           MINOR_VERSION="$((${MINOR_VERSION} + 1))"


### PR DESCRIPTION
### Description

**Problem**:  The first nightly build after v0.4.0 was v0.4.0-nightly.20221216, and not v0.5.0-nightly.20221216.

The reason for this is the following: when creating a tag for a nightly build we first try to find the latest tag. To do so, we use `git describe`, which, by default lists only annotated tags. v0.4.0 is a lightweight tag though.

We have two options here: recreate v0.4.0 or change the nightly release procedure to include lightweight tags as well. It looks like recreating a tag would silently delete a release ([link](https://stackoverflow.com/questions/5002555/can-a-lightweight-tag-be-converted-to-an-annotated-tag#comment110678542_5002886)), so option #2 appears to be better.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.