### PR TITLE
fix(ui): use field value w inclusion when present

### DIFF
--- a/ui/app/components/pipeline-editor/config-field.js
+++ b/ui/app/components/pipeline-editor/config-field.js
@@ -23,7 +23,9 @@ export default class PipelineEditorConfigFieldComponent extends Component {
 
     if (this.fieldType === 'select') {
       this.selectOptions = this.generateSelectOptions();
-      this.selectSelected = this.selectOptions.firstObject;
+      this.selectSelected =
+        this.selectOptions.findBy('value', this.args.field.value) ||
+        this.selectOptions.firstObject;
     }
   }
 

--- a/ui/app/utils/blueprints/generate-blueprint-data.js
+++ b/ui/app/utils/blueprints/generate-blueprint-data.js
@@ -42,12 +42,13 @@ export function generateBlueprint(
   return blueprint;
 }
 
-export function generateBlankBlueprintField(
+export function generateBlueprintField(
   id,
   label,
   description,
   type,
-  validationOpts = {}
+  validationOpts = {},
+  populatedValue
 ) {
   const blueprint = generateBlueprint(
     id,
@@ -57,7 +58,14 @@ export function generateBlankBlueprintField(
     validationOpts
   );
 
-  const configurable = EmberObject.create();
+  let configurable;
+
+  if (populatedValue) {
+    configurable = EmberObject.create({ config: { settings: {} } });
+    configurable.set(`config.settings.${id}`, populatedValue);
+  } else {
+    configurable = EmberObject.create();
+  }
 
   const blueprintFields = generateBlueprintFields(blueprint, configurable);
 

--- a/ui/tests/integration/components/pipeline-editor/config-field-test.js
+++ b/ui/tests/integration/components/pipeline-editor/config-field-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { generateBlankBlueprintField } from 'conduit-ui/utils/blueprints/generate-blueprint-data';
+import { generateBlueprintField } from 'conduit-ui/utils/blueprints/generate-blueprint-data';
 
 module(
   'Integration | Component | pipeline-editor/config-field',
@@ -14,7 +14,7 @@ module(
         'with a string type and no inclusion validation',
         function (hooks) {
           hooks.beforeEach(async function () {
-            const field = generateBlankBlueprintField(
+            const field = generateBlueprintField(
               'titanName',
               'Titan Name',
               'Enter Titan Name',
@@ -39,7 +39,7 @@ module(
         'with a string, no inclusion validation, and a required validation',
         function (hooks) {
           hooks.beforeEach(async function () {
-            const field = generateBlankBlueprintField(
+            const field = generateBlueprintField(
               'titanName',
               'Titan Name',
               'Enter Titan Name',
@@ -76,7 +76,7 @@ module(
     module('number input', function () {
       module('with an int type and no inclusion validation', function (hooks) {
         hooks.beforeEach(async function () {
-          const field = generateBlankBlueprintField(
+          const field = generateBlueprintField(
             'titan:height',
             'Titan Height',
             'Enter Titan Height',
@@ -99,7 +99,7 @@ module(
         'with an int type, no inclusion validation, and a required validation',
         function (hooks) {
           hooks.beforeEach(async function () {
-            const field = generateBlankBlueprintField(
+            const field = generateBlueprintField(
               'titan:height',
               'Titan Height',
               'Enter Titan Height',
@@ -146,7 +146,7 @@ module(
         'with an int type, no inclusion validation, and both a greater than and less than validation',
         function (hooks) {
           hooks.beforeEach(async function () {
-            const field = generateBlankBlueprintField(
+            const field = generateBlueprintField(
               'titan:height',
               'Titan Height',
               'Enter Titan Height',
@@ -195,7 +195,7 @@ module(
     module('boolean input', function () {
       module('with a boolean type', function (hooks) {
         hooks.beforeEach(async function () {
-          const field = generateBlankBlueprintField(
+          const field = generateBlueprintField(
             'titan:eatingyou',
             'Is eating you',
             '',
@@ -220,8 +220,8 @@ module(
         'with a string type and an inclusion validation',
         function (hooks) {
           hooks.beforeEach(async function () {
-            const field = generateBlankBlueprintField(
-              'titan.type',
+            const field = generateBlueprintField(
+              'titan:type',
               'Titan Type',
               'Pick titan type',
               'TYPE_STRING',
@@ -232,7 +232,8 @@ module(
                     value: 'Attack,Founding,Warhammer',
                   },
                 ],
-              }
+              },
+              'Warhammer'
             );
 
             this.field = field;
@@ -245,6 +246,12 @@ module(
 
           test('it renders', function (assert) {
             assert.dom('[data-test-select-button]').exists();
+          });
+
+          test('it retains and renders populated values', function (assert) {
+            assert
+              .dom('[data-test-select-display-selected]')
+              .containsText('Warhammer');
           });
         }
       );


### PR DESCRIPTION
### Description
Fixes https://github.com/ConduitIO/conduit/issues/793

Ensures if a value is already set in the configurable object, we populate it in select input config fields

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.