### PR TITLE
Parse built-in plugin versions from build info

### DIFF
--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -179,7 +179,7 @@ func newServices(
 	processorService := processor.NewService(logger, db, processor.GlobalBuilderRegistry)
 	pluginService := plugin.NewService(
 		logger,
-		builtin.NewRegistry(logger, builtin.DefaultDispenserFactories...),
+		builtin.NewRegistry(logger, builtin.DefaultDispenserFactories),
 		standalone.NewRegistry(logger, pluginsPath),
 	)
 

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -70,7 +70,7 @@ func TestPipelineSimple(t *testing.T) {
 
 	pluginService := plugin.NewService(
 		logger,
-		builtin.NewRegistry(logger, builtin.DefaultDispenserFactories...),
+		builtin.NewRegistry(logger, builtin.DefaultDispenserFactories),
 		standalone.NewRegistry(logger, ""),
 	)
 

--- a/pkg/provisioning/service_test.go
+++ b/pkg/provisioning/service_test.go
@@ -651,7 +651,7 @@ func TestProvision_IntegrationTestServices(t *testing.T) {
 
 	pluginService := plugin.NewService(
 		logger,
-		builtin.NewRegistry(logger, builtin.DefaultDispenserFactories...),
+		builtin.NewRegistry(logger, builtin.DefaultDispenserFactories),
 		standalone.NewRegistry(logger, ""),
 	)
 


### PR DESCRIPTION
### Description

Standalone plugins have the correct version because we set it with `-ldflags` when building the binary. Built-in plugins on the other hand currently report their version using a constant that we need to remember to update before every release ([example](https://github.com/ConduitIO/conduit-connector-kafka/blob/0808ebd29f7135d989ffdf51c9c8b0962eefc4ab/spec.go#L24)). This PR makes this step unnecessary, because Conduit will overwrite the version with the version reported by go.mod.

I wanted to add unit tests but `debug.BuildInfo` is [not populated in tests](https://github.com/golang/go/issues/33976) 😕

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.