### PR TITLE
Upgrade to Go 1.20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: '1.20'
 
       - name: Test
         run: make test-integration GOTEST_FLAGS="-v -count=1"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,5 +17,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.1
+          version: v1.51.0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: '1.20'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: '1.20'
 
       - name: Set GORELEASER_PREVIOUS_TAG in actual release
         if: ${{ !contains(github.ref, '-nightly') }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start with a golang base
-FROM golang:1.18 AS base
+FROM golang:1.20 AS base
 
 # Install core tools
 RUN apt-get update &&\

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ of available options, run `./conduit --help`.
 
 Requirements:
 
-* [Go](https://golang.org/) (1.18 or later)
+* [Go](https://golang.org/) (1.20 or later)
 * [Node.js](https://nodejs.org/) (16.x)
 * [Yarn](https://yarnpkg.com/) (latest 1.x)
 * [Ember CLI](https://ember-cli.com/)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/conduitio/conduit
 
-go 1.18
+go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.0

--- a/scripts/check-go-version.sh
+++ b/scripts/check-go-version.sh
@@ -6,9 +6,8 @@
 function version_lt() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" != "$1"; }
 
 GO_VERSION=$(go version | { read -r _ _ v _; echo "${v#go}"; })
-# needs to be changed each time conduit Go version is upgraded
-REQUIRED_GO_VERSION="1.20"
+MIN_GO_VERSION=$(go list -m -f "{{.GoVersion}}")
 
-if version_lt "$GO_VERSION" "$REQUIRED_GO_VERSION"; then
-    echo "ERROR: min Go version required is go$REQUIRED_GO_VERSION, version installed is go$GO_VERSION"
+if version_lt "$GO_VERSION" "$MIN_GO_VERSION"; then
+    echo "ERROR: min Go version required is go$MIN_GO_VERSION, version installed is go$GO_VERSION"
 fi

--- a/scripts/check-go-version.sh
+++ b/scripts/check-go-version.sh
@@ -7,7 +7,7 @@ function version_lt() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)"
 
 GO_VERSION=$(go version | { read -r _ _ v _; echo "${v#go}"; })
 # needs to be changed each time conduit Go version is upgraded
-REQUIRED_GO_VERSION="1.18"
+REQUIRED_GO_VERSION="1.20"
 
 if version_lt "$GO_VERSION" "$REQUIRED_GO_VERSION"; then
     echo "ERROR: min Go version required is go$REQUIRED_GO_VERSION, version installed is go$GO_VERSION"


### PR DESCRIPTION
### Description

Upgrades Go to the latest version and improves the `check-go-version.sh` script so we don't have a hardcoded version there.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests. (well existing ones should check that this works)
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.