### PR TITLE
Add channel utilities for input channels

### DIFF
--- a/pkg/foundation/cchan/chan.go
+++ b/pkg/foundation/cchan/chan.go
@@ -19,13 +19,13 @@ import (
 	"time"
 )
 
-// Chan is a channel with utility methods.
-type Chan[T any] <-chan T
+// ChanOut is an output channel with utility methods.
+type ChanOut[T any] <-chan T
 
 // Recv will try to receive a value from the channel, same as <-c. If the
 // context is canceled before a value is received, it will return the context
 // error.
-func (c Chan[T]) Recv(ctx context.Context) (T, bool, error) {
+func (c ChanOut[T]) Recv(ctx context.Context) (T, bool, error) {
 	select {
 	case val, ok := <-c:
 		return val, ok, nil
@@ -36,10 +36,63 @@ func (c Chan[T]) Recv(ctx context.Context) (T, bool, error) {
 }
 
 // RecvTimeout will try to receive a value from the channel, same as <-c. If the
-// context is canceled before a values is received or the timeout is reached, it
+// context is canceled before a value is received or the timeout is reached, it
 // will return the context error.
-func (c Chan[T]) RecvTimeout(ctx context.Context, timeout time.Duration) (T, bool, error) {
+func (c ChanOut[T]) RecvTimeout(ctx context.Context, timeout time.Duration) (T, bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	return c.Recv(ctx)
+}
+
+// ChanIn is an input channel with utility methods.
+type ChanIn[T any] chan<- T
+
+// Send will try to send a value to the channel, same as c<-v. If the context is
+// canceled before a value is sent, it will return the context error.
+func (c ChanIn[T]) Send(ctx context.Context, v T) error {
+	select {
+	case c <- v:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// SendTimeout will try to send a value to the channel, same as c<-v. If the
+// context is canceled before a value is sent or the timeout is reached, it will
+// return the context error.
+func (c ChanIn[T]) SendTimeout(ctx context.Context, v T, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return c.Send(ctx, v)
+}
+
+// Chan is a channel with utility methods.
+type Chan[T any] chan T
+
+// Recv will try to receive a value from the channel, same as <-c. If the
+// context is canceled before a value is received, it will return the context
+// error.
+func (c Chan[T]) Recv(ctx context.Context) (T, bool, error) {
+	return ChanOut[T]((chan T)(c)).Recv(ctx)
+}
+
+// RecvTimeout will try to receive a value from the channel, same as <-c. If the
+// context is canceled before a value is received or the timeout is reached, it
+// will return the context error.
+func (c Chan[T]) RecvTimeout(ctx context.Context, timeout time.Duration) (T, bool, error) {
+	return ChanOut[T]((chan T)(c)).RecvTimeout(ctx, timeout)
+}
+
+// Send will try to send a value to the channel, same as c<-v. If the context is
+// canceled before a value is sent, it will return the context error.
+func (c Chan[T]) Send(ctx context.Context, v T) error {
+	return ChanIn[T]((chan T)(c)).Send(ctx, v)
+}
+
+// SendTimeout will try to send a value to the channel, same as c<-v. If the
+// context is canceled before a value is sent or the timeout is reached, it will
+// return the context error.
+func (c Chan[T]) SendTimeout(ctx context.Context, v T, timeout time.Duration) error {
+	return ChanIn[T]((chan T)(c)).SendTimeout(ctx, v, timeout)
 }

--- a/pkg/foundation/cchan/chan_test.go
+++ b/pkg/foundation/cchan/chan_test.go
@@ -110,6 +110,7 @@ func TestChanIn_Send_Closed(t *testing.T) {
 	defer func() {
 		r := recover()
 		is.True(r != nil)
+		is.Equal(r.(error).Error(), "send on closed channel")
 	}()
 	_ = ChanIn[int](c).Send(ctx, 1)
 	is.Fail() // unreachable

--- a/pkg/foundation/csync/waitgroup.go
+++ b/pkg/foundation/csync/waitgroup.go
@@ -55,7 +55,7 @@ func (wg *WaitGroup) Wait(ctx context.Context) error {
 		(*sync.WaitGroup)(wg).Wait()
 		close(done)
 	}()
-	_, _, err := cchan.Chan[struct{}](done).Recv(ctx)
+	_, _, err := cchan.ChanOut[struct{}](done).Recv(ctx)
 	return err
 }
 

--- a/pkg/foundation/grpcutil/websocket_test.go
+++ b/pkg/foundation/grpcutil/websocket_test.go
@@ -150,7 +150,7 @@ func TestWebSocket_Read_ClientClosed(t *testing.T) {
 	err = ws.Close()
 	is.NoErr(err)
 
-	_, ok, err := cchan.Chan[struct{}](handlerDone).RecvTimeout(context.Background(), time.Second)
+	_, ok, err := cchan.ChanOut[struct{}](handlerDone).RecvTimeout(context.Background(), time.Second)
 	is.True(!ok) // expected channel to be closed
 	is.NoErr(err)
 }

--- a/pkg/inspector/inspector_test.go
+++ b/pkg/inspector/inspector_test.go
@@ -94,7 +94,7 @@ func TestInspector_Send_SessionCtxCanceled(t *testing.T) {
 
 	cancel()
 
-	_, got, err := cchan.Chan[record.Record](s.C).RecvTimeout(context.Background(), 100*time.Millisecond)
+	_, got, err := cchan.ChanOut[record.Record](s.C).RecvTimeout(context.Background(), 100*time.Millisecond)
 	is.NoErr(err)
 	is.True(!got) // expected no record
 }
@@ -130,13 +130,13 @@ func TestInspector_Send_SlowConsumer(t *testing.T) {
 		)
 	}
 
-	_, got, err := cchan.Chan[record.Record](s.C).RecvTimeout(context.Background(), 100*time.Millisecond)
+	_, got, err := cchan.ChanOut[record.Record](s.C).RecvTimeout(context.Background(), 100*time.Millisecond)
 	is.True(cerrors.Is(err, context.DeadlineExceeded))
 	is.True(!got)
 }
 
 func assertGotRecord(is *is.I, s *Session, recWant record.Record) {
-	recGot, got, err := cchan.Chan[record.Record](s.C).RecvTimeout(context.Background(), 100*time.Millisecond)
+	recGot, got, err := cchan.ChanOut[record.Record](s.C).RecvTimeout(context.Background(), 100*time.Millisecond)
 	is.NoErr(err)
 	is.True(got)
 	is.Equal(recWant, recGot)

--- a/pkg/pipeline/stream/source_acker_test.go
+++ b/pkg/pipeline/stream/source_acker_test.go
@@ -56,7 +56,7 @@ func TestSourceAckerNode_ForwardAck(t *testing.T) {
 	close(in)
 
 	// make sure out channel is closed
-	_, ok, err := cchan.Chan[*Message](out).RecvTimeout(ctx, time.Second)
+	_, ok, err := cchan.ChanOut[*Message](out).RecvTimeout(ctx, time.Second)
 	is.NoErr(err)
 	is.True(!ok)
 }

--- a/pkg/pipeline/stream/source_test.go
+++ b/pkg/pipeline/stream/source_test.go
@@ -51,7 +51,7 @@ func TestSourceNode_Run(t *testing.T) {
 	}()
 
 	for _, wantRecord := range wantRecords {
-		gotMsg, ok, err := cchan.Chan[*Message](out).RecvTimeout(ctx, time.Second)
+		gotMsg, ok, err := cchan.ChanOut[*Message](out).RecvTimeout(ctx, time.Second)
 		is.NoErr(err)
 		is.True(ok)
 		is.Equal(gotMsg.Record, wantRecord)
@@ -65,11 +65,11 @@ func TestSourceNode_Run(t *testing.T) {
 	err := node.Stop(ctx, nil)
 	is.NoErr(err)
 
-	_, ok, err := cchan.Chan[*Message](out).RecvTimeout(ctx, time.Second)
+	_, ok, err := cchan.ChanOut[*Message](out).RecvTimeout(ctx, time.Second)
 	is.NoErr(err) // expected node to close outgoing channel
 	is.True(!ok)  // expected node to close outgoing channel
 
-	_, ok, err = cchan.Chan[struct{}](nodeDone).RecvTimeout(ctx, time.Second)
+	_, ok, err = cchan.ChanOut[struct{}](nodeDone).RecvTimeout(ctx, time.Second)
 	is.NoErr(err) // expected node to stop running
 	is.True(!ok)  // expected nodeDone to be closed
 }
@@ -108,11 +108,11 @@ func TestSourceNode_StopWhileNextNodeIsStuck(t *testing.T) {
 	err := node.Stop(ctx, nil)
 	is.NoErr(err)
 
-	_, ok, err := cchan.Chan[*Message](out).RecvTimeout(ctx, time.Second)
+	_, ok, err := cchan.ChanOut[*Message](out).RecvTimeout(ctx, time.Second)
 	is.NoErr(err) // expected node to close outgoing channel
 	is.True(!ok)  // expected node to close outgoing channel
 
-	_, ok, err = cchan.Chan[struct{}](nodeDone).RecvTimeout(ctx, time.Second)
+	_, ok, err = cchan.ChanOut[struct{}](nodeDone).RecvTimeout(ctx, time.Second)
 	is.NoErr(err) // expected node to stop running
 	is.True(!ok)  // expected nodeDone to be closed
 }

--- a/pkg/processor/procbuiltin/func_wrapper_test.go
+++ b/pkg/processor/procbuiltin/func_wrapper_test.go
@@ -59,7 +59,7 @@ func TestFuncWrapper_InspectIn(t *testing.T) {
 			session := underTest.InspectIn(ctx)
 			_, _ = underTest.Process(ctx, wantIn)
 
-			gotIn, got, err := cchan.Chan[record.Record](session.C).RecvTimeout(ctx, 100*time.Millisecond)
+			gotIn, got, err := cchan.ChanOut[record.Record](session.C).RecvTimeout(ctx, 100*time.Millisecond)
 			is.NoErr(err)
 			is.True(got)
 			is.Equal(wantIn, gotIn)
@@ -85,7 +85,7 @@ func TestFuncWrapper_InspectOut_Ok(t *testing.T) {
 	session := underTest.InspectOut(ctx)
 	_, _ = underTest.Process(ctx, record.Record{})
 
-	gotOut, got, err := cchan.Chan[record.Record](session.C).RecvTimeout(ctx, 100*time.Millisecond)
+	gotOut, got, err := cchan.ChanOut[record.Record](session.C).RecvTimeout(ctx, 100*time.Millisecond)
 	is.NoErr(err)
 	is.True(got)
 	is.Equal(wantOut, gotOut)
@@ -109,6 +109,6 @@ func TestFuncWrapper_InspectOut_ProcessingFailed(t *testing.T) {
 	session := underTest.InspectOut(ctx)
 	_, _ = underTest.Process(ctx, record.Record{})
 
-	_, _, err := cchan.Chan[record.Record](session.C).RecvTimeout(ctx, 100*time.Millisecond)
+	_, _, err := cchan.ChanOut[record.Record](session.C).RecvTimeout(ctx, 100*time.Millisecond)
 	is.True(cerrors.Is(err, context.DeadlineExceeded))
 }

--- a/pkg/processor/procjs/processor_test.go
+++ b/pkg/processor/procjs/processor_test.go
@@ -420,12 +420,12 @@ func TestJSProcessor_Inspect(t *testing.T) {
 	recOut, err := underTest.Process(ctx, recIn)
 	is.NoErr(err)
 
-	inspIn, got, err := cchan.Chan[record.Record](in.C).RecvTimeout(ctx, 100*time.Millisecond)
+	inspIn, got, err := cchan.ChanOut[record.Record](in.C).RecvTimeout(ctx, 100*time.Millisecond)
 	is.NoErr(err)
 	is.True(got)
 	is.Equal(recIn, inspIn)
 
-	inspOut, got, err := cchan.Chan[record.Record](out.C).RecvTimeout(ctx, 100*time.Millisecond)
+	inspOut, got, err := cchan.ChanOut[record.Record](out.C).RecvTimeout(ctx, 100*time.Millisecond)
 	is.NoErr(err)
 	is.True(got)
 	is.Equal(recOut, inspOut)

--- a/pkg/web/api/connector_v1_test.go
+++ b/pkg/web/api/connector_v1_test.go
@@ -274,7 +274,7 @@ func TestConnectorAPIv1_InspectConnector_SendErr(t *testing.T) {
 	}()
 	ins.Send(ctx, generateTestRecord())
 
-	err, b, err2 := cchan.Chan[error](errC).RecvTimeout(context.Background(), 100*time.Millisecond)
+	err, b, err2 := cchan.ChanOut[error](errC).RecvTimeout(context.Background(), 100*time.Millisecond)
 	assert.Ok(t, err2)
 	assert.True(t, b, "expected to receive an error")
 	assert.True(t, cerrors.Is(err, errSend), "expected 'I'm sorry, but no.' error")

--- a/pkg/web/api/processor_v1_test.go
+++ b/pkg/web/api/processor_v1_test.go
@@ -485,7 +485,7 @@ func TestProcessorAPIv1_InspectIn_SendErr(t *testing.T) {
 	}()
 	ins.Send(ctx, generateTestRecord())
 
-	err, b, err2 := cchan.Chan[error](errC).RecvTimeout(context.Background(), 100*time.Millisecond)
+	err, b, err2 := cchan.ChanOut[error](errC).RecvTimeout(context.Background(), 100*time.Millisecond)
 	assert.Ok(t, err2)
 	assert.True(t, b, "expected to receive an error")
 	assert.True(t, cerrors.Is(err, errSend), "expected 'I'm sorry, but no.' error")


### PR DESCRIPTION
### Description

In a test I saw the need for an utility to send an object to a channel and timeout if the operation doesn't succeed. I extended the `cchan` package with utilities for output channels, input channels and two-way channels. This means that the existing `cchan.Chan` object was renamed to `cchan.ChanOut` and additionally `cchan.ChanIn` and `cchan.Chan` were introduced.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.