### PR TITLE
Default context logger

### DIFF
--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -159,6 +159,7 @@ func newLogger(level string, format string) log.CtxLogger {
 		ctxutil.MessageIDLogCtxHook{},
 		ctxutil.RequestIDLogCtxHook{},
 	)
+	zerolog.DefaultContextLogger = &logger.Logger
 	return logger
 }
 


### PR DESCRIPTION
### Description

Sets the default context logger. Connectors rely on fetching the connector from a context and we want to provide a logger even if the context doesn't contain one (e.g. in case the code doesn't have access to the correct context). This makes sure we don't lose messages from built-in connectors.