### PR TITLE
Return error when pipeline is not in a running state

### DIFF
--- a/cmd/conduit-pipeline-check/main.go
+++ b/cmd/conduit-pipeline-check/main.go
@@ -92,10 +92,7 @@ func checkPipeline(ctx context.Context) error {
 		// success
 		return nil
 	default:
-		if *verbose {
-			fmt.Printf("pipeline %q is not running: %v", *pipelineName, p.Pipeline.State.Status)
-		}
-		return nil
+		return fmt.Errorf("pipeline %q is not running: %v", *pipelineName, p.Pipeline.State.Status)
 	}
 }
 


### PR DESCRIPTION
### Description

The command should be returning an error when the pipeline is not in a  running state.

Fixes #887 

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.