### PR TITLE
Timeconverter proc should always use UTC when converting from UNIX

### DIFF
--- a/pkg/processor/procbuiltin/timestampconvertor.go
+++ b/pkg/processor/procbuiltin/timestampconvertor.go
@@ -92,7 +92,7 @@ func timestampConvertor(
 			var tm time.Time
 			switch v := d[field].(type) {
 			case int64:
-				tm = time.Unix(0, v)
+				tm = time.Unix(0, v).UTC()
 			case string:
 				if format == "" {
 					return record.Record{}, cerrors.Errorf("%s: no format to parse the date", processorType)


### PR DESCRIPTION
### Description

Timezone information cannot be inferred from unix time, because of this we can see discrepancies in what time looks like in the different timezones. For consistency, we should always convert unix time to UTC time.

Fixes #889 

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.