### PR TITLE
Keep tomb alive when starting pipeline

### DIFF
--- a/pkg/pipeline/lifecycle.go
+++ b/pkg/pipeline/lifecycle.go
@@ -500,6 +500,16 @@ func (s *Service) runPipeline(ctx context.Context, pl *Instance) error {
 
 	// the tomb is responsible for running goroutines related to the pipeline
 	pl.t = &tomb.Tomb{}
+
+	// keep tomb alive until the end of this function, this way we guarantee we
+	// can run the cleanup goroutine even if all nodes stop before we get to it
+	keepAlive := make(chan struct{})
+	pl.t.Go(func() error {
+		<-keepAlive
+		return nil
+	})
+	defer close(keepAlive)
+
 	// nodesWg is done once all nodes stop running
 	var nodesWg sync.WaitGroup
 	var isGracefulShutdown atomic.Bool


### PR DESCRIPTION
### Description

When starting the pipeline it can happen that all nodes stop (e.g. because of an error) before we manage to start the [cleanup goroutine](https://github.com/ConduitIO/conduit/blob/7a8181be77497e69d91fd5270ed8daec0d027aba/pkg/pipeline/lifecycle.go#L555). In that case the tomb will be dead and will panic if we try to start another goroutine.

It's a race condition and is hard to reproduce, I could not reproduce it in my local environment, but the error message in [this run of `TestServiceLifecycle_PipelineStop`](https://github.com/ConduitIO/conduit/actions/runs/4265073002/jobs/7423970338#step:4:912) is pretty straight forward:

```
panic: tomb.Go called after all goroutines terminated [recovered]
	panic: tomb.Go called after all goroutines terminated

...

gopkg.in/tomb%2ev2.(*Tomb).Go(0xc0000899a0, 0xc00033a480)
	/home/runner/go/pkg/mod/gopkg.in/tomb.v2@v2.0.0-20161208151619-d5d1b5820637/tomb.go:155 +0x236
github.com/conduitio/conduit/pkg/pipeline.(*Service).runPipeline(0xc000176fa0, {0xceb738, 0xc000089860}, 0xc00015a3c0)
	/home/runner/work/conduit/conduit/pkg/pipeline/lifecycle.go:555 +0xa45
```

The fix in this PR spawns a goroutine that keeps the tomb alive until the end of that function. This way we can safely spawn goroutines without worrying about the tomb being dead.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.