### PR TITLE
Glob patterns exclude double digits in tags

### DIFF
--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -27,7 +27,7 @@ jobs:
           # A previous release was created using a lightweight tag
           # git describe by default includes only annotated tags
           # git describe --tags includes lightweight tags as well
-          DESCRIBE=`git describe --tags --match "v[0-9].[0-9].[0-9]" --abbrev=0`
+          DESCRIBE=`git tag -l --sort=-v:refname | grep -v nightly | head -n 1`
           MAJOR_VERSION=`echo $DESCRIBE | awk '{split($0,a,"."); print a[1]}'`
           MINOR_VERSION=`echo $DESCRIBE | awk '{split($0,a,"."); print a[2]}'`
           MINOR_VERSION="$((${MINOR_VERSION} + 1))"


### PR DESCRIPTION
### Description

Nightly build tags for releases where a version is >= 10 are wrong, because of the sorting used. This is a port of https://github.com/meroxa/cli/pull/656. Credits go to @janelletavares. 

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.