### PR TITLE
Lifecycle Events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/conduitio/conduit-connector-kafka v0.4.1
 	github.com/conduitio/conduit-connector-log v0.1.2
 	github.com/conduitio/conduit-connector-postgres v0.3.0
-	github.com/conduitio/conduit-connector-protocol v0.4.1
+	github.com/conduitio/conduit-connector-protocol v0.4.2-0.20230317135836-683b23ba5a0a
 	github.com/conduitio/conduit-connector-s3 v0.3.0
 	github.com/conduitio/conduit-connector-sdk v0.5.2
 	github.com/conduitio/yaml/v3 v3.2.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/conduitio/conduit-connector-postgres v0.3.0
 	github.com/conduitio/conduit-connector-protocol v0.4.2-0.20230317135836-683b23ba5a0a
 	github.com/conduitio/conduit-connector-s3 v0.3.0
-	github.com/conduitio/conduit-connector-sdk v0.5.2
+	github.com/conduitio/conduit-connector-sdk v0.5.3-0.20230317175521-1ef859feda37
 	github.com/conduitio/yaml/v3 v3.2.0
 	github.com/dgraph-io/badger/v3 v3.2103.5
 	github.com/dop251/goja v0.0.0-20230304130813-e2f543bf4b4c

--- a/go.sum
+++ b/go.sum
@@ -160,14 +160,12 @@ github.com/conduitio/conduit-connector-log v0.1.2 h1:CPlsdgr1Ui6j3fNVYpp/qHVwXKb
 github.com/conduitio/conduit-connector-log v0.1.2/go.mod h1:mnox8F5YrwQpuX+Y/WJidgqi6882Id6i8MslW0ic+XA=
 github.com/conduitio/conduit-connector-postgres v0.3.0 h1:owlVIXeAWVAuHW0Hzr3+zxrAB9/LXIedINduFQM/HoM=
 github.com/conduitio/conduit-connector-postgres v0.3.0/go.mod h1:I8Yz4t90QbGZUObt+0+bWpDwJ2qZ5iv4bbFjRB19xGA=
-github.com/conduitio/conduit-connector-protocol v0.4.1 h1:QIqvkpfVVSxsBHltMKRpy4l5u1M3psAF0SePxhv+CTU=
-github.com/conduitio/conduit-connector-protocol v0.4.1/go.mod h1:UIhHWxq52hvwwbkvQDaRgZRHfbpDDmU7tZaw0mwLdd4=
 github.com/conduitio/conduit-connector-protocol v0.4.2-0.20230317135836-683b23ba5a0a h1:xGtOYeXg6+7HMGlJ+Vjp/0FnP+tnjjIe26xEdeEep+Y=
 github.com/conduitio/conduit-connector-protocol v0.4.2-0.20230317135836-683b23ba5a0a/go.mod h1:UIhHWxq52hvwwbkvQDaRgZRHfbpDDmU7tZaw0mwLdd4=
 github.com/conduitio/conduit-connector-s3 v0.3.0 h1:Zy+TYRnZKw09mks4qsXW43qnp0PuO/SsgvYbbuMUhss=
 github.com/conduitio/conduit-connector-s3 v0.3.0/go.mod h1:ims2iWZJcOSjEPY1nal/DQrxiqG+xHPYFV5nN1ia/Pk=
-github.com/conduitio/conduit-connector-sdk v0.5.2 h1:YOPWaG/+NrAzJNkuFbvN6pPk3SdQDErRtipiSH3XT2c=
-github.com/conduitio/conduit-connector-sdk v0.5.2/go.mod h1:Ih8mHJWX2+TvFj429hcrj361vJNULw7FWk4iz1W5l9s=
+github.com/conduitio/conduit-connector-sdk v0.5.3-0.20230317175521-1ef859feda37 h1:DtFWsVSPtaXE8OlJ56mMTR23QBG6k94wInZRXwEQLCk=
+github.com/conduitio/conduit-connector-sdk v0.5.3-0.20230317175521-1ef859feda37/go.mod h1:qkXvR+JeTWQWlqw8MXPCOAe5ZdCcShuDgBaDYwrSsk4=
 github.com/conduitio/yaml/v3 v3.2.0 h1:itolFiK0dzUYG6PdlOpmCi1fcMYFoaWdZ1wbNNTEnlI=
 github.com/conduitio/yaml/v3 v3.2.0/go.mod h1:JNgFMOX1t8W4YJuRZOh6GggVtSMsgP9XgTw+7dIenpc=
 github.com/containerd/stargz-snapshotter/estargz v0.12.1 h1:+7nYmHJb0tEkcRaAW+MHqoKaJYZmkikupxCqVtmPuY0=

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,8 @@ github.com/conduitio/conduit-connector-postgres v0.3.0 h1:owlVIXeAWVAuHW0Hzr3+zx
 github.com/conduitio/conduit-connector-postgres v0.3.0/go.mod h1:I8Yz4t90QbGZUObt+0+bWpDwJ2qZ5iv4bbFjRB19xGA=
 github.com/conduitio/conduit-connector-protocol v0.4.1 h1:QIqvkpfVVSxsBHltMKRpy4l5u1M3psAF0SePxhv+CTU=
 github.com/conduitio/conduit-connector-protocol v0.4.1/go.mod h1:UIhHWxq52hvwwbkvQDaRgZRHfbpDDmU7tZaw0mwLdd4=
+github.com/conduitio/conduit-connector-protocol v0.4.2-0.20230317135836-683b23ba5a0a h1:xGtOYeXg6+7HMGlJ+Vjp/0FnP+tnjjIe26xEdeEep+Y=
+github.com/conduitio/conduit-connector-protocol v0.4.2-0.20230317135836-683b23ba5a0a/go.mod h1:UIhHWxq52hvwwbkvQDaRgZRHfbpDDmU7tZaw0mwLdd4=
 github.com/conduitio/conduit-connector-s3 v0.3.0 h1:Zy+TYRnZKw09mks4qsXW43qnp0PuO/SsgvYbbuMUhss=
 github.com/conduitio/conduit-connector-s3 v0.3.0/go.mod h1:ims2iWZJcOSjEPY1nal/DQrxiqG+xHPYFV5nN1ia/Pk=
 github.com/conduitio/conduit-connector-sdk v0.5.2 h1:YOPWaG/+NrAzJNkuFbvN6pPk3SdQDErRtipiSH3XT2c=

--- a/pkg/plugin/builtin/v1/destination.go
+++ b/pkg/plugin/builtin/v1/destination.go
@@ -57,10 +57,7 @@ func (s *destinationPluginAdapter) withLogger(ctx context.Context) context.Conte
 }
 
 func (s *destinationPluginAdapter) Configure(ctx context.Context, cfg map[string]string) error {
-	req, err := toplugin.DestinationConfigureRequest(cfg)
-	if err != nil {
-		return err
-	}
+	req := toplugin.DestinationConfigureRequest(cfg)
 	s.logger.Trace(ctx).Msg("calling Configure")
 	resp, err := runSandbox(s.impl.Configure, s.withLogger(ctx), req)
 	if err != nil {
@@ -159,6 +156,39 @@ func (s *destinationPluginAdapter) Stop(ctx context.Context, lastPosition record
 func (s *destinationPluginAdapter) Teardown(ctx context.Context) error {
 	s.logger.Trace(ctx).Msg("calling Teardown")
 	resp, err := runSandbox(s.impl.Teardown, s.withLogger(ctx), toplugin.DestinationTeardownRequest())
+	if err != nil {
+		return err
+	}
+	_ = resp // empty response
+
+	return nil
+}
+
+func (s *destinationPluginAdapter) LifecycleOnCreated(ctx context.Context, cfg map[string]string) error {
+	s.logger.Trace(ctx).Msg("calling LifecycleOnCreated")
+	resp, err := runSandbox(s.impl.LifecycleOnCreated, s.withLogger(ctx), toplugin.DestinationLifecycleOnCreatedRequest(cfg))
+	if err != nil {
+		return err
+	}
+	_ = resp // empty response
+
+	return nil
+}
+
+func (s *destinationPluginAdapter) LifecycleOnUpdated(ctx context.Context, cfgBefore, cfgAfter map[string]string) error {
+	s.logger.Trace(ctx).Msg("calling LifecycleOnUpdated")
+	resp, err := runSandbox(s.impl.LifecycleOnUpdated, s.withLogger(ctx), toplugin.DestinationLifecycleOnUpdatedRequest(cfgBefore, cfgAfter))
+	if err != nil {
+		return err
+	}
+	_ = resp // empty response
+
+	return nil
+}
+
+func (s *destinationPluginAdapter) LifecycleOnDeleted(ctx context.Context, cfg map[string]string) error {
+	s.logger.Trace(ctx).Msg("calling LifecycleOnDeleted")
+	resp, err := runSandbox(s.impl.LifecycleOnDeleted, s.withLogger(ctx), toplugin.DestinationLifecycleOnDeletedRequest(cfg))
 	if err != nil {
 		return err
 	}

--- a/pkg/plugin/builtin/v1/destination.go
+++ b/pkg/plugin/builtin/v1/destination.go
@@ -57,16 +57,8 @@ func (s *destinationPluginAdapter) withLogger(ctx context.Context) context.Conte
 }
 
 func (s *destinationPluginAdapter) Configure(ctx context.Context, cfg map[string]string) error {
-	req := toplugin.DestinationConfigureRequest(cfg)
 	s.logger.Trace(ctx).Msg("calling Configure")
-	resp, err := runSandbox(s.impl.Configure, s.withLogger(ctx), req)
-	if err != nil {
-		// TODO create new errors as strings, this happens when they are
-		//  transmitted through gRPC and we don't want to falsely rely on types
-		//  in built-in plugins
-		return err
-	}
-	_ = resp // empty response
+	_, err := runSandbox(s.impl.Configure, s.withLogger(ctx), toplugin.DestinationConfigureRequest(cfg))
 	return err
 }
 
@@ -77,11 +69,10 @@ func (s *destinationPluginAdapter) Start(ctx context.Context) error {
 
 	req := toplugin.DestinationStartRequest()
 	s.logger.Trace(ctx).Msg("calling Start")
-	resp, err := runSandbox(s.impl.Start, s.withLogger(ctx), req)
+	_, err := runSandbox(s.impl.Start, s.withLogger(ctx), req)
 	if err != nil {
 		return err
 	}
-	_ = resp // empty response
 
 	s.stream = newDestinationRunStream(ctx)
 	go func() {
@@ -97,10 +88,10 @@ func (s *destinationPluginAdapter) Start(ctx context.Context) error {
 		s.logger.Trace(ctx).Msg("Run stopped")
 	}()
 
-	return err
+	return nil
 }
 
-func (s *destinationPluginAdapter) Write(ctx context.Context, r record.Record) (err error) {
+func (s *destinationPluginAdapter) Write(ctx context.Context, r record.Record) error {
 	if s.stream == nil {
 		return plugin.ErrStreamNotOpen
 	}
@@ -144,57 +135,32 @@ func (s *destinationPluginAdapter) Stop(ctx context.Context, lastPosition record
 	}
 
 	s.logger.Trace(ctx).Bytes(log.RecordPositionField, lastPosition).Msg("calling Stop")
-	resp, err := runSandbox(s.impl.Stop, s.withLogger(ctx), toplugin.DestinationStopRequest(lastPosition))
-	if err != nil {
-		return err
-	}
-	_ = resp // empty response
-
-	return nil
+	_, err := runSandbox(s.impl.Stop, s.withLogger(ctx), toplugin.DestinationStopRequest(lastPosition))
+	return err
 }
 
 func (s *destinationPluginAdapter) Teardown(ctx context.Context) error {
 	s.logger.Trace(ctx).Msg("calling Teardown")
-	resp, err := runSandbox(s.impl.Teardown, s.withLogger(ctx), toplugin.DestinationTeardownRequest())
-	if err != nil {
-		return err
-	}
-	_ = resp // empty response
-
-	return nil
+	_, err := runSandbox(s.impl.Teardown, s.withLogger(ctx), toplugin.DestinationTeardownRequest())
+	return err
 }
 
 func (s *destinationPluginAdapter) LifecycleOnCreated(ctx context.Context, cfg map[string]string) error {
 	s.logger.Trace(ctx).Msg("calling LifecycleOnCreated")
-	resp, err := runSandbox(s.impl.LifecycleOnCreated, s.withLogger(ctx), toplugin.DestinationLifecycleOnCreatedRequest(cfg))
-	if err != nil {
-		return err
-	}
-	_ = resp // empty response
-
-	return nil
+	_, err := runSandbox(s.impl.LifecycleOnCreated, s.withLogger(ctx), toplugin.DestinationLifecycleOnCreatedRequest(cfg))
+	return err
 }
 
 func (s *destinationPluginAdapter) LifecycleOnUpdated(ctx context.Context, cfgBefore, cfgAfter map[string]string) error {
 	s.logger.Trace(ctx).Msg("calling LifecycleOnUpdated")
-	resp, err := runSandbox(s.impl.LifecycleOnUpdated, s.withLogger(ctx), toplugin.DestinationLifecycleOnUpdatedRequest(cfgBefore, cfgAfter))
-	if err != nil {
-		return err
-	}
-	_ = resp // empty response
-
-	return nil
+	_, err := runSandbox(s.impl.LifecycleOnUpdated, s.withLogger(ctx), toplugin.DestinationLifecycleOnUpdatedRequest(cfgBefore, cfgAfter))
+	return err
 }
 
 func (s *destinationPluginAdapter) LifecycleOnDeleted(ctx context.Context, cfg map[string]string) error {
 	s.logger.Trace(ctx).Msg("calling LifecycleOnDeleted")
-	resp, err := runSandbox(s.impl.LifecycleOnDeleted, s.withLogger(ctx), toplugin.DestinationLifecycleOnDeletedRequest(cfg))
-	if err != nil {
-		return err
-	}
-	_ = resp // empty response
-
-	return nil
+	_, err := runSandbox(s.impl.LifecycleOnDeleted, s.withLogger(ctx), toplugin.DestinationLifecycleOnDeletedRequest(cfg))
+	return err
 }
 
 func newDestinationRunStream(ctx context.Context) *stream[cpluginv1.DestinationRunRequest, cpluginv1.DestinationRunResponse] {

--- a/pkg/plugin/builtin/v1/internal/toplugin/destination.go
+++ b/pkg/plugin/builtin/v1/internal/toplugin/destination.go
@@ -19,13 +19,13 @@ import (
 	"github.com/conduitio/conduit/pkg/record"
 )
 
-func DestinationConfigureRequest(in map[string]string) (cpluginv1.DestinationConfigureRequest, error) {
+func DestinationConfigureRequest(in map[string]string) cpluginv1.DestinationConfigureRequest {
 	out := cpluginv1.DestinationConfigureRequest{}
 	if len(in) > 0 {
 		// gRPC sends `nil` if the map is empty, match behavior
 		out.Config = in
 	}
-	return out, nil
+	return out
 }
 
 func DestinationStartRequest() cpluginv1.DestinationStartRequest {
@@ -52,4 +52,34 @@ func DestinationStopRequest(in record.Position) cpluginv1.DestinationStopRequest
 
 func DestinationTeardownRequest() cpluginv1.DestinationTeardownRequest {
 	return cpluginv1.DestinationTeardownRequest{}
+}
+
+func DestinationLifecycleOnCreatedRequest(cfg map[string]string) cpluginv1.DestinationLifecycleOnCreatedRequest {
+	out := cpluginv1.DestinationLifecycleOnCreatedRequest{}
+	if len(cfg) > 0 {
+		// gRPC sends `nil` if the map is empty, match behavior
+		out.Config = cfg
+	}
+	return out
+}
+
+func DestinationLifecycleOnUpdatedRequest(cfgBefore, cfgAfter map[string]string) cpluginv1.DestinationLifecycleOnUpdatedRequest {
+	out := cpluginv1.DestinationLifecycleOnUpdatedRequest{}
+	// gRPC sends `nil` if the map is empty, match behavior
+	if len(cfgBefore) > 0 {
+		out.ConfigBefore = cfgBefore
+	}
+	if len(cfgAfter) > 0 {
+		out.ConfigAfter = cfgAfter
+	}
+	return out
+}
+
+func DestinationLifecycleOnDeletedRequest(cfg map[string]string) cpluginv1.DestinationLifecycleOnDeletedRequest {
+	out := cpluginv1.DestinationLifecycleOnDeletedRequest{}
+	if len(cfg) > 0 {
+		// gRPC sends `nil` if the map is empty, match behavior
+		out.Config = cfg
+	}
+	return out
 }

--- a/pkg/plugin/builtin/v1/internal/toplugin/source.go
+++ b/pkg/plugin/builtin/v1/internal/toplugin/source.go
@@ -19,27 +19,25 @@ import (
 	"github.com/conduitio/conduit/pkg/record"
 )
 
-func SourceConfigureRequest(in map[string]string) (cpluginv1.SourceConfigureRequest, error) {
+func SourceConfigureRequest(in map[string]string) cpluginv1.SourceConfigureRequest {
 	out := cpluginv1.SourceConfigureRequest{}
 	if len(in) > 0 {
 		// gRPC sends `nil` if the map is empty, match behavior
 		out.Config = in
 	}
-	return out, nil
+	return out
 }
 
-func SourceStartRequest(in record.Position) (cpluginv1.SourceStartRequest, error) {
-	out := cpluginv1.SourceStartRequest{
+func SourceStartRequest(in record.Position) cpluginv1.SourceStartRequest {
+	return cpluginv1.SourceStartRequest{
 		Position: in,
 	}
-	return out, nil
 }
 
-func SourceRunRequest(in record.Position) (cpluginv1.SourceRunRequest, error) {
-	out := cpluginv1.SourceRunRequest{
+func SourceRunRequest(in record.Position) cpluginv1.SourceRunRequest {
+	return cpluginv1.SourceRunRequest{
 		AckPosition: in,
 	}
-	return out, nil
 }
 
 func SourceStopRequest() cpluginv1.SourceStopRequest {
@@ -48,4 +46,34 @@ func SourceStopRequest() cpluginv1.SourceStopRequest {
 
 func SourceTeardownRequest() cpluginv1.SourceTeardownRequest {
 	return cpluginv1.SourceTeardownRequest{}
+}
+
+func SourceLifecycleOnCreatedRequest(cfg map[string]string) cpluginv1.SourceLifecycleOnCreatedRequest {
+	out := cpluginv1.SourceLifecycleOnCreatedRequest{}
+	if len(cfg) > 0 {
+		// gRPC sends `nil` if the map is empty, match behavior
+		out.Config = cfg
+	}
+	return out
+}
+
+func SourceLifecycleOnUpdatedRequest(cfgBefore, cfgAfter map[string]string) cpluginv1.SourceLifecycleOnUpdatedRequest {
+	out := cpluginv1.SourceLifecycleOnUpdatedRequest{}
+	// gRPC sends `nil` if the map is empty, match behavior
+	if len(cfgBefore) > 0 {
+		out.ConfigBefore = cfgBefore
+	}
+	if len(cfgAfter) > 0 {
+		out.ConfigAfter = cfgAfter
+	}
+	return out
+}
+
+func SourceLifecycleOnDeletedRequest(cfg map[string]string) cpluginv1.SourceLifecycleOnDeletedRequest {
+	out := cpluginv1.SourceLifecycleOnDeletedRequest{}
+	if len(cfg) > 0 {
+		// gRPC sends `nil` if the map is empty, match behavior
+		out.Config = cfg
+	}
+	return out
 }

--- a/pkg/plugin/builtin/v1/source.go
+++ b/pkg/plugin/builtin/v1/source.go
@@ -58,10 +58,7 @@ func (s *sourcePluginAdapter) withLogger(ctx context.Context) context.Context {
 }
 
 func (s *sourcePluginAdapter) Configure(ctx context.Context, cfg map[string]string) error {
-	req, err := toplugin.SourceConfigureRequest(cfg)
-	if err != nil {
-		return err
-	}
+	req := toplugin.SourceConfigureRequest(cfg)
 	s.logger.Trace(ctx).Msg("calling Configure")
 	resp, err := runSandbox(s.impl.Configure, s.withLogger(ctx), req)
 	if err != nil {
@@ -79,10 +76,7 @@ func (s *sourcePluginAdapter) Start(ctx context.Context, p record.Position) erro
 		return cerrors.New("plugin already running")
 	}
 
-	req, err := toplugin.SourceStartRequest(p)
-	if err != nil {
-		return err
-	}
+	req := toplugin.SourceStartRequest(p)
 
 	s.logger.Trace(ctx).Msg("calling Start")
 	resp, err := runSandbox(s.impl.Start, s.withLogger(ctx), req)
@@ -132,13 +126,10 @@ func (s *sourcePluginAdapter) Ack(ctx context.Context, p record.Position) error 
 		return plugin.ErrStreamNotOpen
 	}
 
-	req, err := toplugin.SourceRunRequest(p)
-	if err != nil {
-		return err
-	}
+	req := toplugin.SourceRunRequest(p)
 
 	s.logger.Trace(ctx).Msg("sending ack")
-	err = s.stream.sendInternal(req)
+	err := s.stream.sendInternal(req)
 	if err != nil {
 		return cerrors.Errorf("builtin plugin send failed: %w", err)
 	}
@@ -167,6 +158,39 @@ func (s *sourcePluginAdapter) Stop(ctx context.Context) (record.Position, error)
 func (s *sourcePluginAdapter) Teardown(ctx context.Context) error {
 	s.logger.Trace(ctx).Msg("calling Teardown")
 	resp, err := runSandbox(s.impl.Teardown, s.withLogger(ctx), toplugin.SourceTeardownRequest())
+	if err != nil {
+		return err
+	}
+	_ = resp // empty response
+
+	return nil
+}
+
+func (s *sourcePluginAdapter) LifecycleOnCreated(ctx context.Context, cfg map[string]string) error {
+	s.logger.Trace(ctx).Msg("calling LifecycleOnCreated")
+	resp, err := runSandbox(s.impl.LifecycleOnCreated, s.withLogger(ctx), toplugin.SourceLifecycleOnCreatedRequest(cfg))
+	if err != nil {
+		return err
+	}
+	_ = resp // empty response
+
+	return nil
+}
+
+func (s *sourcePluginAdapter) LifecycleOnUpdated(ctx context.Context, cfgBefore, cfgAfter map[string]string) error {
+	s.logger.Trace(ctx).Msg("calling LifecycleOnUpdated")
+	resp, err := runSandbox(s.impl.LifecycleOnUpdated, s.withLogger(ctx), toplugin.SourceLifecycleOnUpdatedRequest(cfgBefore, cfgAfter))
+	if err != nil {
+		return err
+	}
+	_ = resp // empty response
+
+	return nil
+}
+
+func (s *sourcePluginAdapter) LifecycleOnDeleted(ctx context.Context, cfg map[string]string) error {
+	s.logger.Trace(ctx).Msg("calling LifecycleOnDeleted")
+	resp, err := runSandbox(s.impl.LifecycleOnDeleted, s.withLogger(ctx), toplugin.SourceLifecycleOnDeletedRequest(cfg))
 	if err != nil {
 		return err
 	}

--- a/pkg/plugin/builtin/v1/source.go
+++ b/pkg/plugin/builtin/v1/source.go
@@ -58,16 +58,8 @@ func (s *sourcePluginAdapter) withLogger(ctx context.Context) context.Context {
 }
 
 func (s *sourcePluginAdapter) Configure(ctx context.Context, cfg map[string]string) error {
-	req := toplugin.SourceConfigureRequest(cfg)
 	s.logger.Trace(ctx).Msg("calling Configure")
-	resp, err := runSandbox(s.impl.Configure, s.withLogger(ctx), req)
-	if err != nil {
-		// TODO create new errors as strings, this happens when they are
-		//  transmitted through gRPC and we don't want to falsely rely on types
-		//  in built-in plugins
-		return err
-	}
-	_ = resp // empty response
+	_, err := runSandbox(s.impl.Configure, s.withLogger(ctx), toplugin.SourceConfigureRequest(cfg))
 	return err
 }
 
@@ -99,7 +91,7 @@ func (s *sourcePluginAdapter) Start(ctx context.Context, p record.Position) erro
 		s.logger.Trace(ctx).Msg("Run stopped")
 	}()
 
-	return err
+	return nil
 }
 
 func (s *sourcePluginAdapter) Read(ctx context.Context) (record.Record, error) {
@@ -147,56 +139,31 @@ func (s *sourcePluginAdapter) Stop(ctx context.Context) (record.Position, error)
 	if err != nil {
 		return nil, err
 	}
-	out, err := fromplugin.SourceStopResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	return out, nil
+	return fromplugin.SourceStopResponse(resp)
 }
 
 func (s *sourcePluginAdapter) Teardown(ctx context.Context) error {
 	s.logger.Trace(ctx).Msg("calling Teardown")
-	resp, err := runSandbox(s.impl.Teardown, s.withLogger(ctx), toplugin.SourceTeardownRequest())
-	if err != nil {
-		return err
-	}
-	_ = resp // empty response
-
-	return nil
+	_, err := runSandbox(s.impl.Teardown, s.withLogger(ctx), toplugin.SourceTeardownRequest())
+	return err
 }
 
 func (s *sourcePluginAdapter) LifecycleOnCreated(ctx context.Context, cfg map[string]string) error {
 	s.logger.Trace(ctx).Msg("calling LifecycleOnCreated")
-	resp, err := runSandbox(s.impl.LifecycleOnCreated, s.withLogger(ctx), toplugin.SourceLifecycleOnCreatedRequest(cfg))
-	if err != nil {
-		return err
-	}
-	_ = resp // empty response
-
-	return nil
+	_, err := runSandbox(s.impl.LifecycleOnCreated, s.withLogger(ctx), toplugin.SourceLifecycleOnCreatedRequest(cfg))
+	return err
 }
 
 func (s *sourcePluginAdapter) LifecycleOnUpdated(ctx context.Context, cfgBefore, cfgAfter map[string]string) error {
 	s.logger.Trace(ctx).Msg("calling LifecycleOnUpdated")
-	resp, err := runSandbox(s.impl.LifecycleOnUpdated, s.withLogger(ctx), toplugin.SourceLifecycleOnUpdatedRequest(cfgBefore, cfgAfter))
-	if err != nil {
-		return err
-	}
-	_ = resp // empty response
-
-	return nil
+	_, err := runSandbox(s.impl.LifecycleOnUpdated, s.withLogger(ctx), toplugin.SourceLifecycleOnUpdatedRequest(cfgBefore, cfgAfter))
+	return err
 }
 
 func (s *sourcePluginAdapter) LifecycleOnDeleted(ctx context.Context, cfg map[string]string) error {
 	s.logger.Trace(ctx).Msg("calling LifecycleOnDeleted")
-	resp, err := runSandbox(s.impl.LifecycleOnDeleted, s.withLogger(ctx), toplugin.SourceLifecycleOnDeletedRequest(cfg))
-	if err != nil {
-		return err
-	}
-	_ = resp // empty response
-
-	return nil
+	_, err := runSandbox(s.impl.LifecycleOnDeleted, s.withLogger(ctx), toplugin.SourceLifecycleOnDeletedRequest(cfg))
+	return err
 }
 
 func newSourceRunStream(ctx context.Context) *stream[cpluginv1.SourceRunRequest, cpluginv1.SourceRunResponse] {

--- a/pkg/plugin/errors.go
+++ b/pkg/plugin/errors.go
@@ -23,8 +23,8 @@ import (
 var (
 	ErrStreamNotOpen    = cerrors.New("stream not open")
 	ErrPluginNotFound   = cerrors.New("plugin not found")
-	ErrPluginRunning    = cerrors.New("plugin is running")
 	ErrPluginNotRunning = cerrors.New("plugin is not running")
+	ErrUnimplemented    = cerrors.New("method not implemented")
 )
 
 type ValidationError struct {

--- a/pkg/plugin/mock/plugin.go
+++ b/pkg/plugin/mock/plugin.go
@@ -133,6 +133,48 @@ func (mr *DestinationPluginMockRecorder) Configure(arg0, arg1 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Configure", reflect.TypeOf((*DestinationPlugin)(nil).Configure), arg0, arg1)
 }
 
+// LifecycleOnCreated mocks base method.
+func (m *DestinationPlugin) LifecycleOnCreated(arg0 context.Context, arg1 map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LifecycleOnCreated", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LifecycleOnCreated indicates an expected call of LifecycleOnCreated.
+func (mr *DestinationPluginMockRecorder) LifecycleOnCreated(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LifecycleOnCreated", reflect.TypeOf((*DestinationPlugin)(nil).LifecycleOnCreated), arg0, arg1)
+}
+
+// LifecycleOnDeleted mocks base method.
+func (m *DestinationPlugin) LifecycleOnDeleted(arg0 context.Context, arg1 map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LifecycleOnDeleted", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LifecycleOnDeleted indicates an expected call of LifecycleOnDeleted.
+func (mr *DestinationPluginMockRecorder) LifecycleOnDeleted(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LifecycleOnDeleted", reflect.TypeOf((*DestinationPlugin)(nil).LifecycleOnDeleted), arg0, arg1)
+}
+
+// LifecycleOnUpdated mocks base method.
+func (m *DestinationPlugin) LifecycleOnUpdated(arg0 context.Context, arg1, arg2 map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LifecycleOnUpdated", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LifecycleOnUpdated indicates an expected call of LifecycleOnUpdated.
+func (mr *DestinationPluginMockRecorder) LifecycleOnUpdated(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LifecycleOnUpdated", reflect.TypeOf((*DestinationPlugin)(nil).LifecycleOnUpdated), arg0, arg1, arg2)
+}
+
 // Start mocks base method.
 func (m *DestinationPlugin) Start(arg0 context.Context) error {
 	m.ctrl.T.Helper()
@@ -238,6 +280,48 @@ func (m *SourcePlugin) Configure(arg0 context.Context, arg1 map[string]string) e
 func (mr *SourcePluginMockRecorder) Configure(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Configure", reflect.TypeOf((*SourcePlugin)(nil).Configure), arg0, arg1)
+}
+
+// LifecycleOnCreated mocks base method.
+func (m *SourcePlugin) LifecycleOnCreated(arg0 context.Context, arg1 map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LifecycleOnCreated", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LifecycleOnCreated indicates an expected call of LifecycleOnCreated.
+func (mr *SourcePluginMockRecorder) LifecycleOnCreated(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LifecycleOnCreated", reflect.TypeOf((*SourcePlugin)(nil).LifecycleOnCreated), arg0, arg1)
+}
+
+// LifecycleOnDeleted mocks base method.
+func (m *SourcePlugin) LifecycleOnDeleted(arg0 context.Context, arg1 map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LifecycleOnDeleted", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LifecycleOnDeleted indicates an expected call of LifecycleOnDeleted.
+func (mr *SourcePluginMockRecorder) LifecycleOnDeleted(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LifecycleOnDeleted", reflect.TypeOf((*SourcePlugin)(nil).LifecycleOnDeleted), arg0, arg1)
+}
+
+// LifecycleOnUpdated mocks base method.
+func (m *SourcePlugin) LifecycleOnUpdated(arg0 context.Context, arg1, arg2 map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LifecycleOnUpdated", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LifecycleOnUpdated indicates an expected call of LifecycleOnUpdated.
+func (mr *SourcePluginMockRecorder) LifecycleOnUpdated(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LifecycleOnUpdated", reflect.TypeOf((*SourcePlugin)(nil).LifecycleOnUpdated), arg0, arg1, arg2)
 }
 
 // Read mocks base method.

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -70,6 +70,18 @@ type SourcePlugin interface {
 	// plugin. It signals to the plugin it can release any open resources and
 	// prepare for a graceful shutdown.
 	Teardown(context.Context) error
+
+	// LifecycleOnCreated should be called after Configure and before Start when
+	// the connector is run for the first time. This call should be skipped if
+	// the connector was already started before.
+	LifecycleOnCreated(ctx context.Context, cfg map[string]string) error
+	// LifecycleOnUpdated should be called after Configure and before Start when
+	// the connector configuration has changed since the last run. This call
+	// should be skipped if the connector configuration did not change.
+	LifecycleOnUpdated(ctx context.Context, cfgBefore, cfgAfter map[string]string) error
+	// LifecycleOnDeleted should be called when the connector was deleted. It
+	// should be the only method that is called in that case.
+	LifecycleOnDeleted(ctx context.Context, cfg map[string]string) error
 }
 
 type DestinationPlugin interface {
@@ -117,6 +129,18 @@ type DestinationPlugin interface {
 	// plugin. It signals to the plugin it can release any open resources and
 	// prepare for a graceful shutdown.
 	Teardown(context.Context) error
+
+	// LifecycleOnCreated should be called after Configure and before Start when
+	// the connector is run for the first time. This call should be skipped if
+	// the connector was already started before.
+	LifecycleOnCreated(ctx context.Context, cfg map[string]string) error
+	// LifecycleOnUpdated should be called after Configure and before Start when
+	// the connector configuration has changed since the last run. This call
+	// should be skipped if the connector configuration did not change.
+	LifecycleOnUpdated(ctx context.Context, cfgBefore, cfgAfter map[string]string) error
+	// LifecycleOnDeleted should be called when the connector was deleted. It
+	// should be the only method that is called in that case.
+	LifecycleOnDeleted(ctx context.Context, cfg map[string]string) error
 }
 
 type SpecifierPlugin interface {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -79,7 +79,7 @@ type SourcePlugin interface {
 	// the connector configuration has changed since the last run. This call
 	// should be skipped if the connector configuration did not change.
 	LifecycleOnUpdated(ctx context.Context, cfgBefore, cfgAfter map[string]string) error
-	// LifecycleOnDeleted should be called when the connector was deleted. It
+	// LifecycleOnDeleted should be called when the connector is deleted. It
 	// should be the only method that is called in that case.
 	LifecycleOnDeleted(ctx context.Context, cfg map[string]string) error
 }

--- a/pkg/plugin/standalone/v1/client.go
+++ b/pkg/plugin/standalone/v1/client.go
@@ -21,8 +21,10 @@ import (
 	"os/exec"
 
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	cplugin "github.com/conduitio/conduit/pkg/plugin"
 	"github.com/hashicorp/go-plugin"
 	"github.com/rs/zerolog"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -153,6 +155,9 @@ func unwrapGRPCError(err error) error {
 	st, ok := status.FromError(err)
 	if !ok {
 		return err
+	}
+	if st.Code() == codes.Unimplemented {
+		return cerrors.Errorf("%s: %w", st.Message(), cplugin.ErrUnimplemented)
 	}
 	if knownErr, ok := knownErrors[st.Message()]; ok {
 		return knownErr

--- a/pkg/plugin/standalone/v1/destination.go
+++ b/pkg/plugin/standalone/v1/destination.go
@@ -53,21 +53,19 @@ var _ plugin.DestinationPlugin = (*destinationPluginClient)(nil)
 
 func (s *destinationPluginClient) Configure(ctx context.Context, cfg map[string]string) error {
 	protoReq := toproto.DestinationConfigureRequest(cfg)
-	protoResp, err := s.grpcClient.Configure(ctx, protoReq)
+	_, err := s.grpcClient.Configure(ctx, protoReq)
 	if err != nil {
 		return unwrapGRPCError(err)
 	}
-	_ = protoResp // response is empty
 	return nil
 }
 
 func (s *destinationPluginClient) Start(ctx context.Context) error {
 	protoReq := toproto.DestinationStartRequest()
-	protoResp, err := s.grpcClient.Start(ctx, protoReq)
+	_, err := s.grpcClient.Start(ctx, protoReq)
 	if err != nil {
 		return unwrapGRPCError(err)
 	}
-	_ = protoResp // response is empty
 
 	s.stream, err = s.grpcClient.Run(ctx)
 	if err != nil {
@@ -125,53 +123,43 @@ func (s *destinationPluginClient) Stop(ctx context.Context, lastPosition record.
 	}
 
 	protoReq := toproto.DestinationStopRequest(lastPosition)
-	protoResp, err := s.grpcClient.Stop(ctx, protoReq)
+	_, err := s.grpcClient.Stop(ctx, protoReq)
 	if err != nil {
 		return unwrapGRPCError(err)
 	}
-	_ = protoResp // response is empty
-
 	return nil
 }
 
 func (s *destinationPluginClient) Teardown(ctx context.Context) error {
 	protoReq := toproto.DestinationTeardownRequest()
-	protoResp, err := s.grpcClient.Teardown(ctx, protoReq)
+	_, err := s.grpcClient.Teardown(ctx, protoReq)
 	if err != nil {
 		return unwrapGRPCError(err)
 	}
-	_ = protoResp // response is empty
-
 	return nil
 }
 
 func (s *destinationPluginClient) LifecycleOnCreated(ctx context.Context, cfg map[string]string) error {
 	protoReq := toproto.DestinationLifecycleOnCreatedRequest(cfg)
-	protoResp, err := s.grpcClient.LifecycleOnCreated(ctx, protoReq)
+	_, err := s.grpcClient.LifecycleOnCreated(ctx, protoReq)
 	if err != nil {
 		return unwrapGRPCError(err)
 	}
-	_ = protoResp // response is empty
-
 	return nil
 }
 func (s *destinationPluginClient) LifecycleOnUpdated(ctx context.Context, cfgBefore map[string]string, cfgAfter map[string]string) error {
 	protoReq := toproto.DestinationLifecycleOnUpdatedRequest(cfgBefore, cfgAfter)
-	protoResp, err := s.grpcClient.LifecycleOnUpdated(ctx, protoReq)
+	_, err := s.grpcClient.LifecycleOnUpdated(ctx, protoReq)
 	if err != nil {
 		return unwrapGRPCError(err)
 	}
-	_ = protoResp // response is empty
-
 	return nil
 }
 func (s *destinationPluginClient) LifecycleOnDeleted(ctx context.Context, cfg map[string]string) error {
 	protoReq := toproto.DestinationLifecycleOnDeletedRequest(cfg)
-	protoResp, err := s.grpcClient.LifecycleOnDeleted(ctx, protoReq)
+	_, err := s.grpcClient.LifecycleOnDeleted(ctx, protoReq)
 	if err != nil {
 		return unwrapGRPCError(err)
 	}
-	_ = protoResp // response is empty
-
 	return nil
 }

--- a/pkg/plugin/standalone/v1/destination.go
+++ b/pkg/plugin/standalone/v1/destination.go
@@ -52,10 +52,7 @@ type destinationPluginClient struct {
 var _ plugin.DestinationPlugin = (*destinationPluginClient)(nil)
 
 func (s *destinationPluginClient) Configure(ctx context.Context, cfg map[string]string) error {
-	protoReq, err := toproto.DestinationConfigureRequest(cfg)
-	if err != nil {
-		return err
-	}
+	protoReq := toproto.DestinationConfigureRequest(cfg)
 	protoResp, err := s.grpcClient.Configure(ctx, protoReq)
 	if err != nil {
 		return unwrapGRPCError(err)
@@ -140,6 +137,37 @@ func (s *destinationPluginClient) Stop(ctx context.Context, lastPosition record.
 func (s *destinationPluginClient) Teardown(ctx context.Context) error {
 	protoReq := toproto.DestinationTeardownRequest()
 	protoResp, err := s.grpcClient.Teardown(ctx, protoReq)
+	if err != nil {
+		return unwrapGRPCError(err)
+	}
+	_ = protoResp // response is empty
+
+	return nil
+}
+
+func (s *destinationPluginClient) LifecycleOnCreated(ctx context.Context, cfg map[string]string) error {
+	protoReq := toproto.DestinationLifecycleOnCreatedRequest(cfg)
+	protoResp, err := s.grpcClient.LifecycleOnCreated(ctx, protoReq)
+	if err != nil {
+		return unwrapGRPCError(err)
+	}
+	_ = protoResp // response is empty
+
+	return nil
+}
+func (s *destinationPluginClient) LifecycleOnUpdated(ctx context.Context, cfgBefore map[string]string, cfgAfter map[string]string) error {
+	protoReq := toproto.DestinationLifecycleOnUpdatedRequest(cfgBefore, cfgAfter)
+	protoResp, err := s.grpcClient.LifecycleOnUpdated(ctx, protoReq)
+	if err != nil {
+		return unwrapGRPCError(err)
+	}
+	_ = protoResp // response is empty
+
+	return nil
+}
+func (s *destinationPluginClient) LifecycleOnDeleted(ctx context.Context, cfg map[string]string) error {
+	protoReq := toproto.DestinationLifecycleOnDeletedRequest(cfg)
+	protoResp, err := s.grpcClient.LifecycleOnDeleted(ctx, protoReq)
 	if err != nil {
 		return unwrapGRPCError(err)
 	}

--- a/pkg/plugin/standalone/v1/internal/toproto/destination.go
+++ b/pkg/plugin/standalone/v1/internal/toproto/destination.go
@@ -19,11 +19,10 @@ import (
 	"github.com/conduitio/conduit/pkg/record"
 )
 
-func DestinationConfigureRequest(in map[string]string) (*connectorv1.Destination_Configure_Request, error) {
-	out := connectorv1.Destination_Configure_Request{
+func DestinationConfigureRequest(in map[string]string) *connectorv1.Destination_Configure_Request {
+	return &connectorv1.Destination_Configure_Request{
 		Config: in,
 	}
-	return &out, nil
 }
 
 func DestinationStartRequest() *connectorv1.Destination_Start_Request {
@@ -49,4 +48,23 @@ func DestinationStopRequest(in record.Position) *connectorv1.Destination_Stop_Re
 
 func DestinationTeardownRequest() *connectorv1.Destination_Teardown_Request {
 	return &connectorv1.Destination_Teardown_Request{}
+}
+
+func DestinationLifecycleOnCreatedRequest(cfg map[string]string) *connectorv1.Destination_Lifecycle_OnCreated_Request {
+	return &connectorv1.Destination_Lifecycle_OnCreated_Request{
+		Config: cfg,
+	}
+}
+
+func DestinationLifecycleOnUpdatedRequest(cfgBefore, cfgAfter map[string]string) *connectorv1.Destination_Lifecycle_OnUpdated_Request {
+	return &connectorv1.Destination_Lifecycle_OnUpdated_Request{
+		ConfigBefore: cfgBefore,
+		ConfigAfter:  cfgAfter,
+	}
+}
+
+func DestinationLifecycleOnDeletedRequest(cfg map[string]string) *connectorv1.Destination_Lifecycle_OnDeleted_Request {
+	return &connectorv1.Destination_Lifecycle_OnDeleted_Request{
+		Config: cfg,
+	}
 }

--- a/pkg/plugin/standalone/v1/internal/toproto/source.go
+++ b/pkg/plugin/standalone/v1/internal/toproto/source.go
@@ -19,25 +19,22 @@ import (
 	"github.com/conduitio/conduit/pkg/record"
 )
 
-func SourceConfigureRequest(in map[string]string) (*connectorv1.Source_Configure_Request, error) {
-	out := connectorv1.Source_Configure_Request{
+func SourceConfigureRequest(in map[string]string) *connectorv1.Source_Configure_Request {
+	return &connectorv1.Source_Configure_Request{
 		Config: in,
 	}
-	return &out, nil
 }
 
-func SourceStartRequest(in record.Position) (*connectorv1.Source_Start_Request, error) {
-	out := connectorv1.Source_Start_Request{
+func SourceStartRequest(in record.Position) *connectorv1.Source_Start_Request {
+	return &connectorv1.Source_Start_Request{
 		Position: in,
 	}
-	return &out, nil
 }
 
-func SourceRunRequest(in record.Position) (*connectorv1.Source_Run_Request, error) {
-	out := connectorv1.Source_Run_Request{
+func SourceRunRequest(in record.Position) *connectorv1.Source_Run_Request {
+	return &connectorv1.Source_Run_Request{
 		AckPosition: in,
 	}
-	return &out, nil
 }
 
 func SourceStopRequest() *connectorv1.Source_Stop_Request {
@@ -46,4 +43,23 @@ func SourceStopRequest() *connectorv1.Source_Stop_Request {
 
 func SourceTeardownRequest() *connectorv1.Source_Teardown_Request {
 	return &connectorv1.Source_Teardown_Request{}
+}
+
+func SourceLifecycleOnCreatedRequest(cfg map[string]string) *connectorv1.Source_Lifecycle_OnCreated_Request {
+	return &connectorv1.Source_Lifecycle_OnCreated_Request{
+		Config: cfg,
+	}
+}
+
+func SourceLifecycleOnUpdatedRequest(cfgBefore, cfgAfter map[string]string) *connectorv1.Source_Lifecycle_OnUpdated_Request {
+	return &connectorv1.Source_Lifecycle_OnUpdated_Request{
+		ConfigBefore: cfgBefore,
+		ConfigAfter:  cfgAfter,
+	}
+}
+
+func SourceLifecycleOnDeletedRequest(cfg map[string]string) *connectorv1.Source_Lifecycle_OnDeleted_Request {
+	return &connectorv1.Source_Lifecycle_OnDeleted_Request{
+		Config: cfg,
+	}
 }

--- a/pkg/plugin/standalone/v1/source.go
+++ b/pkg/plugin/standalone/v1/source.go
@@ -52,10 +52,7 @@ type sourcePluginClient struct {
 var _ plugin.SourcePlugin = (*sourcePluginClient)(nil)
 
 func (s *sourcePluginClient) Configure(ctx context.Context, cfg map[string]string) error {
-	protoReq, err := toproto.SourceConfigureRequest(cfg)
-	if err != nil {
-		return err
-	}
+	protoReq := toproto.SourceConfigureRequest(cfg)
 	protoResp, err := s.grpcClient.Configure(ctx, protoReq)
 	if err != nil {
 		return unwrapGRPCError(err)
@@ -65,10 +62,7 @@ func (s *sourcePluginClient) Configure(ctx context.Context, cfg map[string]strin
 }
 
 func (s *sourcePluginClient) Start(ctx context.Context, p record.Position) error {
-	protoReq, err := toproto.SourceStartRequest(p)
-	if err != nil {
-		return err
-	}
+	protoReq := toproto.SourceStartRequest(p)
 	protoResp, err := s.grpcClient.Start(ctx, protoReq)
 	if err != nil {
 		return unwrapGRPCError(err)
@@ -107,12 +101,8 @@ func (s *sourcePluginClient) Ack(ctx context.Context, p record.Position) error {
 		return plugin.ErrStreamNotOpen
 	}
 
-	protoReq, err := toproto.SourceRunRequest(p)
-	if err != nil {
-		return err
-	}
-
-	err = s.stream.Send(protoReq)
+	protoReq := toproto.SourceRunRequest(p)
+	err := s.stream.Send(protoReq)
 	if err != nil {
 		if err == io.EOF {
 			// stream was gracefully closed
@@ -143,6 +133,37 @@ func (s *sourcePluginClient) Stop(ctx context.Context) (record.Position, error) 
 func (s *sourcePluginClient) Teardown(ctx context.Context) error {
 	protoReq := toproto.SourceTeardownRequest()
 	protoResp, err := s.grpcClient.Teardown(ctx, protoReq)
+	if err != nil {
+		return unwrapGRPCError(err)
+	}
+	_ = protoResp // response is empty
+
+	return nil
+}
+
+func (s *sourcePluginClient) LifecycleOnCreated(ctx context.Context, cfg map[string]string) error {
+	protoReq := toproto.SourceLifecycleOnCreatedRequest(cfg)
+	protoResp, err := s.grpcClient.LifecycleOnCreated(ctx, protoReq)
+	if err != nil {
+		return unwrapGRPCError(err)
+	}
+	_ = protoResp // response is empty
+
+	return nil
+}
+func (s *sourcePluginClient) LifecycleOnUpdated(ctx context.Context, cfgBefore map[string]string, cfgAfter map[string]string) error {
+	protoReq := toproto.SourceLifecycleOnUpdatedRequest(cfgBefore, cfgAfter)
+	protoResp, err := s.grpcClient.LifecycleOnUpdated(ctx, protoReq)
+	if err != nil {
+		return unwrapGRPCError(err)
+	}
+	_ = protoResp // response is empty
+
+	return nil
+}
+func (s *sourcePluginClient) LifecycleOnDeleted(ctx context.Context, cfg map[string]string) error {
+	protoReq := toproto.SourceLifecycleOnDeletedRequest(cfg)
+	protoResp, err := s.grpcClient.LifecycleOnDeleted(ctx, protoReq)
 	if err != nil {
 		return unwrapGRPCError(err)
 	}

--- a/pkg/plugin/standalone/v1/source.go
+++ b/pkg/plugin/standalone/v1/source.go
@@ -53,21 +53,19 @@ var _ plugin.SourcePlugin = (*sourcePluginClient)(nil)
 
 func (s *sourcePluginClient) Configure(ctx context.Context, cfg map[string]string) error {
 	protoReq := toproto.SourceConfigureRequest(cfg)
-	protoResp, err := s.grpcClient.Configure(ctx, protoReq)
+	_, err := s.grpcClient.Configure(ctx, protoReq)
 	if err != nil {
 		return unwrapGRPCError(err)
 	}
-	_ = protoResp // response is empty
 	return nil
 }
 
 func (s *sourcePluginClient) Start(ctx context.Context, p record.Position) error {
 	protoReq := toproto.SourceStartRequest(p)
-	protoResp, err := s.grpcClient.Start(ctx, protoReq)
+	_, err := s.grpcClient.Start(ctx, protoReq)
 	if err != nil {
 		return unwrapGRPCError(err)
 	}
-	_ = protoResp // response is empty
 
 	s.stream, err = s.grpcClient.Run(ctx)
 	if err != nil {
@@ -132,42 +130,34 @@ func (s *sourcePluginClient) Stop(ctx context.Context) (record.Position, error) 
 
 func (s *sourcePluginClient) Teardown(ctx context.Context) error {
 	protoReq := toproto.SourceTeardownRequest()
-	protoResp, err := s.grpcClient.Teardown(ctx, protoReq)
+	_, err := s.grpcClient.Teardown(ctx, protoReq)
 	if err != nil {
 		return unwrapGRPCError(err)
 	}
-	_ = protoResp // response is empty
-
 	return nil
 }
 
 func (s *sourcePluginClient) LifecycleOnCreated(ctx context.Context, cfg map[string]string) error {
 	protoReq := toproto.SourceLifecycleOnCreatedRequest(cfg)
-	protoResp, err := s.grpcClient.LifecycleOnCreated(ctx, protoReq)
+	_, err := s.grpcClient.LifecycleOnCreated(ctx, protoReq)
 	if err != nil {
 		return unwrapGRPCError(err)
 	}
-	_ = protoResp // response is empty
-
 	return nil
 }
 func (s *sourcePluginClient) LifecycleOnUpdated(ctx context.Context, cfgBefore map[string]string, cfgAfter map[string]string) error {
 	protoReq := toproto.SourceLifecycleOnUpdatedRequest(cfgBefore, cfgAfter)
-	protoResp, err := s.grpcClient.LifecycleOnUpdated(ctx, protoReq)
+	_, err := s.grpcClient.LifecycleOnUpdated(ctx, protoReq)
 	if err != nil {
 		return unwrapGRPCError(err)
 	}
-	_ = protoResp // response is empty
-
 	return nil
 }
 func (s *sourcePluginClient) LifecycleOnDeleted(ctx context.Context, cfg map[string]string) error {
 	protoReq := toproto.SourceLifecycleOnDeletedRequest(cfg)
-	protoResp, err := s.grpcClient.LifecycleOnDeleted(ctx, protoReq)
+	_, err := s.grpcClient.LifecycleOnDeleted(ctx, protoReq)
 	if err != nil {
 		return unwrapGRPCError(err)
 	}
-	_ = protoResp // response is empty
-
 	return nil
 }


### PR DESCRIPTION
### Description

This PR is the follow-up to https://github.com/ConduitIO/conduit-connector-protocol/pull/22, where connector lifecycle events were added to the connector protocol. In this PR we expose those methods in Conduit so it can produce these events (coming in the next PR).

Fixes #937

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.