### PR TITLE
parsejson processor fix

### DIFF
--- a/pkg/processor/procbuiltin/parsejson.go
+++ b/pkg/processor/procbuiltin/parsejson.go
@@ -35,18 +35,17 @@ func init() {
 
 // ParseJSONKey parses the record key from raw to structured data
 func ParseJSONKey(config processor.Config) (processor.Interface, error) {
-	return parseJSON(parseJSONKeyProcType, recordKeyGetSetter{}, config)
+	return parseJSON(parseJSONKeyProcType, recordKeyGetSetter{})
 }
 
 // ParseJSONPayload parses the record payload from raw to structured data
 func ParseJSONPayload(config processor.Config) (processor.Interface, error) {
-	return parseJSON(parseJSONPayloadProcType, recordPayloadGetSetter{}, config)
+	return parseJSON(parseJSONPayloadProcType, recordPayloadGetSetter{})
 }
 
 func parseJSON(
 	processorType string,
 	getSetter recordDataGetSetter,
-	config processor.Config,
 ) (processor.Interface, error) {
 	return NewFuncWrapper(func(_ context.Context, r record.Record) (record.Record, error) {
 		data := getSetter.Get(r)

--- a/pkg/processor/procbuiltin/parsejson.go
+++ b/pkg/processor/procbuiltin/parsejson.go
@@ -54,6 +54,11 @@ func parseJSON(
 		switch data.(type) {
 		case record.RawData:
 			var jsonData record.StructuredData
+			if len(data.Bytes()) == 0 {
+				// change empty raw data to empty structured data
+				r = getSetter.Set(r, jsonData)
+				return r, nil
+			}
 			err := json.Unmarshal(data.Bytes(), &jsonData)
 			if err != nil {
 				return record.Record{}, cerrors.Errorf("%s: failed to unmarshal raw data as JSON: %w", processorType, err)

--- a/pkg/processor/procbuiltin/parsejson_test.go
+++ b/pkg/processor/procbuiltin/parsejson_test.go
@@ -159,6 +159,21 @@ func TestParseJSONPayload_Process(t *testing.T) {
 				},
 			}},
 		wantErr: true,
+	}, {
+		name: "empty raw data parsed into empty structured data",
+		record: record.Record{
+			Payload: record.Change{
+				Before: nil,
+				After:  record.RawData{},
+			},
+		},
+		want: record.Record{
+			Payload: record.Change{
+				Before: nil,
+				After:  record.StructuredData(nil),
+			},
+		},
+		wantErr: false,
 	},
 	}
 


### PR DESCRIPTION
### Description

for the parsejson processor, we accept the payload being nil, but if it's an empty rawData then it fails.
we should still convert rawData to structuredData if it was empty.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.