### PR TITLE
docs(connectors): add section about adding built-in connectors

### DIFF
--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -46,7 +46,7 @@ Once you have chosen a connector to be built-in, you can:
 
 - Import the Go module defining the connector
 into the [builtin registry](https://github.com/ConduitIO/conduit/blob/main/pkg/plugin/builtin/registry.go)
-and add a new key to the `DispenserFactory`:
+and add a new key to `DefaultDispenserFactories `:
 
 ```go
 package builtin

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -44,18 +44,19 @@ Alternatively, you can also create your own
 
 Once you have chosen a connector to be built-in, you can:
 
+- Download the new package and its dependencies: `go get "github.com/foo/conduit-connector-new"`
 - Import the Go module defining the connector
 into the [builtin registry](https://github.com/ConduitIO/conduit/blob/main/pkg/plugin/builtin/registry.go)
-and add a new key to `DefaultDispenserFactories `:
+and add a new key to `DefaultDispenserFactories`:
 
-```go
+```diff
 package builtin
 
 import (
   // ...
   file "github.com/conduitio/conduit-connector-file"
   // ...
-  myNewConnector "github.com/foo/conduit-connector-new"
++ myNewConnector "github.com/foo/conduit-connector-new"
 )
 
 var (
@@ -65,12 +66,11 @@ var (
   DefaultDispenserFactories = map[string]DispenserFactory{
     "github.com/conduitio/conduit-connector-file":    sdkDispenserFactory(file.Connector),
     // ...
-    "github.com/foo/conduit-connector-new":           sdkDispenserFactory(myNewConnector.Connector),
++   "github.com/foo/conduit-connector-new":           sdkDispenserFactory(myNewConnector.Connector),
   }
 )
 ```
 
-- Download the new package and its dependencies: `go get "github.com/foo/conduit-connector-new"`
 - Run `make`
 - You now have a binary with your own, custom set of built-in connectors! 🎉
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -71,7 +71,7 @@ var (
 ```
 
 - Download the new package and its dependencies: `go get "github.com/foo/conduit-connector-new"`
-- Re-run `make`
+- Run `make`
 - You now have a binary with your own, custom set of built-in connectors! 🎉
 
 ### Standalone connectors

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -44,7 +44,7 @@ Alternatively, you can also create your own
 
 Once you have chosen a connector to be built-in, you can:
 
-- Import the Github repository defining the connector
+- Import the Go module defining the connector
 into the [builtin registry](https://github.com/ConduitIO/conduit/blob/main/pkg/plugin/builtin/registry.go)
 and add a new key to the `DispenserFactory`:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -1,13 +1,18 @@
 # Conduit Connectors
 
-Connectors are an integral part of Conduit. Conduit ships with a couple of connectors that are built into the service
-to help developers bootstrap pipelines much more quickly. The built-in connectors include Postgres, File, Random Data
-Generator, Kafka and Amazon S3 connectors.
+Connectors are an integral part of Conduit. Conduit ships with a couple of
+[connectors that are directly built into](#built-in-connectors) the service,
+but it can also be expanded with additional
+[standalone connectors](#standalone-connectors).
 
-The difference between Conduit connectors and those you might find from other services is that Conduit connectors are
-Change Data Capture-first (CDC). CDC allows your pipeline to only get the changes that have happened over time instead
-of pulling down an entire upstream data store and then tracking diffs between some period of time. This is critical for
-building real-time event-driven pipelines and applications. But, we'll note where connectors don't have CDC capabilities.
+One of the main differences between Conduit connectors and those that you might find from other services is
+that all Conduit connectors are Change Data Capture-first (CDC).
+
+CDC allows your pipeline to only get the changes that have happened over time
+instead of pulling down an entire upstream data store and then tracking diffs
+between some period of time.
+This is critical for building real-time, event-driven pipelines and applications.
+But, we'll note where connectors do or do not have CDC capabilities.
 
 ## Roadmap & Feedback
 
@@ -18,12 +23,69 @@ Give the issue a `+1` if you really need that connector. The upvote will help th
 particular connector. If you find that an issue hasn't been created for your data store, please create a new issue in
 the Conduit repo.
 
-## Connectors
+## More about Connectors
+
+### Built-in connectors
+
+To help developers bootstrap pipelines much more quickly,
+Conduit ships with several built-in connectors by default.
+This includes the Postgres, File, Random Data Generator, Kafka and Amazon S3 connectors.
+
+If you are creating and distributing customized, pre-built Conduit binaries yourself,
+you may want to modify the list of built-in connectors, too.
+By modifying the list of built-in connectors,
+your compiled binary will include a set of pre-installed connectors specific to your end users' needs,
+and it can be run by others, as is, without them having to follow any additional installation instructions.
+
+If you want to create your own Conduit binary with a different set of built-in connectors,
+you can build-in an [existing standalone connector](#the-list).
+Alternatively, you can also create your own
+[using the Conduit connector template or the Conduit Connector SDK](https://conduit.io/docs/connectors/building/).
+
+Once you have chosen a connector to be built-in, you can:
+
+- Import the Github repository defining the connector
+into the [builtin registry](https://github.com/ConduitIO/conduit/blob/main/pkg/plugin/builtin/registry.go)
+and add a new key to the `DispenserFactory`:
+
+```go
+package builtin
+
+import (
+  // ...
+  file "github.com/conduitio/conduit-connector-file"
+  // ...
+  myNewConnector "github.com/foo/conduit-connector-new"
+)
+
+var (
+  // DefaultDispenserFactories contains default dispenser factories for
+  // built-in plugins. The key of the map is the import path of the module
+  // containing the connector implementation.
+  DefaultDispenserFactories = map[string]DispenserFactory{
+    "github.com/conduitio/conduit-connector-file":    sdkDispenserFactory(file.Connector),
+    // ...
+    "github.com/foo/conduit-connector-new":           sdkDispenserFactory(myNewConnector.Connector),
+  }
+)
+```
+
+- Download the new package and its dependencies: `go get "github.com/foo/conduit-connector-new"`
+- Re-run `make`
+- You now have a binary with your own, custom set of built-in connectors! 🎉
+
+### Standalone connectors
+
+In addition to built-in connectors, Conduit can be used together with standalone connectors
+to enable even more data streaming use cases.
+The Conduit team and other community developers create and maintain standalone connectors.
+
+Learn more about how you can install [standalone connectors to Conduit here](https://conduit.io/docs/connectors/installing).
 
 ### Support Types
 
 - `Conduit` - These are connectors that are built by the Conduit. Any issues or problems filed on those repos will be
-  respond to by the Conduit team.
+  responded to by the Conduit team.
 - `Community` - A community connector is one where a developer created a connector and they're the ones supporting it
   not the Conduit team.
 - `Legacy` - Some connectors are built using non-preferred methods. For example, Kafka Connect connectors can be used

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -38,7 +38,7 @@ your compiled binary will include a set of pre-installed connectors specific to 
 and it can be run by others, as is, without them having to follow any additional installation instructions.
 
 If you want to create your own Conduit binary with a different set of built-in connectors,
-you can build-in an [existing standalone connector](#the-list).
+you can build-in an [existing connector](#the-list).
 Alternatively, you can also create your own
 [using the Conduit connector template or the Conduit Connector SDK](https://conduit.io/docs/connectors/building/).
 


### PR DESCRIPTION
### Description

Following our [discussion on Slack](https://meroxa.slack.com/archives/C01SNJCR9RP/p1682947440427559?thread_ts=1682941993.546719&cid=C01SNJCR9RP), this is adding additional documentation around built-in connectors and how to add them to custom binaries.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.

### Preview

[Preview Link](https://github.com/ConduitIO/conduit/blob/jj/add-docs-for-builtins/docs/connectors.md)