### PR TITLE
Return context when new transaction fails

### DIFF
--- a/pkg/foundation/database/postgres/db.go
+++ b/pkg/foundation/database/postgres/db.go
@@ -121,7 +121,7 @@ func (d *DB) NewTransaction(ctx context.Context, update bool) (database.Transact
 
 	pgxTx, err := d.pool.BeginTx(ctx, pgx.TxOptions{AccessMode: accessMode})
 	if err != nil {
-		return nil, nil, cerrors.Errorf("could not begin transaction: %w", err)
+		return nil, ctx, cerrors.Errorf("could not begin transaction: %w", err)
 	}
 
 	txn := &Txn{


### PR DESCRIPTION
### Description

If we fail to create a new DB transaction we should still return a valid context, otherwise the caller might end up with a `nil` context. I noticed it [here](https://github.com/ConduitIO/conduit/blob/0697903beb6664daef13e0678c979e079fc2e319/pkg/connector/persister.go#L178) where we use the context to log and the empty context caused a panic in one of the logger hooks.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.