### PR TITLE
Don't ignore .git folder in docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 .github
 .gitignore
 .golangci.goheader.template
@@ -11,3 +10,5 @@ conduit.db
 docs
 examples
 githooks
+scripts
+test


### PR DESCRIPTION
### Description

This makes sure our docker build includes the `.git` folder, which should give us access to the git tag and let us build the version string 🤞

Fixes (hopefully) https://github.com/ConduitIO/conduit/issues/895