### PR TITLE
build(actions): match node version for ember

### DIFF
--- a/.github/workflows/ui-code-coverage.yml
+++ b/.github/workflows/ui-code-coverage.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Use Node
       uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: '16'
     - name: Install dependencies
       run: make ui-dependencies
     - uses: mydea/ember-cli-code-coverage-action@4d49818fff56371e4fdacdfbb1c00573f4cdda01

--- a/.github/workflows/ui-lint.yml
+++ b/.github/workflows/ui-lint.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
 
       - name: Install dependencies
         run: make ui-dependencies

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
 
       - name: Install dependencies
         run: make ui-dependencies


### PR DESCRIPTION
### Description
Make sure we are using node 16 in gh actions

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.