### PR TITLE
doc: add mongodb connector

### DIFF
--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -117,7 +117,7 @@ to write to a downstream data store.
 | [Kafka Connect Wrapper](https://github.com/ConduitIO/conduit-kafka-connect-wrapper) | ✅ | ✅ | Legacy |v0.3.0|
 | [Marketo](https://github.com/conduitio-labs/conduit-connector-marketo) |✅ | | Community |v0.3.0|
 | [Materialize](https://github.com/conduitio-labs/conduit-connector-materialize) | |✅ | Community |v0.3.0|
-| [MongoDB](https://github.com/conduitio-labs/conduit-connector-mongo) | |✅ | Conduit |v0.6.0|
+| [MongoDB](https://github.com/conduitio-labs/conduit-connector-mongo) | |✅ | Community |v0.6.0|
 | [Nats Jetstream](https://github.com/conduitio-labs/conduit-connector-nats-jetstream) |✅ |✅ | Community |v0.3.0|
 | [Nats PubSub](https://github.com/conduitio-labs/conduit-connector-nats-pubsub) |✅|✅ | Community |v0.3.0|
 | [Oracle DB](https://github.com/conduitio-labs/conduit-connector-oracle) |WIP|WIP| Community |WIP|

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -117,7 +117,7 @@ to write to a downstream data store.
 | [Kafka Connect Wrapper](https://github.com/ConduitIO/conduit-kafka-connect-wrapper) | ✅ | ✅ | Legacy |v0.3.0|
 | [Marketo](https://github.com/conduitio-labs/conduit-connector-marketo) |✅ | | Community |v0.3.0|
 | [Materialize](https://github.com/conduitio-labs/conduit-connector-materialize) | |✅ | Community |v0.3.0|
-| [MongoDB](https://github.com/conduitio-labs/conduit-connector-mongo) | |✅ | Community |v0.6.0|
+| [MongoDB](https://github.com/conduitio-labs/conduit-connector-mongo) |✅ |✅ | Community |v0.6.0|
 | [Nats Jetstream](https://github.com/conduitio-labs/conduit-connector-nats-jetstream) |✅ |✅ | Community |v0.3.0|
 | [Nats PubSub](https://github.com/conduitio-labs/conduit-connector-nats-pubsub) |✅|✅ | Community |v0.3.0|
 | [Oracle DB](https://github.com/conduitio-labs/conduit-connector-oracle) |WIP|WIP| Community |WIP|

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -117,6 +117,7 @@ to write to a downstream data store.
 | [Kafka Connect Wrapper](https://github.com/ConduitIO/conduit-kafka-connect-wrapper) | ✅ | ✅ | Legacy |v0.3.0|
 | [Marketo](https://github.com/conduitio-labs/conduit-connector-marketo) |✅ | | Community |v0.3.0|
 | [Materialize](https://github.com/conduitio-labs/conduit-connector-materialize) | |✅ | Community |v0.3.0|
+| [MongoDB](https://github.com/conduitio-labs/conduit-connector-mongo) | |✅ | Conduit |v0.6.0|
 | [Nats Jetstream](https://github.com/conduitio-labs/conduit-connector-nats-jetstream) |✅ |✅ | Community |v0.3.0|
 | [Nats PubSub](https://github.com/conduitio-labs/conduit-connector-nats-pubsub) |✅|✅ | Community |v0.3.0|
 | [Oracle DB](https://github.com/conduitio-labs/conduit-connector-oracle) |WIP|WIP| Community |WIP|


### PR DESCRIPTION
### Description

Noticed the [MongoDB](https://github.com/conduitio-labs/conduit-connector-mongo) is not part of this list.

It was first added on 0.3.0, but it's 0.6.0 now, so unsure whether we should leave it on current version. 

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.