### PR TITLE
Use Debian Bullseye in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start with a golang base
-FROM golang:1.20 AS base
+FROM golang:1.20-bullseye AS base
 
 # Install core tools
 RUN apt-get update &&\


### PR DESCRIPTION
### Description

Fixes #1107. I didn't find a pressing need to use `debian:bookworm` so I believe it's fine that we use `debian:bullseye`.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
  - Tested manually.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.