### PR TITLE
Add make lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,5 +17,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
+          # The version here also needs to be used as GOLANG_CI_LINT_VER in Makefile
           version: v1.52.2
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ golangci-lint-install:
 
 .PHONY: lint
 lint: golangci-lint-install
-	golangci-lint run -v --go $(shell awk '/^go/ {print $$2}' go.mod)
+	golangci-lint run -v
 
 build-server: check-go-version
 	go build -ldflags "-X 'github.com/conduitio/conduit/pkg/conduit.version=${VERSION}'" -o conduit ./cmd/conduit/main.go

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@
 # the correct version.
 VERSION=`git describe --tags --dirty`
 GO_VERSION_CHECK=`./scripts/check-go-version.sh`
+# Needs to match with what's in .github/workflows/lint.yml
+GOLANG_CI_LINT_VER	:= v1.52.2
 
 # The build target should stay at the top since we want it to be the default target.
 build: check-go-version pkg/web/ui/dist build-pipeline-check
@@ -24,6 +26,14 @@ test-integration:
 	go test $(GOTEST_FLAGS) -race --tags=integration ./...; ret=$$?; \
 		docker compose -f test/docker-compose-postgres.yml -f test/docker-compose-schemaregistry.yml down; \
 		exit $$ret
+
+.PHONY: golangci-lint-install
+golangci-lint-install:
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANG_CI_LINT_VER)
+
+.PHONY: lint
+lint: golangci-lint-install
+	golangci-lint run -v --go $(shell awk '/^go/ {print $$2}' go.mod)
 
 build-server: check-go-version
 	go build -ldflags "-X 'github.com/conduitio/conduit/pkg/conduit.version=${VERSION}'" -o conduit ./cmd/conduit/main.go

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -1,6 +1,6 @@
 #!/bin/sh
 EXIT_STATUS=0
 make test || EXIT_STATUS=$?
-golangci-lint run || EXIT_STATUS=$?
+make lint || EXIT_STATUS=$?
 make markdown-lint || EXIT_STATUS=$?
 exit $EXIT_STATUS

--- a/pkg/plugin/service.go
+++ b/pkg/plugin/service.go
@@ -16,7 +16,6 @@ package plugin
 
 import (
 	"context"
-	"github.com/pkg/errors"
 
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/log"
@@ -95,7 +94,7 @@ func (s *Service) List(context.Context) (map[string]Specification, error) {
 func (s *Service) ValidateSourceConfig(ctx context.Context, d Dispenser, settings map[string]string) (err error) {
 	src, err := d.DispenseSource()
 	if err != nil {
-		return errors.Errorf("could not dispense source: %w", err)
+		return cerrors.Errorf("could not dispense source: %w", err)
 	}
 
 	defer func() {

--- a/pkg/plugin/service.go
+++ b/pkg/plugin/service.go
@@ -16,6 +16,7 @@ package plugin
 
 import (
 	"context"
+	"github.com/pkg/errors"
 
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/log"
@@ -94,7 +95,7 @@ func (s *Service) List(context.Context) (map[string]Specification, error) {
 func (s *Service) ValidateSourceConfig(ctx context.Context, d Dispenser, settings map[string]string) (err error) {
 	src, err := d.DispenseSource()
 	if err != nil {
-		return cerrors.Errorf("could not dispense source: %w", err)
+		return errors.Errorf("could not dispense source: %w", err)
 	}
 
 	defer func() {


### PR DESCRIPTION
### Description

Adds `make lint` which also installs the appropriate version of `golangci-lint`.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.