### PR TITLE
bump golangci-lint to v1.53.3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,5 +18,5 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # The version here also needs to be used as GOLANG_CI_LINT_VER in Makefile
-          version: v1.52.2
+          version: v1.53.3
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,15 +5,13 @@ run:
 
 linters-settings:
   depguard:
-    list-type: blacklist
-    include-go-root: true
-    packages:
-      - errors
-      - golang.org/x/xerrors
-    packages-with-error-message:
-      # specify an error message to output when a blacklisted package is used
-      - errors: "To accommodate for custom error creation and handling use Conduit's 'cerrors' package instead."
-      - golang.org/x/xerrors: "To accommodate for custom error creation and handling use Conduit's 'cerrors' package instead."
+    rules:
+      Main:
+        deny:
+          - pkg: errors
+            desc: To accommodate for custom error creation and handling use Conduit's 'cerrors' package instead.
+          - pkg: golang.org/x/xerrors
+            desc: To accommodate for custom error creation and handling use Conduit's 'cerrors' package instead.
   gofmt:
     simplify: false
   govet:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 VERSION=`git describe --tags --dirty`
 GO_VERSION_CHECK=`./scripts/check-go-version.sh`
 # Needs to match with what's in .github/workflows/lint.yml
-GOLANG_CI_LINT_VER	:= v1.52.2
+GOLANG_CI_LINT_VER	:= v1.53.3
 
 # The build target should stay at the top since we want it to be the default target.
 build: check-go-version pkg/web/ui/dist build-pipeline-check


### PR DESCRIPTION
### Description

bump golangci-lint version

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.