### PR TITLE
Fix make target install-tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ download:
 
 install-tools: download
 	@echo Installing tools from tools.go
-	@go list -f '{{ join .Imports "\n" }}' tools.go | xargs -tI % go install %
+	@go list -e -f '{{ join .Imports "\n" }}' tools.go | xargs -tI % go install %
 	@go mod tidy
 
 generate:


### PR DESCRIPTION
A very simple change fixing the `install-tools` target. I noticed that the target complains about the imports pointing to non-importable packages (`main`). I added `-e` to `go tools` which ignores those errors.