### PR TITLE
Remove Assert Package 2/3

### DIFF
--- a/pkg/processor/procbuiltin/extractfield_test.go
+++ b/pkg/processor/procbuiltin/extractfield_test.go
@@ -19,10 +19,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/processor"
 	"github.com/conduitio/conduit/pkg/record"
 	"github.com/conduitio/conduit/pkg/record/schema/mock"
+	"github.com/matryer/is"
 )
 
 func TestExtractFieldKey_Build(t *testing.T) {
@@ -68,6 +68,8 @@ func TestExtractFieldKey_Build(t *testing.T) {
 }
 
 func TestExtractFieldKey_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -135,7 +137,7 @@ func TestExtractFieldKey_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := ExtractFieldKey(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)
@@ -191,6 +193,8 @@ func TestExtractFieldPayload_Build(t *testing.T) {
 }
 
 func TestExtractFieldPayload_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -273,7 +277,7 @@ func TestExtractFieldPayload_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := ExtractFieldPayload(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)

--- a/pkg/processor/procbuiltin/filterfield_test.go
+++ b/pkg/processor/procbuiltin/filterfield_test.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/processor"
 	"github.com/conduitio/conduit/pkg/record"
 	"github.com/google/go-cmp/cmp"
+	"github.com/matryer/is"
 )
 
 func TestFilterFieldKey_Build(t *testing.T) {
@@ -101,6 +101,8 @@ func TestFilterFieldKey_Build(t *testing.T) {
 }
 
 func TestFilterFieldKey_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -231,7 +233,7 @@ func TestFilterFieldKey_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := FilterFieldKey(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FilterFieldKey() error = %v, wantErr %v", err, tt.wantErr)
@@ -316,6 +318,8 @@ func TestFilterFieldPayload_Build(t *testing.T) {
 }
 
 func TestFilterFieldPayload_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		config processor.Config
 		r      record.Record
@@ -421,7 +425,7 @@ func TestFilterFieldPayload_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := FilterFieldPayload(tt.args.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != (tt.err != nil) {
 				t.Errorf("FilterFieldPayload Error: %s - wanted: %s", err, tt.err)

--- a/pkg/processor/procbuiltin/hoistfield_test.go
+++ b/pkg/processor/procbuiltin/hoistfield_test.go
@@ -19,10 +19,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/processor"
 	"github.com/conduitio/conduit/pkg/record"
 	"github.com/conduitio/conduit/pkg/record/schema/mock"
+	"github.com/matryer/is"
 )
 
 func TestHoistFieldKey_Build(t *testing.T) {
@@ -69,6 +69,8 @@ func TestHoistFieldKey_Build(t *testing.T) {
 }
 
 func TestHoistFieldKey_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -132,7 +134,7 @@ func TestHoistFieldKey_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := HoistFieldKey(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)
@@ -189,6 +191,8 @@ func TestHoistFieldPayload_Build(t *testing.T) {
 }
 
 func TestHoistFieldPayload_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -267,7 +271,7 @@ func TestHoistFieldPayload_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := HoistFieldPayload(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)

--- a/pkg/processor/procbuiltin/insertfield_test.go
+++ b/pkg/processor/procbuiltin/insertfield_test.go
@@ -19,10 +19,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/processor"
 	"github.com/conduitio/conduit/pkg/record"
 	"github.com/conduitio/conduit/pkg/record/schema/mock"
+	"github.com/matryer/is"
 )
 
 func TestInsertFieldKey_Build(t *testing.T) {
@@ -82,6 +82,8 @@ func TestInsertFieldKey_Build(t *testing.T) {
 }
 
 func TestInsertFieldKey_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -244,7 +246,7 @@ func TestInsertFieldKey_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := InsertFieldKey(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)
@@ -312,6 +314,8 @@ func TestInsertFieldPayload_Build(t *testing.T) {
 }
 
 func TestInsertFieldPayload_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -503,7 +507,7 @@ func TestInsertFieldPayload_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := InsertFieldPayload(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)

--- a/pkg/processor/procbuiltin/maskfield_test.go
+++ b/pkg/processor/procbuiltin/maskfield_test.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/processor"
 	"github.com/conduitio/conduit/pkg/record"
 	"github.com/conduitio/conduit/pkg/record/schema/mock"
 	"github.com/google/go-cmp/cmp"
+	"github.com/matryer/is"
 )
 
 func TestMaskFieldKey_Build(t *testing.T) {
@@ -68,6 +68,8 @@ func TestMaskFieldKey_Build(t *testing.T) {
 }
 
 func TestMaskFieldKey_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -160,7 +162,7 @@ func TestMaskFieldKey_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := MaskFieldKey(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)
@@ -216,6 +218,8 @@ func TestMaskFieldPayload_Build(t *testing.T) {
 }
 
 func TestMaskFieldPayload_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -332,7 +336,7 @@ func TestMaskFieldPayload_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := MaskFieldPayload(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)

--- a/pkg/processor/procbuiltin/replacefield_test.go
+++ b/pkg/processor/procbuiltin/replacefield_test.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/processor"
 	"github.com/conduitio/conduit/pkg/record"
 	"github.com/conduitio/conduit/pkg/record/schema/mock"
 	"github.com/google/go-cmp/cmp"
+	"github.com/matryer/is"
 )
 
 func TestReplaceFieldKey_Build(t *testing.T) {
@@ -108,6 +108,8 @@ func TestReplaceFieldKey_Build(t *testing.T) {
 }
 
 func TestReplaceFieldKey_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -292,7 +294,7 @@ func TestReplaceFieldKey_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := ReplaceFieldKey(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)
@@ -389,6 +391,8 @@ func TestReplaceFieldPayload_Build(t *testing.T) {
 }
 
 func TestReplaceFieldPayload_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -621,7 +625,7 @@ func TestReplaceFieldPayload_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := ReplaceFieldPayload(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)

--- a/pkg/processor/procbuiltin/timestampconverter_test.go
+++ b/pkg/processor/procbuiltin/timestampconverter_test.go
@@ -19,11 +19,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/processor"
 	"github.com/conduitio/conduit/pkg/record"
 	"github.com/conduitio/conduit/pkg/record/schema/mock"
 	"github.com/google/go-cmp/cmp"
+	"github.com/matryer/is"
 )
 
 func TestTimestampConverterKey_Build(t *testing.T) {
@@ -101,6 +101,8 @@ func TestTimestampConverterKey_Build(t *testing.T) {
 }
 
 func TestTimestampConverterKey_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -298,7 +300,7 @@ func TestTimestampConverterKey_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := TimestampConverterKey(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)
@@ -357,6 +359,8 @@ func TestTimestampConverterPayload_Build(t *testing.T) {
 }
 
 func TestTimestampConverterPayload_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -601,7 +605,7 @@ func TestTimestampConverterPayload_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := TimestampConverterPayload(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)

--- a/pkg/processor/procbuiltin/valuetokey_test.go
+++ b/pkg/processor/procbuiltin/valuetokey_test.go
@@ -19,10 +19,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/processor"
 	"github.com/conduitio/conduit/pkg/record"
 	"github.com/conduitio/conduit/pkg/record/schema/mock"
+	"github.com/matryer/is"
 )
 
 func TestValueToKey_Build(t *testing.T) {
@@ -68,6 +68,8 @@ func TestValueToKey_Build(t *testing.T) {
 }
 
 func TestValueToKey_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -140,7 +142,7 @@ func TestValueToKey_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := ValueToKey(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)


### PR DESCRIPTION
### Description

Refactor all `_test.go` that used `pkg/foundation/assert` to use [(https://github.com/matryer/is)](https://github.com/matryer/is) in the following packages:

### PR (1/3)
- [x] `./pipeline`
- [x] `./record`
- [x] `./conduit`
- [x] `./web`

### PR (2/3)
- [x] `./processor` 
- [x] `./orchestrator` 

### PR (3/3)
- [ ] `./foundation`


Partially Fixes #260

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests. Can you even write tests for tests :o
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.