### PR TITLE
Add json tags to v2 provisioning model

### DIFF
--- a/pkg/provisioning/config/yaml/v2/model.go
+++ b/pkg/provisioning/config/yaml/v2/model.go
@@ -29,41 +29,41 @@ var Changelog = internal.Changelog{
 }
 
 type Configuration struct {
-	Version   string     `yaml:"version"`
-	Pipelines []Pipeline `yaml:"pipelines"`
+	Version   string     `yaml:"version" json:"version"`
+	Pipelines []Pipeline `yaml:"pipelines" json:"pipelines"`
 }
 
 type Pipeline struct {
-	ID          string      `yaml:"id"`
-	Status      string      `yaml:"status"`
-	Name        string      `yaml:"name"`
-	Description string      `yaml:"description"`
-	Connectors  []Connector `yaml:"connectors"`
-	Processors  []Processor `yaml:"processors"`
-	DLQ         DLQ         `yaml:"dead-letter-queue"`
+	ID          string      `yaml:"id" json:"id"`
+	Status      string      `yaml:"status" json:"status"`
+	Name        string      `yaml:"name" json:"name"`
+	Description string      `yaml:"description" json:"description"`
+	Connectors  []Connector `yaml:"connectors" json:"connectors"`
+	Processors  []Processor `yaml:"processors" json:"processors"`
+	DLQ         DLQ         `yaml:"dead-letter-queue" json:"dead-letter-queue"`
 }
 
 type Connector struct {
-	ID         string            `yaml:"id"`
-	Type       string            `yaml:"type"`
-	Plugin     string            `yaml:"plugin"`
-	Name       string            `yaml:"name"`
-	Settings   map[string]string `yaml:"settings"`
-	Processors []Processor       `yaml:"processors"`
+	ID         string            `yaml:"id" json:"id"`
+	Type       string            `yaml:"type" json:"type"`
+	Plugin     string            `yaml:"plugin" json:"plugin"`
+	Name       string            `yaml:"name" json:"name"`
+	Settings   map[string]string `yaml:"settings" json:"settings"`
+	Processors []Processor       `yaml:"processors" json:"processors"`
 }
 
 type Processor struct {
-	ID       string            `yaml:"id"`
-	Type     string            `yaml:"type"`
-	Settings map[string]string `yaml:"settings"`
-	Workers  int               `yaml:"workers"`
+	ID       string            `yaml:"id" json:"id"`
+	Type     string            `yaml:"type" json:"type"`
+	Settings map[string]string `yaml:"settings" json:"settings"`
+	Workers  int               `yaml:"workers" json:"workers"`
 }
 
 type DLQ struct {
-	Plugin              string            `yaml:"plugin"`
-	Settings            map[string]string `yaml:"settings"`
-	WindowSize          *int              `yaml:"window-size"`
-	WindowNackThreshold *int              `yaml:"window-nack-threshold"`
+	Plugin              string            `yaml:"plugin" json:"plugin"`
+	Settings            map[string]string `yaml:"settings" json:"settings"`
+	WindowSize          *int              `yaml:"window-size" json:"window-size"`
+	WindowNackThreshold *int              `yaml:"window-nack-threshold" json:"window-nack-threshold"`
 }
 
 func (c Configuration) ToConfig() []config.Pipeline {

--- a/pkg/provisioning/config/yaml/v2/model_test.go
+++ b/pkg/provisioning/config/yaml/v2/model_test.go
@@ -1,0 +1,126 @@
+// Copyright © 2023 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+func TestConfiguration_JSON(t *testing.T) {
+	is := is.New(t)
+	intPtr := func(i int) *int { return &i }
+	p := Pipeline{
+		ID:          "pipeline1",
+		Status:      "running",
+		Name:        "pipeline1",
+		Description: "desc1",
+		Processors: []Processor{
+			{
+				ID:   "pipeline1proc1",
+				Type: "js",
+				Settings: map[string]string{
+					"additionalProp1": "string",
+					"additionalProp2": "string",
+				},
+			},
+		},
+		Connectors: []Connector{
+			{
+				ID:     "con1",
+				Type:   "source",
+				Plugin: "builtin:s3",
+				Name:   "s3-source",
+				Settings: map[string]string{
+					"aws.region": "us-east-1",
+					"aws.bucket": "my-bucket",
+				},
+				Processors: []Processor{
+					{
+						ID:   "proc1",
+						Type: "js",
+						Settings: map[string]string{
+							"additionalProp1": "string",
+							"additionalProp2": "string",
+						},
+					},
+				},
+			},
+		},
+		DLQ: DLQ{
+			Plugin: "my-plugin",
+			Settings: map[string]string{
+				"foo": "bar",
+			},
+			WindowSize:          intPtr(4),
+			WindowNackThreshold: intPtr(2),
+		},
+	}
+
+	want := `{
+  "id": "pipeline1",
+  "status": "running",
+  "name": "pipeline1",
+  "description": "desc1",
+  "connectors": [
+    {
+      "id": "con1",
+      "type": "source",
+      "plugin": "builtin:s3",
+      "name": "s3-source",
+      "settings": {
+        "aws.bucket": "my-bucket",
+        "aws.region": "us-east-1"
+      },
+      "processors": [
+        {
+          "id": "proc1",
+          "type": "js",
+          "settings": {
+            "additionalProp1": "string",
+            "additionalProp2": "string"
+          },
+          "workers": 0
+        }
+      ]
+    }
+  ],
+  "processors": [
+    {
+      "id": "pipeline1proc1",
+      "type": "js",
+      "settings": {
+        "additionalProp1": "string",
+        "additionalProp2": "string"
+      },
+      "workers": 0
+    }
+  ],
+  "dead-letter-queue": {
+    "plugin": "my-plugin",
+    "settings": {
+      "foo": "bar"
+    },
+    "window-size": 4,
+    "window-nack-threshold": 2
+  }
+}`
+	got, err := json.MarshalIndent(p, "", "  ")
+	is.NoErr(err)
+
+	is.Equal(string(got), want)
+}


### PR DESCRIPTION
### Description

This change adds JSON tags to the structs of the v2 provisioning model. This way the config file can be marshalled into json if need be.