### PR TITLE
Remove Assert Package 3/3 

### DIFF
--- a/pkg/foundation/cerrors/cerrors_test.go
+++ b/pkg/foundation/cerrors/cerrors_test.go
@@ -19,7 +19,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/matryer/is"
 )
@@ -45,20 +44,22 @@ func (w *unwrapPanicError) Unwrap() error {
 }
 
 func TestNew(t *testing.T) {
+	is := is.New(t)
+
 	err := newError()
 	s := fmt.Sprintf("%+v", err)
-	assert.Equal(
-		t,
+	is.Equal(
 		"foobar:\n    github.com/conduitio/conduit/pkg/foundation/cerrors_test.newError\n        "+helperFilePath+":26",
 		s,
 	)
 }
 
 func TestErrorf(t *testing.T) {
+	is := is.New(t)
+
 	err := cerrors.Errorf("caused by: %w", newError())
 	s := fmt.Sprintf("%+v", err)
-	assert.Equal(
-		t,
+	is.Equal(
 		"caused by:\n    github.com/conduitio/conduit/pkg/foundation/cerrors_test.TestErrorf\n        "+
 			testFileLocation+":58\n  - "+
 			"foobar:\n    github.com/conduitio/conduit/pkg/foundation/cerrors_test.newError\n        "+
@@ -68,6 +69,8 @@ func TestErrorf(t *testing.T) {
 }
 
 func TestGetStackTrace(t *testing.T) {
+	is := is.New(t)
+
 	testCases := []struct {
 		desc     string
 		err      error
@@ -137,12 +140,12 @@ func TestGetStackTrace(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			res := cerrors.GetStackTrace(tc.err)
 			if tc.expected == nil {
-				assert.Nil(t, res)
+				is.True(res == nil)
 				return
 			}
 			act, ok := res.([]cerrors.Frame)
-			assert.True(t, ok, "expected []cerrors.Frame")
-			assert.Equal(t, tc.expected, act)
+			is.True(ok) // expected []cerrors.Frame
+			is.Equal(tc.expected, act)
 		})
 	}
 }

--- a/pkg/foundation/ctxutil/filepath_test.go
+++ b/pkg/foundation/ctxutil/filepath_test.go
@@ -20,23 +20,27 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/google/uuid"
+	"github.com/matryer/is"
 	"github.com/rs/zerolog"
 )
 
 func TestContextWithFilepath_Success(t *testing.T) {
+	is := is.New(t)
+
 	ctx := context.Background()
 	filepath := uuid.NewString()
 
 	ctx = ContextWithFilepath(ctx, filepath)
 	got := FilepathFromContext(ctx)
 
-	assert.Equal(t, filepath, got)
+	is.Equal(filepath, got)
 }
 
 func TestContextWithFilepath_Twice(t *testing.T) {
+	is := is.New(t)
+
 	ctx := context.Background()
 	filepath := uuid.NewString()
 
@@ -44,17 +48,21 @@ func TestContextWithFilepath_Twice(t *testing.T) {
 	ctx = ContextWithFilepath(ctx, filepath)
 	got := FilepathFromContext(ctx)
 
-	assert.Equal(t, filepath, got)
+	is.Equal(filepath, got)
 }
 
 func TestFilepathFromContext_Empty(t *testing.T) {
+	is := is.New(t)
+
 	ctx := context.Background()
 	got := FilepathFromContext(ctx)
 
-	assert.Equal(t, "", got)
+	is.Equal("", got)
 }
 
 func TestFilepathLogCtxHook_Success(t *testing.T) {
+	is := is.New(t)
+
 	ctx := context.Background()
 	filepath := uuid.NewString()
 
@@ -66,10 +74,12 @@ func TestFilepathLogCtxHook_Success(t *testing.T) {
 	FilepathLogCtxHook{}.Run(e, zerolog.InfoLevel, "")
 	e.Send()
 
-	assert.Equal(t, fmt.Sprintf(`{"level":"info","%s":"%s"}`, log.FilepathField, filepath)+"\n", logOutput.String())
+	is.Equal(fmt.Sprintf(`{"level":"info","%s":"%s"}`, log.FilepathField, filepath)+"\n", logOutput.String())
 }
 
 func TestFilepathLogCtxHook_EmptyCtx(t *testing.T) {
+	is := is.New(t)
+
 	ctx := context.Background()
 
 	var logOutput bytes.Buffer
@@ -78,5 +88,5 @@ func TestFilepathLogCtxHook_EmptyCtx(t *testing.T) {
 	FilepathLogCtxHook{}.Run(e, zerolog.InfoLevel, "")
 	e.Send()
 
-	assert.Equal(t, `{"level":"info"}`+"\n", logOutput.String())
+	is.Equal(`{"level":"info"}`+"\n", logOutput.String())
 }

--- a/pkg/foundation/ctxutil/messageid_test.go
+++ b/pkg/foundation/ctxutil/messageid_test.go
@@ -20,23 +20,27 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/google/uuid"
+	"github.com/matryer/is"
 	"github.com/rs/zerolog"
 )
 
 func TestContextWithMessageID_Success(t *testing.T) {
+	is := is.New(t)
+
 	ctx := context.Background()
 	messageID := uuid.NewString()
 
 	ctx = ContextWithMessageID(ctx, messageID)
 	got := MessageIDFromContext(ctx)
 
-	assert.Equal(t, messageID, got)
+	is.Equal(messageID, got)
 }
 
 func TestContextWithMessageID_Twice(t *testing.T) {
+	is := is.New(t)
+
 	ctx := context.Background()
 	messageID := uuid.NewString()
 
@@ -44,17 +48,21 @@ func TestContextWithMessageID_Twice(t *testing.T) {
 	ctx = ContextWithMessageID(ctx, messageID)
 	got := MessageIDFromContext(ctx)
 
-	assert.Equal(t, messageID, got)
+	is.Equal(messageID, got)
 }
 
 func TestMessageIDFromContext_Empty(t *testing.T) {
+	is := is.New(t)
+
 	ctx := context.Background()
 	got := MessageIDFromContext(ctx)
 
-	assert.Equal(t, "", got)
+	is.Equal("", got)
 }
 
 func TestMessageIDLogCtxHook_Success(t *testing.T) {
+	is := is.New(t)
+
 	ctx := context.Background()
 	messageID := uuid.NewString()
 
@@ -66,10 +74,12 @@ func TestMessageIDLogCtxHook_Success(t *testing.T) {
 	MessageIDLogCtxHook{}.Run(e, zerolog.InfoLevel, "")
 	e.Send()
 
-	assert.Equal(t, fmt.Sprintf(`{"level":"info","%s":"%s"}`, log.MessageIDField, messageID)+"\n", logOutput.String())
+	is.Equal(fmt.Sprintf(`{"level":"info","%s":"%s"}`, log.MessageIDField, messageID)+"\n", logOutput.String())
 }
 
 func TestMessageIDLogCtxHook_EmptyCtx(t *testing.T) {
+	is := is.New(t)
+
 	ctx := context.Background()
 
 	var logOutput bytes.Buffer
@@ -78,5 +88,5 @@ func TestMessageIDLogCtxHook_EmptyCtx(t *testing.T) {
 	MessageIDLogCtxHook{}.Run(e, zerolog.InfoLevel, "")
 	e.Send()
 
-	assert.Equal(t, `{"level":"info"}`+"\n", logOutput.String())
+	is.Equal(`{"level":"info"}`+"\n", logOutput.String())
 }

--- a/pkg/foundation/ctxutil/requestid_test.go
+++ b/pkg/foundation/ctxutil/requestid_test.go
@@ -20,23 +20,27 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/google/uuid"
+	"github.com/matryer/is"
 	"github.com/rs/zerolog"
 )
 
 func TestContextWithRequestID_Success(t *testing.T) {
+	is := is.New(t)
+
 	ctx := context.Background()
 	requestID := uuid.NewString()
 
 	ctx = ContextWithRequestID(ctx, requestID)
 	got := RequestIDFromContext(ctx)
 
-	assert.Equal(t, requestID, got)
+	is.Equal(requestID, got)
 }
 
 func TestContextWithRequestID_Twice(t *testing.T) {
+	is := is.New(t)
+
 	ctx := context.Background()
 	requestID := uuid.NewString()
 
@@ -44,17 +48,21 @@ func TestContextWithRequestID_Twice(t *testing.T) {
 	ctx = ContextWithRequestID(ctx, requestID)
 	got := RequestIDFromContext(ctx)
 
-	assert.Equal(t, requestID, got)
+	is.Equal(requestID, got)
 }
 
 func TestRequestIDFromContext_Empty(t *testing.T) {
+	is := is.New(t)
+
 	ctx := context.Background()
 	got := RequestIDFromContext(ctx)
 
-	assert.Equal(t, "", got)
+	is.Equal("", got)
 }
 
 func TestRequestIDLogCtxHook_Success(t *testing.T) {
+	is := is.New(t)
+
 	ctx := context.Background()
 	requestID := uuid.NewString()
 
@@ -66,10 +74,12 @@ func TestRequestIDLogCtxHook_Success(t *testing.T) {
 	RequestIDLogCtxHook{}.Run(e, zerolog.InfoLevel, "")
 	e.Send()
 
-	assert.Equal(t, fmt.Sprintf(`{"level":"info","%s":"%s"}`, log.RequestIDField, requestID)+"\n", logOutput.String())
+	is.Equal(fmt.Sprintf(`{"level":"info","%s":"%s"}`, log.RequestIDField, requestID)+"\n", logOutput.String())
 }
 
 func TestRequestIDLogCtxHook_EmptyCtx(t *testing.T) {
+	is := is.New(t)
+
 	ctx := context.Background()
 
 	var logOutput bytes.Buffer
@@ -78,5 +88,5 @@ func TestRequestIDLogCtxHook_EmptyCtx(t *testing.T) {
 	RequestIDLogCtxHook{}.Run(e, zerolog.InfoLevel, "")
 	e.Send()
 
-	assert.Equal(t, `{"level":"info"}`+"\n", logOutput.String())
+	is.Equal(`{"level":"info"}`+"\n", logOutput.String())
 }

--- a/pkg/foundation/database/badger/db_test.go
+++ b/pkg/foundation/database/badger/db_test.go
@@ -18,18 +18,20 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/foundation/database"
+	"github.com/matryer/is"
 	"github.com/rs/zerolog"
 )
 
 func TestDB(t *testing.T) {
+	is := is.New(t)
+
 	path := filepath.Join(t.TempDir(), "badger.db")
 	badger, err := New(zerolog.Nop(), path)
-	assert.Ok(t, err)
+	is.NoErr(err)
 	t.Cleanup(func() {
 		err := badger.Close()
-		assert.Ok(t, err)
+		is.NoErr(err)
 	})
 	database.AcceptanceTest(t, badger)
 }

--- a/pkg/foundation/database/postgres/db_integration_test.go
+++ b/pkg/foundation/database/postgres/db_integration_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/foundation/database"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 )
@@ -32,12 +31,12 @@ func TestDB(t *testing.T) {
 	ctx := context.Background()
 	logger := log.Nop()
 	db, err := New(ctx, logger, "postgres://meroxauser:meroxapass@localhost:5432/meroxadb?sslmode=disable", testTable)
-	assert.Ok(t, err)
+	is.NoErr(err)
 	t.Cleanup(func() {
 		_, err := db.pool.Exec(ctx, fmt.Sprintf("DROP TABLE %q", testTable))
-		assert.Ok(t, err)
+		is.NoErr(err)
 		err = db.Close()
-		assert.Ok(t, err)
+		is.NoErr(err)
 	})
 	database.AcceptanceTest(t, db)
 }

--- a/pkg/foundation/metrics/prometheus/counter_test.go
+++ b/pkg/foundation/metrics/prometheus/counter_test.go
@@ -19,14 +19,16 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/foundation/metrics"
+	"github.com/matryer/is"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"google.golang.org/protobuf/proto"
 )
 
 func TestCounter(t *testing.T) {
+	is := is.New(t)
+
 	testCases := []struct {
 		name      string
 		observe   func(m metrics.Counter)
@@ -78,11 +80,11 @@ func TestCounter(t *testing.T) {
 
 			promRegistry := prometheus.NewRegistry()
 			err := promRegistry.Register(reg)
-			assert.Ok(t, err)
+			is.NoErr(err)
 
 			got, err := promRegistry.Gather()
-			assert.Ok(t, err)
-			assert.Equal(t, want, got)
+			is.NoErr(err)
+			is.Equal(want, got)
 		})
 	}
 }
@@ -100,6 +102,8 @@ func TestCounter_IncNegative(t *testing.T) {
 }
 
 func TestLabeledCounter(t *testing.T) {
+	is := is.New(t)
+
 	testCases := []struct {
 		name       string
 		observe    func(m metrics.LabeledCounter)
@@ -171,11 +175,11 @@ func TestLabeledCounter(t *testing.T) {
 
 			promRegistry := prometheus.NewRegistry()
 			err := promRegistry.Register(reg)
-			assert.Ok(t, err)
+			is.NoErr(err)
 
 			got, err := promRegistry.Gather()
-			assert.Ok(t, err)
-			assert.Equal(t, want, got)
+			is.NoErr(err)
+			is.Equal(want, got)
 		})
 	}
 }

--- a/pkg/foundation/metrics/prometheus/gauge_test.go
+++ b/pkg/foundation/metrics/prometheus/gauge_test.go
@@ -19,14 +19,16 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/foundation/metrics"
+	"github.com/matryer/is"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"google.golang.org/protobuf/proto"
 )
 
 func TestGauge(t *testing.T) {
+	is := is.New(t)
+
 	testCases := []struct {
 		name      string
 		observe   func(m metrics.Gauge)
@@ -121,16 +123,18 @@ func TestGauge(t *testing.T) {
 
 			promRegistry := prometheus.NewRegistry()
 			err := promRegistry.Register(reg)
-			assert.Ok(t, err)
+			is.NoErr(err)
 
 			got, err := promRegistry.Gather()
-			assert.Ok(t, err)
-			assert.Equal(t, want, got)
+			is.NoErr(err)
+			is.Equal(want, got)
 		})
 	}
 }
 
 func TestLabeledGauge(t *testing.T) {
+	is := is.New(t)
+
 	testCases := []struct {
 		name       string
 		observe    func(m metrics.LabeledGauge)
@@ -202,11 +206,11 @@ func TestLabeledGauge(t *testing.T) {
 
 			promRegistry := prometheus.NewRegistry()
 			err := promRegistry.Register(reg)
-			assert.Ok(t, err)
+			is.NoErr(err)
 
 			got, err := promRegistry.Gather()
-			assert.Ok(t, err)
-			assert.Equal(t, want, got)
+			is.NoErr(err)
+			is.Equal(want, got)
 		})
 	}
 }

--- a/pkg/foundation/metrics/prometheus/histogram_test.go
+++ b/pkg/foundation/metrics/prometheus/histogram_test.go
@@ -19,14 +19,16 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/foundation/metrics"
+	"github.com/matryer/is"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"google.golang.org/protobuf/proto"
 )
 
 func TestHistogram(t *testing.T) {
+	is := is.New(t)
+
 	testCases := []struct {
 		name       string
 		observe    func(m metrics.Histogram)
@@ -87,16 +89,18 @@ func TestHistogram(t *testing.T) {
 
 			promRegistry := prometheus.NewRegistry()
 			err := promRegistry.Register(reg)
-			assert.Ok(t, err)
+			is.NoErr(err)
 
 			got, err := promRegistry.Gather()
-			assert.Ok(t, err)
-			assert.Equal(t, want, got)
+			is.NoErr(err)
+			is.Equal(want, got)
 		})
 	}
 }
 
 func TestLabeledHistogram(t *testing.T) {
+	is := is.New(t)
+
 	testCases := []struct {
 		name        string
 		observe     func(m metrics.LabeledHistogram)
@@ -188,11 +192,11 @@ func TestLabeledHistogram(t *testing.T) {
 
 			promRegistry := prometheus.NewRegistry()
 			err := promRegistry.Register(reg)
-			assert.Ok(t, err)
+			is.NoErr(err)
 
 			got, err := promRegistry.Gather()
-			assert.Ok(t, err)
-			assert.Equal(t, want, got)
+			is.NoErr(err)
+			is.Equal(want, got)
 		})
 	}
 }

--- a/pkg/foundation/metrics/prometheus/timer_test.go
+++ b/pkg/foundation/metrics/prometheus/timer_test.go
@@ -20,14 +20,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/foundation/metrics"
+	"github.com/matryer/is"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"google.golang.org/protobuf/proto"
 )
 
 func TestTimer(t *testing.T) {
+	is := is.New(t)
+
 	testCases := []struct {
 		name       string
 		observe    func(m metrics.Timer)
@@ -88,16 +90,18 @@ func TestTimer(t *testing.T) {
 
 			promRegistry := prometheus.NewRegistry()
 			err := promRegistry.Register(reg)
-			assert.Ok(t, err)
+			is.NoErr(err)
 
 			got, err := promRegistry.Gather()
-			assert.Ok(t, err)
-			assert.Equal(t, want, got)
+			is.NoErr(err)
+			is.Equal(want, got)
 		})
 	}
 }
 
 func TestTimer_Since(t *testing.T) {
+	is := is.New(t)
+
 	reg := NewRegistry(nil)
 
 	m := reg.NewTimer("my_timer", "test timer")
@@ -120,10 +124,10 @@ func TestTimer_Since(t *testing.T) {
 
 	promRegistry := prometheus.NewRegistry()
 	err := promRegistry.Register(reg)
-	assert.Ok(t, err)
+	is.NoErr(err)
 
 	got, err := promRegistry.Gather()
-	assert.Ok(t, err)
+	is.NoErr(err)
 
 	// first manually check the difference, we can't know the actual sum
 	diff := *got[0].Metric[0].Histogram.SampleSum - *want[0].Metric[0].Histogram.SampleSum
@@ -133,10 +137,12 @@ func TestTimer_Since(t *testing.T) {
 
 	// add difference to our estimate and make sure everything else matches
 	*want[0].Metric[0].Histogram.SampleSum += diff
-	assert.Equal(t, want, got)
+	is.Equal(want, got)
 }
 
 func TestLabeledTimer(t *testing.T) {
+	is := is.New(t)
+
 	testCases := []struct {
 		name        string
 		observe     func(m metrics.LabeledTimer)
@@ -228,11 +234,11 @@ func TestLabeledTimer(t *testing.T) {
 
 			promRegistry := prometheus.NewRegistry()
 			err := promRegistry.Register(reg)
-			assert.Ok(t, err)
+			is.NoErr(err)
 
 			got, err := promRegistry.Gather()
-			assert.Ok(t, err)
-			assert.Equal(t, want, got)
+			is.NoErr(err)
+			is.Equal(want, got)
 		})
 	}
 }

--- a/pkg/processor/procbuiltin/extractfield_test.go
+++ b/pkg/processor/procbuiltin/extractfield_test.go
@@ -19,10 +19,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/processor"
 	"github.com/conduitio/conduit/pkg/record"
 	"github.com/conduitio/conduit/pkg/record/schema/mock"
+	"github.com/matryer/is"
 )
 
 func TestExtractFieldKey_Build(t *testing.T) {
@@ -68,6 +68,8 @@ func TestExtractFieldKey_Build(t *testing.T) {
 }
 
 func TestExtractFieldKey_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -135,7 +137,7 @@ func TestExtractFieldKey_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := ExtractFieldKey(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)
@@ -191,6 +193,8 @@ func TestExtractFieldPayload_Build(t *testing.T) {
 }
 
 func TestExtractFieldPayload_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -273,7 +277,7 @@ func TestExtractFieldPayload_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := ExtractFieldPayload(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)

--- a/pkg/processor/procbuiltin/filterfield_test.go
+++ b/pkg/processor/procbuiltin/filterfield_test.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/processor"
 	"github.com/conduitio/conduit/pkg/record"
 	"github.com/google/go-cmp/cmp"
+	"github.com/matryer/is"
 )
 
 func TestFilterFieldKey_Build(t *testing.T) {
@@ -101,6 +101,8 @@ func TestFilterFieldKey_Build(t *testing.T) {
 }
 
 func TestFilterFieldKey_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -231,7 +233,7 @@ func TestFilterFieldKey_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := FilterFieldKey(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FilterFieldKey() error = %v, wantErr %v", err, tt.wantErr)
@@ -316,6 +318,8 @@ func TestFilterFieldPayload_Build(t *testing.T) {
 }
 
 func TestFilterFieldPayload_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		config processor.Config
 		r      record.Record
@@ -421,7 +425,7 @@ func TestFilterFieldPayload_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := FilterFieldPayload(tt.args.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != (tt.err != nil) {
 				t.Errorf("FilterFieldPayload Error: %s - wanted: %s", err, tt.err)

--- a/pkg/processor/procbuiltin/hoistfield_test.go
+++ b/pkg/processor/procbuiltin/hoistfield_test.go
@@ -19,10 +19,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/processor"
 	"github.com/conduitio/conduit/pkg/record"
 	"github.com/conduitio/conduit/pkg/record/schema/mock"
+	"github.com/matryer/is"
 )
 
 func TestHoistFieldKey_Build(t *testing.T) {
@@ -69,6 +69,8 @@ func TestHoistFieldKey_Build(t *testing.T) {
 }
 
 func TestHoistFieldKey_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -132,7 +134,7 @@ func TestHoistFieldKey_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := HoistFieldKey(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)
@@ -189,6 +191,8 @@ func TestHoistFieldPayload_Build(t *testing.T) {
 }
 
 func TestHoistFieldPayload_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -267,7 +271,7 @@ func TestHoistFieldPayload_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := HoistFieldPayload(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)

--- a/pkg/processor/procbuiltin/insertfield_test.go
+++ b/pkg/processor/procbuiltin/insertfield_test.go
@@ -19,10 +19,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/processor"
 	"github.com/conduitio/conduit/pkg/record"
 	"github.com/conduitio/conduit/pkg/record/schema/mock"
+	"github.com/matryer/is"
 )
 
 func TestInsertFieldKey_Build(t *testing.T) {
@@ -82,6 +82,8 @@ func TestInsertFieldKey_Build(t *testing.T) {
 }
 
 func TestInsertFieldKey_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -244,7 +246,7 @@ func TestInsertFieldKey_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := InsertFieldKey(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)
@@ -312,6 +314,8 @@ func TestInsertFieldPayload_Build(t *testing.T) {
 }
 
 func TestInsertFieldPayload_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -503,7 +507,7 @@ func TestInsertFieldPayload_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := InsertFieldPayload(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)

--- a/pkg/processor/procbuiltin/maskfield_test.go
+++ b/pkg/processor/procbuiltin/maskfield_test.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/processor"
 	"github.com/conduitio/conduit/pkg/record"
 	"github.com/conduitio/conduit/pkg/record/schema/mock"
 	"github.com/google/go-cmp/cmp"
+	"github.com/matryer/is"
 )
 
 func TestMaskFieldKey_Build(t *testing.T) {
@@ -68,6 +68,8 @@ func TestMaskFieldKey_Build(t *testing.T) {
 }
 
 func TestMaskFieldKey_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -160,7 +162,7 @@ func TestMaskFieldKey_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := MaskFieldKey(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)
@@ -216,6 +218,8 @@ func TestMaskFieldPayload_Build(t *testing.T) {
 }
 
 func TestMaskFieldPayload_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -332,7 +336,7 @@ func TestMaskFieldPayload_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := MaskFieldPayload(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)

--- a/pkg/processor/procbuiltin/replacefield_test.go
+++ b/pkg/processor/procbuiltin/replacefield_test.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/processor"
 	"github.com/conduitio/conduit/pkg/record"
 	"github.com/conduitio/conduit/pkg/record/schema/mock"
 	"github.com/google/go-cmp/cmp"
+	"github.com/matryer/is"
 )
 
 func TestReplaceFieldKey_Build(t *testing.T) {
@@ -108,6 +108,8 @@ func TestReplaceFieldKey_Build(t *testing.T) {
 }
 
 func TestReplaceFieldKey_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -292,7 +294,7 @@ func TestReplaceFieldKey_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := ReplaceFieldKey(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)
@@ -389,6 +391,8 @@ func TestReplaceFieldPayload_Build(t *testing.T) {
 }
 
 func TestReplaceFieldPayload_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -621,7 +625,7 @@ func TestReplaceFieldPayload_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := ReplaceFieldPayload(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)

--- a/pkg/processor/procbuiltin/timestampconverter_test.go
+++ b/pkg/processor/procbuiltin/timestampconverter_test.go
@@ -19,11 +19,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/processor"
 	"github.com/conduitio/conduit/pkg/record"
 	"github.com/conduitio/conduit/pkg/record/schema/mock"
 	"github.com/google/go-cmp/cmp"
+	"github.com/matryer/is"
 )
 
 func TestTimestampConverterKey_Build(t *testing.T) {
@@ -101,6 +101,8 @@ func TestTimestampConverterKey_Build(t *testing.T) {
 }
 
 func TestTimestampConverterKey_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -298,7 +300,7 @@ func TestTimestampConverterKey_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := TimestampConverterKey(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)
@@ -357,6 +359,8 @@ func TestTimestampConverterPayload_Build(t *testing.T) {
 }
 
 func TestTimestampConverterPayload_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -601,7 +605,7 @@ func TestTimestampConverterPayload_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := TimestampConverterPayload(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)

--- a/pkg/processor/procbuiltin/valuetokey_test.go
+++ b/pkg/processor/procbuiltin/valuetokey_test.go
@@ -19,10 +19,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/conduitio/conduit/pkg/foundation/assert"
 	"github.com/conduitio/conduit/pkg/processor"
 	"github.com/conduitio/conduit/pkg/record"
 	"github.com/conduitio/conduit/pkg/record/schema/mock"
+	"github.com/matryer/is"
 )
 
 func TestValueToKey_Build(t *testing.T) {
@@ -68,6 +68,8 @@ func TestValueToKey_Build(t *testing.T) {
 }
 
 func TestValueToKey_Process(t *testing.T) {
+	is := is.New(t)
+
 	type args struct {
 		r record.Record
 	}
@@ -140,7 +142,7 @@ func TestValueToKey_Process(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			underTest, err := ValueToKey(tt.config)
-			assert.Ok(t, err)
+			is.NoErr(err)
 			got, err := underTest.Process(context.Background(), tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("process() error = %v, wantErr = %v", err, tt.wantErr)


### PR DESCRIPTION
### Description

Removes the assert package from ./foundation.

Refactor all `_test.go` that used `pkg/foundation/assert` to use [(https://github.com/matryer/is)](https://github.com/matryer/is) in the following packages:

### PR (1/3)
- [x] `./pipeline`
- [x] `./record`
- [x] `./conduit`
- [x] `./web`

### PR (2/3)
- [x] `./processor` 
- [x] `./orchestrator` 

### PR (3/3)
- [x] `./foundation`

Partially Fixes #260

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests. Can you even write tests for tests :o
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.