### PR TITLE
[Perf] Profiling flags

### DIFF
--- a/pkg/conduit/config.go
+++ b/pkg/conduit/config.go
@@ -75,6 +75,11 @@ type Config struct {
 
 	PluginDispenserFactories map[string]builtin.DispenserFactory
 	ProcessorBuilderRegistry *processor.BuilderRegistry
+
+	dev struct {
+		cpuprofile string
+		memprofile string
+	}
 }
 
 func DefaultConfig() Config {


### PR DESCRIPTION
### Description

This PR adds hidden development flags that allow us to gather the CPU and memory profile of Conduit. The flags are hidden from normal users in the help usage. They are only shown if you run conduit with flags `-dev -help`:

```
$ conduit -dev -help
Usage of conduit:
  -dev.cpuprofile string
    	write cpu profile to file
  -dev.memprofile string
    	write memory profile to file
```

Conduit can now be executed with these flags to enable profiling:

```
conduit -dev.cpuprofile cpu.prof -dev.memprofile mem.prof
```

See https://pkg.go.dev/runtime/pprof for more info about profiling.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.