### PR TITLE
[Perf] Inspector refactoring and optimization

### DIFF
--- a/pkg/inspector/inspector.go
+++ b/pkg/inspector/inspector.go
@@ -17,6 +17,7 @@ package inspector
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/foundation/metrics/measure"
@@ -32,23 +33,9 @@ const DefaultBufferSize = 1000
 type Session struct {
 	C chan record.Record
 
-	id      string
-	logger  log.CtxLogger
-	onClose func()
-	once    *sync.Once
-}
-
-func (s *Session) close() {
-	// close() can be called multiple times on a session. One example is:
-	// There's an active inspector session on a component (processor or connector),
-	// during which the component is deleted.
-	// The session channel will be closed, which terminate the API request fetching
-	// record from this session.
-	// However, the API request termination also closes the session.
-	s.once.Do(func() {
-		s.onClose()
-		close(s.C)
-	})
+	id          string
+	componentID string
+	logger      log.CtxLogger
 }
 
 // send a record to the session's channel.
@@ -74,7 +61,12 @@ type Inspector struct {
 	// keys are sessions IDs.
 	sessions map[string]*Session
 	// guards access to sessions
-	lock       sync.Mutex
+	lock sync.Mutex
+	// hasSessions is set to true when there are open sessions. This allows us
+	// to take a shortcut without acquiring the lock in the happy path, when
+	// there are no sessions.
+	hasSessions atomic.Bool
+
 	logger     log.CtxLogger
 	bufferSize int
 }
@@ -87,73 +79,65 @@ func New(logger log.CtxLogger, bufferSize int) *Inspector {
 	}
 }
 
+// NewSession creates a new session in given inspector.
+// componentID is the ID of the component being inspected (connector or processor).
+func (i *Inspector) NewSession(ctx context.Context, componentID string) *Session {
+	s := &Session{
+		C:           make(chan record.Record, i.bufferSize),
+		id:          uuid.NewString(),
+		componentID: componentID,
+		logger:      i.logger.WithComponent("inspector.Session"),
+	}
+
+	i.add(s)
+	go func() {
+		<-ctx.Done()
+		i.remove(s.id)
+	}()
+
+	return s
+}
+
 // Send the given record to all registered sessions.
 // The method does not wait for consumers to get the records.
 func (i *Inspector) Send(ctx context.Context, r record.Record) {
-	// copy metadata, to prevent issues when concurrently accessing the metadata
-	var meta record.Metadata
-	if len(r.Metadata) != 0 {
-		meta = make(record.Metadata, len(r.Metadata))
-		for k, v := range r.Metadata {
-			meta[k] = v
-		}
+	// shortcut - we don't expect any sessions, so we check the atomic variable
+	// before acquiring an actual lock
+	if !i.hasSessions.Load() {
+		return
 	}
 
-	// todo optimize this, as we have locks for every record.
+	// clone record only once, the listeners aren't expected to manipulate the records
+	rClone := r.Clone()
+
 	// locks are needed to make sure the `sessions` slice
 	// is not modified as we're iterating over it
 	i.lock.Lock()
 	defer i.lock.Unlock()
 	for _, s := range i.sessions {
-		s.send(ctx, record.Record{
-			Position:  r.Position,
-			Operation: r.Operation,
-			Metadata:  meta,
-			Key:       r.Key,
-			Payload:   r.Payload,
-		})
+		s.send(ctx, rClone)
 	}
-}
-
-// NewSession creates a new session in given inspector.
-// componentID is the ID of the component being inspected (connector or processor).
-func (i *Inspector) NewSession(ctx context.Context, componentID string) *Session {
-	id := uuid.NewString()
-	s := &Session{
-		C:      make(chan record.Record, i.bufferSize),
-		id:     id,
-		logger: i.logger.WithComponent("inspector.Session"),
-		onClose: func() {
-			i.remove(id)
-			measure.InspectorsGauge.WithValues(componentID).Dec()
-		},
-		once: &sync.Once{},
-	}
-	measure.InspectorsGauge.WithValues(componentID).Inc()
-
-	go func() {
-		<-ctx.Done()
-		s.logger.
-			Debug(context.Background()).
-			Msgf("context done: %v", ctx.Err())
-		s.close()
-	}()
-
-	i.lock.Lock()
-	defer i.lock.Unlock()
-
-	i.sessions[id] = s
-	i.logger.
-		Info(context.Background()).
-		Str(log.InspectorSessionID, id).
-		Msg("session created")
-	return s
 }
 
 func (i *Inspector) Close() {
-	for _, s := range i.sessions {
-		s.close()
+	for k := range i.sessions {
+		i.remove(k)
 	}
+}
+
+// add a session with given ID to this Inspector.
+func (i *Inspector) add(s *Session) {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	i.sessions[s.id] = s
+	i.hasSessions.Store(true)
+	measure.InspectorsGauge.WithValues(s.componentID).Inc()
+
+	i.logger.
+		Info(context.Background()).
+		Str(log.InspectorSessionID, s.id).
+		Msg("session created")
 }
 
 // remove a session with given ID from this Inspector.
@@ -161,7 +145,18 @@ func (i *Inspector) remove(id string) {
 	i.lock.Lock()
 	defer i.lock.Unlock()
 
+	s, ok := i.sessions[id]
+	if !ok {
+		return // session already removed
+	}
+
+	close(s.C)
 	delete(i.sessions, id)
+	if len(i.sessions) == 0 {
+		i.hasSessions.Store(false)
+	}
+	measure.InspectorsGauge.WithValues(s.componentID).Dec()
+
 	i.logger.
 		Info(context.Background()).
 		Str(log.InspectorSessionID, id).

--- a/pkg/inspector/inspector_benchmark_test.go
+++ b/pkg/inspector/inspector_benchmark_test.go
@@ -22,9 +22,28 @@ import (
 	"github.com/conduitio/conduit/pkg/record"
 )
 
+func BenchmarkInspector_NoSession_Send(b *testing.B) {
+	ins := New(log.Nop(), 10)
+
+	for i := 0; i < b.N; i++ {
+		ins.Send(context.Background(), record.Record{Position: record.Position("test-pos")})
+	}
+}
+
 func BenchmarkInspector_SingleSession_Send(b *testing.B) {
 	ins := New(log.Nop(), 10)
 	ins.NewSession(context.Background(), "test-id")
+
+	for i := 0; i < b.N; i++ {
+		ins.Send(context.Background(), record.Record{Position: record.Position("test-pos")})
+	}
+}
+
+func BenchmarkInspector_10Sessions_Send(b *testing.B) {
+	ins := New(log.Nop(), 10)
+	for i := 0; i < 10; i++ {
+		ins.NewSession(context.Background(), "test-id")
+	}
 
 	for i := 0; i < b.N; i++ {
 		ins.Send(context.Background(), record.Record{Position: record.Position("test-pos")})

--- a/pkg/inspector/inspector_benchmark_test.go
+++ b/pkg/inspector/inspector_benchmark_test.go
@@ -25,6 +25,7 @@ import (
 func BenchmarkInspector_NoSession_Send(b *testing.B) {
 	ins := New(log.Nop(), 10)
 
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ins.Send(context.Background(), record.Record{Position: record.Position("test-pos")})
 	}
@@ -34,6 +35,7 @@ func BenchmarkInspector_SingleSession_Send(b *testing.B) {
 	ins := New(log.Nop(), 10)
 	ins.NewSession(context.Background(), "test-id")
 
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ins.Send(context.Background(), record.Record{Position: record.Position("test-pos")})
 	}
@@ -45,6 +47,7 @@ func BenchmarkInspector_10Sessions_Send(b *testing.B) {
 		ins.NewSession(context.Background(), "test-id")
 	}
 
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ins.Send(context.Background(), record.Record{Position: record.Position("test-pos")})
 	}

--- a/pkg/inspector/inspector_test.go
+++ b/pkg/inspector/inspector_test.go
@@ -70,7 +70,7 @@ func TestInspector_Send_SessionClosed(t *testing.T) {
 	underTest.Send(context.Background(), r)
 	assertGotRecord(is, s, r)
 
-	s.close()
+	underTest.remove(s.id)
 	underTest.Send(
 		context.Background(),
 		record.Record{

--- a/pkg/inspector/inspector_test.go
+++ b/pkg/inspector/inspector_test.go
@@ -123,7 +123,7 @@ func TestInspector_Send_SlowConsumer(t *testing.T) {
 	s := underTest.NewSession(context.Background(), "test-id")
 
 	for i := 0; i < bufferSize+1; i++ {
-		s.send(
+		underTest.Send(
 			context.Background(),
 			record.Record{
 				Position: record.Position(fmt.Sprintf("test-pos-%v", i)),


### PR DESCRIPTION
### Description

The inspector was allocating quite a lot of data even if no sessions were open. Now it's optimized for the hot path when there are no open sessions.

```
goos: darwin
goarch: amd64
pkg: github.com/conduitio/conduit/pkg/inspector
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
                                │  bench.old  │              bench.new               │
                                │   sec/op    │    sec/op     vs base                │
Inspector_NoSession_Send-16       31.96n ± 2%    14.70n ± 1%  -54.01% (p=0.000 n=10)
Inspector_SingleSession_Send-16   92.88n ± 1%   122.15n ± 2%  +31.52% (p=0.000 n=10)
Inspector_10Sessions_Send-16      447.6n ± 2%    447.1n ± 2%        ~ (p=0.895 n=10)
geomean                           109.9n         92.94n       -15.46%
```

Note that the single session benchmark is slower now because of the use of `Record.Clone()`, although that usage is now correct, since we previously did not clone all fields. Note that cloning of records was sped up in #1247.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [X] I have written unit tests. (existing tests)
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.