### PR TITLE
[Perf] Lazy encode connectors in persister

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/dop251/goja v0.0.0-20230531210528-d7324b2d74f7
 	github.com/dop251/goja_nodejs v0.0.0-20230602164024-804a84515562
 	github.com/gammazero/deque v0.2.1
+	github.com/goccy/go-json v0.10.2
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -262,6 +262,8 @@ github.com/go-sourcemap/sourcemap v2.1.3+incompatible h1:W1iEw64niKVGogNgBN3ePyL
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
+github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=

--- a/pkg/connector/persister.go
+++ b/pkg/connector/persister.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	DefaultPersisterDelayThreshold       = time.Second
-	DefaultPersisterBundleCountThreshold = 100
+	DefaultPersisterBundleCountThreshold = 10000
 )
 
 // Persister is responsible for persisting connectors and their state when


### PR DESCRIPTION
### Description

With this change the connector persister lazily encodes connectors only when they are flushed. The connector data is still copied at the time the connector requests to be persisted. This is currently required because of the locking mechanism (see https://github.com/ConduitIO/conduit/pull/857 for more info), there is still room for improvement here as most copies will be thrown away, especially on fast pipelines.

This also changes the library used for encoding to [github.com/goccy/go-json](https://github.com/goccy/go-json), which is quite a lot faster.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [X] I have written unit tests. (existing tests)
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.