### PR TITLE
Downgrade container policy action to v2.1.2

### DIFF
--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.NIGHTLY_BUILD_GH_TOKEN }}
       - name: 'Delete nightly containers older than a week'
-        uses: snok/container-retention-policy@v2
+        uses: snok/container-retention-policy@v2.1.2
         with:
           image-names: conduit
           cut-off: 1 week ago UTC


### PR DESCRIPTION
The latest version has a bug that deleted all our released containers. This PR pins the version to the last working version.