### PR TITLE
fix: opencdc unwrap

### DIFF
--- a/pkg/processor/procbuiltin/unwrap_test.go
+++ b/pkg/processor/procbuiltin/unwrap_test.go
@@ -631,8 +631,8 @@ func TestUnwrap_Process(t *testing.T) {
 							"opencdc.readAt":              "1706028953595546000",
 							"opencdc.version":             "v1",
 						},
-						"key": record.RawData{
-							Raw: []byte("MTc3NzQ5NDEtNTdhMi00MmZhLWI0MzAtODkxMmE5NDI0YjNh"),
+						"key": map[string]interface{}{
+							"id": "MTc3NzQ5NDEtNTdhMi00MmZhLWI0MzAtODkxMmE5NDI0YjNh",
 						},
 						"payload": record.Change{
 							Before: nil,
@@ -665,7 +665,7 @@ func TestUnwrap_Process(t *testing.T) {
 						"triggered":    false,
 					},
 				},
-				Key:      record.RawData{Raw: []byte("MTc3NzQ5NDEtNTdhMi00MmZhLWI0MzAtODkxMmE5NDI0YjNh")},
+				Key:      record.StructuredData{"id": "MTc3NzQ5NDEtNTdhMi00MmZhLWI0MzAtODkxMmE5NDI0YjNh"},
 				Position: []byte("eyJHcm91cElEIjoiNGQ2ZTBhMjktNzAwZi00Yjk4LWEzY2MtZWUyNzZhZTc4MjVjIiwiVG9waWMiOiJzdHJlYW0tNzhscG5jaHg3dHpweXF6LWdlbmVyYXRvciIsIlBhcnRpdGlvbiI6MCwiT2Zmc2V0IjoyMjF9"),
 			},
 			wantErr: false,
@@ -710,7 +710,7 @@ func TestUnwrap_Process(t *testing.T) {
 						"triggered":    false,
 					},
 				},
-				Key:      record.RawData{Raw: []byte("MTc3NzQ5NDEtNTdhMi00MmZhLWI0MzAtODkxMmE5NDI0YjNh")},
+				Key:      record.RawData{Raw: []byte("17774941-57a2-42fa-b430-8912a9424b3a")},
 				Position: []byte("eyJHcm91cElEIjoiNGQ2ZTBhMjktNzAwZi00Yjk4LWEzY2MtZWUyNzZhZTc4MjVjIiwiVG9waWMiOiJzdHJlYW0tNzhscG5jaHg3dHpweXF6LWdlbmVyYXRvciIsIlBhcnRpdGlvbiI6MCwiT2Zmc2V0IjoyMjF9"),
 			},
 			wantErr: false,


### PR DESCRIPTION
### Description

Follow up from https://github.com/ConduitIO/conduit/pull/1343.

Using this OpenCDC processor, I encountered this issue when trying to unwrap a record. Test was using two chained pipelines (file -> kafka, kafka -> file).

```
2024-01-31T16:33:39+00:00 ERR node stopped error="node dest-log-ciy690a2b3921p0:foo stopped with error: error executing processor: failed to write message to DLQ: DLQ nack threshold exceeded (0/1), original error: unwrap: error unwrapping record: record payload after payload.after is not a map" component=pipeline.Service node_id=dest-log-ciy690a2b3921p0:foo stack=[{"file":"/Users/rb/code/conduitio/conduit/pkg/pipeline/lifecycle.go","func":"github.com/conduitio/conduit/pkg/pipeline.(*Service).runPipeline.func2","line":577},{"file":"/Users/rb/code/conduitio/conduit/pkg/pipeline/stream/processor.go","func":"github.com/conduitio/conduit/pkg/pipeline/stream.(*ProcessorNode).Run","line":68},{"file":"/Users/rb/code/conduitio/conduit/pkg/pipeline/stream/source_acker.go","func":"github.com/conduitio/conduit/pkg/pipeline/stream.(*SourceAckerNode).registerNackHandler.func1","line":129},{"file":"/Users/rb/code/conduitio/conduit/pkg/pipeline/stream/dlq.go","func":"github.com/conduitio/conduit/pkg/pipeline/stream.(*DLQHandlerNode).Nack","line":149},{"file":"/Users/rb/code/conduitio/conduit/pkg/processor/procbuiltin/unwrap.go","func":"github.com/conduitio/conduit/pkg/processor/procbuiltin.(*unwrapProcessor).Process","line":95},{"file":"/Users/rb/code/conduitio/conduit/pkg/processor/procbuiltin/unwrap.go","func":"github.com/conduitio/conduit/pkg/processor/procbuiltin.(*openCDCUnwrapper).UnwrapPayload","line":214}]
```

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.