### PR TITLE
Improve builtin plugin sandbox

### DIFF
--- a/pkg/plugin/builtin/v1/destination.go
+++ b/pkg/plugin/builtin/v1/destination.go
@@ -58,7 +58,7 @@ func (s *destinationPluginAdapter) withLogger(ctx context.Context) context.Conte
 
 func (s *destinationPluginAdapter) Configure(ctx context.Context, cfg map[string]string) error {
 	s.logger.Trace(ctx).Msg("calling Configure")
-	_, err := runSandbox(s.impl.Configure, s.withLogger(ctx), toplugin.DestinationConfigureRequest(cfg))
+	_, err := runSandbox(s.impl.Configure, s.withLogger(ctx), toplugin.DestinationConfigureRequest(cfg), s.logger)
 	return err
 }
 
@@ -69,7 +69,7 @@ func (s *destinationPluginAdapter) Start(ctx context.Context) error {
 
 	req := toplugin.DestinationStartRequest()
 	s.logger.Trace(ctx).Msg("calling Start")
-	_, err := runSandbox(s.impl.Start, s.withLogger(ctx), req)
+	_, err := runSandbox(s.impl.Start, s.withLogger(ctx), req, s.logger)
 	if err != nil {
 		return err
 	}
@@ -77,7 +77,7 @@ func (s *destinationPluginAdapter) Start(ctx context.Context) error {
 	s.stream = newDestinationRunStream(ctx)
 	go func() {
 		s.logger.Trace(ctx).Msg("calling Run")
-		err := runSandboxNoResp(s.impl.Run, s.withLogger(ctx), cpluginv1.DestinationRunStream(s.stream))
+		err := runSandboxNoResp(s.impl.Run, s.withLogger(ctx), cpluginv1.DestinationRunStream(s.stream), s.logger)
 		if err != nil {
 			if !s.stream.stop(err) {
 				s.logger.Err(ctx, err).Msg("stream already stopped")
@@ -130,36 +130,32 @@ func (s *destinationPluginAdapter) Ack(ctx context.Context) (record.Position, er
 }
 
 func (s *destinationPluginAdapter) Stop(ctx context.Context, lastPosition record.Position) error {
-	if s.stream == nil {
-		return plugin.ErrStreamNotOpen
-	}
-
 	s.logger.Trace(ctx).Bytes(log.RecordPositionField, lastPosition).Msg("calling Stop")
-	_, err := runSandbox(s.impl.Stop, s.withLogger(ctx), toplugin.DestinationStopRequest(lastPosition))
+	_, err := runSandbox(s.impl.Stop, s.withLogger(ctx), toplugin.DestinationStopRequest(lastPosition), s.logger)
 	return err
 }
 
 func (s *destinationPluginAdapter) Teardown(ctx context.Context) error {
 	s.logger.Trace(ctx).Msg("calling Teardown")
-	_, err := runSandbox(s.impl.Teardown, s.withLogger(ctx), toplugin.DestinationTeardownRequest())
+	_, err := runSandbox(s.impl.Teardown, s.withLogger(ctx), toplugin.DestinationTeardownRequest(), s.logger)
 	return err
 }
 
 func (s *destinationPluginAdapter) LifecycleOnCreated(ctx context.Context, cfg map[string]string) error {
 	s.logger.Trace(ctx).Msg("calling LifecycleOnCreated")
-	_, err := runSandbox(s.impl.LifecycleOnCreated, s.withLogger(ctx), toplugin.DestinationLifecycleOnCreatedRequest(cfg))
+	_, err := runSandbox(s.impl.LifecycleOnCreated, s.withLogger(ctx), toplugin.DestinationLifecycleOnCreatedRequest(cfg), s.logger)
 	return err
 }
 
 func (s *destinationPluginAdapter) LifecycleOnUpdated(ctx context.Context, cfgBefore, cfgAfter map[string]string) error {
 	s.logger.Trace(ctx).Msg("calling LifecycleOnUpdated")
-	_, err := runSandbox(s.impl.LifecycleOnUpdated, s.withLogger(ctx), toplugin.DestinationLifecycleOnUpdatedRequest(cfgBefore, cfgAfter))
+	_, err := runSandbox(s.impl.LifecycleOnUpdated, s.withLogger(ctx), toplugin.DestinationLifecycleOnUpdatedRequest(cfgBefore, cfgAfter), s.logger)
 	return err
 }
 
 func (s *destinationPluginAdapter) LifecycleOnDeleted(ctx context.Context, cfg map[string]string) error {
 	s.logger.Trace(ctx).Msg("calling LifecycleOnDeleted")
-	_, err := runSandbox(s.impl.LifecycleOnDeleted, s.withLogger(ctx), toplugin.DestinationLifecycleOnDeletedRequest(cfg))
+	_, err := runSandbox(s.impl.LifecycleOnDeleted, s.withLogger(ctx), toplugin.DestinationLifecycleOnDeletedRequest(cfg), s.logger)
 	return err
 }
 

--- a/pkg/plugin/builtin/v1/dispenser.go
+++ b/pkg/plugin/builtin/v1/dispenser.go
@@ -45,7 +45,7 @@ func NewDispenser(
 }
 
 func (d *Dispenser) DispenseSpecifier() (plugin.SpecifierPlugin, error) {
-	return newSpecifierPluginAdapter(d.specifierPlugin()), nil
+	return newSpecifierPluginAdapter(d.specifierPlugin(), d.pluginLogger("specifier")), nil
 }
 
 func (d *Dispenser) DispenseSource() (plugin.SourcePlugin, error) {

--- a/pkg/plugin/builtin/v1/internal/fromplugin/specifier.go
+++ b/pkg/plugin/builtin/v1/internal/fromplugin/specifier.go
@@ -70,9 +70,11 @@ func SpecifierParameter(in cpluginv1.SpecifierParameter) plugin.Parameter {
 			requiredExists = true
 		}
 	}
-	// needed for backward compatibility, in.Required is converted to a validation of type ValidationTypeRequired
-	// making sure not to duplicate the required validation
+	//nolint:staticcheck // needed for backward compatibility, in.Required is
+	// converted to a validation of type ValidationTypeRequired making sure not
+	// to duplicate the required validation
 	if in.Required && !requiredExists {
+		//nolint:makezero // false positive, we actually want to append here
 		validations = append(validations, plugin.Validation{
 			Type: plugin.ValidationTypeRequired,
 		})

--- a/pkg/plugin/builtin/v1/sandbox.go
+++ b/pkg/plugin/builtin/v1/sandbox.go
@@ -16,9 +16,17 @@ package builtinv1
 
 import (
 	"context"
+	"sync"
 
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
 )
+
+var sandboxChanPool = sync.Pool{
+	New: func() any {
+		return make(chan any)
+	},
+}
 
 // runSandbox takes a function and runs it in a sandboxed mode that catches
 // panics and converts them into an error instead.
@@ -28,27 +36,71 @@ func runSandbox[REQ any, RES any](
 	f func(context.Context, REQ) (RES, error),
 	ctx context.Context, // context is the second parameter on purpose
 	req REQ,
+	logger log.CtxLogger,
 ) (res RES, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			panicErr, ok := r.(error)
-			if !ok {
-				panicErr = cerrors.Errorf("panic: %v", r)
-			}
-			err = panicErr
+	c := sandboxChanPool.Get().(chan any)
+
+	returnResponse := func(ctx context.Context, res RES, err error) {
+		defer sandboxChanPool.Put(c)
+		select {
+		case <-ctx.Done():
+			// The context was cancelled, nobody will fetch the result.
+			logger.Error(ctx).
+				Any("response", res).
+				Err(err).
+				Msg("context cancelled when trying to return response from builtin connector plugin (this message comes from a detached plugin)")
+		case c <- res:
+			// The result was sent, now send the error if any and return the
+			// channel to the pool.
+			c <- err
 		}
+	}
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				err, ok := r.(error)
+				if !ok {
+					err = cerrors.Errorf("panic: %v", r)
+				}
+				// return the panic error
+				returnResponse(ctx, res, err)
+			}
+		}()
+
+		res, err := f(ctx, req)
+		returnResponse(ctx, res, err)
 	}()
-	return f(ctx, req)
+
+	select {
+	case <-ctx.Done():
+		// Context was cancelled, detach from calling goroutine and return.
+		logger.Error(ctx).Msg("context cancelled while waiting for builtin connector plugin to respond, detaching from plugin")
+		return res, ctx.Err()
+	case v := <-c:
+		// We got a response, which means the goroutine will send another value
+		// (the error) and then return the channel to the pool.
+		if v != nil {
+			res = v.(RES)
+		}
+		v = <-c
+		if v != nil {
+			err = v.(error)
+		}
+	}
+
+	return res, err
 }
 
 func runSandboxNoResp[REQ any](
 	f func(context.Context, REQ) error,
 	ctx context.Context, // context is the second parameter on purpose
 	req REQ,
+	logger log.CtxLogger,
 ) error {
 	_, err := runSandbox(func(ctx context.Context, req REQ) (any, error) {
 		err := f(ctx, req)
 		return nil, err
-	}, ctx, req)
+	}, ctx, req, logger)
 	return err
 }

--- a/pkg/plugin/builtin/v1/sandbox_test.go
+++ b/pkg/plugin/builtin/v1/sandbox_test.go
@@ -19,13 +19,16 @@ import (
 	"testing"
 
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/matryer/is"
+	"github.com/rs/zerolog"
 )
 
 func TestRunSandbox(t *testing.T) {
 	ctx := context.Background()
 	is := is.New(t)
 	haveErr := cerrors.New("test error")
+	logger := log.New(zerolog.New(zerolog.NewTestWriter(t)))
 
 	type testReq struct {
 		foo string
@@ -84,7 +87,7 @@ func TestRunSandbox(t *testing.T) {
 
 	for _, td := range testData {
 		t.Run(td.name, func(t *testing.T) {
-			gotResp, gotErr := runSandbox(td.f, ctx, td.req)
+			gotResp, gotErr := runSandbox(td.f, ctx, td.req, logger)
 			is.Equal(gotResp, td.resp)
 			if td.strict {
 				// strict mode means we expect a very specific error
@@ -100,7 +103,9 @@ func TestRunSandbox(t *testing.T) {
 func TestRunSandboxNoResp(t *testing.T) {
 	ctx := context.Background()
 	is := is.New(t)
+	logger := log.New(zerolog.New(zerolog.NewTestWriter(t)))
+
 	wantErr := cerrors.New("test error")
-	gotErr := runSandboxNoResp(func(context.Context, any) error { panic(wantErr) }, ctx, nil)
+	gotErr := runSandboxNoResp(func(context.Context, any) error { panic(wantErr) }, ctx, nil, logger)
 	is.Equal(gotErr, wantErr)
 }

--- a/pkg/plugin/builtin/v1/source.go
+++ b/pkg/plugin/builtin/v1/source.go
@@ -59,7 +59,7 @@ func (s *sourcePluginAdapter) withLogger(ctx context.Context) context.Context {
 
 func (s *sourcePluginAdapter) Configure(ctx context.Context, cfg map[string]string) error {
 	s.logger.Trace(ctx).Msg("calling Configure")
-	_, err := runSandbox(s.impl.Configure, s.withLogger(ctx), toplugin.SourceConfigureRequest(cfg))
+	_, err := runSandbox(s.impl.Configure, s.withLogger(ctx), toplugin.SourceConfigureRequest(cfg), s.logger)
 	return err
 }
 
@@ -71,7 +71,7 @@ func (s *sourcePluginAdapter) Start(ctx context.Context, p record.Position) erro
 	req := toplugin.SourceStartRequest(p)
 
 	s.logger.Trace(ctx).Msg("calling Start")
-	resp, err := runSandbox(s.impl.Start, s.withLogger(ctx), req)
+	resp, err := runSandbox(s.impl.Start, s.withLogger(ctx), req, s.logger)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func (s *sourcePluginAdapter) Start(ctx context.Context, p record.Position) erro
 	s.stream = newSourceRunStream(ctx)
 	go func() {
 		s.logger.Trace(ctx).Msg("calling Run")
-		err := runSandboxNoResp(s.impl.Run, s.withLogger(ctx), cpluginv1.SourceRunStream(s.stream))
+		err := runSandboxNoResp(s.impl.Run, s.withLogger(ctx), cpluginv1.SourceRunStream(s.stream), s.logger)
 		if err != nil {
 			if !s.stream.stop(err) {
 				s.logger.Err(ctx, err).Msg("stream already stopped")
@@ -130,12 +130,8 @@ func (s *sourcePluginAdapter) Ack(ctx context.Context, p record.Position) error 
 }
 
 func (s *sourcePluginAdapter) Stop(ctx context.Context) (record.Position, error) {
-	if s.stream == nil {
-		return nil, plugin.ErrStreamNotOpen
-	}
-
 	s.logger.Trace(ctx).Msg("calling Stop")
-	resp, err := runSandbox(s.impl.Stop, s.withLogger(ctx), toplugin.SourceStopRequest())
+	resp, err := runSandbox(s.impl.Stop, s.withLogger(ctx), toplugin.SourceStopRequest(), s.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -144,25 +140,25 @@ func (s *sourcePluginAdapter) Stop(ctx context.Context) (record.Position, error)
 
 func (s *sourcePluginAdapter) Teardown(ctx context.Context) error {
 	s.logger.Trace(ctx).Msg("calling Teardown")
-	_, err := runSandbox(s.impl.Teardown, s.withLogger(ctx), toplugin.SourceTeardownRequest())
+	_, err := runSandbox(s.impl.Teardown, s.withLogger(ctx), toplugin.SourceTeardownRequest(), s.logger)
 	return err
 }
 
 func (s *sourcePluginAdapter) LifecycleOnCreated(ctx context.Context, cfg map[string]string) error {
 	s.logger.Trace(ctx).Msg("calling LifecycleOnCreated")
-	_, err := runSandbox(s.impl.LifecycleOnCreated, s.withLogger(ctx), toplugin.SourceLifecycleOnCreatedRequest(cfg))
+	_, err := runSandbox(s.impl.LifecycleOnCreated, s.withLogger(ctx), toplugin.SourceLifecycleOnCreatedRequest(cfg), s.logger)
 	return err
 }
 
 func (s *sourcePluginAdapter) LifecycleOnUpdated(ctx context.Context, cfgBefore, cfgAfter map[string]string) error {
 	s.logger.Trace(ctx).Msg("calling LifecycleOnUpdated")
-	_, err := runSandbox(s.impl.LifecycleOnUpdated, s.withLogger(ctx), toplugin.SourceLifecycleOnUpdatedRequest(cfgBefore, cfgAfter))
+	_, err := runSandbox(s.impl.LifecycleOnUpdated, s.withLogger(ctx), toplugin.SourceLifecycleOnUpdatedRequest(cfgBefore, cfgAfter), s.logger)
 	return err
 }
 
 func (s *sourcePluginAdapter) LifecycleOnDeleted(ctx context.Context, cfg map[string]string) error {
 	s.logger.Trace(ctx).Msg("calling LifecycleOnDeleted")
-	_, err := runSandbox(s.impl.LifecycleOnDeleted, s.withLogger(ctx), toplugin.SourceLifecycleOnDeletedRequest(cfg))
+	_, err := runSandbox(s.impl.LifecycleOnDeleted, s.withLogger(ctx), toplugin.SourceLifecycleOnDeletedRequest(cfg), s.logger)
 	return err
 }
 

--- a/pkg/plugin/builtin/v1/specifier.go
+++ b/pkg/plugin/builtin/v1/specifier.go
@@ -18,27 +18,30 @@ import (
 	"context"
 
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1"
+	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/plugin"
 	"github.com/conduitio/conduit/pkg/plugin/builtin/v1/internal/fromplugin"
 	"github.com/conduitio/conduit/pkg/plugin/builtin/v1/internal/toplugin"
 )
 
-// TODO make sure a panic in a plugin doesn't crash Conduit
 type specifierPluginAdapter struct {
 	impl cpluginv1.SpecifierPlugin
+	// logger is used as the internal logger of specifierPluginAdapter.
+	logger log.CtxLogger
 }
 
 var _ plugin.SpecifierPlugin = (*specifierPluginAdapter)(nil)
 
-func newSpecifierPluginAdapter(impl cpluginv1.SpecifierPlugin) *specifierPluginAdapter {
+func newSpecifierPluginAdapter(impl cpluginv1.SpecifierPlugin, logger log.CtxLogger) *specifierPluginAdapter {
 	return &specifierPluginAdapter{
-		impl: impl,
+		impl:   impl,
+		logger: logger.WithComponent("builtinv1.specifierPluginAdapter"),
 	}
 }
 
 func (s *specifierPluginAdapter) Specify() (plugin.Specification, error) {
 	req := toplugin.SpecifierSpecifyRequest()
-	resp, err := runSandbox(s.impl.Specify, context.Background(), req)
+	resp, err := runSandbox(s.impl.Specify, context.Background(), req, s.logger)
 	if err != nil {
 		return plugin.Specification{}, err
 	}

--- a/pkg/plugin/service.go
+++ b/pkg/plugin/service.go
@@ -56,8 +56,6 @@ func (s *Service) Check(_ context.Context) error {
 }
 
 func (s *Service) NewDispenser(logger log.CtxLogger, name string) (Dispenser, error) {
-	logger = logger.WithComponent("plugin")
-
 	fullName := FullName(name)
 	switch fullName.PluginType() {
 	case PluginTypeStandalone:

--- a/pkg/plugin/standalone/registry.go
+++ b/pkg/plugin/standalone/registry.go
@@ -191,6 +191,7 @@ func (r *Registry) NewDispenser(logger log.CtxLogger, fullName plugin.FullName) 
 		return nil, cerrors.Errorf("could not find standalone plugin, only found versions %v: %w", availableVersions, plugin.ErrPluginNotFound)
 	}
 
+	logger = logger.WithComponent("plugin.standalone")
 	return standalonev1.NewDispenser(logger.ZerologWithComponent(), bp.path)
 }
 

--- a/pkg/plugin/standalone/v1/destination.go
+++ b/pkg/plugin/standalone/v1/destination.go
@@ -118,10 +118,6 @@ func (s *destinationPluginClient) Ack(_ context.Context) (record.Position, error
 }
 
 func (s *destinationPluginClient) Stop(ctx context.Context, lastPosition record.Position) error {
-	if s.stream == nil {
-		return plugin.ErrStreamNotOpen
-	}
-
 	protoReq := toproto.DestinationStopRequest(lastPosition)
 	_, err := s.grpcClient.Stop(ctx, protoReq)
 	if err != nil {

--- a/pkg/plugin/standalone/v1/source.go
+++ b/pkg/plugin/standalone/v1/source.go
@@ -112,10 +112,6 @@ func (s *sourcePluginClient) Ack(_ context.Context, p record.Position) error {
 }
 
 func (s *sourcePluginClient) Stop(ctx context.Context) (record.Position, error) {
-	if s.stream == nil {
-		return nil, plugin.ErrStreamNotOpen
-	}
-
 	protoReq := toproto.SourceStopRequest()
 	protoResp, err := s.grpcClient.Stop(ctx, protoReq)
 	if err != nil {


### PR DESCRIPTION
### Description

In this PR we change the behavior of the builtin plugin sandbox. Plugin functions are now run in a goroutine so we can detach from the call in case it blocks forever (e.g. a plugin bug). We add tests to confirm that this behavior matches the behavior in standalone plugins.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.