### PR TITLE
Remove redundant CI actions

### DIFF
--- a/.github/workflows/validate-generated-files.yml
+++ b/.github/workflows/validate-generated-files.yml
@@ -16,12 +16,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-
-      - name: Set up Buf
-        uses: bufbuild/buf-setup-action@v1.29.0
-
       - name: Check generated files
         run: |
           export PATH=$PATH:$(go env GOPATH)/bin


### PR DESCRIPTION
### Description

Follow-up to #1429, we don't need to install protoc anymore and buf is installed using `make install-tools`.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.