### PR TITLE
Make sure plugins with non-semantic version are registered as `latest`

### DIFF
--- a/pkg/plugin/name.go
+++ b/pkg/plugin/name.go
@@ -72,17 +72,27 @@ func (fn FullName) PluginVersion() string {
 	return PluginVersionLatest // default
 }
 
-func (fn FullName) PluginVersionGreaterThan(other FullName) bool {
-	leftVersion := fn.PluginVersion()
-	rightVersion := other.PluginVersion()
-
-	leftSemver, err := semver.NewVersion(leftVersion)
-	if err != nil {
-		return false // left is an invalid semver, right is greater either way
+func (fn FullName) PluginVersionGreaterThan(right FullName) bool {
+	if right == "" {
+		return true // right is empty, left is greater either way
 	}
-	rightSemver, err := semver.NewVersion(rightVersion)
-	if err != nil {
-		return true // left is a valid semver, right is not, left is greater
+	if fn == "" {
+		return true // left is empty, right is greater either way
+	}
+
+	leftVersion := fn.PluginVersion()
+	leftSemver, errLeft := semver.NewVersion(leftVersion)
+
+	rightVersion := right.PluginVersion()
+	rightSemver, errRight := semver.NewVersion(rightVersion)
+
+	if errLeft != nil && errRight != nil {
+		// both are invalid semvers, compare as strings
+		return leftVersion < rightVersion
+	} else if errRight != nil {
+		return true // right is an invalid semver, left is greater either way
+	} else if errLeft != nil {
+		return false // left is an invalid semver, right is greater either way
 	}
 
 	return leftSemver.GreaterThan(rightSemver)

--- a/pkg/plugin/name.go
+++ b/pkg/plugin/name.go
@@ -86,12 +86,13 @@ func (fn FullName) PluginVersionGreaterThan(right FullName) bool {
 	rightVersion := right.PluginVersion()
 	rightSemver, errRight := semver.NewVersion(rightVersion)
 
-	if errLeft != nil && errRight != nil {
+	switch {
+	case errLeft != nil && errRight != nil:
 		// both are invalid semvers, compare as strings
 		return leftVersion < rightVersion
-	} else if errRight != nil {
+	case errRight != nil:
 		return true // right is an invalid semver, left is greater either way
-	} else if errLeft != nil {
+	case errLeft != nil:
 		return false // left is an invalid semver, right is greater either way
 	}
 

--- a/pkg/plugin/name.go
+++ b/pkg/plugin/name.go
@@ -73,13 +73,6 @@ func (fn FullName) PluginVersion() string {
 }
 
 func (fn FullName) PluginVersionGreaterThan(right FullName) bool {
-	if right == "" {
-		return true // right is empty, left is greater either way
-	}
-	if fn == "" {
-		return true // left is empty, right is greater either way
-	}
-
 	leftVersion := fn.PluginVersion()
 	leftSemver, errLeft := semver.NewVersion(leftVersion)
 
@@ -88,6 +81,12 @@ func (fn FullName) PluginVersionGreaterThan(right FullName) bool {
 
 	switch {
 	case errLeft != nil && errRight != nil:
+		switch {
+		case leftVersion == PluginVersionLatest:
+			return false // latest could be anything, we prioritize explicit versions
+		case rightVersion == PluginVersionLatest:
+			return true // latest could be anything, we prioritize explicit versions
+		}
 		// both are invalid semvers, compare as strings
 		return leftVersion < rightVersion
 	case errRight != nil:

--- a/pkg/plugin/name_test.go
+++ b/pkg/plugin/name_test.go
@@ -28,6 +28,7 @@ func TestFullName(t *testing.T) {
 		pn string // expected plugin name
 		pv string // expected plugin version
 	}{
+		{fn: "", pt: "any", pn: "", pv: "latest"},
 		{fn: "my-plugin", pt: "any", pn: "my-plugin", pv: "latest"},
 		{fn: "builtin:my-plugin", pt: "builtin", pn: "my-plugin", pv: "latest"},
 		{fn: "my-plugin@v0.1.1", pt: "any", pn: "my-plugin", pv: "v0.1.1"},
@@ -50,7 +51,7 @@ func TestFullName_PluginVersionGreaterThanP(t *testing.T) {
 	testCases := []struct {
 		v1 string // left version
 		v2 string // right version
-		gt bool   // want greater than
+		gt bool   // is left greater than right
 	}{
 		{v1: "v0.0.1", v2: "v0.0.1", gt: false},
 		{v1: "v0.1", v2: "v0.0.1", gt: true},
@@ -60,8 +61,12 @@ func TestFullName_PluginVersionGreaterThanP(t *testing.T) {
 		{v1: "foo", v2: "v0.0.1", gt: false},
 		{v1: "v0.0.1", v2: "foo", gt: true},
 		{v1: "foo", v2: "bar", gt: false},
-		{v1: "bar", v2: "foo", gt: false},
+		{v1: "bar", v2: "foo", gt: true},
 		{v1: "v0.0.1", v2: "v0.0.1-dirty", gt: true},
+		{v1: "bar", v2: "", gt: true},
+		{v1: "v1", v2: "", gt: true},
+		{v1: "", v2: "bar", gt: false},
+		{v1: "", v2: "v1", gt: false},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/plugin/name_test.go
+++ b/pkg/plugin/name_test.go
@@ -47,7 +47,7 @@ func TestFullName(t *testing.T) {
 	}
 }
 
-func TestFullName_PluginVersionGreaterThanP(t *testing.T) {
+func TestFullName_PluginVersionGreaterThan(t *testing.T) {
 	testCases := []struct {
 		v1 string // left version
 		v2 string // right version
@@ -63,10 +63,11 @@ func TestFullName_PluginVersionGreaterThanP(t *testing.T) {
 		{v1: "foo", v2: "bar", gt: false},
 		{v1: "bar", v2: "foo", gt: true},
 		{v1: "v0.0.1", v2: "v0.0.1-dirty", gt: true},
-		{v1: "bar", v2: "", gt: true},
+		{v1: "zoo", v2: "", gt: true},
 		{v1: "v1", v2: "", gt: true},
-		{v1: "", v2: "bar", gt: false},
+		{v1: "", v2: "zoo", gt: false},
 		{v1: "", v2: "v1", gt: false},
+		{v1: "", v2: "", gt: false},
 	}
 
 	for _, tc := range testCases {
@@ -74,6 +75,12 @@ func TestFullName_PluginVersionGreaterThanP(t *testing.T) {
 			is := is.New(t)
 			v1 := NewFullName("builtin", "test", tc.v1)
 			v2 := NewFullName("builtin", "test", tc.v2)
+			is.Equal(v1.PluginVersionGreaterThan(v2), tc.gt)
+
+			// even if plugin type and plugin name are empty, the version
+			// comparison should still work the same
+			v1 = NewFullName("", "", tc.v1)
+			v2 = NewFullName("", "", tc.v2)
 			is.Equal(v1.PluginVersionGreaterThan(v2), tc.gt)
 		})
 	}


### PR DESCRIPTION
### Description

Given this change https://github.com/ConduitIO/conduit-processor-sdk/pull/31 it would be nice if Conduit allowed you to use `my-processor@latest` (or no version) when using a processor without a semantic version. This fixes the behavior both for connectors and processors.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.