### PR TITLE
Add support for converting []byte to string

### DIFF
--- a/pkg/plugin/processor/builtin/impl/field/convert.go
+++ b/pkg/plugin/processor/builtin/impl/field/convert.go
@@ -133,6 +133,8 @@ func (p *convertProcessor) stringToType(value, typ string) (any, error) {
 
 func (p *convertProcessor) toString(value any) string {
 	switch v := value.(type) {
+	case []byte:
+		return string(v)
 	case string:
 		return v
 	case int:

--- a/pkg/plugin/processor/builtin/impl/field/convert_test.go
+++ b/pkg/plugin/processor/builtin/impl/field/convert_test.go
@@ -197,6 +197,16 @@ func TestConvertField_Process(t *testing.T) {
 			want: sdk.SingleRecord{
 				Key: opencdc.StructuredData{"id": "false"},
 			},
+		}, {
+			name:  "bytes to string",
+			field: ".Key.id",
+			typ:   "string",
+			record: opencdc.Record{
+				Key: opencdc.StructuredData{"id": []byte("foo")},
+			},
+			want: sdk.SingleRecord{
+				Key: opencdc.StructuredData{"id": "foo"},
+			},
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
### Description

I discovered this issue while working on my champagne project. I expected the `field.convert` processor to be able to convert raw `[]byte` to `string`. This change makes it able to do that.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.