### PR TITLE
Upgrade Go version in docker image to 1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start with a golang base
-FROM golang:1.21-bullseye AS base
+FROM golang:1.22-bullseye AS base
 
 # Install core tools
 RUN apt-get update &&\


### PR DESCRIPTION
### Description

Fixes failed [nightly release](https://github.com/ConduitIO/conduit/commit/cef8ae473320f2489927b7447c324c7bea83381f).