### PR TITLE
http processor: replace space with +

### DIFF
--- a/pkg/plugin/processor/builtin/impl/webhook/http.go
+++ b/pkg/plugin/processor/builtin/impl/webhook/http.go
@@ -164,7 +164,8 @@ func (p *httpProcessor) EvaluateURL(rec opencdc.Record) (string, error) {
 	if err != nil {
 		return "", cerrors.Errorf("error while evaluating URL template: %w", err)
 	}
-	return b.String(), nil
+	url := strings.ReplaceAll(b.String(), " ", "+")
+	return url, nil
 }
 
 func (p *httpProcessor) Process(ctx context.Context, records []opencdc.Record) []sdk.ProcessedRecord {

--- a/pkg/plugin/processor/builtin/impl/webhook/http.go
+++ b/pkg/plugin/processor/builtin/impl/webhook/http.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"text/template"
@@ -164,8 +165,16 @@ func (p *httpProcessor) EvaluateURL(rec opencdc.Record) (string, error) {
 	if err != nil {
 		return "", cerrors.Errorf("error while evaluating URL template: %w", err)
 	}
-	url := strings.ReplaceAll(b.String(), " ", "+")
-	return url, nil
+	u, err := url.Parse(b.String())
+	if err != nil {
+		return "", cerrors.Errorf("error parsing URL: %w", err)
+	}
+	q, err := url.ParseQuery(u.RawQuery)
+	if err != nil {
+		return "", cerrors.Errorf("error parsing URL query: %w", err)
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
 }
 
 func (p *httpProcessor) Process(ctx context.Context, records []opencdc.Record) []sdk.ProcessedRecord {

--- a/pkg/plugin/processor/builtin/impl/webhook/http_test.go
+++ b/pkg/plugin/processor/builtin/impl/webhook/http_test.go
@@ -400,13 +400,13 @@ func TestHTTPProcessor_URLTemplate(t *testing.T) {
 			}},
 		},
 		{
-			name:     "URL template, value that has spaces",
-			pathTmpl: `/{{.Payload.Before.query}}`,
-			path:     "/what+is+conduit",
+			name:     "URL template, path and query have spaces",
+			pathTmpl: `/{{.Payload.Before.url}}`,
+			path:     "/what%20is%20conduit?id=my+id",
 			args: []opencdc.Record{{
 				Payload: opencdc.Change{
 					Before: opencdc.StructuredData{
-						"query": "what is conduit",
+						"url": "what is conduit?id=my id",
 					},
 				},
 			}},
@@ -419,7 +419,7 @@ func TestHTTPProcessor_URLTemplate(t *testing.T) {
 
 			srv := httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 				// check the expected path with the evaluated URL
-				is.Equal(req.URL.Path, tc.path)
+				is.Equal(req.URL.String(), tc.path)
 			}))
 			defer srv.Close()
 

--- a/pkg/plugin/processor/builtin/impl/webhook/http_test.go
+++ b/pkg/plugin/processor/builtin/impl/webhook/http_test.go
@@ -399,6 +399,18 @@ func TestHTTPProcessor_URLTemplate(t *testing.T) {
 				},
 			}},
 		},
+		{
+			name:     "URL template, value that has spaces",
+			pathTmpl: `/{{.Payload.Before.query}}`,
+			path:     "/what+is+conduit",
+			args: []opencdc.Record{{
+				Payload: opencdc.Change{
+					Before: opencdc.StructuredData{
+						"query": "what is conduit",
+					},
+				},
+			}},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
### Description

if the URL template values contain spaces, the spaces will be replaced by `+`

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.