### PR TITLE
update nightly releases and docs' docker image to point to our scarf package

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,7 +51,7 @@ release:
 
     To pull the image, you can execute the following command:
     ```
-    docker pull ghcr.io/conduitio/conduit:{{ .Tag }}
+    docker pull conduit.docker.scarf.sh/conduitio/conduit:{{ .Tag }}
     ```
 nfpms:
   - license: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Our Docker images are hosted on GitHub's Container Registry. To run the latest
 Conduit version, you should run the following command:
 
 ```sh
-docker run -p 8080:8080 ghcr.io/conduitio/conduit:latest
+docker run -p 8080:8080 conduit.docker.scarf.sh/conduitio/conduit:latest
 ```
 
 The Docker image includes the [UI](#ui), you can access it by navigating


### PR DESCRIPTION
### Description

updated some missed docker links to sacrf

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.