### PR TITLE
Manually set current tag in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
   build-push-docker-image:
     name: Build and push Docker image


### PR DESCRIPTION
### Description

As can be seen in this [CI action run](https://github.com/ConduitIO/conduit/actions/runs/9338795310/job/25702373999#step:5:23), the current tag chosen by goreleaser was `v0.11.0-nightly.20240601` instead of `v0.10.1`, which was the actually pushed tag. This change manually sets the current tag using an [ENV variable](https://goreleaser.com/cookbooks/set-a-custom-git-tag/) set to [`github.ref_name`](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context), which will contain the name of the pushed tag. The action is restricted to only run when a tag is pushed, so `github.ref_name` should always contain the name of the tag.