### PR TITLE
Add handling for time.Time in avro encode processor

### DIFF
--- a/pkg/plugin/processor/builtin/impl/avro/schemaregistry/avro/extractor.go
+++ b/pkg/plugin/processor/builtin/impl/avro/schemaregistry/avro/extractor.go
@@ -61,7 +61,6 @@ func (e extractor) Extract(v any) (avro.Schema, error) {
 }
 
 func (e extractor) extract(path []string, v reflect.Value, t reflect.Type) (avro.Schema, error) {
-
 	if t == nil {
 		return nil, cerrors.Errorf("%s: can't get schema for untyped nil", strings.Join(path, ".")) // untyped nil
 	}

--- a/pkg/plugin/processor/builtin/impl/avro/schemaregistry/avro/schema_test.go
+++ b/pkg/plugin/processor/builtin/impl/avro/schemaregistry/avro/schema_test.go
@@ -507,7 +507,7 @@ func TestSchema_MarshalUnmarshal(t *testing.T) {
 			"foo": "bar",
 			"bar": 1,
 			"baz": []any{1, 2, 3},
-			"tz":  now,
+			"tz":  now.Truncate(time.Microsecond), // Avro cannot does not support nanoseconds
 		},
 		wantSchema: must(avro.NewRecordSchema(
 			"record.foo",

--- a/pkg/plugin/processor/builtin/impl/avro/schemaregistry/avro/schema_test.go
+++ b/pkg/plugin/processor/builtin/impl/avro/schemaregistry/avro/schema_test.go
@@ -17,6 +17,7 @@ package avro
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/conduitio/conduit-commons/opencdc"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
@@ -25,6 +26,8 @@ import (
 )
 
 func TestSchema_MarshalUnmarshal(t *testing.T) {
+	now := time.Now().UTC()
+
 	testCases := []struct {
 		name string
 		// haveValue is the value we use to extract the schema and which gets marshaled
@@ -498,11 +501,13 @@ func TestSchema_MarshalUnmarshal(t *testing.T) {
 			"foo": "bar",
 			"bar": 1,
 			"baz": []int{1, 2, 3},
+			"tz":  now,
 		},
 		wantValue: map[string]any{ // structured data is unmarshaled into a map
 			"foo": "bar",
 			"bar": 1,
 			"baz": []any{1, 2, 3},
+			"tz":  now,
 		},
 		wantSchema: must(avro.NewRecordSchema(
 			"record.foo",
@@ -511,6 +516,7 @@ func TestSchema_MarshalUnmarshal(t *testing.T) {
 				must(avro.NewField("foo", avro.NewPrimitiveSchema(avro.String, nil))),
 				must(avro.NewField("bar", avro.NewPrimitiveSchema(avro.Int, nil))),
 				must(avro.NewField("baz", avro.NewArraySchema(avro.NewPrimitiveSchema(avro.Int, nil)))),
+				must(avro.NewField("tz", avro.NewPrimitiveSchema(avro.Long, avro.NewPrimitiveLogicalSchema(avro.TimestampMicros)))),
 			},
 		)),
 	}}


### PR DESCRIPTION
### Description

This change is only applicable for builtin connectors, since complex types such as `time.Time` are not
allowed in standalone connector due to restrictions in the plugin framework.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.