### PR TITLE
support empty .payload.After / .payload.Before in avro.decode

### DIFF
--- a/pkg/plugin/processor/builtin/impl/avro/encode.go
+++ b/pkg/plugin/processor/builtin/impl/avro/encode.go
@@ -211,7 +211,12 @@ func (p *encodeProcessor) structuredData(data any) (opencdc.StructuredData, erro
 	var sd opencdc.StructuredData
 	switch v := data.(type) {
 	case opencdc.RawData:
-		err := json.Unmarshal(v.Bytes(), &sd)
+		b := v.Bytes()
+		// if data is empty, then return empty structured data
+		if len(b) == 0 || b == nil {
+			return sd, nil
+		}
+		err := json.Unmarshal(b, &sd)
 		if err != nil {
 			return nil, cerrors.Errorf("failed unmarshalling JSON from raw data: %w", err)
 		}

--- a/pkg/plugin/processor/builtin/impl/avro/encode.go
+++ b/pkg/plugin/processor/builtin/impl/avro/encode.go
@@ -213,7 +213,7 @@ func (p *encodeProcessor) structuredData(data any) (opencdc.StructuredData, erro
 	case opencdc.RawData:
 		b := v.Bytes()
 		// if data is empty, then return empty structured data
-		if len(b) == 0 || b == nil {
+		if len(b) == 0 {
 			return sd, nil
 		}
 		err := json.Unmarshal(b, &sd)

--- a/pkg/plugin/processor/builtin/impl/avro/encode_test.go
+++ b/pkg/plugin/processor/builtin/impl/avro/encode_test.go
@@ -164,43 +164,89 @@ func TestEncodeProcessor_Process_RawData_CustomField(t *testing.T) {
 	}
 }
 
-func TestEncodeProcessor_Process_EmptyPayloadAfter(t *testing.T) {
-	t.Run("empty .Payload.After", func(t *testing.T) {
-		is := is.New(t)
-		ctx := context.Background()
-
-		config := map[string]string{
-			"url":                         "http://localhost",
-			"field":                       ".Payload.After",
-			"schema.strategy":             "autoRegister",
-			"schema.autoRegister.subject": "testsubject",
-		}
-		input := opencdc.Record{
-			Payload: opencdc.Change{
-				Before: opencdc.StructuredData{
-					"something": opencdc.RawData(`{"field_int": 123}`),
+func TestEncodeProcessor_Process_EmptyPayloadField(t *testing.T) {
+	testCases := []struct {
+		name              string
+		field             string
+		input             opencdc.Record
+		mockEncoder       func(ctx context.Context) *MockEncoder
+		wantPayloadBefore opencdc.Data
+		wantPayloadAfter  opencdc.Data
+	}{
+		{
+			name:  "empty payload.Before encoding",
+			field: ".Payload.Before",
+			input: opencdc.Record{
+				Payload: opencdc.Change{
+					Before: opencdc.StructuredData{},
+					After: opencdc.StructuredData{
+						"something": opencdc.RawData(`{"field_int": 123}`),
+					},
 				},
-				After: opencdc.StructuredData{},
 			},
-		}
+			wantPayloadBefore: opencdc.RawData(`{}`),
+			wantPayloadAfter: opencdc.StructuredData{
+				"something": opencdc.RawData(`{"field_int": 123}`),
+			},
+			mockEncoder: func(ctx context.Context) *MockEncoder {
+				m := NewMockEncoder(gomock.NewController(t))
+				m.EXPECT().
+					Encode(ctx, opencdc.StructuredData{}).
+					Return(opencdc.RawData(`{}`), nil)
+				return m
+			},
+		},
+		{
+			name:  "empty payload.After encoding",
+			field: ".Payload.After",
+			input: opencdc.Record{
+				Payload: opencdc.Change{
+					Before: opencdc.StructuredData{
+						"something": opencdc.RawData(`{"field_int": 123}`),
+					},
+					After: opencdc.StructuredData{},
+				},
+			},
+			wantPayloadBefore: opencdc.StructuredData{
+				"something": opencdc.RawData(`{"field_int": 123}`),
+			},
+			wantPayloadAfter: opencdc.RawData(`{}`),
+			mockEncoder: func(ctx context.Context) *MockEncoder {
+				m := NewMockEncoder(gomock.NewController(t))
+				m.EXPECT().
+					Encode(ctx, opencdc.StructuredData{}).
+					Return(opencdc.RawData(`{}`), nil)
+				return m
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			ctx := context.Background()
 
-		encodedValue := opencdc.RawData("{}")
-		want := sdk.SingleRecord(input.Clone())
-		want.Payload.After = encodedValue
+			config := map[string]string{
+				"url":                         "http://localhost",
+				"field":                       tc.field,
+				"schema.strategy":             "autoRegister",
+				"schema.autoRegister.subject": "testsubject",
+			}
 
-		underTest := NewEncodeProcessor(log.Nop())
-		err := underTest.Configure(ctx, config)
-		is.NoErr(err)
+			want := sdk.SingleRecord(tc.input.Clone())
+			want.Payload.After = tc.wantPayloadAfter
+			want.Payload.Before = tc.wantPayloadBefore
 
-		// skipping Open(), so we can inject a mock encoder
-		mockEncoder := NewMockEncoder(gomock.NewController(t))
-		mockEncoder.EXPECT().
-			Encode(ctx, opencdc.StructuredData{}).
-			Return(encodedValue, nil)
-		underTest.(*encodeProcessor).encoder = mockEncoder
+			underTest := NewEncodeProcessor(log.Nop())
+			err := underTest.Configure(ctx, config)
+			is.NoErr(err)
 
-		got := underTest.Process(ctx, []opencdc.Record{input})
-		is.Equal(1, len(got))
-		is.Equal("", cmp.Diff(want, got[0], internal.CmpProcessedRecordOpts...))
-	})
+			// skipping Open(), so we can inject a mock encoder
+			mockEncoder := tc.mockEncoder(ctx)
+			underTest.(*encodeProcessor).encoder = mockEncoder
+
+			got := underTest.Process(ctx, []opencdc.Record{tc.input})
+			is.Equal(1, len(got))
+			is.Equal("", cmp.Diff(want, got[0], internal.CmpProcessedRecordOpts...))
+		})
+	}
 }


### PR DESCRIPTION
### Description

The avro decode processor states the following:
> If a specific field is set to nil the processor won't have enough information to determine the type and will default to a nullable string.

In the case that the entire `.payload.after` is nil, the processor fails with the following error:
```
failed getting structured data: failed unmarshalling JSON from raw data: expected {} for map
```

This attempts to alleviate the issue, by instead returning an empty `sdk.StructuredData` in this scenario.

Fixes # (issue)

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.