### PR TITLE
Enable container-retention-policy action

### DIFF
--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -51,4 +51,3 @@ jobs:
           image-tags: '*-nightly*'
           cut-off: 1w
           token: ${{ secrets.NIGHTLY_BUILD_GH_TOKEN }}
-          dry-run: true


### PR DESCRIPTION
### Description

Re-enable container retention policy CI action. The last run would have deleted 8 container images, all older than 1 week, looks good.