### PR TITLE
Don't release win/i386

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,9 @@ builds:
       - darwin
       - linux
       - windows
+    ignore:
+      - goos: windows
+        goarch: "386"
     env:
       - CGO_ENABLED=0
     tags:
@@ -71,7 +74,6 @@ release:
     ### Windows
     
     - 📦 [conduit_{{ .Version }}_Windows_arm64.zip](https://conduit.gateway.scarf.sh/conduit/download/{{ .Tag }}/conduit_{{ .Version }}_Windows_arm64.zip)
-    - 📦 [conduit_{{ .Version }}_Windows_i386.zip](https://conduit.gateway.scarf.sh/conduit/download/{{ .Tag }}/conduit_{{ .Version }}_Windows_i386.zip)
     - 📦 [conduit_{{ .Version }}_Windows_x86_64.zip](https://conduit.gateway.scarf.sh/conduit/download/{{ .Tag }}/conduit_{{ .Version }}_Windows_x86_64.zip)
 
     ## Docker images


### PR DESCRIPTION
### Description

The addition of [sqlite](https://github.com/ConduitIO/conduit/pull/1682) broke our [windows i386](https://github.com/ConduitIO/conduit/actions/runs/9883266155/job/27297691161#step:5:47) build. This PR removes the support for this os/arch combination.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.