### PR TITLE
Tests and examples for converting time using `field.convert`

### DIFF
--- a/pkg/plugin/processor/builtin/impl/field/convert.go
+++ b/pkg/plugin/processor/builtin/impl/field/convert.go
@@ -117,7 +117,7 @@ func (p *convertProcessor) stringToType(value, typ string) (any, error) {
 		unixnano, err := strconv.Atoi(value)
 		if err == nil {
 			// it's a number, use it as a unix nanosecond timestamp
-			return time.Unix(0, int64(unixnano)), nil
+			return time.Unix(0, int64(unixnano)).UTC(), nil
 		}
 		// try to parse it as a time string
 		return time.Parse(time.RFC3339Nano, value)

--- a/pkg/plugin/processor/builtin/impl/field/convert_examples_test.go
+++ b/pkg/plugin/processor/builtin/impl/field/convert_examples_test.go
@@ -15,6 +15,8 @@
 package field
 
 import (
+	"time"
+
 	"github.com/conduitio/conduit-commons/config"
 	"github.com/conduitio/conduit-commons/opencdc"
 	sdk "github.com/conduitio/conduit-processor-sdk"
@@ -140,6 +142,49 @@ func ExampleConvertProcessor_floatToString() {
 	//      "before": null,
 	//      "after": {
 	//        "foo": "bar"
+	//      }
+	//    }
+	//  }
+}
+
+//nolint:govet // a more descriptive example description
+func ExampleConvertProcessor_intTotime() {
+	p := NewConvertProcessor(log.Nop())
+
+	timeObj := time.Date(2024, 1, 2, 12, 34, 56, 123456789, time.UTC)
+
+	exampleutil.RunExample(p, exampleutil.Example{
+		Summary:     "Convert `string` to `time`",
+		Description: "This example takes an `int` in field `.Payload.After.createdAt` and parses it as a unix timestamp into a `time.Time` value.",
+		Config:      config.Config{"field": ".Payload.After.createdAt", "type": "time"},
+		Have: opencdc.Record{
+			Operation: opencdc.OperationCreate,
+			Key:       opencdc.StructuredData{"id": 123.345},
+			Payload:   opencdc.Change{After: opencdc.StructuredData{"createdAt": timeObj.UnixNano()}},
+		},
+		Want: sdk.SingleRecord{
+			Operation: opencdc.OperationCreate,
+			Key:       opencdc.StructuredData{"id": 123.345},
+			Payload:   opencdc.Change{After: opencdc.StructuredData{"createdAt": timeObj}},
+		}})
+
+	// Output:
+	// processor transformed record:
+	// --- before
+	// +++ after
+	// @@ -1,14 +1,14 @@
+	//  {
+	//    "position": null,
+	//    "operation": "create",
+	//    "metadata": null,
+	//    "key": {
+	//      "id": 123.345
+	//    },
+	//    "payload": {
+	//      "before": null,
+	//      "after": {
+	// -      "createdAt": 1704198896123456789
+	// +      "createdAt": "2024-01-02T12:34:56.123456789Z"
 	//      }
 	//    }
 	//  }

--- a/pkg/plugin/processor/builtin/impl/field/convert_examples_test.go
+++ b/pkg/plugin/processor/builtin/impl/field/convert_examples_test.go
@@ -154,7 +154,7 @@ func ExampleConvertProcessor_intTotime() {
 	timeObj := time.Date(2024, 1, 2, 12, 34, 56, 123456789, time.UTC)
 
 	exampleutil.RunExample(p, exampleutil.Example{
-		Summary:     "Convert `string` to `time`",
+		Summary:     "Convert `int` to `time`",
 		Description: "This example takes an `int` in field `.Payload.After.createdAt` and parses it as a unix timestamp into a `time.Time` value.",
 		Config:      config.Config{"field": ".Payload.After.createdAt", "type": "time"},
 		Have: opencdc.Record{

--- a/pkg/plugin/processor/builtin/impl/field/convert_test.go
+++ b/pkg/plugin/processor/builtin/impl/field/convert_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/conduitio/conduit-commons/config"
 	"github.com/conduitio/conduit-commons/opencdc"
@@ -208,6 +209,26 @@ func TestConvertField_Process(t *testing.T) {
 			want: sdk.SingleRecord{
 				Key: opencdc.StructuredData{"id": "foo"},
 			},
+		}, {
+			name:  "int to time",
+			field: ".Key.id",
+			typ:   "time",
+			record: opencdc.Record{
+				Key: opencdc.StructuredData{"id": 1611254412345678999},
+			},
+			want: sdk.SingleRecord{
+				Key: opencdc.StructuredData{"id": time.Date(2021, 1, 21, 18, 40, 12, 345678999, time.UTC)},
+			},
+		}, {
+			name:  "string to time",
+			field: ".Key.id",
+			typ:   "time",
+			record: opencdc.Record{
+				Key: opencdc.StructuredData{"id": "2021-01-21T18:40:12.345678999Z"},
+			},
+			want: sdk.SingleRecord{
+				Key: opencdc.StructuredData{"id": time.Date(2021, 1, 21, 18, 40, 12, 345678999, time.UTC)},
+			},
 		},
 	}
 	for _, tc := range testCases {
@@ -259,6 +280,14 @@ func TestConvertField_ProcessFail(t *testing.T) {
 				Key: opencdc.StructuredData{"id": 9999999999999999999.0},
 			},
 			wantErr: "value out of range",
+		}, {
+			name:  "string to time, invalid format",
+			field: ".Key.id",
+			typ:   "time",
+			record: opencdc.Record{
+				Key: opencdc.StructuredData{"id": "21.01.2021 18:40:12"},
+			},
+			wantErr: `parsing time "21.01.2021 18:40:12" as "2006-01-02T15:04:05.999999999Z07:00": cannot parse "21.01.2021 18:40:12" as "2006"`,
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/plugin/processor/builtin/internal/exampleutil/specs/field.convert.json
+++ b/pkg/plugin/processor/builtin/internal/exampleutil/specs/field.convert.json
@@ -40,7 +40,7 @@
   },
   "examples": [
     {
-      "summary": "Convert `string` to `time`",
+      "summary": "Convert `int` to `time`",
       "description": "This example takes an `int` in field `.Payload.After.createdAt` and parses it as a unix timestamp into a `time.Time` value.",
       "config": {
         "field": ".Payload.After.createdAt",

--- a/pkg/plugin/processor/builtin/internal/exampleutil/specs/field.convert.json
+++ b/pkg/plugin/processor/builtin/internal/exampleutil/specs/field.convert.json
@@ -40,6 +40,42 @@
   },
   "examples": [
     {
+      "summary": "Convert `string` to `time`",
+      "description": "This example takes an `int` in field `.Payload.After.createdAt` and parses it as a unix timestamp into a `time.Time` value.",
+      "config": {
+        "field": ".Payload.After.createdAt",
+        "type": "time"
+      },
+      "have": {
+        "position": null,
+        "operation": "create",
+        "metadata": null,
+        "key": {
+          "id": 123.345
+        },
+        "payload": {
+          "before": null,
+          "after": {
+            "createdAt": 1704198896123456789
+          }
+        }
+      },
+      "want": {
+        "position": null,
+        "operation": "create",
+        "metadata": null,
+        "key": {
+          "id": 123.345
+        },
+        "payload": {
+          "before": null,
+          "after": {
+            "createdAt": "2024-01-02T12:34:56.123456789Z"
+          }
+        }
+      }
+    },
+    {
       "summary": "Convert `float` to `string`",
       "description": "This example takes the `float` in field `.Key.id` and changes its data type to `string`.",
       "config": {


### PR DESCRIPTION
### Description

The title pretty much describes it. One small but important change is the line where we ensure the timezone is set to `UTC` when converting the value.

### Quick checks

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
