### PR TITLE
Use interpreter runtime in wasm tests

### DIFF
--- a/pkg/plugin/processor/standalone/registry.go
+++ b/pkg/plugin/processor/standalone/registry.go
@@ -32,6 +32,11 @@ import (
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 )
 
+// newRuntime is a function that creates a new Wazero runtime. This is used to
+// allow tests to replace the runtime with an interpreter runtime, as it's much
+// faster than the compiler runtime.
+var newRuntime = wazero.NewRuntime
+
 // Registry is a directory registry of processor plugins, organized by plugin
 // type, name and version.
 // Every file in the specified directory is considered a plugin
@@ -81,7 +86,7 @@ func NewRegistry(logger log.CtxLogger, pluginDir string, schemaService pprocutil
 	}
 
 	// we are using the wasm compiler, context is not used
-	runtime := wazero.NewRuntime(ctx)
+	runtime := newRuntime(ctx)
 	// TODO close runtime on shutdown
 
 	_, err := wasi_snapshot_preview1.Instantiate(ctx, runtime)

--- a/pkg/plugin/processor/standalone/registry_test.go
+++ b/pkg/plugin/processor/standalone/registry_test.go
@@ -32,21 +32,6 @@ import (
 	"github.com/matryer/is"
 )
 
-func TestRegistry_List(t *testing.T) {
-	is := is.New(t)
-
-	underTest, err := NewRegistry(log.Test(t), testPluginChaosDir, schema.NewInMemoryService())
-	is.NoErr(err)
-	list := underTest.List()
-	is.Equal(1, len(list))
-	got, ok := list["standalone:chaos-processor@v1.3.5"]
-	is.True(ok) // expected spec for standalone:chaos-processor@v1.3.5
-
-	want := ChaosProcessorSpecifications()
-
-	is.Equal("", cmp.Diff(got, want))
-}
-
 func TestRegistry_MalformedProcessor(t *testing.T) {
 	is := is.New(t)
 
@@ -105,9 +90,9 @@ func TestRegistry_ChaosProcessor(t *testing.T) {
 
 	t.Run("ConcurrentProcessors", func(t *testing.T) {
 		const (
-			// spawn 50 processors, each processing 50 records simultaneously
-			processorCount = 50
-			recordCount    = 50
+			// spawn 25 processors, each processing 25 records simultaneously
+			processorCount = 25
+			recordCount    = 25
 		)
 
 		var wg csync.WaitGroup
@@ -138,7 +123,7 @@ func TestRegistry_ChaosProcessor(t *testing.T) {
 				is.NoErr(p.Teardown(ctx))
 			}(i + 1)
 		}
-		err = wg.WaitTimeout(ctx, time.Minute)
+		err = wg.WaitTimeout(ctx, 2*time.Minute)
 		is.NoErr(err)
 	})
 

--- a/pkg/plugin/processor/standalone/standalone_test.go
+++ b/pkg/plugin/processor/standalone/standalone_test.go
@@ -89,9 +89,6 @@ func TestMain(m *testing.M) {
 		cfg := wazero.NewRuntimeConfigInterpreter()
 		return wazero.NewRuntimeWithConfig(ctx, cfg)
 	}
-	defer func() {
-		newRuntime = wazero.NewRuntime // reset to default
-	}()
 
 	TestRuntime = newRuntime(ctx)
 

--- a/pkg/plugin/processor/standalone/standalone_test.go
+++ b/pkg/plugin/processor/standalone/standalone_test.go
@@ -85,9 +85,6 @@ func TestMain(m *testing.M) {
 	ctx := context.Background()
 
 	// use interpreter runtime as it's faster for tests
-	cfg := wazero.NewRuntimeConfigInterpreter()
-	TestRuntime = wazero.NewRuntimeWithConfig(ctx, cfg)
-
 	newRuntime = func(ctx context.Context) wazero.Runtime {
 		cfg := wazero.NewRuntimeConfigInterpreter()
 		return wazero.NewRuntimeWithConfig(ctx, cfg)
@@ -95,6 +92,8 @@ func TestMain(m *testing.M) {
 	defer func() {
 		newRuntime = wazero.NewRuntime // reset to default
 	}()
+
+	TestRuntime = newRuntime(ctx)
 
 	_, err := wasi_snapshot_preview1.Instantiate(ctx, TestRuntime)
 	exitOnError(err, "error instantiating WASI")

--- a/pkg/plugin/processor/standalone/standalone_test.go
+++ b/pkg/plugin/processor/standalone/standalone_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/conduitio/conduit-commons/config"
-	"github.com/conduitio/conduit-commons/csync"
 	sdk "github.com/conduitio/conduit-processor-sdk"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/stealthrocket/wazergo"
@@ -72,21 +71,38 @@ func TestMain(m *testing.M) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	err := cmd.Run()
-	exitOnError(err, "error executing bash script")
+	{
+		fmt.Printf("Building test processors (%s)...\n", cmd.String())
+		start := time.Now()
+
+		err := cmd.Run()
+		exitOnError(err, "error executing bash script")
+
+		fmt.Printf("Built test processors in %v\n", time.Since(start))
+	}
 
 	// instantiate shared test runtime
 	ctx := context.Background()
-	TestRuntime = wazero.NewRuntime(ctx)
 
-	_, err = wasi_snapshot_preview1.Instantiate(ctx, TestRuntime)
+	// use interpreter runtime as it's faster for tests
+	cfg := wazero.NewRuntimeConfigInterpreter()
+	TestRuntime = wazero.NewRuntimeWithConfig(ctx, cfg)
+
+	newRuntime = func(ctx context.Context) wazero.Runtime {
+		cfg := wazero.NewRuntimeConfigInterpreter()
+		return wazero.NewRuntimeWithConfig(ctx, cfg)
+	}
+	defer func() {
+		newRuntime = wazero.NewRuntime // reset to default
+	}()
+
+	_, err := wasi_snapshot_preview1.Instantiate(ctx, TestRuntime)
 	exitOnError(err, "error instantiating WASI")
 
 	CompiledHostModule, err = wazergo.Compile(ctx, TestRuntime, hostModule)
 	exitOnError(err, "error compiling host module")
 
 	// load test processors
-	var wg csync.WaitGroup
 	for path, t := range testProcessorPaths {
 		*t.V1, err = os.ReadFile(path)
 		exitOnError(err, "error reading file "+path)
@@ -95,13 +111,16 @@ func TestMain(m *testing.M) {
 			continue
 		}
 
+		fmt.Printf("Compiling module %s...\n", path)
+		start := time.Now()
+
 		// note that modules can't be compiled in parallel, because the runtime
 		// is not thread-safe
 		*t.V2, err = TestRuntime.CompileModule(ctx, *t.V1)
 		exitOnError(err, "error compiling module "+path)
+
+		fmt.Printf("Compiled module %s in %v\n", path, time.Since(start))
 	}
-	err = wg.WaitTimeout(ctx, time.Minute)
-	exitOnError(err, "timed out waiting on modules to compile")
 
 	// run tests
 	code := m.Run()


### PR DESCRIPTION
### Description

This increases the speed of our WASM tests by using the interpreter runtime, since most of the time in our tests is spent compiling WASM modules. It also removes the test `TestRegistry_List`, since it was exactly the same as the subtest `List` in `TestRegistry_ChaosProcessor`. The last thing is the reduction of workers in the runtime test from 50 to 25.

On my machine this resulted in tests in this package finishing in 1m instead of 8m 30s.

Fixes #1649

### Quick checks

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
