### PR TITLE
chore: remove docker warnings

### DIFF
--- a/test/docker-compose-postgres.yml
+++ b/test/docker-compose-postgres.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   pg-0:
     image: postgres:16

--- a/test/docker-compose-schemaregistry.yml
+++ b/test/docker-compose-schemaregistry.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:7.6.1


### PR DESCRIPTION
### Description

This pull-request removes the following warnings:

```
time="2024-08-30T14:15:15Z" level=warning msg="/home/runner/work/conduit/conduit/test/docker-compose-postgres.yml: `version` is obsolete"
time="2024-08-30T14:15:15Z" level=warning msg="/home/runner/work/conduit/conduit/test/docker-compose-schemaregistry.yml: `version` is obsolete"
```
### Quick checks

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
