### PR TITLE
 [Recovery] Make backoff parameters globally configurable

### DIFF
--- a/pkg/conduit/config.go
+++ b/pkg/conduit/config.go
@@ -16,6 +16,7 @@ package conduit
 
 import (
 	"os"
+	"time"
 
 	"github.com/conduitio/conduit-commons/database"
 	sdk "github.com/conduitio/conduit-connector-sdk"
@@ -81,8 +82,15 @@ type Config struct {
 	}
 
 	Pipelines struct {
-		Path        string
-		ExitOnError bool
+		Path          string
+		ExitOnError   bool
+		ErrorRecovery struct {
+			MinDelay      time.Duration
+			MaxDelay      time.Duration
+			BackoffFactor int
+			MaxRetries    int
+			HealthyAfter  time.Duration
+		}
 	}
 
 	ConnectorPlugins map[string]sdk.Connector
@@ -104,19 +112,30 @@ type Config struct {
 
 func DefaultConfig() Config {
 	var cfg Config
+
 	cfg.DB.Type = DBTypeBadger
 	cfg.DB.Badger.Path = "conduit.db"
 	cfg.DB.Postgres.Table = "conduit_kv_store"
 	cfg.DB.SQLite.Path = "conduit.db"
 	cfg.DB.SQLite.Table = "conduit_kv_store"
+
 	cfg.API.Enabled = true
 	cfg.API.HTTP.Address = ":8080"
 	cfg.API.GRPC.Address = ":8084"
+
 	cfg.Log.Level = "info"
 	cfg.Log.Format = "cli"
+
 	cfg.Connectors.Path = "./connectors"
+
 	cfg.Processors.Path = "./processors"
+
 	cfg.Pipelines.Path = "./pipelines"
+	cfg.Pipelines.ErrorRecovery.MinDelay = time.Second
+	cfg.Pipelines.ErrorRecovery.MaxDelay = 10 * time.Minute
+	cfg.Pipelines.ErrorRecovery.BackoffFactor = 2
+	cfg.Pipelines.ErrorRecovery.MaxRetries = 0
+
 	cfg.SchemaRegistry.Type = SchemaRegistryTypeBuiltin
 
 	cfg.ConnectorPlugins = builtin.DefaultBuiltinConnectors

--- a/pkg/conduit/entrypoint.go
+++ b/pkg/conduit/entrypoint.go
@@ -98,8 +98,49 @@ func (*Entrypoint) Flags(cfg *Config) *flag.FlagSet {
 	flags.StringVar(&cfg.Connectors.Path, "connectors.path", cfg.Connectors.Path, "path to standalone connectors' directory")
 	flags.StringVar(&cfg.Processors.Path, "processors.path", cfg.Processors.Path, "path to standalone processors' directory")
 
-	flags.StringVar(&cfg.Pipelines.Path, "pipelines.path", cfg.Pipelines.Path, "path to the directory that has the yaml pipeline configuration files, or a single pipeline configuration file")
-	flags.BoolVar(&cfg.Pipelines.ExitOnError, "pipelines.exit-on-error", cfg.Pipelines.ExitOnError, "exit Conduit if a pipeline experiences an error while running")
+	// Pipeline configuration
+	flags.StringVar(
+		&cfg.Pipelines.Path,
+		"pipelines.path",
+		cfg.Pipelines.Path,
+		"path to the directory that has the yaml pipeline configuration files, or a single pipeline configuration file",
+	)
+	flags.BoolVar(
+		&cfg.Pipelines.ExitOnError,
+		"pipelines.exit-on-error",
+		cfg.Pipelines.ExitOnError,
+		"exit Conduit if a pipeline experiences an error while running",
+	)
+	flags.DurationVar(
+		&cfg.Pipelines.ErrorRecovery.MinDelay,
+		"pipelines.error-recovery.min-delay",
+		cfg.Pipelines.ErrorRecovery.MinDelay,
+		"minimum delay before restart",
+	)
+	flags.DurationVar(
+		&cfg.Pipelines.ErrorRecovery.MaxDelay,
+		"pipelines.error-recovery.max-delay",
+		cfg.Pipelines.ErrorRecovery.MaxDelay,
+		"maximum delay before restart",
+	)
+	flags.IntVar(
+		&cfg.Pipelines.ErrorRecovery.BackoffFactor,
+		"pipelines.error-recovery.backoff-factor",
+		cfg.Pipelines.ErrorRecovery.BackoffFactor,
+		"backoff factor applied to the last delay",
+	)
+	flags.IntVar(
+		&cfg.Pipelines.ErrorRecovery.MaxRetries,
+		"pipelines.error-recovery.max-retries",
+		cfg.Pipelines.ErrorRecovery.MaxRetries,
+		"maximum number of retries",
+	)
+	flags.DurationVar(
+		&cfg.Pipelines.ErrorRecovery.HealthyAfter,
+		"pipelines.error-recovery.healthy-after",
+		cfg.Pipelines.ErrorRecovery.HealthyAfter,
+		"amount of time running without any errors after which a pipeline is considered healthy",
+	)
 
 	flags.StringVar(&cfg.SchemaRegistry.Type, "schema-registry.type", cfg.SchemaRegistry.Type, "schema registry type; accepts builtin,confluent")
 	flags.StringVar(&cfg.SchemaRegistry.Confluent.ConnectionString, "schema-registry.confluent.connection-string", cfg.SchemaRegistry.Confluent.ConnectionString, "confluent schema registry connection string")


### PR DESCRIPTION
### Description

Closes #1782.

### Quick checks

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
