### PR TITLE
Use own registry for the stats handler

### DIFF
--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -249,8 +249,10 @@ func createSchemaRegistry(config Config, logger log.CtxLogger, db database.DB) (
 }
 
 func newGRPCStatsHandler() *promgrpc.StatsHandler {
+	reg := promclient.NewRegistry()
 	h := promgrpc.ServerStatsHandler()
-	promclient.MustRegister(h)
+	promclient.MustRegister(reg)
+	reg.MustRegister(h)
 
 	return h
 }


### PR DESCRIPTION
### Description

Use own registry for the stats handler to create separation between the global/default prom client registry.
Conduit metrics are already using a separate registry. 

When testing Conduit embedded, `..MustRegister()` may fail due to the stats handler already registered in the global registry. 

![Screenshot 2024-09-09 at 13 28 07](https://github.com/user-attachments/assets/c0eee50f-305a-46f3-b85a-3cd3a54cc957)


### Quick checks

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
