### PR TITLE
Don't enrich id if it's not provided

### DIFF
--- a/pkg/provisioning/config/enrich.go
+++ b/pkg/provisioning/config/enrich.go
@@ -65,8 +65,11 @@ func enrichConnectors(mp []Connector, pipelineID string) []Connector {
 		if cfg.Settings == nil {
 			cfg.Settings = make(map[string]string)
 		}
-		// attach the pipelineID to the connectorID
-		cfg.ID = pipelineID + ":" + cfg.ID
+		if cfg.ID != "" {
+			// attach the pipelineID to the connectorID only if the connectorID
+			// is actually provided, otherwise the validation will miss it later
+			cfg.ID = pipelineID + ":" + cfg.ID
+		}
 		cfg.Processors = enrichProcessors(cfg.Processors, cfg.ID)
 		out[i] = cfg
 	}
@@ -86,7 +89,11 @@ func enrichProcessors(mp []Processor, parentID string) []Processor {
 		if cfg.Settings == nil {
 			cfg.Settings = make(map[string]string)
 		}
-		cfg.ID = parentID + ":" + cfg.ID
+		if cfg.ID != "" {
+			// attach the parentID to the processorID only if the processorID
+			// is actually provided, otherwise the validation will miss it later
+			cfg.ID = parentID + ":" + cfg.ID
+		}
 		out[i] = cfg
 	}
 	return out

--- a/pkg/provisioning/config/enrich_test.go
+++ b/pkg/provisioning/config/enrich_test.go
@@ -132,7 +132,7 @@ func TestEnrich_DefaultValues(t *testing.T) {
 			Status:      "stopped",
 			Description: "empty",
 			Connectors: []Connector{
-				{ID: "con1"},
+				{ID: ""},
 			},
 			Processors: []Processor{
 				{ID: "proc1"},
@@ -151,8 +151,8 @@ func TestEnrich_DefaultValues(t *testing.T) {
 			},
 			Connectors: []Connector{
 				{
-					ID:       "pipeline3:con1",
-					Name:     "con1",
+					ID:       "",
+					Name:     "",
 					Settings: map[string]string{},
 				},
 			},

--- a/pkg/provisioning/config/validate.go
+++ b/pkg/provisioning/config/validate.go
@@ -56,24 +56,24 @@ func Validate(cfg Pipeline) error {
 func validateConnectors(mp []Connector) []error {
 	var errs []error
 	ids := make(map[string]bool)
-	for _, cfg := range mp {
+	for i, cfg := range mp {
 		if cfg.ID == "" {
-			errs = append(errs, cerrors.Errorf(`id is mandatory: %w`, ErrMandatoryField))
+			errs = append(errs, cerrors.Errorf("connector %d: id is mandatory: %w", i+1, ErrMandatoryField))
 		}
 		if len(cfg.ID) > connector.IDLengthLimit {
-			errs = append(errs, connector.ErrIDOverLimit)
+			errs = append(errs, cerrors.Errorf("connector %q: %w", cfg.ID, connector.ErrIDOverLimit))
 		}
 		if len(cfg.Name) > connector.NameLengthLimit {
-			errs = append(errs, connector.ErrNameOverLimit)
+			errs = append(errs, cerrors.Errorf("connector %q: %w", cfg.ID, connector.ErrNameOverLimit))
 		}
 		if cfg.Plugin == "" {
-			errs = append(errs, cerrors.Errorf("connector %q: \"plugin\" is mandatory: %w", cfg.ID, ErrMandatoryField))
+			errs = append(errs, cerrors.Errorf(`connector %q: "plugin" is mandatory: %w`, cfg.ID, ErrMandatoryField))
 		}
 		if cfg.Type == "" {
-			errs = append(errs, cerrors.Errorf("connector %q: \"type\" is mandatory: %w", cfg.ID, ErrMandatoryField))
+			errs = append(errs, cerrors.Errorf(`connector %q: "type" is mandatory: %w`, cfg.ID, ErrMandatoryField))
 		}
 		if cfg.Type != "" && cfg.Type != TypeSource && cfg.Type != TypeDestination {
-			errs = append(errs, cerrors.Errorf("connector %q: \"type\" is invalid: %w", cfg.ID, ErrInvalidField))
+			errs = append(errs, cerrors.Errorf(`connector %q: "type" is invalid: %w`, cfg.ID, ErrInvalidField))
 		}
 
 		pErrs := validateProcessors(cfg.Processors)
@@ -82,7 +82,7 @@ func validateConnectors(mp []Connector) []error {
 		}
 
 		if ids[cfg.ID] {
-			errs = append(errs, cerrors.Errorf("connector %q: \"id\" must be unique: %w", cfg.ID, ErrDuplicateID))
+			errs = append(errs, cerrors.Errorf(`connector %q: "id" must be unique: %w`, cfg.ID, ErrDuplicateID))
 		}
 		ids[cfg.ID] = true
 	}
@@ -93,15 +93,18 @@ func validateConnectors(mp []Connector) []error {
 func validateProcessors(mp []Processor) []error {
 	var errs []error
 	ids := make(map[string]bool)
-	for _, cfg := range mp {
+	for i, cfg := range mp {
+		if cfg.ID == "" {
+			errs = append(errs, cerrors.Errorf("processor %d: id is mandatory: %w", i+1, ErrMandatoryField))
+		}
 		if cfg.Plugin == "" {
-			errs = append(errs, cerrors.Errorf("processor %q: \"plugin\" is mandatory: %w", cfg.ID, ErrMandatoryField))
+			errs = append(errs, cerrors.Errorf(`processor %q: "plugin" is mandatory: %w`, cfg.ID, ErrMandatoryField))
 		}
 		if cfg.Workers < 0 {
-			errs = append(errs, cerrors.Errorf("processor %q: \"workers\" can't be negative: %w", cfg.ID, ErrInvalidField))
+			errs = append(errs, cerrors.Errorf(`processor %q: "workers" can't be negative: %w`, cfg.ID, ErrInvalidField))
 		}
 		if ids[cfg.ID] {
-			errs = append(errs, cerrors.Errorf("processor %q: \"id\" must be unique: %w", cfg.ID, ErrDuplicateID))
+			errs = append(errs, cerrors.Errorf(`processor %q: "id" must be unique: %w`, cfg.ID, ErrDuplicateID))
 		}
 		ids[cfg.ID] = true
 	}


### PR DESCRIPTION
### Description

Fixes a bug, where Conduit accepts a connector or processor without an ID in a pipeline config file.

### Quick checks

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
