### PR TITLE
fix: go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/conduitio/conduit
 
-go 1.23.0
+go 1.23.1
 
 require (
 	buf.build/gen/go/grpc-ecosystem/grpc-gateway/protocolbuffers/go v1.34.2-20240617172850-a48fcebcf8f1.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/conduitio/conduit
 
-go 1.23
+go 1.23.0
 
 require (
 	buf.build/gen/go/grpc-ecosystem/grpc-gateway/protocolbuffers/go v1.34.2-20240617172850-a48fcebcf8f1.2


### PR DESCRIPTION
### Description

Fixes

```
go: downloading go1.23 (darwin/arm64)
go: download go1.23 for darwin/arm64: toolchain not available
go: downloading go1.23 (darwin/arm64)
go: download go1.23 for darwin/arm64: toolchain not available
go build -ldflags "-X 'github.com/conduitio/conduit/pkg/conduit.version=`git describe --tags --dirty`'" -o conduit -tags ui ./cmd/conduit/main.go
go: downloading go1.23 (darwin/arm64)
go: download go1.23 for darwin/arm64: toolchain not available
make: *** [build] Error 1
```

### Quick checks

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
