### PR TITLE
Do not use a sandbox for `Run`

### DIFF
--- a/pkg/plugin/connector/builtin/destination.go
+++ b/pkg/plugin/connector/builtin/destination.go
@@ -81,7 +81,7 @@ func (d *destinationPluginAdapter) Run(ctx context.Context, stream pconnector.De
 
 	d.logger.Debug(ctx).Msg("calling Run")
 	go func() {
-		err := runSandboxNoResp(d.impl.Run, d.withLogger(ctx), stream, d.logger)
+		err := d.impl.Run(d.withLogger(ctx), stream)
 		if err != nil {
 			if !inmemStream.Close(err) {
 				d.logger.Err(ctx, err).Msg("stream already stopped")

--- a/pkg/plugin/connector/builtin/sandbox.go
+++ b/pkg/plugin/connector/builtin/sandbox.go
@@ -94,16 +94,3 @@ func returnResponse(ctx context.Context, res any, err error, c chan<- any, logge
 		c <- err
 	}
 }
-
-func runSandboxNoResp[REQ any](
-	f func(context.Context, REQ) error,
-	ctx context.Context,
-	req REQ,
-	logger log.CtxLogger,
-) error {
-	_, err := runSandbox(func(ctx context.Context, req REQ) (any, error) {
-		err := f(ctx, req)
-		return nil, err
-	}, ctx, req, logger)
-	return err
-}

--- a/pkg/plugin/connector/builtin/sandbox_test.go
+++ b/pkg/plugin/connector/builtin/sandbox_test.go
@@ -99,13 +99,3 @@ func TestRunSandbox(t *testing.T) {
 		})
 	}
 }
-
-func TestRunSandboxNoResp(t *testing.T) {
-	ctx := context.Background()
-	is := is.New(t)
-	logger := log.New(zerolog.New(zerolog.NewTestWriter(t)))
-
-	wantErr := cerrors.New("test error")
-	gotErr := runSandboxNoResp(func(context.Context, any) error { panic(wantErr) }, ctx, nil, logger)
-	is.Equal(gotErr, wantErr)
-}

--- a/pkg/plugin/connector/builtin/source.go
+++ b/pkg/plugin/connector/builtin/source.go
@@ -81,7 +81,7 @@ func (s *sourcePluginAdapter) Run(ctx context.Context, stream pconnector.SourceR
 
 	s.logger.Debug(ctx).Msg("calling Run")
 	go func() {
-		err := runSandboxNoResp(s.impl.Run, s.withLogger(ctx), stream, s.logger)
+		err := s.impl.Run(s.withLogger(ctx), stream)
 		if err != nil {
 			if !inmemStream.Close(err) {
 				s.logger.Err(ctx, err).Msg("stream already stopped")


### PR DESCRIPTION
### Description

We run builtin connector functions in a sandbox, making it possible to "detach" from the plugin. In this PR we remove this sandbox for calls to `Run`, as it prevents us from doing a graceful shutdown.

<details>
  <summary>Shutdown logs before the change</summary>

```
2024-10-08T19:37:19+00:00 ERR stopping source connector error="graceful shutdown" component=SourceNode node_id=file-to-file:example.in pipeline_id=file-to-file stack=[{"file":"/Users/lovro/dev/conduitio/conduit/pkg/pipeline/errors.go","func":"github.com/conduitio/conduit/pkg/pipeline.init","line":21}]
2024-10-08T19:37:19+00:00 INF source connector plugin successfully responded to stop signal component=connector.Source connector_id=file-to-file:example.in record_position=
2024-10-08T19:37:19+00:00 ERR stopping source node error="graceful shutdown" component=SourceNode node_id=file-to-file:example.in pipeline_id=file-to-file record_position=<nil> stack=[{"file":"/Users/lovro/dev/conduitio/conduit/pkg/pipeline/errors.go","func":"github.com/conduitio/conduit/pkg/pipeline.init","line":21}]
2024-10-08T19:37:19+00:00 INF source connector plugin successfully torn down component=connector.Source connector_id=file-to-file:example.in
2024-10-08T19:37:19+00:00 ERR context cancelled while waiting for builtin connector plugin to respond, detaching from plugin component=builtin.sourcePluginAdapter connector_id=file-to-file:example.in plugin_name=file plugin_type=source
2024-10-08T19:37:19+00:00 ERR context cancelled when trying to return response from builtin connector plugin (this message comes from a detached plugin) error="ack stream error: context canceled" component=builtin.sourcePluginAdapter connector_id=file-to-file:example.in plugin_name=file plugin_type=source response=null stack=null
2024-10-08T19:37:19+00:00 INF destination connector plugin successfully torn down component=connector.Destination connector_id=file-to-file-dlq
2024-10-08T19:37:19+00:00 ERR context cancelled while waiting for builtin connector plugin to respond, detaching from plugin component=builtin.destinationPluginAdapter connector_id=file-to-file-dlq plugin_name=builtin:log plugin_type=destination
2024-10-08T19:37:19+00:00 INF destination connector plugin successfully torn down component=connector.Destination connector_id=file-to-file:example.out
2024-10-08T19:37:19+00:00 ERR context cancelled while waiting for builtin connector plugin to respond, detaching from plugin component=builtin.destinationPluginAdapter connector_id=file-to-file:example.out plugin_name=builtin:file plugin_type=destination
2024-10-08T19:37:19+00:00 ERR context cancelled when trying to return response from builtin connector plugin (this message comes from a detached plugin) error="write stream error: context canceled" component=builtin.destinationPluginAdapter connector_id=file-to-file-dlq plugin_name=builtin:log plugin_type=destination response=null stack=null
2024-10-08T19:37:19+00:00 ERR context cancelled when trying to return response from builtin connector plugin (this message comes from a detached plugin) error="write stream error: context canceled" component=builtin.destinationPluginAdapter connector_id=file-to-file:example.out plugin_name=builtin:file plugin_type=destination response=null stack=null
2024-10-08T19:37:19+00:00 INF pipeline stopped component=lifecycle.Service pipeline_id=file-to-file
```  
</details>

<details>
  <summary>Shutdown logs after the change</summary>

```
2024-10-08T19:38:44+00:00 INF gracefully stopping pipeline component=lifecycle.Service pipeline_id=file-to-file pipeline_status=1
2024-10-08T19:38:44+00:00 ERR stopping source connector error="graceful shutdown" component=SourceNode node_id=file-to-file:example.in pipeline_id=file-to-file stack=[{"file":"/Users/lovro/dev/conduitio/conduit/pkg/pipeline/errors.go","func":"github.com/conduitio/conduit/pkg/pipeline.init","line":21}]
2024-10-08T19:38:44+00:00 INF source connector plugin successfully responded to stop signal component=connector.Source connector_id=file-to-file:example.in record_position=
2024-10-08T19:38:44+00:00 ERR stopping source node error="graceful shutdown" component=SourceNode node_id=file-to-file:example.in pipeline_id=file-to-file record_position=<nil> stack=[{"file":"/Users/lovro/dev/conduitio/conduit/pkg/pipeline/errors.go","func":"github.com/conduitio/conduit/pkg/pipeline.init","line":21}]
2024-10-08T19:38:44+00:00 INF source connector plugin successfully torn down component=connector.Source connector_id=file-to-file:example.in
2024-10-08T19:38:44+00:00 INF destination connector plugin successfully torn down component=connector.Destination connector_id=file-to-file-dlq
2024-10-08T19:38:44+00:00 INF destination connector plugin successfully torn down component=connector.Destination connector_id=file-to-file:example.out
2024-10-08T19:38:44+00:00 INF pipeline stopped component=lifecycle.Service pipeline_id=file-to-file
```  
</details>

When the pipeline stops we cancel the context passed to `Run` with the intention to close the bi-directional stream opened between the connector and Conduit. However, the sandbox interprets the closed context as the intention that we want to detach from that function and keep it running in the background. In case of `Run` this doesn't make sense, because it is already running in the background, so we will never want to detach from it.

The second reason for the sandbox is to catch any panics the connector might produce (well at least it's a best effort). Again, in `Run` this won't make a difference, because the SDK will spawn two separate goroutines for the incoming and outgoing stream (acks and records), so panics that happen in those goroutines won't be caught by the sandbox anyway.

### Quick checks

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
