### PR TITLE
add conduit release view pixel to the release template

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -82,6 +82,7 @@ release:
     ```
     docker pull conduit.docker.scarf.sh/conduitio/conduit:{{ .Tag }}
     ```
+    ![conduit-release-view](https://static.scarf.sh/a.png?x-pxid=3df89eef-1623-4cd5-9dbc-a6b36588a0eb)
 nfpms:
   - license: Apache-2.0
     maintainer: Conduit Developers <conduit-dev@meroxa.io>


### PR DESCRIPTION
### Description

noticed that we don't have this pixel in the template, would be nice to track these views

### Quick checks

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
