### PR TITLE
Update `pipeline_recovering` metric on recovery

### DIFF
--- a/pkg/lifecycle/service.go
+++ b/pkg/lifecycle/service.go
@@ -821,6 +821,7 @@ func (s *Service) runPipeline(ctx context.Context, rp *runnablePipeline) error {
 // recoverPipeline attempts to recover a pipeline that has stopped running.
 func (s *Service) recoverPipeline(ctx context.Context, rp *runnablePipeline) error {
 	s.logger.Trace(ctx).Str(log.PipelineIDField, rp.pipeline.ID).Msg("recovering pipeline")
+	measure.PipelineRecoveringCount.WithValues(rp.pipeline.Config.Name).Inc()
 
 	err := s.pipelines.UpdateStatus(ctx, rp.pipeline.ID, pipeline.StatusRecovering, "")
 	if err != nil {


### PR DESCRIPTION
### Description

We forgot this in the pipeline recovery PRs.

### Quick checks

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
