### PR TITLE
Configure SonarCloud

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Test
+        # The test coverate and the test report are needed for the SonarCloud analysis
         run: make test-integration GOTEST_FLAGS="-v -count=1 -coverprofile coverage.out" 2>&1 | tee test-report.out
 
       - name: SonarCloud Scan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,10 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Test
-        run: make test-integration GOTEST_FLAGS="-v -count=1"
+        run: make test-integration GOTEST_FLAGS="-v -count=1 -coverprofile coverage.out" 2>&1 | tee test-report.out
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@v3.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,13 @@
 run:
   timeout: 3m
 
+output:
+  formats:
+    - format: colored-line-number
+      path: stdout
+    - format: checkstyle
+      path: golangci-report.xml
+
 linters-settings:
   depguard:
     rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ output:
   formats:
     - format: colored-line-number
       path: stdout
+    # Needed for the SonarCloud analysis
     - format: checkstyle
       path: golangci-report.xml
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,7 +8,7 @@ sonar.organization=conduitio
 sonar.projectName=Conduit
 
 sonar.sources=.
-sonar.exclusions=**/*_test.go,**/vendor/**
+sonar.exclusions=**/*_test.go,**/vendor/**,**/ui/**
  
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -26,5 +26,6 @@ sonar.links.issue=https://github.com/ConduitIO/conduit/issues
 #   Properties specific to Go
 # =====================================================
 
+sonar.go.gometalinter.reportPaths=golangci-report.xml
 sonar.go.tests.reportPaths=test-report.out
 sonar.go.coverage.reportPaths=coverage.out

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,32 @@
+
+# =====================================================
+#   Standard properties
+# =====================================================
+
+sonar.projectKey=conduit
+sonar.organization=conduitio
+sonar.projectName=Conduit
+
+sonar.sources=.
+sonar.exclusions=**/*_test.go,**/vendor/**
+ 
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+sonar.test.exclusions=**/vendor/**
+# =====================================================
+#   Meta-data for the project
+# =====================================================
+
+sonar.links.homepage=https://conduit.io/
+sonar.links.scm=https://github.com/hariso/conduit/
+sonar.links.issue=https://github.com/hariso/conduit/issues
+
+# =====================================================
+#   Properties specific to Go
+# =====================================================
+
+sonar.go.gometalinter.reportPaths=gometalinter-report.out
+#sonar.go.govet.reportPaths=govet-report.out
+#sonar.go.golint.reportPaths=golint-report.out
+sonar.go.tests.reportPaths=test-report.out
+sonar.go.coverage.reportPaths=coverage.out

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,20 +13,18 @@ sonar.exclusions=**/*_test.go,**/vendor/**,**/ui/**
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
 sonar.test.exclusions=**/vendor/**
+
 # =====================================================
-#   Meta-data for the project
+#   Metadata for the project
 # =====================================================
 
 sonar.links.homepage=https://conduit.io/
-sonar.links.scm=https://github.com/hariso/conduit/
-sonar.links.issue=https://github.com/hariso/conduit/issues
+sonar.links.scm=https://github.com/ConduitIO/conduit
+sonar.links.issue=https://github.com/ConduitIO/conduit/issues
 
 # =====================================================
 #   Properties specific to Go
 # =====================================================
 
-sonar.go.gometalinter.reportPaths=gometalinter-report.out
-#sonar.go.govet.reportPaths=govet-report.out
-#sonar.go.golint.reportPaths=golint-report.out
 sonar.go.tests.reportPaths=test-report.out
 sonar.go.coverage.reportPaths=coverage.out


### PR DESCRIPTION
### Description

Configures SonarCloud for Conduit, so that we can get the test coverage displayed and checked in PRs and in our README. I'll add a SonarCloud badge once the PR is merged to main.

### Quick checks

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
