### PR TITLE
doc: Add GitHub issue template for releasing Conduit

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-conduit-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-conduit-release.yml
@@ -1,0 +1,109 @@
+name: Release Checklist
+description: Use this template to guide you through the Conduit release process.
+title: '[Release] Conduit vX.Y.Z'
+labels:
+  - release
+assignees: ''
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Conduit Release Checklist
+
+        This issue serves as a checklist for releasing a new version of Conduit. Follow the steps below to ensure a smooth release process.
+
+  - type: markdown
+    attributes:
+      value: |
+        ## General Information
+
+        A Conduit release includes:
+        - A GitHub release with packages for different OS and architectures, checksums, a changelog, and source code.
+        - A GitHub package for the official Docker image, available on GitHub's Container Registry, tagged with `latest`.
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Before a Release
+
+        ### Update Dependencies
+
+        Update dependencies in the following order, ensuring all repositories are cloned in the same directory:
+
+  - type: checkboxes
+    attributes:
+      label: Update Dependencies
+      options:
+        - label: 'conduit-commons: Run `scripts/get-compare-link.sh ../conduit-commons/` to compare the latest tag and `main` branch. If changes are needed, push a new tag.'
+        - label: 'conduit-connector-protocol: Update `conduit-commons` if necessary: `go get github.com/conduitio/conduit-commons@vX.Y.Z`. Run `scripts/get-compare-link.sh ../conduit-connector-protocol/` and tag if needed.'
+        - label: 'conduit-connector-sdk: Update dependencies (`conduit-commons`, `conduit-connector-protocol`) as needed. Run `scripts/get-compare-link.sh ../conduit-connector-sdk/` and tag if needed.'
+        - label: 'conduit-processor-sdk: Update `conduit-commons` if necessary. Run `scripts/get-compare-link.sh ../conduit-processor-sdk/` and tag if needed.'
+        - label: 'conduit-schema-registry: Update `conduit-commons` if necessary. Run `scripts/get-compare-link.sh ../conduit-schema-registry/` and tag if needed.'
+        - label: 'Connector SDK in conduit-connector-template: Bump the Connector SDK dependency.'
+        - label: 'Built-in connectors: Bump the Connector SDK: `scripts/bump-sdk-in-connectors.sh vX.Y.Z`. For each built-in connector (file, kafka, generator, s3, postgres, log), run `scripts/get-compare-link.sh ../conduit-processor-sdk/` and tag if needed.'
+        - label: 'Bump built-in connectors: Run `scripts/bump-builtin-connectors.sh`'
+        - label: 'Conduit: Update dependencies (`conduit-schema-registry`, `conduit-connector-sdk`, `conduit-processor-sdk`, `conduit-connector-protocol`, `conduit-commons`) if needed. Release Conduit (see instructions below).'
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Documentation
+
+  - type: checkboxes
+    attributes:
+      label: Documentation
+      options:
+        - label: 'Write a blog post.'
+        - label: 'Regenerate processor documentation on [conduit-site](https://github.com/ConduitIO/conduit-site).'
+        - label: 'Update the banner on the website.'
+        - label: 'Search and replace the latest version in `conduit-site`.'
+        - label: 'Search and replace the latest version in [README.md](../README.md).'
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Releasing Conduit
+
+  - type: checkboxes
+    attributes:
+      label: Releasing Conduit
+      options:
+        - label: 'Trigger a release by pushing a new tag starting with `v` (e.g., `v1.2.3`).'
+        - label: 'Use the script [scripts/tag.sh](https://github.com/ConduitIO/conduit/blob/main/scripts/tag.sh) to ensure version conformity.'
+
+  - type: markdown
+    attributes:
+      value: |
+        ```sh
+        scripts/tag.sh 1.2.3
+        ```
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Nightly Builds
+
+        - Nightly builds (binaries and Docker images) are provided and kept for 7 days.
+        - The latest nightly Docker image is tagged with `latest-nightly`.
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Implementation
+
+        - The GitHub release is created with [GoReleaser](https://github.com/goreleaser/goreleaser/).
+        - Nightly builds are triggered by a GitHub action, defined in [trigger-nightly.yml](/.github/workflows/trigger-nightly.yml).
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Notes
+
+        - The "Trigger nightly build" GitHub action requires a personal access token, not the GitHub token provided by Actions.
+
+        For more information, refer to [Triggering a workflow from a workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow).
+
+---
+
+Please ensure each step is completed before closing this issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: 📄 Documentation Issue
     url: https://github.com/ConduitIO/conduit-site
     about: Please report issues regarding documentation here.
+  - name: 💬 Chat with us
+    url: https://discord.com/channels/828680256877363200/933725823813451797
+    about: Join our Discord server to chat with us.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -12,69 +12,6 @@ A Conduit release has the following parts:
 - a GitHub package, which is the official Docker image for Conduit. It's available on GitHub's Container Registry. The
 latest Docker image which is not a nightly is tagged with `latest`.
 
-## Before a release
-
-### Update dependencies
-
-Dependencies should be updated in the order described below. The instructions
-assume that this repository and the other Conduit repositories are all cloned in
-the same directory.
-
-1. [`conduit-commons`](https://github.com/ConduitIO/conduit-commons)
-    - Run `scripts/get-compare-link.sh ../conduit-commons/` to compare the latest tag and the `main` branch.
-    - If the changes should be released/tagged, push a new tag.
-2. [`conduit-connector-protocol`](https://github.com/conduitio/conduit-connector-protocol)
-    - Update `conduit-commons` if needed: `go get github.com/conduitio/conduit-commons@vX.Y.Z`
-    - Run `scripts/get-compare-link.sh ../conduit-connector-protocol/` to compare the latest tag and the `main` branch.
-    - If the changes should be released/tagged, push a new tag.
-3. [`conduit-connector-sdk`](https://github.com/ConduitIO/conduit-connector-sdk)
-    - Update `conduit-commons` if needed: `go get github.com/conduitio/conduit-commons@vX.Y.Z`
-    - Update `conduit-connector-protocol` if needed: `go get github.com/conduitio/conduit-connector-protocol@vX.Y.Z`
-    - Run `scripts/get-compare-link.sh ../conduit-connector-sdk/` to compare the latest tag and the `main` branch.
-    - If the changes should be released/tagged, push a new tag.
-4. [`conduit-processor-sdk`](https://github.com/ConduitIO/conduit-processor-sdk)
-    - Update `conduit-commons` if needed: `go get github.com/conduitio/conduit-commons@vX.Y.Z`
-    - Run `scripts/get-compare-link.sh ../conduit-processor-sdk/` to compare the latest tag and the `main` branch.
-    - If the changes should be released/tagged, push a new tag.
-5. [`conduit-schema-registry`](https://github.com/ConduitIO/conduit-schema-registry/)
-   - Update `conduit-commons` if needed: `go get github.com/conduitio/conduit-commons@vX.Y.Z`
-   - Run `scripts/get-compare-link.sh ../conduit-schema-registry/` to compare the latest tag and the `main` branch.
-   - If the changes should be released/tagged, push a new tag.
-6. Bump the Connector SDK dependency on [`conduit-connector-template`](https://github.com/ConduitIO/conduit-connector-template)
-7. Bump the Connector SDK in all the built-in connectors: `scripts/bump-sdk-in-connectors.sh vX.Y.Z`
-8. For each of the built-in connectors (file, kafka, generator, s3, postgres, log):
-    - Run `scripts/get-compare-link.sh ../conduit-processor-sdk/` to compare the latest tag and the `main` branch.
-    - If the changes should be released/tagged, push a new tag.
-9. Bump the built-in connectors: `scripts/bump-builtin-connectors.sh`
-10. Conduit itself
-    - Update `conduit-schema-registry` if needed
-    - Update `conduit-connector-sdk` if needed
-    - Update `conduit-processor-sdk` if needed
-    - Update `conduit-connector-protocol` if needed
-    - Update `conduit-commons` if needed
-    - Release Conduit (see instructions below)
-
-## Documentation
-
-1. Write a blog post.
-2. Regenerate processor documentation on [`conduit-site`](https://github.com/ConduitIO/conduit-site).
-3. Update banner on the
-   web-site ([example](https://github.com/ConduitIO/conduit-site/pull/47/files#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784)).
-4. Search for the latest version in `conduit-site` and replace with new
-   version (e.g. search for 0.11.1 and replace with 0.12.0)
-5. Search for the latest version in [README.md](../README.md) and replace with
-   new version (e.g. search for 0.11 and replace with 0.12)
-
-## Releasing Conduit
-
-A release is triggered by pushing a new tag which starts with `v` (for example `v1.2.3`). Everything else is then
-handled by GoReleaser and GitHub actions. To push a new tag, please use the script [scripts/tag.sh](https://github.com/ConduitIO/conduit/blob/main/scripts/tag.sh),
-which also checks if the version conforms to SemVer. Example:
-
-```sh
-scripts/tag.sh 1.2.3
-```
-
 ## Nightly builds
 
 We provide nightly builds (binaries and Docker images) and keep them for 7 days. The latest nightly Docker image is tagged
@@ -94,3 +31,11 @@ Docker images.
 The "Trigger nightly build" GH action requires a personal access token, and _not_ a GitHub token provided by Actions. The
 reason is that a workflow which produces an event using a GitHub token cannot trigger another workflow through that event.
 For more information, please check [Triggering a workflow from a workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow).
+
+## How to release
+
+In order to create a new Conduit release, you'll need to create a new issue using the ["Release" template](https://github.com/ConduitIO/conduit/issues/new?template=release-checklist.yml&title=%5BRelease%5D%20Conduit%20vX.Y.Z).
+
+The issue will guide you through the process of creating a new release. 
+
+It will also provide you with a checklist to make sure you don't forget anything.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -36,6 +36,6 @@ For more information, please check [Triggering a workflow from a workflow](https
 
 In order to create a new Conduit release, you'll need to create a new issue using the ["Release" template](https://github.com/ConduitIO/conduit/issues/new?template=release-checklist.yml&title=%5BRelease%5D%20Conduit%20vX.Y.Z).
 
-The issue will guide you through the process of creating a new release. 
+The issue will guide you through the process of creating a new release.
 
 It will also provide you with a checklist to make sure you don't forget anything.


### PR DESCRIPTION
### Description

Every time we have to do a Conduit release, we have to go through this document, which contains all the necessary information. This however, often involves having to follow through a checklist elsewhere. The idea with this issue template is that we could create an issue for every future release, and follow through so we can also document the process and maintain up to date.

I'll still want to update the releases document to refer to this template so we don't have the same information in two places.

### Quick checks

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
