### PR TITLE
Fix GH action for running unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,4 @@ jobs:
 
       - name: Test
         # The test coverate and the test report are needed for the SonarCloud analysis
-        run: make test-integration GOTEST_FLAGS="-v -count=1 -coverprofile coverage.out" 2>&1 | tee test-report.out
-
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v3.1.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: make test-integration GOTEST_FLAGS="-v -count=1"

--- a/cmd/cli/cli_test.go
+++ b/cmd/cli/cli_test.go
@@ -43,7 +43,7 @@ func TestBuildRootCmd_HelpOutput(t *testing.T) {
 		"db.postgres.table",
 		"db.sqlite.path",
 		"db.sqlite.table",
-		"dev.blockprofileblockprofile",
+		"dev.blockprofile",
 		"dev.cpuprofile",
 		"dev.memprofile",
 		"api.enabled",

--- a/pkg/conduit/entrypoint_test.go
+++ b/pkg/conduit/entrypoint_test.go
@@ -36,7 +36,7 @@ func TestFlags_HelpOutput(t *testing.T) {
 		"db.postgres.table",
 		"db.sqlite.path",
 		"db.sqlite.table",
-		"dev.blockprofileblockprofile",
+		"dev.blockprofile",
 		"dev.cpuprofile",
 		"dev.memprofile",
 		"api.enabled",


### PR DESCRIPTION
### Description

Test failures were "swallowed" in the test GitHub action. It probably has to do with writing the test output/coverage to a file (even though the logs show the make target failed).

This PR fixes that and two unit tests that were failing.

### Quick checks

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
