### PR TITLE
Remove make ui-dist from goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,4 @@
 version: 2
-before:
-  hooks:
-    - make ui-dist
 builds:
   - main: ./cmd/conduit/main.go
     id: conduit

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,7 +32,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-snapshot"
+  version_template: "{{ incpatch .Version }}-snapshot"
 changelog:
   sort: asc
   use: github


### PR DESCRIPTION
### Description

The release action is failing because goreleaser is trying to build the UI, which was removed.