### PR TITLE
feat: show connector type on ls

### DIFF
--- a/cmd/conduit/internal/print_utils.go
+++ b/cmd/conduit/internal/print_utils.go
@@ -195,3 +195,17 @@ func formatValidations(v []*configv1.Validation) string {
 	}
 	return result.String()
 }
+
+// ConnectorTypeToString returns a human-readable string from a connector type
+func ConnectorTypeToString(connectorType apiv1.Connector_Type) string {
+	switch connectorType {
+	case apiv1.Connector_TYPE_SOURCE:
+		return "source"
+	case apiv1.Connector_TYPE_DESTINATION:
+		return "destination"
+	case apiv1.Connector_TYPE_UNSPECIFIED:
+		return "unspecified"
+	default:
+		return "unknown"
+	}
+}

--- a/cmd/conduit/internal/print_utils_test.go
+++ b/cmd/conduit/internal/print_utils_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2025 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package internal
 
 import (

--- a/cmd/conduit/internal/print_utils_test.go
+++ b/cmd/conduit/internal/print_utils_test.go
@@ -1,0 +1,39 @@
+package internal
+
+import (
+	"testing"
+
+	apiv1 "github.com/conduitio/conduit/proto/api/v1"
+	"github.com/matryer/is"
+)
+
+func TestConnectorTypeToString(t *testing.T) {
+	is := is.New(t)
+
+	tests := []struct {
+		name     string
+		connType apiv1.Connector_Type
+		want     string
+	}{
+		{
+			name:     "Source",
+			connType: apiv1.Connector_TYPE_SOURCE,
+			want:     "source",
+		},
+		{
+			name:     "Destination",
+			connType: apiv1.Connector_TYPE_DESTINATION,
+			want:     "destination",
+		},
+		{
+			name:     "Unspecified",
+			connType: apiv1.Connector_TYPE_UNSPECIFIED,
+			want:     "unspecified",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			is.Equal(ConnectorTypeToString(tt.connType), tt.want)
+		})
+	}
+}

--- a/cmd/conduit/root/connectors/describe.go
+++ b/cmd/conduit/root/connectors/describe.go
@@ -100,20 +100,7 @@ func displayConnector(connector *apiv1.Connector, processors []*apiv1.Processor)
 
 	fmt.Printf("ID: %s\n", connector.Id)
 
-	var connectorType string
-
-	switch connector.Type {
-	case apiv1.Connector_TYPE_SOURCE:
-		connectorType = "Source"
-	case apiv1.Connector_TYPE_DESTINATION:
-		connectorType = "Destination"
-	case apiv1.Connector_TYPE_UNSPECIFIED:
-		connectorType = "Unspecified"
-	default:
-		connectorType = "Unknown"
-	}
-
-	fmt.Printf("Type: %s\n", connectorType)
+	fmt.Printf("Type: %s\n", internal.ConnectorTypeToString(connector.Type))
 	fmt.Printf("Plugin: %s\n", connector.Plugin)
 	fmt.Printf("Pipeline ID: %s\n", connector.PipelineId)
 

--- a/cmd/conduit/root/connectors/list.go
+++ b/cmd/conduit/root/connectors/list.go
@@ -87,19 +87,21 @@ func displayConnectors(connectors []*apiv1.Connector) {
 		Cells: []*simpletable.Cell{
 			{Align: simpletable.AlignCenter, Text: "ID"},
 			{Align: simpletable.AlignCenter, Text: "PLUGIN"},
+			{Align: simpletable.AlignCenter, Text: "TYPE"},
 			{Align: simpletable.AlignCenter, Text: "PIPELINE_ID"},
 			{Align: simpletable.AlignCenter, Text: "CREATED"},
 			{Align: simpletable.AlignCenter, Text: "LAST_UPDATED"},
 		},
 	}
 
-	for _, p := range connectors {
+	for _, c := range connectors {
 		r := []*simpletable.Cell{
-			{Align: simpletable.AlignLeft, Text: p.Id},
-			{Align: simpletable.AlignLeft, Text: p.Plugin},
-			{Align: simpletable.AlignLeft, Text: p.PipelineId},
-			{Align: simpletable.AlignLeft, Text: internal.PrintTime(p.CreatedAt)},
-			{Align: simpletable.AlignLeft, Text: internal.PrintTime(p.UpdatedAt)},
+			{Align: simpletable.AlignLeft, Text: c.Id},
+			{Align: simpletable.AlignLeft, Text: c.Plugin},
+			{Align: simpletable.AlignLeft, Text: internal.ConnectorTypeToString(c.Type)},
+			{Align: simpletable.AlignLeft, Text: c.PipelineId},
+			{Align: simpletable.AlignLeft, Text: internal.PrintTime(c.CreatedAt)},
+			{Align: simpletable.AlignLeft, Text: internal.PrintTime(c.UpdatedAt)},
 		}
 
 		table.Body.Cells = append(table.Body.Cells, r)


### PR DESCRIPTION
### Description

Fixes #2091 

**Before**

```
+----------------------------------------------------+-------------------+----------------------------------------+----------------------+----------------------+
|                         ID                         |      PLUGIN       |              PIPELINE_ID               |       CREATED        |     LAST_UPDATED     |
+----------------------------------------------------+-------------------+----------------------------------------+----------------------+----------------------+
| add-department:employees-1                         | builtin:generator | add-department                         | 2025-01-09T12:23:13Z | 2025-01-09T12:45:03Z |
| add-department:employees-2                         | builtin:generator | add-department                         | 2025-01-09T12:23:13Z | 2025-01-09T12:45:03Z |
| add-department:file-destination                    | builtin:file      | add-department                         | 2025-01-09T12:23:13Z | 2025-01-09T12:23:13Z |
| chaos-to-file:chaos-source                         | standalone:chaos  | chaos-to-file                          | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| chaos-to-file:file-destination                     | builtin:file      | chaos-to-file                          | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| chaos-to-log:destination                           | builtin:log       | chaos-to-log                           | 2025-01-10T11:17:33Z | 2025-01-10T11:17:33Z |
| chaos-to-log:example                               | generator         | chaos-to-log                           | 2025-01-10T11:17:33Z | 2025-01-10T11:17:33Z |
| example-pipeline:example-destination               | log               | example-pipeline                       | 2025-01-10T11:17:33Z | 2025-01-14T18:16:31Z |
| example-pipeline:example-source                    | generator         | example-pipeline                       | 2025-01-10T11:17:33Z | 2025-01-15T10:31:46Z |
| failing-pipeline-invalid-configuration:example.in  | builtin:file      | failing-pipeline-invalid-configuration | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| failing-pipeline-invalid-configuration:example.out | builtin:file      | failing-pipeline-invalid-configuration | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| failing-pipeline-unknown-plugin:example.in         | builtin:something | failing-pipeline-unknown-plugin        | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| failing-pipeline-unknown-plugin:example.out        | builtin:file      | failing-pipeline-unknown-plugin        | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| file-to-file-stopped:example.in                    | builtin:file      | file-to-file-stopped                   | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| file-to-file-stopped:example.out                   | builtin:file      | file-to-file-stopped                   | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| file-to-file:example.in                            | builtin:file      | file-to-file                           | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| file-to-file:example.out                           | builtin:file      | file-to-file                           | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| multiple-destinations:employees-source             | builtin:generator | multiple-destinations                  | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| multiple-destinations:file-destination-1           | builtin:file      | multiple-destinations                  | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| multiple-destinations:file-destination-2           | builtin:file      | multiple-destinations                  | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| multiple-source-with-processor:employees-1         | builtin:generator | multiple-source-with-processor         | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| multiple-source-with-processor:employees-2         | builtin:generator | multiple-source-with-processor         | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| multiple-source-with-processor:file-destination    | builtin:file      | multiple-source-with-processor         | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| pipeline-with-dlq:file-destination                 | builtin:file      | pipeline-with-dlq                      | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| pipeline-with-dlq:generator-source                 | builtin:generator | pipeline-with-dlq                      | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| pipeline-with-js-processor:file-destination        | builtin:file      | pipeline-with-js-processor             | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| pipeline-with-js-processor:file-source             | builtin:file      | pipeline-with-js-processor             | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| pipeline-with-source-processor:employees-1         | builtin:generator | pipeline-with-source-processor         | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| pipeline-with-source-processor:employees-2         | builtin:generator | pipeline-with-source-processor         | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| pipeline-with-source-processor:file-destination    | builtin:file      | pipeline-with-source-processor         | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
+----------------------------------------------------+-------------------+----------------------------------------+----------------------+----------------------+
```

**After**

```
+----------------------------------------------------+-------------------+-------------+----------------------------------------+----------------------+----------------------+
|                         ID                         |      PLUGIN       |    TYPE     |              PIPELINE_ID               |       CREATED        |     LAST_UPDATED     |
+----------------------------------------------------+-------------------+-------------+----------------------------------------+----------------------+----------------------+
| add-department:employees-1                         | builtin:generator | source      | add-department                         | 2025-01-09T12:23:13Z | 2025-01-09T12:45:03Z |
| add-department:employees-2                         | builtin:generator | source      | add-department                         | 2025-01-09T12:23:13Z | 2025-01-09T12:45:03Z |
| add-department:file-destination                    | builtin:file      | destination | add-department                         | 2025-01-09T12:23:13Z | 2025-01-09T12:23:13Z |
| chaos-to-file:chaos-source                         | standalone:chaos  | source      | chaos-to-file                          | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| chaos-to-file:file-destination                     | builtin:file      | destination | chaos-to-file                          | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| chaos-to-log:destination                           | builtin:log       | destination | chaos-to-log                           | 2025-01-10T11:17:33Z | 2025-01-10T11:17:33Z |
| chaos-to-log:example                               | generator         | source      | chaos-to-log                           | 2025-01-10T11:17:33Z | 2025-01-10T11:17:33Z |
| example-pipeline:example-destination               | log               | destination | example-pipeline                       | 2025-01-10T11:17:33Z | 2025-01-14T18:16:31Z |
| example-pipeline:example-source                    | generator         | source      | example-pipeline                       | 2025-01-10T11:17:33Z | 2025-01-15T10:31:46Z |
| failing-pipeline-invalid-configuration:example.in  | builtin:file      | source      | failing-pipeline-invalid-configuration | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| failing-pipeline-invalid-configuration:example.out | builtin:file      | destination | failing-pipeline-invalid-configuration | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| failing-pipeline-unknown-plugin:example.in         | builtin:something | source      | failing-pipeline-unknown-plugin        | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| failing-pipeline-unknown-plugin:example.out        | builtin:file      | destination | failing-pipeline-unknown-plugin        | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| file-to-file-stopped:example.in                    | builtin:file      | source      | file-to-file-stopped                   | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| file-to-file-stopped:example.out                   | builtin:file      | destination | file-to-file-stopped                   | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| file-to-file:example.in                            | builtin:file      | source      | file-to-file                           | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| file-to-file:example.out                           | builtin:file      | destination | file-to-file                           | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| multiple-destinations:employees-source             | builtin:generator | source      | multiple-destinations                  | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| multiple-destinations:file-destination-1           | builtin:file      | destination | multiple-destinations                  | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| multiple-destinations:file-destination-2           | builtin:file      | destination | multiple-destinations                  | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| multiple-source-with-processor:employees-1         | builtin:generator | source      | multiple-source-with-processor         | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| multiple-source-with-processor:employees-2         | builtin:generator | source      | multiple-source-with-processor         | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| multiple-source-with-processor:file-destination    | builtin:file      | destination | multiple-source-with-processor         | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| pipeline-with-dlq:file-destination                 | builtin:file      | destination | pipeline-with-dlq                      | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| pipeline-with-dlq:generator-source                 | builtin:generator | source      | pipeline-with-dlq                      | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| pipeline-with-js-processor:file-destination        | builtin:file      | destination | pipeline-with-js-processor             | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| pipeline-with-js-processor:file-source             | builtin:file      | source      | pipeline-with-js-processor             | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| pipeline-with-source-processor:employees-1         | builtin:generator | source      | pipeline-with-source-processor         | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| pipeline-with-source-processor:employees-2         | builtin:generator | source      | pipeline-with-source-processor         | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
| pipeline-with-source-processor:file-destination    | builtin:file      | destination | pipeline-with-source-processor         | 2025-01-21T12:18:20Z | 2025-01-21T12:18:20Z |
+----------------------------------------------------+-------------------+-------------+----------------------------------------+----------------------+----------------------+
```

### Quick checks

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
