### PR TITLE
feat: add docs command

### DIFF
--- a/cmd/conduit/root/docs/docs.go
+++ b/cmd/conduit/root/docs/docs.go
@@ -19,9 +19,7 @@ import (
 	"github.com/conduitio/ecdysis"
 )
 
-var (
-	_ ecdysis.CommandWithHidden = (*DocsCommand)(nil)
-)
+var _ ecdysis.CommandWithHidden = (*DocsCommand)(nil)
 
 type DocsCommand struct {
 	open.DocsCommand

--- a/cmd/conduit/root/docs/docs.go
+++ b/cmd/conduit/root/docs/docs.go
@@ -1,0 +1,21 @@
+// Copyright © 2025 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import "github.com/conduitio/conduit/cmd/conduit/root/open"
+
+type DocsCommand struct {
+	open.DocsCommand
+}

--- a/cmd/conduit/root/docs/docs.go
+++ b/cmd/conduit/root/docs/docs.go
@@ -14,8 +14,19 @@
 
 package docs
 
-import "github.com/conduitio/conduit/cmd/conduit/root/open"
+import (
+	"github.com/conduitio/conduit/cmd/conduit/root/open"
+	"github.com/conduitio/ecdysis"
+)
+
+var (
+	_ ecdysis.CommandWithHidden = (*DocsCommand)(nil)
+)
 
 type DocsCommand struct {
 	open.DocsCommand
+}
+
+func (d *DocsCommand) Hidden() bool {
+	return true
 }

--- a/cmd/conduit/root/open/docs.go
+++ b/cmd/conduit/root/open/docs.go
@@ -34,8 +34,7 @@ type DocsCommand struct{}
 func (c *DocsCommand) Aliases() []string { return []string{"documentation", "docs"} }
 
 func (c *DocsCommand) Execute(_ context.Context) error {
-	browser.OpenURL(ConduitDocsURL)
-	return nil
+	return browser.OpenURL(ConduitDocsURL)
 }
 
 func (c *DocsCommand) Usage() string { return "docs" }

--- a/cmd/conduit/root/open/docs.go
+++ b/cmd/conduit/root/open/docs.go
@@ -1,0 +1,44 @@
+// Copyright © 2025 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package open
+
+import (
+	"context"
+
+	"github.com/conduitio/ecdysis"
+	"github.com/pkg/browser"
+)
+
+const ConduitDocsURL = "https://conduit.io/docs"
+
+var (
+	_ ecdysis.CommandWithDocs    = (*DocsCommand)(nil)
+	_ ecdysis.CommandWithExecute = (*DocsCommand)(nil)
+)
+
+type DocsCommand struct{}
+
+func (c *DocsCommand) Execute(_ context.Context) error {
+	browser.OpenURL(ConduitDocsURL)
+	return nil
+}
+
+func (c *DocsCommand) Usage() string { return "docs" }
+
+func (c *DocsCommand) Docs() ecdysis.Docs {
+	return ecdysis.Docs{
+		Short: "Open Conduit documentation in a web browser",
+	}
+}

--- a/cmd/conduit/root/open/docs.go
+++ b/cmd/conduit/root/open/docs.go
@@ -26,9 +26,12 @@ const ConduitDocsURL = "https://conduit.io/docs"
 var (
 	_ ecdysis.CommandWithDocs    = (*DocsCommand)(nil)
 	_ ecdysis.CommandWithExecute = (*DocsCommand)(nil)
+	_ ecdysis.CommandWithAliases = (*DocsCommand)(nil)
 )
 
 type DocsCommand struct{}
+
+func (c *DocsCommand) Aliases() []string { return []string{"documentation", "docs"} }
 
 func (c *DocsCommand) Execute(_ context.Context) error {
 	browser.OpenURL(ConduitDocsURL)

--- a/cmd/conduit/root/open/open.go
+++ b/cmd/conduit/root/open/open.go
@@ -1,0 +1,40 @@
+// Copyright © 2025 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package open
+
+import (
+	"github.com/conduitio/ecdysis"
+)
+
+var (
+	_ ecdysis.CommandWithDocs        = (*OpenCommand)(nil)
+	_ ecdysis.CommandWithSubCommands = (*OpenCommand)(nil)
+)
+
+type OpenCommand struct{}
+
+func (c *OpenCommand) Usage() string { return "open" }
+
+func (c *OpenCommand) Docs() ecdysis.Docs {
+	return ecdysis.Docs{
+		Short: "Open in a web browser",
+	}
+}
+
+func (c *OpenCommand) SubCommands() []ecdysis.Command {
+	return []ecdysis.Command{
+		&DocsCommand{},
+	}
+}

--- a/cmd/conduit/root/root.go
+++ b/cmd/conduit/root/root.go
@@ -22,7 +22,9 @@ import (
 	"github.com/conduitio/conduit/cmd/conduit/root/config"
 	"github.com/conduitio/conduit/cmd/conduit/root/connectorplugins"
 	"github.com/conduitio/conduit/cmd/conduit/root/connectors"
+	"github.com/conduitio/conduit/cmd/conduit/root/docs"
 	"github.com/conduitio/conduit/cmd/conduit/root/initialize"
+	"github.com/conduitio/conduit/cmd/conduit/root/open"
 	"github.com/conduitio/conduit/cmd/conduit/root/pipelines"
 	"github.com/conduitio/conduit/cmd/conduit/root/processorplugins"
 	"github.com/conduitio/conduit/cmd/conduit/root/processors"
@@ -84,7 +86,9 @@ func (c *RootCommand) SubCommands() []ecdysis.Command {
 		&config.ConfigCommand{RunCmd: runCmd},
 		&connectors.ConnectorsCommand{},
 		&connectorplugins.ConnectorPluginsCommand{},
+		&docs.DocsCommand{},
 		&initialize.InitCommand{Cfg: &runCmd.Cfg},
+		&open.OpenCommand{},
 		&pipelines.PipelinesCommand{},
 		&processors.ProcessorsCommand{},
 		&processorplugins.ProcessorPluginsCommand{},

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/matryer/is v1.4.1
 	github.com/neilotoole/slogt v1.1.0
 	github.com/piotrkowalczuk/promgrpc/v4 v4.1.4
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.62.0
@@ -286,7 +287,6 @@ require (
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
-	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect


### PR DESCRIPTION
### Description

Fixes #2037

This adds `conduit docs` (hidden as of now so root is not too crowded) which is an alias to `conduit open docs`. The idea here that we'll be able to expand the open command for more things in the future (`open api`, etc...).

### Quick checks

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
