### PR TITLE
add usage parameters

### DIFF
--- a/cmd/conduit/root/connectorplugins/describe.go
+++ b/cmd/conduit/root/connectorplugins/describe.go
@@ -48,7 +48,7 @@ func (c *DescribeCommand) Output(output ecdysis.Output) {
 	c.output = output
 }
 
-func (c *DescribeCommand) Usage() string { return "describe <connector-plugin-id>" }
+func (c *DescribeCommand) Usage() string { return "describe CONNECTOR_PLUGIN_ID" }
 
 func (c *DescribeCommand) Docs() ecdysis.Docs {
 	return ecdysis.Docs{
@@ -80,7 +80,7 @@ func (c *DescribeCommand) ExecuteWithClient(ctx context.Context, client *api.Cli
 		Name: c.args.connectorPluginID,
 	})
 	if err != nil {
-		return cerrors.Errorf("failed to list connector plguin: %w", err)
+		return cerrors.Errorf("failed to list connector plugin: %w", err)
 	}
 
 	if len(resp.Plugins) == 0 {

--- a/cmd/conduit/root/connectorplugins/describe.go
+++ b/cmd/conduit/root/connectorplugins/describe.go
@@ -48,7 +48,7 @@ func (c *DescribeCommand) Output(output ecdysis.Output) {
 	c.output = output
 }
 
-func (c *DescribeCommand) Usage() string { return "describe" }
+func (c *DescribeCommand) Usage() string { return "describe <connector-plugin-id>" }
 
 func (c *DescribeCommand) Docs() ecdysis.Docs {
 	return ecdysis.Docs{

--- a/cmd/conduit/root/connectors/describe.go
+++ b/cmd/conduit/root/connectors/describe.go
@@ -48,7 +48,7 @@ func (c *DescribeCommand) Output(output ecdysis.Output) {
 	c.output = output
 }
 
-func (c *DescribeCommand) Usage() string { return "describe <connector-id>" }
+func (c *DescribeCommand) Usage() string { return "describe CONNECTOR_ID" }
 
 func (c *DescribeCommand) Docs() ecdysis.Docs {
 	return ecdysis.Docs{

--- a/cmd/conduit/root/connectors/describe.go
+++ b/cmd/conduit/root/connectors/describe.go
@@ -48,7 +48,7 @@ func (c *DescribeCommand) Output(output ecdysis.Output) {
 	c.output = output
 }
 
-func (c *DescribeCommand) Usage() string { return "describe" }
+func (c *DescribeCommand) Usage() string { return "describe <connector-id>" }
 
 func (c *DescribeCommand) Docs() ecdysis.Docs {
 	return ecdysis.Docs{

--- a/cmd/conduit/root/pipelines/describe.go
+++ b/cmd/conduit/root/pipelines/describe.go
@@ -60,7 +60,7 @@ func (c *DescribeCommand) Output(output ecdysis.Output) {
 
 func (c *DescribeCommand) Aliases() []string { return []string{"desc"} }
 
-func (c *DescribeCommand) Usage() string { return "describe <pipeline-id>" }
+func (c *DescribeCommand) Usage() string { return "describe PIPELINE_ID" }
 
 func (c *DescribeCommand) Args(args []string) error {
 	if len(args) == 0 {

--- a/cmd/conduit/root/pipelines/describe.go
+++ b/cmd/conduit/root/pipelines/describe.go
@@ -60,7 +60,7 @@ func (c *DescribeCommand) Output(output ecdysis.Output) {
 
 func (c *DescribeCommand) Aliases() []string { return []string{"desc"} }
 
-func (c *DescribeCommand) Usage() string { return "describe" }
+func (c *DescribeCommand) Usage() string { return "describe <pipeline-id>" }
 
 func (c *DescribeCommand) Args(args []string) error {
 	if len(args) == 0 {

--- a/cmd/conduit/root/pipelines/init.go
+++ b/cmd/conduit/root/pipelines/init.go
@@ -70,6 +70,8 @@ func (c *InitCommand) Flags() []ecdysis.Flag {
 	}
 
 	flags.SetDefault("pipelines.path", filepath.Join(currentPath, "./pipelines"))
+	flags.SetDefault("source", "generator")
+	flags.SetDefault("destination", "file")
 	return flags
 }
 
@@ -85,7 +87,7 @@ func (c *InitCommand) Args(args []string) error {
 	return nil
 }
 
-func (c *InitCommand) Usage() string { return "init" }
+func (c *InitCommand) Usage() string { return "init <pipeline-name>" }
 
 func (c *InitCommand) Docs() ecdysis.Docs {
 	return ecdysis.Docs{
@@ -99,6 +101,8 @@ a simple and runnable generator-to-log pipeline is configured.`,
 }
 
 func (c *InitCommand) getSourceSpec() (connectorSpec, error) {
+	fmt.Println("src: ", c.flags.Source)
+	fmt.Println("dest: ", c.flags.Destination)
 	for _, conn := range builtin.DefaultBuiltinConnectors {
 		specs := conn.NewSpecification()
 		if specs.Name == c.flags.Source || specs.Name == "builtin:"+c.flags.Source {

--- a/cmd/conduit/root/pipelines/init.go
+++ b/cmd/conduit/root/pipelines/init.go
@@ -101,8 +101,6 @@ a simple and runnable generator-to-log pipeline is configured.`,
 }
 
 func (c *InitCommand) getSourceSpec() (connectorSpec, error) {
-	fmt.Println("src: ", c.flags.Source)
-	fmt.Println("dest: ", c.flags.Destination)
 	for _, conn := range builtin.DefaultBuiltinConnectors {
 		specs := conn.NewSpecification()
 		if specs.Name == c.flags.Source || specs.Name == "builtin:"+c.flags.Source {

--- a/cmd/conduit/root/pipelines/init.go
+++ b/cmd/conduit/root/pipelines/init.go
@@ -87,7 +87,7 @@ func (c *InitCommand) Args(args []string) error {
 	return nil
 }
 
-func (c *InitCommand) Usage() string { return "init <pipeline-name>" }
+func (c *InitCommand) Usage() string { return "init PIPELINE_NAME" }
 
 func (c *InitCommand) Docs() ecdysis.Docs {
 	return ecdysis.Docs{

--- a/cmd/conduit/root/processorplugins/describe.go
+++ b/cmd/conduit/root/processorplugins/describe.go
@@ -48,7 +48,7 @@ func (c *DescribeCommand) Output(output ecdysis.Output) {
 	c.output = output
 }
 
-func (c *DescribeCommand) Usage() string { return "describe <processor-plugin-id>" }
+func (c *DescribeCommand) Usage() string { return "describe PROCESSOR_PLUGIN_ID" }
 
 func (c *DescribeCommand) Docs() ecdysis.Docs {
 	return ecdysis.Docs{

--- a/cmd/conduit/root/processorplugins/describe.go
+++ b/cmd/conduit/root/processorplugins/describe.go
@@ -48,7 +48,7 @@ func (c *DescribeCommand) Output(output ecdysis.Output) {
 	c.output = output
 }
 
-func (c *DescribeCommand) Usage() string { return "describe" }
+func (c *DescribeCommand) Usage() string { return "describe <processor-plugin-id>" }
 
 func (c *DescribeCommand) Docs() ecdysis.Docs {
 	return ecdysis.Docs{

--- a/cmd/conduit/root/processors/describe.go
+++ b/cmd/conduit/root/processors/describe.go
@@ -48,7 +48,7 @@ func (c *DescribeCommand) Output(output ecdysis.Output) {
 	c.output = output
 }
 
-func (c *DescribeCommand) Usage() string { return "describe <processor-id>" }
+func (c *DescribeCommand) Usage() string { return "describe PROCESSOR_ID" }
 
 func (c *DescribeCommand) Docs() ecdysis.Docs {
 	return ecdysis.Docs{

--- a/cmd/conduit/root/processors/describe.go
+++ b/cmd/conduit/root/processors/describe.go
@@ -48,7 +48,7 @@ func (c *DescribeCommand) Output(output ecdysis.Output) {
 	c.output = output
 }
 
-func (c *DescribeCommand) Usage() string { return "describe" }
+func (c *DescribeCommand) Usage() string { return "describe <processor-id>" }
 
 func (c *DescribeCommand) Docs() ecdysis.Docs {
 	return ecdysis.Docs{


### PR DESCRIPTION
### Description

when running `./conduit pipelines desc --help` , the Usage doesn't show the required <pipeline-name>
this PR adds this for all the `desc` commands, and `pipelines init`


### Quick checks

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
