### PR TITLE
 [arch-v2] Make it possible to enable or disable metrics 

### DIFF
--- a/cmd/conduit/root/run/run.go
+++ b/cmd/conduit/root/run/run.go
@@ -99,7 +99,7 @@ func (c *RunCommand) Flags() []ecdysis.Flag {
 	flags.SetDefault("schema-registry.type", c.Cfg.SchemaRegistry.Type)
 	flags.SetDefault("schema-registry.confluent.connection-string", c.Cfg.SchemaRegistry.Confluent.ConnectionString)
 	flags.SetDefault("preview.pipeline-arch-v2", c.Cfg.Preview.PipelineArchV2)
-	flags.SetDefault("preview.pipeline-arch-v2-enable-metrics", c.Cfg.Preview.PipelineArchV2EnableMetrics)
+	flags.SetDefault("preview.pipeline-arch-v2-disable-metrics", c.Cfg.Preview.PipelineArchV2DisableMetrics)
 	return flags
 }
 

--- a/cmd/conduit/root/run/run.go
+++ b/cmd/conduit/root/run/run.go
@@ -99,6 +99,7 @@ func (c *RunCommand) Flags() []ecdysis.Flag {
 	flags.SetDefault("schema-registry.type", c.Cfg.SchemaRegistry.Type)
 	flags.SetDefault("schema-registry.confluent.connection-string", c.Cfg.SchemaRegistry.Confluent.ConnectionString)
 	flags.SetDefault("preview.pipeline-arch-v2", c.Cfg.Preview.PipelineArchV2)
+	flags.SetDefault("preview.pipeline-arch-v2.enable-metrics", c.Cfg.Preview.PipelineArchV2EnableMetrics)
 	return flags
 }
 

--- a/cmd/conduit/root/run/run.go
+++ b/cmd/conduit/root/run/run.go
@@ -99,7 +99,7 @@ func (c *RunCommand) Flags() []ecdysis.Flag {
 	flags.SetDefault("schema-registry.type", c.Cfg.SchemaRegistry.Type)
 	flags.SetDefault("schema-registry.confluent.connection-string", c.Cfg.SchemaRegistry.Confluent.ConnectionString)
 	flags.SetDefault("preview.pipeline-arch-v2", c.Cfg.Preview.PipelineArchV2)
-	flags.SetDefault("preview.pipeline-arch-v2.enable-metrics", c.Cfg.Preview.PipelineArchV2EnableMetrics)
+	flags.SetDefault("preview.pipeline-arch-v2-enable-metrics", c.Cfg.Preview.PipelineArchV2EnableMetrics)
 	return flags
 }
 

--- a/cmd/conduit/root/run/run_test.go
+++ b/cmd/conduit/root/run/run_test.go
@@ -55,6 +55,7 @@ func TestRunCommandFlags(t *testing.T) {
 		{longName: "schema-registry.type", usage: "schema registry type; accepts builtin,confluent"},
 		{longName: "schema-registry.confluent.connection-string", usage: "confluent schema registry connection string"},
 		{longName: "preview.pipeline-arch-v2", usage: "enables experimental pipeline architecture v2 (note that the new architecture currently supports only 1 source and 1 destination per pipeline)"},
+		{longName: "preview.pipeline-arch-v2.enable-metrics", usage: "enables metrics about amount of data (in bytes) moved through in pipeline architecture v2 (at the cost of reduced performance)"},
 		{longName: "dev.cpuprofile", usage: "write CPU profile to file"},
 		{longName: "dev.memprofile", usage: "write memory profile to file"},
 		{longName: "dev.blockprofile", usage: "write block profile to file"},

--- a/cmd/conduit/root/run/run_test.go
+++ b/cmd/conduit/root/run/run_test.go
@@ -55,7 +55,7 @@ func TestRunCommandFlags(t *testing.T) {
 		{longName: "schema-registry.type", usage: "schema registry type; accepts builtin,confluent"},
 		{longName: "schema-registry.confluent.connection-string", usage: "confluent schema registry connection string"},
 		{longName: "preview.pipeline-arch-v2", usage: "enables experimental pipeline architecture v2 (note that the new architecture currently supports only 1 source and 1 destination per pipeline)"},
-		{longName: "preview.pipeline-arch-v2.enable-metrics", usage: "enables metrics about amount of data (in bytes) moved through in pipeline architecture v2 (at the cost of reduced performance)"},
+		{longName: "preview.pipeline-arch-v2-enable-metrics", usage: "enables metrics about amount of data (in bytes) moved through in pipeline architecture v2 (at the cost of reduced performance)"},
 		{longName: "dev.cpuprofile", usage: "write CPU profile to file"},
 		{longName: "dev.memprofile", usage: "write memory profile to file"},
 		{longName: "dev.blockprofile", usage: "write block profile to file"},

--- a/cmd/conduit/root/run/run_test.go
+++ b/cmd/conduit/root/run/run_test.go
@@ -55,7 +55,7 @@ func TestRunCommandFlags(t *testing.T) {
 		{longName: "schema-registry.type", usage: "schema registry type; accepts builtin,confluent"},
 		{longName: "schema-registry.confluent.connection-string", usage: "confluent schema registry connection string"},
 		{longName: "preview.pipeline-arch-v2", usage: "enables experimental pipeline architecture v2 (note that the new architecture currently supports only 1 source and 1 destination per pipeline)"},
-		{longName: "preview.pipeline-arch-v2-enable-metrics", usage: "enables metrics about amount of data (in bytes) moved through in pipeline architecture v2 (at the cost of reduced performance)"},
+		{longName: "preview.pipeline-arch-v2-disable-metrics", usage: "disables metrics about amount of data (in bytes) moved in pipeline architecture v2 (increases performance)"},
 		{longName: "dev.cpuprofile", usage: "write CPU profile to file"},
 		{longName: "dev.memprofile", usage: "write memory profile to file"},
 		{longName: "dev.blockprofile", usage: "write block profile to file"},

--- a/pkg/conduit/config.go
+++ b/pkg/conduit/config.go
@@ -121,7 +121,8 @@ type Config struct {
 
 	Preview struct {
 		// PipelineArchV2 enables the new pipeline architecture.
-		PipelineArchV2 bool `long:"preview.pipeline-arch-v2" mapstructure:"pipeline-arch-v2" usage:"enables experimental pipeline architecture v2 (note that the new architecture currently supports only 1 source and 1 destination per pipeline)"`
+		PipelineArchV2              bool `long:"preview.pipeline-arch-v2" mapstructure:"pipeline-arch-v2" usage:"enables experimental pipeline architecture v2 (note that the new architecture currently supports only 1 source and 1 destination per pipeline)"`
+		PipelineArchV2EnableMetrics bool `long:"preview.pipeline-arch-v2.enable-metrics" mapstructure:"pipeline-arch-v2.enable-metrics" usage:"enables metrics about amount of data (in bytes) moved through in pipeline architecture v2 (at the cost of reduced performance)"`
 	}
 
 	Dev struct {

--- a/pkg/conduit/config.go
+++ b/pkg/conduit/config.go
@@ -121,8 +121,8 @@ type Config struct {
 
 	Preview struct {
 		// PipelineArchV2 enables the new pipeline architecture.
-		PipelineArchV2              bool `long:"preview.pipeline-arch-v2" mapstructure:"pipeline-arch-v2" usage:"enables experimental pipeline architecture v2 (note that the new architecture currently supports only 1 source and 1 destination per pipeline)"`
-		PipelineArchV2EnableMetrics bool `long:"preview.pipeline-arch-v2-enable-metrics" mapstructure:"pipeline-arch-v2-enable-metrics" usage:"enables metrics about amount of data (in bytes) moved through in pipeline architecture v2 (at the cost of reduced performance)"`
+		PipelineArchV2               bool `long:"preview.pipeline-arch-v2" mapstructure:"pipeline-arch-v2" usage:"enables experimental pipeline architecture v2 (note that the new architecture currently supports only 1 source and 1 destination per pipeline)"`
+		PipelineArchV2DisableMetrics bool `long:"preview.pipeline-arch-v2-disable-metrics" mapstructure:"pipeline-arch-v2-disable-metrics" usage:"disables metrics about amount of data (in bytes) moved in pipeline architecture v2 (increases performance)"`
 	}
 
 	Dev struct {

--- a/pkg/conduit/config.go
+++ b/pkg/conduit/config.go
@@ -122,7 +122,7 @@ type Config struct {
 	Preview struct {
 		// PipelineArchV2 enables the new pipeline architecture.
 		PipelineArchV2              bool `long:"preview.pipeline-arch-v2" mapstructure:"pipeline-arch-v2" usage:"enables experimental pipeline architecture v2 (note that the new architecture currently supports only 1 source and 1 destination per pipeline)"`
-		PipelineArchV2EnableMetrics bool `long:"preview.pipeline-arch-v2.enable-metrics" mapstructure:"pipeline-arch-v2.enable-metrics" usage:"enables metrics about amount of data (in bytes) moved through in pipeline architecture v2 (at the cost of reduced performance)"`
+		PipelineArchV2EnableMetrics bool `long:"preview.pipeline-arch-v2-enable-metrics" mapstructure:"pipeline-arch-v2-enable-metrics" usage:"enables metrics about amount of data (in bytes) moved through in pipeline architecture v2 (at the cost of reduced performance)"`
 	}
 
 	Dev struct {

--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -218,7 +218,14 @@ func createServices(r *Runtime) error {
 	var lifecycleService lifecycleService
 	if r.Config.Preview.PipelineArchV2 {
 		r.logger.Info(context.Background()).Msg("using lifecycle service v2")
-		lifecycleService = lifecycle_v2.NewService(r.logger, connService, procService, connPluginService, plService)
+		lifecycleService = lifecycle_v2.NewService(
+			r.logger,
+			connService,
+			procService,
+			connPluginService,
+			plService,
+			r.Config.Preview.PipelineArchV2EnableMetrics,
+		)
 	} else {
 		// Error recovery configuration
 		errRecoveryCfg := &lifecycle.ErrRecoveryCfg{

--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -224,7 +224,7 @@ func createServices(r *Runtime) error {
 			procService,
 			connPluginService,
 			plService,
-			r.Config.Preview.PipelineArchV2EnableMetrics,
+			r.Config.Preview.PipelineArchV2DisableMetrics,
 		)
 	} else {
 		// Error recovery configuration

--- a/pkg/lifecycle-poc/funnel/connector_metrics.go
+++ b/pkg/lifecycle-poc/funnel/connector_metrics.go
@@ -1,0 +1,73 @@
+// Copyright © 2025 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funnel
+
+import (
+	"strings"
+	"time"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/connector"
+	"github.com/conduitio/conduit/pkg/foundation/metrics"
+	"github.com/conduitio/conduit/pkg/foundation/metrics/measure"
+)
+
+type ConnectorMetrics interface {
+	Observe(records []opencdc.Record, start time.Time)
+}
+
+type NoOpConnectorMetrics struct{}
+
+func (m *NoOpConnectorMetrics) Observe([]opencdc.Record, time.Time) {}
+
+type ConnectorMetricsImpl struct {
+	timer     metrics.Timer
+	histogram metrics.RecordBytesHistogram
+}
+
+func NewConnectorMetrics(pipelineName, pluginName string, connType connector.Type) *ConnectorMetricsImpl {
+	timer := measure.ConnectorExecutionDurationTimer.WithValues(
+		pipelineName,
+		pluginName,
+		strings.ToLower(connType.String()),
+	)
+
+	histogram := measure.ConnectorBytesHistogram.WithValues(
+		pipelineName,
+		pluginName,
+		strings.ToLower(connType.String()),
+	)
+
+	return &ConnectorMetricsImpl{
+		timer:     timer,
+		histogram: metrics.NewRecordBytesHistogram(histogram),
+	}
+}
+
+func (m *ConnectorMetricsImpl) Observe(records []opencdc.Record, start time.Time) {
+	// Precalculate sizes so that we don't need to hold a reference to records
+	// and observations can happen in a goroutine.
+	sizes := make([]float64, len(records))
+	for i, rec := range records {
+		sizes[i] = m.histogram.SizeOf(rec)
+	}
+	tookPerRecord := time.Since(start) / time.Duration(len(sizes))
+	go func() {
+		for i := range len(sizes) {
+			m.timer.Update(tookPerRecord)
+			m.histogram.H.Observe(sizes[i])
+		}
+	}()
+}

--- a/pkg/lifecycle-poc/funnel/connector_metrics.go
+++ b/pkg/lifecycle-poc/funnel/connector_metrics.go
@@ -15,6 +15,7 @@
 package funnel
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -30,7 +31,9 @@ type ConnectorMetrics interface {
 
 type NoOpConnectorMetrics struct{}
 
-func (m *NoOpConnectorMetrics) Observe([]opencdc.Record, time.Time) {}
+func (m *NoOpConnectorMetrics) Observe([]opencdc.Record, time.Time) {
+	fmt.Println("hi there")
+}
 
 type ConnectorMetricsImpl struct {
 	timer     metrics.Timer
@@ -57,6 +60,7 @@ func NewConnectorMetrics(pipelineName, pluginName string, connType connector.Typ
 }
 
 func (m *ConnectorMetricsImpl) Observe(records []opencdc.Record, start time.Time) {
+	fmt.Println("hi there")
 	// Precalculate sizes so that we don't need to hold a reference to records
 	// and observations can happen in a goroutine.
 	sizes := make([]float64, len(records))

--- a/pkg/lifecycle-poc/funnel/connector_metrics.go
+++ b/pkg/lifecycle-poc/funnel/connector_metrics.go
@@ -31,9 +31,7 @@ type ConnectorMetrics interface {
 
 type NoOpConnectorMetrics struct{}
 
-func (m *NoOpConnectorMetrics) Observe([]opencdc.Record, time.Time) {
-	fmt.Println("hi there")
-}
+func (m *NoOpConnectorMetrics) Observe([]opencdc.Record, time.Time) {}
 
 type ConnectorMetricsImpl struct {
 	timer     metrics.Timer

--- a/pkg/lifecycle-poc/funnel/destination.go
+++ b/pkg/lifecycle-poc/funnel/destination.go
@@ -25,7 +25,6 @@ import (
 	"github.com/conduitio/conduit/pkg/connector"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/log"
-	"github.com/conduitio/conduit/pkg/foundation/metrics"
 )
 
 type DestinationTask struct {
@@ -33,8 +32,7 @@ type DestinationTask struct {
 	destination Destination
 	logger      log.CtxLogger
 
-	timer     metrics.Timer
-	histogram metrics.RecordBytesHistogram
+	metrics ConnectorMetrics
 }
 
 type Destination interface {
@@ -54,8 +52,7 @@ func NewDestinationTask(
 	id string,
 	destination Destination,
 	logger log.CtxLogger,
-	timer metrics.Timer,
-	histogram metrics.Histogram,
+	metrics ConnectorMetrics,
 ) *DestinationTask {
 	logger = logger.WithComponent("task:destination")
 	logger.Logger = logger.With().Str(log.ConnectorIDField, id).Logger()
@@ -63,8 +60,7 @@ func NewDestinationTask(
 		id:          id,
 		destination: destination,
 		logger:      logger,
-		timer:       timer,
-		histogram:   metrics.NewRecordBytesHistogram(histogram),
+		metrics:     metrics,
 	}
 }
 
@@ -105,7 +101,7 @@ func (t *DestinationTask) Do(ctx context.Context, batch *Batch) error {
 		if err != nil {
 			return cerrors.Errorf("failed to receive acks for %d records from destination: %w", len(positions), err)
 		}
-		t.observeMetrics(records[len(acks):len(acks)+len(acksResp)], start)
+		t.metrics.Observe(records[len(acks):len(acks)+len(acksResp)], start)
 		acks = append(acks, acksResp...)
 		if len(acks) >= len(positions) {
 			break
@@ -126,20 +122,4 @@ func (t *DestinationTask) Do(ctx context.Context, batch *Batch) error {
 	}
 
 	return nil
-}
-
-func (t *DestinationTask) observeMetrics(records []opencdc.Record, start time.Time) {
-	// Precalculate sizes so that we don't need to hold a reference to records
-	// and observations can happen in a goroutine.
-	sizes := make([]float64, len(records))
-	for i, rec := range records {
-		sizes[i] = t.histogram.SizeOf(rec)
-	}
-	tookPerRecord := time.Since(start) / time.Duration(len(sizes))
-	go func() {
-		for i := range len(sizes) {
-			t.timer.Update(tookPerRecord)
-			t.histogram.H.Observe(sizes[i])
-		}
-	}()
 }

--- a/pkg/lifecycle-poc/funnel/dlq.go
+++ b/pkg/lifecycle-poc/funnel/dlq.go
@@ -22,7 +22,6 @@ import (
 	"github.com/conduitio/conduit-commons/opencdc"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/log"
-	"github.com/conduitio/conduit/pkg/foundation/metrics"
 )
 
 type DLQ struct {
@@ -40,14 +39,13 @@ func NewDLQ(
 	id string,
 	destination Destination,
 	logger log.CtxLogger,
-	timer metrics.Timer,
-	histogram metrics.Histogram,
+	metrics ConnectorMetrics,
 
 	windowSize int,
 	windowNackThreshold int,
 ) *DLQ {
 	return &DLQ{
-		task:                NewDestinationTask(id, destination, logger, timer, histogram),
+		task:                NewDestinationTask(id, destination, logger, metrics),
 		windowSize:          windowSize,
 		windowNackThreshold: windowNackThreshold,
 

--- a/pkg/lifecycle-poc/funnel/dlq_metrics.go
+++ b/pkg/lifecycle-poc/funnel/dlq_metrics.go
@@ -1,0 +1,30 @@
+// Copyright © 2025 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funnel
+
+import (
+	"github.com/conduitio/conduit/pkg/foundation/metrics"
+	"github.com/conduitio/conduit/pkg/foundation/metrics/measure"
+)
+
+func NewDLQMetrics(pipelineName string, plugin string) ConnectorMetrics {
+	timer := measure.DLQExecutionDurationTimer.WithValues(pipelineName, plugin)
+	histogram := measure.DLQBytesHistogram.WithValues(pipelineName, plugin)
+
+	return &ConnectorMetricsImpl{
+		timer:     timer,
+		histogram: metrics.NewRecordBytesHistogram(histogram),
+	}
+}

--- a/pkg/lifecycle-poc/funnel/funnel_test.go
+++ b/pkg/lifecycle-poc/funnel/funnel_test.go
@@ -46,8 +46,7 @@ func Example_simpleStream() {
 		"dlq",
 		noopDLQDestination(ctrl),
 		logger,
-		noop.Timer{},
-		noop.Histogram{},
+		&NoOpConnectorMetrics{},
 		1,
 		0,
 	)
@@ -55,15 +54,13 @@ func Example_simpleStream() {
 		"generator",
 		generatorSource(ctrl, logger, "generator", batchSize, batchCount),
 		logger,
-		noop.Timer{},
-		noop.Histogram{},
+		&NoOpConnectorMetrics{},
 	)
 	destTask := NewDestinationTask(
 		"printer",
 		printerDestination(ctrl, logger, "printer", batchSize),
 		logger,
-		noop.Timer{},
-		noop.Histogram{},
+		&NoOpConnectorMetrics{},
 	)
 
 	w, err := NewWorker(
@@ -153,8 +150,7 @@ func BenchmarkStreamNew(b *testing.B) {
 			"dlq",
 			noopDLQDestination(ctrl),
 			logger,
-			noop.Timer{},
-			noop.Histogram{},
+			&NoOpConnectorMetrics{},
 			1,
 			0,
 		)
@@ -162,15 +158,13 @@ func BenchmarkStreamNew(b *testing.B) {
 			"generator",
 			generatorSource(ctrl, logger, "generator", batchSize, batchCount),
 			logger,
-			noop.Timer{},
-			noop.Histogram{},
+			&NoOpConnectorMetrics{},
 		)
 		destTask := NewDestinationTask(
 			"printer",
 			printerDestination(ctrl, logger, "printer", batchSize),
 			logger,
-			noop.Timer{},
-			noop.Histogram{},
+			&NoOpConnectorMetrics{},
 		)
 
 		w, err := NewWorker(

--- a/pkg/lifecycle-poc/funnel/processor.go
+++ b/pkg/lifecycle-poc/funnel/processor.go
@@ -24,14 +24,14 @@ import (
 	sdk "github.com/conduitio/conduit-processor-sdk"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/log"
-	"github.com/conduitio/conduit/pkg/foundation/metrics"
 )
 
 type ProcessorTask struct {
 	id        string
 	processor Processor
 	logger    log.CtxLogger
-	timer     metrics.Timer
+
+	metrics ProcessorMetrics
 }
 
 type Processor interface {
@@ -47,7 +47,7 @@ func NewProcessorTask(
 	id string,
 	processor Processor,
 	logger log.CtxLogger,
-	timer metrics.Timer,
+	metrics ProcessorMetrics,
 ) *ProcessorTask {
 	logger = logger.WithComponent("task:processor")
 	logger.Logger = logger.With().Str(log.ProcessorIDField, id).Logger()
@@ -55,7 +55,7 @@ func NewProcessorTask(
 		id:        id,
 		processor: processor,
 		logger:    logger,
-		timer:     timer,
+		metrics:   metrics,
 	}
 }
 
@@ -86,7 +86,7 @@ func (t *ProcessorTask) Do(ctx context.Context, b *Batch) error {
 	if len(recsOut) == 0 {
 		return cerrors.Errorf("processor didn't return any records")
 	}
-	t.observeMetrics(len(recsOut), start)
+	t.metrics.Observe(len(recsOut), start)
 
 	// Mark records in the batch as processed, filtered or errored.
 	// We do this a bit smarter, by collecting ranges of records that are
@@ -151,13 +151,4 @@ func (t *ProcessorTask) markBatchRecords(b *Batch, from int, records []sdk.Proce
 		}
 		b.Nack(from, errs...)
 	}
-}
-
-func (t *ProcessorTask) observeMetrics(n int, start time.Time) {
-	tookPerRecord := time.Since(start) / time.Duration(n)
-	go func() {
-		for range n {
-			t.timer.Update(tookPerRecord)
-		}
-	}()
 }

--- a/pkg/lifecycle-poc/funnel/processor_metrics.go
+++ b/pkg/lifecycle-poc/funnel/processor_metrics.go
@@ -1,0 +1,50 @@
+// Copyright © 2025 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funnel
+
+import (
+	"time"
+
+	"github.com/conduitio/conduit/pkg/foundation/metrics"
+	"github.com/conduitio/conduit/pkg/foundation/metrics/measure"
+)
+
+type ProcessorMetrics interface {
+	Observe(recordsNum int, start time.Time)
+}
+
+type NoOpProcessorMetrics struct{}
+
+func (m *NoOpProcessorMetrics) Observe(int, time.Time) {}
+
+type ProcessorMetricsImpl struct {
+	timer metrics.Timer
+}
+
+func (m *ProcessorMetricsImpl) Observe(recordsNum int, start time.Time) {
+	tookPerRecord := time.Since(start) / time.Duration(recordsNum)
+	go func() {
+		for range recordsNum {
+			m.timer.Update(tookPerRecord)
+		}
+	}()
+
+}
+
+func NewProcessorMetrics(pipelineName, plugin string) *ProcessorMetricsImpl {
+	return &ProcessorMetricsImpl{
+		timer: measure.ProcessorExecutionDurationTimer.WithValues(pipelineName, plugin),
+	}
+}

--- a/pkg/lifecycle-poc/funnel/processor_metrics.go
+++ b/pkg/lifecycle-poc/funnel/processor_metrics.go
@@ -40,7 +40,6 @@ func (m *ProcessorMetricsImpl) Observe(recordsNum int, start time.Time) {
 			m.timer.Update(tookPerRecord)
 		}
 	}()
-
 }
 
 func NewProcessorMetrics(pipelineName, plugin string) *ProcessorMetricsImpl {

--- a/pkg/lifecycle-poc/service.go
+++ b/pkg/lifecycle-poc/service.go
@@ -67,7 +67,7 @@ func NewService(
 	processors ProcessorService,
 	connectorPlugins ConnectorPluginService,
 	pipelines PipelineService,
-	metricsEnabled bool,
+	metricsDisabled bool,
 ) *Service {
 	return &Service{
 		logger:           logger.WithComponent("lifecycle.Service"),
@@ -76,7 +76,7 @@ func NewService(
 		connectorPlugins: connectorPlugins,
 		pipelines:        pipelines,
 		runningPipelines: csync.NewMap[string, *runnablePipeline](),
-		metricsDisabled:  metricsEnabled,
+		metricsDisabled:  metricsDisabled,
 	}
 }
 

--- a/pkg/lifecycle-poc/service.go
+++ b/pkg/lifecycle-poc/service.go
@@ -652,28 +652,28 @@ func (s *Service) notify(pipelineID string, err error) {
 
 func (s *Service) newConnectorMetrics(pipelineName string, instance *connector.Instance) funnel.ConnectorMetrics {
 	if s.metricsDisabled {
-		return funnel.NewConnectorMetrics(
-			pipelineName,
-			instance.Plugin,
-			instance.Type,
-		)
+		return &funnel.NoOpConnectorMetrics{}
 	}
 
-	return &funnel.NoOpConnectorMetrics{}
+	return funnel.NewConnectorMetrics(
+		pipelineName,
+		instance.Plugin,
+		instance.Type,
+	)
 }
 
 func (s *Service) newProcessorMetrics(pipelineName, plugin string) funnel.ProcessorMetrics {
 	if s.metricsDisabled {
-		return funnel.NewProcessorMetrics(pipelineName, plugin)
+		return &funnel.NoOpProcessorMetrics{}
 	}
 
-	return &funnel.NoOpProcessorMetrics{}
+	return funnel.NewProcessorMetrics(pipelineName, plugin)
 }
 
 func (s *Service) newDLQMetrics(pipelineName string, plugin string) funnel.ConnectorMetrics {
 	if s.metricsDisabled {
 		return &funnel.NoOpConnectorMetrics{}
 	}
-	
+
 	return funnel.NewDLQMetrics(pipelineName, plugin)
 }

--- a/pkg/lifecycle-poc/service.go
+++ b/pkg/lifecycle-poc/service.go
@@ -676,5 +676,4 @@ func (s *Service) newDLQMetrics(pipelineName string, plugin string) funnel.Conne
 	}
 
 	return &funnel.NoOpConnectorMetrics{}
-
 }

--- a/pkg/lifecycle-poc/service.go
+++ b/pkg/lifecycle-poc/service.go
@@ -57,7 +57,7 @@ type Service struct {
 	runningPipelines *csync.Map[string, *runnablePipeline]
 
 	isGracefulShutdown atomic.Bool
-	metricsEnabled     bool
+	metricsDisabled    bool
 }
 
 // NewService initializes and returns a lifecycle.Service.
@@ -76,7 +76,7 @@ func NewService(
 		connectorPlugins: connectorPlugins,
 		pipelines:        pipelines,
 		runningPipelines: csync.NewMap[string, *runnablePipeline](),
-		metricsEnabled:   metricsEnabled,
+		metricsDisabled:  metricsEnabled,
 	}
 }
 
@@ -651,7 +651,7 @@ func (s *Service) notify(pipelineID string, err error) {
 }
 
 func (s *Service) newConnectorMetrics(pipelineName string, instance *connector.Instance) funnel.ConnectorMetrics {
-	if s.metricsEnabled {
+	if s.metricsDisabled {
 		return funnel.NewConnectorMetrics(
 			pipelineName,
 			instance.Plugin,
@@ -663,7 +663,7 @@ func (s *Service) newConnectorMetrics(pipelineName string, instance *connector.I
 }
 
 func (s *Service) newProcessorMetrics(pipelineName, plugin string) funnel.ProcessorMetrics {
-	if s.metricsEnabled {
+	if s.metricsDisabled {
 		return funnel.NewProcessorMetrics(pipelineName, plugin)
 	}
 
@@ -671,9 +671,9 @@ func (s *Service) newProcessorMetrics(pipelineName, plugin string) funnel.Proces
 }
 
 func (s *Service) newDLQMetrics(pipelineName string, plugin string) funnel.ConnectorMetrics {
-	if s.metricsEnabled {
-		return funnel.NewDLQMetrics(pipelineName, plugin)
+	if s.metricsDisabled {
+		return &funnel.NoOpConnectorMetrics{}
 	}
-
-	return &funnel.NoOpConnectorMetrics{}
+	
+	return funnel.NewDLQMetrics(pipelineName, plugin)
 }

--- a/pkg/lifecycle-poc/service.go
+++ b/pkg/lifecycle-poc/service.go
@@ -67,6 +67,7 @@ func NewService(
 	processors ProcessorService,
 	connectorPlugins ConnectorPluginService,
 	pipelines PipelineService,
+	metricsEnabled bool,
 ) *Service {
 	return &Service{
 		logger:           logger.WithComponent("lifecycle.Service"),
@@ -75,6 +76,7 @@ func NewService(
 		connectorPlugins: connectorPlugins,
 		pipelines:        pipelines,
 		runningPipelines: csync.NewMap[string, *runnablePipeline](),
+		metricsEnabled:   metricsEnabled,
 	}
 }
 

--- a/pkg/lifecycle-poc/service_test.go
+++ b/pkg/lifecycle-poc/service_test.go
@@ -84,6 +84,7 @@ func TestServiceLifecycle_buildRunnablePipeline(t *testing.T) {
 			dlq.Plugin:         pmock.NewDispenser(ctrl),
 		},
 		testPipelineService{},
+		false,
 	)
 
 	got, err := ls.buildRunnablePipeline(
@@ -133,7 +134,8 @@ func TestService_buildRunnablePipeline_NoSourceNode(t *testing.T) {
 	}
 	pl.SetStatus(pipeline.StatusUserStopped)
 
-	ls := NewService(logger,
+	ls := NewService(
+		logger,
 		testConnectorService{
 			destination.ID: destination,
 			testDLQID:      dlq,
@@ -144,6 +146,7 @@ func TestService_buildRunnablePipeline_NoSourceNode(t *testing.T) {
 			dlq.Plugin:         pmock.NewDispenser(ctrl),
 		},
 		testPipelineService{},
+		false,
 	)
 
 	wantErr := "can't build pipeline without any source connectors"
@@ -170,7 +173,8 @@ func TestService_buildRunnablePipeline_NoDestinationNode(t *testing.T) {
 	source := dummySource(persister)
 	dlq := dummyDestination(persister)
 
-	ls := NewService(logger,
+	ls := NewService(
+		logger,
 		testConnectorService{
 			source.ID: source,
 			testDLQID: dlq,
@@ -181,6 +185,7 @@ func TestService_buildRunnablePipeline_NoDestinationNode(t *testing.T) {
 			dlq.Plugin:    pmock.NewDispenser(ctrl),
 		},
 		testPipelineService{},
+		false,
 	)
 
 	wantErr := "can't build pipeline without any destination connectors"
@@ -236,7 +241,8 @@ func TestServiceLifecycle_PipelineSuccess(t *testing.T) {
 	pl, err = ps.AddConnector(ctx, pl.ID, destination.ID)
 	is.NoErr(err)
 
-	ls := NewService(logger,
+	ls := NewService(
+		logger,
 		testConnectorService{
 			source.ID:      source,
 			destination.ID: destination,
@@ -249,6 +255,7 @@ func TestServiceLifecycle_PipelineSuccess(t *testing.T) {
 			dlq.Plugin:         dlqDispenser,
 		},
 		ps,
+		false,
 	)
 
 	// start the pipeline now that everything is set up
@@ -301,7 +308,8 @@ func TestServiceLifecycle_PipelineError(t *testing.T) {
 	pl, err = ps.AddConnector(ctx, pl.ID, destination.ID)
 	is.NoErr(err)
 
-	ls := NewService(logger,
+	ls := NewService(
+		logger,
 		testConnectorService{
 			source.ID:      source,
 			destination.ID: destination,
@@ -314,6 +322,7 @@ func TestServiceLifecycle_PipelineError(t *testing.T) {
 			dlq.Plugin:         dlqDispenser,
 		},
 		ps,
+		false,
 	)
 
 	events := make(chan FailureEvent, 1)
@@ -380,7 +389,8 @@ func TestServiceLifecycle_PipelineStop(t *testing.T) {
 	pl, err = ps.AddConnector(ctx, pl.ID, destination.ID)
 	is.NoErr(err)
 
-	ls := NewService(logger,
+	ls := NewService(
+		logger,
 		testConnectorService{
 			source.ID:      source,
 			destination.ID: destination,
@@ -393,6 +403,7 @@ func TestServiceLifecycle_PipelineStop(t *testing.T) {
 			dlq.Plugin:         dlqDispenser,
 		},
 		ps,
+		false,
 	)
 
 	// start the pipeline now that everything is set up


### PR DESCRIPTION
### Description

Given the performance impact of metrics in the new pipeline architecture, this PR disables the metrics by default but makes it possible to enable those (if needed).

It's done by changing the source, destination, and processor tasks to use a metrics interface that can either be a no-op implementation or a real implementation (depending on a configuration flag). 

See #2268.

### Quick checks

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
