### PR TITLE
 Support reading files in pipelines.path 

### DIFF
--- a/pkg/provisioning/service_test.go
+++ b/pkg/provisioning/service_test.go
@@ -116,38 +116,57 @@ var (
 )
 
 func TestService_Init_Create(t *testing.T) {
-	is := is.New(t)
-	logger := log.Nop()
-	ctrl := gomock.NewController(t)
+	testCases := []struct {
+		name     string
+		testPath string
+	}{
+		{
+			name:     "pipelines directory",
+			testPath: "./test/pipelines1",
+		},
+		{
+			name:     "pipeline file",
+			testPath: "./test/pipelines1/pipeline.yml",
+		},
+	}
 
-	service, pipelineService, connService, procService, _, lifecycleService := newTestService(ctrl, logger)
-	service.pipelinesPath = "./test/pipelines1"
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			logger := log.Nop()
+			ctrl := gomock.NewController(t)
 
-	// return a pipeline not provisioned by API
-	pipelineService.EXPECT().Get(anyCtx, p1.P1.ID).Return(nil, pipeline.ErrInstanceNotFound)
+			service, pipelineService, connService, procService, _, lifecycleService := newTestService(ctrl, logger)
+			service.pipelinesPath = tc.testPath
 
-	pipelineService.EXPECT().List(anyCtx)
-	// pipeline doesn't exist
-	pipelineService.EXPECT().Get(anyCtx, p1.P1.ID).Return(nil, pipeline.ErrInstanceNotFound)
-	// create pipeline
-	pipelineService.EXPECT().CreateWithInstance(anyCtx, p1.P1)
-	pipelineService.EXPECT().UpdateDLQ(anyCtx, p1.P1.ID, p1.P1.DLQ)
-	pipelineService.EXPECT().AddConnector(anyCtx, p1.P1.ID, p1.P1.ConnectorIDs[0])
-	pipelineService.EXPECT().AddConnector(anyCtx, p1.P1.ID, p1.P1.ConnectorIDs[1])
-	pipelineService.EXPECT().AddProcessor(anyCtx, p1.P1.ID, p1.P1.ProcessorIDs[0])
+			// return a pipeline not provisioned by API
+			pipelineService.EXPECT().Get(anyCtx, p1.P1.ID).Return(nil, pipeline.ErrInstanceNotFound)
 
-	connService.EXPECT().CreateWithInstance(anyCtx, p1.P1C1)
-	connService.EXPECT().CreateWithInstance(anyCtx, p1.P1C2)
-	connService.EXPECT().AddProcessor(anyCtx, p1.P1C2.ID, p1.P1C2.ProcessorIDs[0])
+			pipelineService.EXPECT().List(anyCtx)
+			// pipeline doesn't exist
+			pipelineService.EXPECT().Get(anyCtx, p1.P1.ID).Return(nil, pipeline.ErrInstanceNotFound)
+			// create pipeline
+			pipelineService.EXPECT().CreateWithInstance(anyCtx, p1.P1)
+			pipelineService.EXPECT().UpdateDLQ(anyCtx, p1.P1.ID, p1.P1.DLQ)
+			pipelineService.EXPECT().AddConnector(anyCtx, p1.P1.ID, p1.P1.ConnectorIDs[0])
+			pipelineService.EXPECT().AddConnector(anyCtx, p1.P1.ID, p1.P1.ConnectorIDs[1])
+			pipelineService.EXPECT().AddProcessor(anyCtx, p1.P1.ID, p1.P1.ProcessorIDs[0])
 
-	procService.EXPECT().CreateWithInstance(anyCtx, p1.P1C2P1)
-	procService.EXPECT().CreateWithInstance(anyCtx, p1.P1P1)
+			connService.EXPECT().CreateWithInstance(anyCtx, p1.P1C1)
+			connService.EXPECT().CreateWithInstance(anyCtx, p1.P1C2)
+			connService.EXPECT().AddProcessor(anyCtx, p1.P1C2.ID, p1.P1C2.ProcessorIDs[0])
 
-	// start pipeline
-	lifecycleService.EXPECT().Start(anyCtx, p1.P1.ID)
+			procService.EXPECT().CreateWithInstance(anyCtx, p1.P1C2P1)
+			procService.EXPECT().CreateWithInstance(anyCtx, p1.P1P1)
 
-	err := service.Init(context.Background())
-	is.NoErr(err)
+			// start pipeline
+			lifecycleService.EXPECT().Start(anyCtx, p1.P1.ID)
+
+			err := service.Init(context.Background())
+			is.NoErr(err)
+		})
+	}
+
 }
 
 func TestService_Init_Update(t *testing.T) {

--- a/pkg/provisioning/service_test.go
+++ b/pkg/provisioning/service_test.go
@@ -166,7 +166,6 @@ func TestService_Init_Create(t *testing.T) {
 			is.NoErr(err)
 		})
 	}
-
 }
 
 func TestService_Init_Update(t *testing.T) {


### PR DESCRIPTION
### Description

This fixes a regression where the `pipelines.path` parameter doesn't support file paths anymore.

### Quick checks

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
