### PR TITLE
fix: Automate version constant update in built-in connectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ pkg/plugin/processor/standalone/test/wasm_processors/*/processor.wasm
 !pkg/provisioning/test/source-file.txt
 
 golangci-report.xml
+.aider*

--- a/pkg/plugin/connector/builtin/impl/file/connector.go
+++ b/pkg/plugin/connector/builtin/impl/file/connector.go
@@ -1,0 +1,9 @@
+package file
+
+import (
+	connector "github.com/conduitio/conduit-connector-file"
+	sdk "github.com/conduitio/conduit-connector-sdk"
+)
+
+// Connector combines the actual connector implementation with the version constant.
+var Connector sdk.Connector = sdk.NewConnectorWithVersion(connector.Connector, Version)

--- a/pkg/plugin/connector/builtin/impl/file/spec.go
+++ b/pkg/plugin/connector/builtin/impl/file/spec.go
@@ -1,0 +1,4 @@
+package file
+
+// Version is the version of the connector.
+const Version = "v0.0.1-develop"

--- a/pkg/plugin/connector/builtin/impl/generator/connector.go
+++ b/pkg/plugin/connector/builtin/impl/generator/connector.go
@@ -1,0 +1,9 @@
+package generator
+
+import (
+	connector "github.com/conduitio/conduit-connector-generator"
+	sdk "github.com/conduitio/conduit-connector-sdk"
+)
+
+// Connector combines the actual connector implementation with the version constant.
+var Connector sdk.Connector = sdk.NewConnectorWithVersion(connector.Connector, Version)

--- a/pkg/plugin/connector/builtin/impl/generator/spec.go
+++ b/pkg/plugin/connector/builtin/impl/generator/spec.go
@@ -1,0 +1,4 @@
+package generator
+
+// Version is the version of the connector.
+const Version = "v0.0.1-develop"

--- a/pkg/plugin/connector/builtin/impl/kafka/connector.go
+++ b/pkg/plugin/connector/builtin/impl/kafka/connector.go
@@ -1,0 +1,9 @@
+package kafka
+
+import (
+	connector "github.com/conduitio/conduit-connector-kafka"
+	sdk "github.com/conduitio/conduit-connector-sdk"
+)
+
+// Connector combines the actual connector implementation with the version constant.
+var Connector sdk.Connector = sdk.NewConnectorWithVersion(connector.Connector, Version)

--- a/pkg/plugin/connector/builtin/impl/kafka/spec.go
+++ b/pkg/plugin/connector/builtin/impl/kafka/spec.go
@@ -1,0 +1,4 @@
+package kafka
+
+// Version is the version of the connector.
+const Version = "v0.0.1-develop"

--- a/pkg/plugin/connector/builtin/impl/log/connector.go
+++ b/pkg/plugin/connector/builtin/impl/log/connector.go
@@ -1,0 +1,9 @@
+package log
+
+import (
+	connector "github.com/conduitio/conduit-connector-log"
+	sdk "github.com/conduitio/conduit-connector-sdk"
+)
+
+// Connector combines the actual connector implementation with the version constant.
+var Connector sdk.Connector = sdk.NewConnectorWithVersion(connector.Connector, Version)

--- a/pkg/plugin/connector/builtin/impl/log/spec.go
+++ b/pkg/plugin/connector/builtin/impl/log/spec.go
@@ -1,0 +1,4 @@
+package log
+
+// Version is the version of the connector.
+const Version = "v0.0.1-develop"

--- a/pkg/plugin/connector/builtin/impl/postgres/connector.go
+++ b/pkg/plugin/connector/builtin/impl/postgres/connector.go
@@ -1,0 +1,9 @@
+package postgres
+
+import (
+	connector "github.com/conduitio/conduit-connector-postgres"
+	sdk "github.com/conduitio/conduit-connector-sdk"
+)
+
+// Connector combines the actual connector implementation with the version constant.
+var Connector sdk.Connector = sdk.NewConnectorWithVersion(connector.Connector, Version)

--- a/pkg/plugin/connector/builtin/impl/postgres/spec.go
+++ b/pkg/plugin/connector/builtin/impl/postgres/spec.go
@@ -1,0 +1,4 @@
+package postgres
+
+// Version is the version of the connector.
+const Version = "v0.0.1-develop"

--- a/pkg/plugin/connector/builtin/impl/s3/connector.go
+++ b/pkg/plugin/connector/builtin/impl/s3/connector.go
@@ -1,0 +1,9 @@
+package s3
+
+import (
+	connector "github.com/conduitio/conduit-connector-s3"
+	sdk "github.com/conduitio/conduit-connector-sdk"
+)
+
+// Connector combines the actual connector implementation with the version constant.
+var Connector sdk.Connector = sdk.NewConnectorWithVersion(connector.Connector, Version)

--- a/pkg/plugin/connector/builtin/impl/s3/spec.go
+++ b/pkg/plugin/connector/builtin/impl/s3/spec.go
@@ -1,0 +1,4 @@
+package s3
+
+// Version is the version of the connector.
+const Version = "v0.0.1-develop"

--- a/pkg/plugin/connector/builtin/registry.go
+++ b/pkg/plugin/connector/builtin/registry.go
@@ -16,15 +16,16 @@ package builtin
 
 import (
 	"context"
-	"runtime/debug"
 
-	file "github.com/conduitio/conduit-connector-file"
-	generator "github.com/conduitio/conduit-connector-generator"
-	kafka "github.com/conduitio/conduit-connector-kafka"
-	connLog "github.com/conduitio/conduit-connector-log"
-	postgres "github.com/conduitio/conduit-connector-postgres"
+	// Updated imports to local built-in implementations
+	file      "github.com/conduitio/conduit/pkg/plugin/connector/builtin/impl/file"
+	generator "github.com/conduitio/conduit/pkg/plugin/connector/builtin/impl/generator"
+	kafka     "github.com/conduitio/conduit/pkg/plugin/connector/builtin/impl/kafka"
+	connLog   "github.com/conduitio/conduit/pkg/plugin/connector/builtin/impl/log"
+	postgres  "github.com/conduitio/conduit/pkg/plugin/connector/builtin/impl/postgres"
+	s3        "github.com/conduitio/conduit/pkg/plugin/connector/builtin/impl/s3"
+
 	"github.com/conduitio/conduit-connector-protocol/pconnector"
-	s3 "github.com/conduitio/conduit-connector-s3"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 	"github.com/conduitio/conduit-connector-sdk/schema"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
@@ -38,6 +39,7 @@ import (
 // The key of the map is the import path of the module
 // containing the connector implementation.
 var DefaultBuiltinConnectors = map[string]sdk.Connector{
+	// Updated to use the local wrapper connectors
 	"github.com/conduitio/conduit-connector-file":      file.Connector,
 	"github.com/conduitio/conduit-connector-generator": generator.Connector,
 	"github.com/conduitio/conduit-connector-kafka":     kafka.Connector,
@@ -104,23 +106,17 @@ func NewRegistry(logger log.CtxLogger, connectors map[string]sdk.Connector, serv
 }
 
 func (r *Registry) Init(ctx context.Context) {
-	buildInfo, ok := debug.ReadBuildInfo()
-	if !ok {
-		// we are using modules, build info should always be available, we are staying on the safe side
-		r.logger.Warn(ctx).Msg("build info not available, built-in plugin versions may not be read correctly")
-		buildInfo = &debug.BuildInfo{} // prevent nil pointer exceptions
-	}
-
-	r.plugins = r.loadPlugins(buildInfo)
+	// The buildInfo is no longer needed since versions are embedded directly.
+	r.plugins = r.loadPlugins()
 	r.logger.Info(ctx).Int("count", len(r.List())).Msg("builtin connector plugins initialized")
 }
 
-func (r *Registry) loadPlugins(buildInfo *debug.BuildInfo) map[string]map[string]blueprint {
+func (r *Registry) loadPlugins() map[string]map[string]blueprint {
 	plugins := make(map[string]map[string]blueprint, len(r.connectors))
 	for moduleName, conn := range r.connectors {
 		factory := newDispenserFactory(conn)
 
-		specs, err := getSpecification(moduleName, factory, buildInfo)
+		specs, err := getSpecification(factory) // No moduleName or buildInfo needed
 		if err != nil {
 			// stop initialization if a built-in plugin is misbehaving
 			panic(err)
@@ -152,7 +148,7 @@ func (r *Registry) loadPlugins(buildInfo *debug.BuildInfo) map[string]map[string
 	return plugins
 }
 
-func getSpecification(moduleName string, factory dispenserFactory, buildInfo *debug.BuildInfo) (pconnector.Specification, error) {
+func getSpecification(factory dispenserFactory) (pconnector.Specification, error) { // No moduleName or buildInfo needed
 	dispenser := factory("", pconnector.PluginConfig{}, log.CtxLogger{})
 	specPlugin, err := dispenser.DispenseSpecifier()
 	if err != nil {
@@ -163,24 +159,8 @@ func getSpecification(moduleName string, factory dispenserFactory, buildInfo *de
 		return pconnector.Specification{}, cerrors.Errorf("could not get specs for built in plugin: %w", err)
 	}
 
-	if version := getModuleVersion(buildInfo.Deps, moduleName); version != "" {
-		// overwrite version with the import version
-		resp.Specification.Version = version
-	}
-
+	// getModuleVersion logic is removed
 	return resp.Specification, nil
-}
-
-func getModuleVersion(deps []*debug.Module, moduleName string) string {
-	for _, dep := range deps {
-		if dep.Path == moduleName {
-			if dep.Replace != nil {
-				return dep.Replace.Version
-			}
-			return dep.Version
-		}
-	}
-	return ""
 }
 
 func newFullName(pluginName, pluginVersion string) plugin.FullName {

--- a/scripts/calc_next_dev_version.go
+++ b/scripts/calc_next_dev_version.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <current_version>\n", os.Args[0])
+		os.Exit(1)
+	}
+	currentVersionStr := os.Args[1]
+
+	// Ensure version starts with 'v' for semver parsing
+	if !strings.HasPrefix(currentVersionStr, "v") {
+		currentVersionStr = "v" + currentVersionStr
+	}
+
+	v, err := semver.NewVersion(currentVersionStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing version '%s': %v\n", currentVersionStr, err)
+		os.Exit(1)
+	}
+
+	// Increment the minor version and reset patch to 0
+	nextMinor := v.IncMinor()
+	developVersion := fmt.Sprintf("v%d.%d.0-develop", nextMinor.Major(), nextMinor.Minor()) // Reset patch to 0 for minor increment
+
+	fmt.Print(developVersion)
+}

--- a/scripts/find_connector_specs.go
+++ b/scripts/find_connector_specs.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	targetDir    = "pkg/plugin/connector/builtin/impl"
+	targetFile   = "spec.go"
+	versionConst = "const Version = "
+)
+
+func main() {
+	err := filepath.WalkDir(targetDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && d.Name() == targetFile {
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("could not read file %s: %w", path, err)
+			}
+			if strings.Contains(string(content), versionConst) {
+				fmt.Println(path)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error finding connector specs: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/scripts/update_connector_versions.go
+++ b/scripts/update_connector_versions.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <new_version> <file1> [<file2>...]\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	newVersion := os.Args[1]
+	filePaths := os.Args[2:]
+
+	fmt.Printf("Updating connector versions to: %s\n", newVersion)
+
+	for _, filePath := range filePaths {
+		err := updateVersionInFile(filePath, newVersion)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error updating version in %s: %v\n", filePath, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("Successfully updated all connector versions.")
+}
+
+func updateVersionInFile(filePath, newVersion string) error {
+	fset := token.NewFileSet()
+	node, err := parser.ParseFile(fset, filePath, nil, parser.ParseComments)
+	if err != nil {
+		return fmt.Errorf("could not parse file %s: %w", filePath, err)
+	}
+
+	found := false
+	ast.Inspect(node, func(n ast.Node) bool {
+		genDecl, ok := n.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.CONST {
+			return true // Not a const declaration, continue
+		}
+
+		for _, spec := range genDecl.Specs {
+			valueSpec, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+
+			// Look for "Version" identifier
+			for _, ident := range valueSpec.Names {
+				if ident.Name == "Version" {
+					if len(valueSpec.Values) > 0 {
+						basicLit, ok := valueSpec.Values[0].(*ast.BasicLit)
+						if ok && basicLit.Kind == token.STRING {
+							// Update the string literal
+							basicLit.Value = fmt.Sprintf("%q", newVersion)
+							found = true
+							return false // Found and updated, no need to continue inspecting
+						}
+					}
+				}
+			}
+		}
+		return true // Continue inspecting other nodes
+	})
+
+	if !found {
+		return fmt.Errorf("const Version = \"...\" not found in %s", filePath)
+	}
+
+	var buf bytes.Buffer
+	err = format.Node(&buf, fset, node)
+	if err != nil {
+		return fmt.Errorf("could not format AST for %s: %w", filePath, err)
+	}
+
+	err = os.WriteFile(filePath, buf.Bytes(), 0644)
+	if err != nil {
+		return fmt.Errorf("could not write updated file %s: %w", filePath, err)
+	}
+
+	fmt.Printf("  Updated %s to %s\n", filePath, newVersion)
+	return nil
+}


### PR DESCRIPTION
Fixes #645

## Agent Summary

Commit 5da138b fix: implement automated version constant updates for built-in

---
Generated by conduit-agent-experiment (archivist: Gemini Flash, implementer: openrouter/qwen/qwen3-coder-flash, 1 iterations).