### PR TITLE
fix: Error codes needs to be documented in Swagger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ pkg/plugin/processor/standalone/test/wasm_processors/*/processor.wasm
 !pkg/provisioning/test/source-file.txt
 
 golangci-report.xml
+.aider*


### PR DESCRIPTION
Fixes #576

## Agent Summary

g/connector/service.go to the chat.
Added pkg/foundation/grpcutil/interceptor.go to the chat.
Added pkg/http/openapi/openapi.go to the chat.
Added pkg/pipeline/errors.go to the chat.
Added pkg/pipeline/service.go to the chat.
Added proto/api/v1/api.pb.gw.go to the chat.
Added proto/api/v1/api.proto to the chat.


proto/api/v1/api.pb.go

http://localhost:8080/v1/connectors
Scraping http://localhost:8080/v1/connectors...
HTTP error occurred: [Errno 61] Connection refused
Failed to retrieve content from http://localhost:8080/v1/connectors

http://localhost:8080/openapi/`)
Scraping http://localhost:8080/openapi/`)...
HTTP error occurred: [Errno 61] Connection refused
Failed to retrieve content from http://localhost:8080/openapi/`)

http://www.apache.org/licenses/LICENSE-2.0
Scraping http://www.apache.org/licenses/LICENSE-2.0...

http://localhost:8080/v1/pipelines/<pipeline_id>/start
Scraping http://localhost:8080/v1/pipelines/<pipeline_id>/start...
HTTP error occurred: [Errno 54] Connection reset by peer
Failed to retrieve content from 
http://localhost:8080/v1/pipelines/<pipeline_id>/start

https://github.com/ConduitIO/conduit/blob/main/LICENSE.md
Scraping https://github.com/ConduitIO/conduit/blob/main/LICENSE.md...

https://github.com/ConduitIO/conduit/issues/1016
Scraping https://github.com/ConduitIO/conduit/issues/1016...

https://github.com/conduitio/conduit
Scraping https://github.com/conduitio/conduit...
Initial repo scan can be slow in larger repos, but only happens once.
Your estimated chat context of 213,751 tokens exceeds the 128,000 token limit 
for deepseek/deepseek-chat!
To reduce the chat context:
- Use /drop to remove unneeded files from the chat
- Use /clear to clear the chat history
- Break your code into smaller files
It's probably safe to try and send the request, most providers won't charge if 
the context limit is exceeded.
litellm.AuthenticationError: AuthenticationError: DeepseekException - 
Authentication Fails (governor)
The API provider is not able to authenticate you. Check your API key.



---
Generated by conduit-agent-experiment (archivist: Gemini Flash, implementer: deepseek/deepseek-chat, 1 iterations).