### PR TITLE
fix: Automate version constant update in built-in connectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ pkg/plugin/processor/standalone/test/wasm_processors/*/processor.wasm
 !pkg/provisioning/test/source-file.txt
 
 golangci-report.xml
+.aider*


### PR DESCRIPTION
Fixes #645

## Agent Summary


You can skip this check with --no-gitignore
Added .aider* to .gitignore
Warning: deepseek/deepseek-chat expects these environment variables
- DEEPSEEK_API_KEY: Not set
You can skip this check with --no-show-model-warnings

https://aider.chat/docs/llms/warnings.html

Aider v0.86.2
Model: deepseek/deepseek-chat with diff edit format, prompt cache, infinite 
output
Git repo: .git with 638 files
Repo-map: using 4096 tokens, auto refresh
Added Makefile to the chat.
Added cmd/conduit/root/version/version.go to the chat.
Added go.mod to the chat.
Added pkg/conduit/version.go to the chat.
Added pkg/plugin/connector/builtin/registry.go to the chat.


http://www.apache.org/licenses/LICENSE-2.0
Scraping http://www.apache.org/licenses/LICENSE-2.0...
Initial repo scan can be slow in larger repos, but only happens once.
litellm.AuthenticationError: AuthenticationError: DeepseekException - 
Authentication Fails (governor)
The API provider is not able to authenticate you. Check your API key.



---
Generated by conduit-agent-experiment (archivist: Gemini Flash, implementer: deepseek/deepseek-chat, 1 iterations).