### PR TITLE
docs: revival foundation — CLAUDE.md, ROADMAP, GOVERNANCE, ADRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @ConduitIO/conduit-core
+*       @ConduitIO/conduit-core @devarismeroxa

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@
 
 ### Conduit ###
 
+# Internal strategy notes — never ship public (see CLAUDE.md)
+/STRATEGY.md
+
 # Badger DB
 conduit.db
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ direction — competition, positioning, commercial line, SDK rationale — lives
 
 ## What we're doing
 
-Reviving Conduit (github.com/ConduitIO/conduit) as the de facto Kafka Connect replacement:
+Reviving Conduit (<https://github.com/ConduitIO/conduit>) as the de facto Kafka Connect replacement:
 broker-neutral, any-language plugins via gRPC + WASM, embeddable, agent-legible, with a
 first-class Kafka Connect migration path and a lightweight state layer. The public plan is in
 `ROADMAP.md` — check the current phase at the start of every session and ask which phase we're
@@ -20,7 +20,7 @@ executing if it's ambiguous.
   not "start v0.15.0."
 - **Maintainer reality: solo (DeVaris) + Claude.** The PR process below is written for that,
   not for a large org. Where a gate assumes a "second human maintainer," the second human is
-  DeVaris. Gates that require a team switch on by phase — see *Process maturity* below. Do not
+  DeVaris. Gates that require a team switch on by phase — see _Process maturity_ below. Do not
   pretend a review bar is met when it structurally can't be; say what was actually verified.
 
 ## Repo conventions (match what exists — do not invent parallel ones)
@@ -38,7 +38,7 @@ executing if it's ambiguous.
 ## Repo map
 
 | Repo | Purpose |
-|---|---|
+| --- | --- |
 | `ConduitIO/conduit` | Core engine: pipeline orchestration, plugin runtime, HTTP/gRPC API, built-in UI |
 | `ConduitIO/conduit-connector-protocol` | gRPC protocol between Conduit and connector plugins. **Breaking-change territory — flag loudly, version carefully** |
 | `ConduitIO/conduit-connector-sdk` | Go SDK for building connectors (source + destination), acceptance test harness |
@@ -87,7 +87,7 @@ We're building infrastructure people bet their data on. Design like it.
   problem, constraints, alternatives (≥2, with why they lost), failure modes, upgrade/rollback,
   observability. A design doc that doesn't enumerate failure modes is not done.
 - **ADRs for decisions.** Every significant architectural decision gets an immutable ADR in
-  `docs/architecture-decision-records/`. Future contributors should reconstruct *why* without
+  `docs/architecture-decision-records/`. Future contributors should reconstruct _why_ without
   archaeology.
 - **Invariants are documented and enforced** — in package docs, with assertions/tests, not
   comments alone. If you can't state the invariant, the design isn't finished.
@@ -120,7 +120,7 @@ We're building infrastructure people bet their data on. Design like it.
 - **State layer discipline:** local embedded KV state, checkpointed with the pipeline. No
   distributed snapshots, no pluggable state backends, no event-time watermark machinery. If a
   design doc starts growing Flink features, stop and flag it.
-- **Docs move with code:** a feature PR without docs is incomplete. Update conduit.io docs
+- **Docs move with code:** a feature PR without docs is incomplete. Update `conduit.io` docs
   source AND `llms.txt` when behavior changes — maintained together, always.
 
 ## Testing standards
@@ -128,7 +128,7 @@ We're building infrastructure people bet their data on. Design like it.
 The test suite is the product's warranty. **Baseline (live now):** unit + integration, race
 detector on in CI, lint clean, conventional-commit check.
 
-Data-path code additionally requires (see *Process maturity* for when each becomes a hard gate):
+Data-path code additionally requires (see _Process maturity_ for when each becomes a hard gate):
 
 - **Property-based tests** (rapid or gopter) for serialization, position handling, record
   transforms — round-trip, ordering, idempotency properties.
@@ -140,7 +140,7 @@ Data-path code additionally requires (see *Process maturity* for when each becom
 - **Soak:** long-running pipeline suite (24h) with memory/goroutine-leak detection.
 - **Fuzzing** on every parser and protocol boundary: pipeline config, record payloads, protocol
   messages, registry manifests. Native Go fuzzing, CI (short) + scheduled (long).
-- **Coverage floor** 80% on engine packages — a signal, not a goal; review *what's* untested,
+- **Coverage floor** 80% on engine packages — a signal, not a goal; review _what's_ untested,
   especially error paths.
 - **Acceptance tests define "connector":** the SDK acceptance suite is the compatibility
   contract. Expanding it is high-leverage; version it so authors know the bar they passed.
@@ -170,6 +170,7 @@ Every PR is risk-tiered; the tier sets the bar and is declared in the PR descrip
 
 **Tier 1 — Data path** (record flow, ack/position/checkpoint logic, state layer, connector
 protocol, serialization formats):
+
 - Design doc or ADR linked (or explicit waiver for small fixes).
 - **Human sign-off always required** — AI-authored or not, no Tier 1 change merges on automated
   review alone. Solo reality: that human is DeVaris, reviewing with fresh context in a separate
@@ -180,6 +181,7 @@ protocol, serialization formats):
 - Merges freeze 48h before a release cut.
 
 **Tier 2 — Features** (connectors, processors, CLI, UI, registry, docs-adjacent):
+
 - One reviewer approval; acceptance/integration tests green; new surfaces have `--json` + error
   codes; docs updated in the same PR.
 
@@ -207,7 +209,7 @@ in `docs/postmortems/` and produces at least one new automated check.
 Do not claim a bar is met when it structurally isn't. Mark PRs against what's real today.
 
 | Gate | Status |
-|---|---|
+| --- | --- |
 | Lint, race detector, unit + integration, conventional commits | **live now** |
 | Design doc / ADR before non-trivial work | **live now** |
 | Adversarial self-review on AI PRs | **live now** |
@@ -220,6 +222,28 @@ Do not claim a bar is met when it structurally isn't. Mark PRs against what's re
 
 When you add a gate to CI, move its row to **live now** in the same PR. The table is the source
 of truth for "is this rule real yet."
+
+### Merging (solo-maintainer workflow)
+
+`enforce_admins` is off on `main`, so Claude may merge DeVaris-owned PRs with
+`gh pr merge --admin` — but _only_ after a thorough review, never as a rubber stamp. All of the
+following must hold before merging:
+
+- The tier-appropriate review is complete and its findings are documented in the PR (for
+  AI-authored code, the adversarial self-review pass; for Tier 1, the failure-mode analysis).
+- _Every required CI status check is actually green._ Never `--admin`-bypass a failing or
+  pending check to merge — that violates the "no suppressing checks" rule and defeats the point
+  of the gate. Wait for green.
+- Bug fixes include the regression test that would have caught the bug, verified to fail without
+  the fix and pass with it.
+- For a Tier 1 (data-path) change, any _unresolved_ uncertainty about behavior under failure is
+  surfaced to DeVaris for an explicit decision before merging — the standing merge authorization
+  covers reviewed-and-understood changes, not open questions.
+
+This replaces the second-human-approval gate while the project is solo. It re-tightens to real
+peer review at the first co-maintainer; at that point admin-merge goes back to
+exceptional-only. Community (non-maintainer) PRs still require the normal review — the
+admin-merge path is for maintainer-authored work that has cleared the bar above.
 
 ## Working style (how DeVaris operates)
 
@@ -236,11 +260,11 @@ of truth for "is this rule real yet."
 
 - [ ] Risk tier declared; tier-appropriate review completed (Tier 1 = human sign-off +
       failure-mode analysis)
-- [ ] Compiles, lints clean, race detector clean; all *currently-live* tier-required suites pass
+- [ ] Compiles, lints clean, race detector clean; all _currently-live_ tier-required suites pass
 - [ ] Every bug fix includes the test that would have caught it
 - [ ] Godoc on new exported symbols; invariant comments at touched enforcement sites;
       architecture docs updated if behavior changed
-- [ ] Docs updated (README, conduit.io source, llms.txt, changelog entry)
+- [ ] Docs updated (README, `conduit.io` source, llms.txt, changelog entry)
 - [ ] `--json` output and stable error codes on any new CLI surface
 - [ ] Adversarial self-review findings documented in the PR (AI-authored code)
 - [ ] Roadmap item referenced in the PR
@@ -250,12 +274,14 @@ of truth for "is this rule real yet."
 ## Session workflows
 
 ### Issue triage
+
 1. Pull open issues; group by bug / feature / question / stale.
 2. Per item: reproduce if a bug, label, link to a roadmap item or close with a respectful
    explanation.
 3. Output a triage report: closed, labeled, needs-maintainer-decision.
 
 ### New connector
+
 1. Scaffold from `conduit-connector-sdk` template (or `conduit connector new` once it exists).
 2. Implement source and/or destination; wire config validation and schema support.
 3. Pass acceptance tests; add integration tests with docker-compose for the target system.
@@ -263,11 +289,13 @@ of truth for "is this rule real yet."
 5. Add to the connector list in docs and (once live) the registry.
 
 ### New processor
+
 1. Scaffold from `conduit-processor-sdk`; prefer standalone (WASM) unless perf demands built-in.
 2. Unit tests covering record shapes: raw, structured, tombstones, errors.
 3. Add a cookbook recipe to docs.
 
 ### AI-pipeline components (embedding/chunking processors, vector sinks)
+
 1. Follow the connector/processor workflows.
 2. Embedding processors: pluggable provider (OpenAI, Voyage, local), batching, rate-limit
    handling, cost-relevant docs (tokens per record).
@@ -276,22 +304,26 @@ of truth for "is this rule real yet."
 4. Every AI component ships with a working RAG-sync template update.
 
 ### Kafka Connect migration
+
 - Concept mapping: KC worker → Conduit instance · connector+tasks → pipeline · SMT → processor ·
   converter → schema/format config.
 - `conduit migrate kafka-connect` must always emit a compatibility report — never silently drop
   config it can't translate.
 
 ### MCP server
+
 - Tools mirror CLI verbs: scaffold, validate, deploy, inspect, repair. Same code paths as the
   CLI — no divergent logic.
 - Every tool returns structured results with error codes; test with a real agent session (zero →
   running pipeline using only MCP + llms.txt) before calling it done. That's a north-star metric.
 
 ### State layer
+
 - Scope check first: dedup, lookup tables, simple windows — nothing else without explicit
   maintainer sign-off. Checkpoint/recovery tests are mandatory (kill mid-window, verify state).
 
 ### Benchmarks
+
 - Use benchi. Compare against Kafka Connect first. Commit configs and environment specs. Report
   medians with variance, not best runs.
 
@@ -319,5 +351,5 @@ of truth for "is this rule real yet."
   engine — distribution lives in the scheduling layer, per the ADR.
 - Never move anything shipped as open source behind a paywall, and never gate the k8s operator,
   Helm chart, or fleet console core — the one-way ratchet is absolute.
-- Never claim a review or test gate was satisfied when the *Process maturity* table marks it not
+- Never claim a review or test gate was satisfied when the _Process maturity_ table marks it not
   yet live — say what was actually run.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,323 @@
+# CLAUDE.md — Conduit
+
+Operational context for Claude Code sessions working on the ConduitIO org. Read this before
+touching anything. This file is what a session needs to **act**. The strategy behind the
+direction — competition, positioning, commercial line, SDK rationale — lives in `STRATEGY.md`
+(gitignored, internal); read it only when doing strategy or positioning work.
+
+## What we're doing
+
+Reviving Conduit (github.com/ConduitIO/conduit) as the de facto Kafka Connect replacement:
+broker-neutral, any-language plugins via gRPC + WASM, embeddable, agent-legible, with a
+first-class Kafka Connect migration path and a lightweight state layer. The public plan is in
+`ROADMAP.md` — check the current phase at the start of every session and ask which phase we're
+executing if it's ambiguous.
+
+## Project reality (read once, keep in mind)
+
+- The project went dormant (~15 months, last v0.14.x nightly 2025-03, restarted 2026-06). The
+  v0.15.0 nightly train is **already running**. Phase 0's release task is "cut v0.15.0 stable,"
+  not "start v0.15.0."
+- **Maintainer reality: solo (DeVaris) + Claude.** The PR process below is written for that,
+  not for a large org. Where a gate assumes a "second human maintainer," the second human is
+  DeVaris. Gates that require a team switch on by phase — see *Process maturity* below. Do not
+  pretend a review bar is met when it structurally can't be; say what was actually verified.
+
+## Repo conventions (match what exists — do not invent parallel ones)
+
+- **ADRs** live in `docs/architecture-decision-records/`, filename `YYYYMMDD-slug.md`, sections
+  `# Title` → `## Summary` → `## Context` → `## Decision` → `## Consequences` → `## Related`.
+  Immutable once merged (supersede with a new ADR; never edit). **Not** `docs/adr/`, **not**
+  numbered `ADR-001`.
+- **Design docs** live in `docs/design-documents/`, same `YYYYMMDD-slug.md` naming. **Not**
+  `docs/design/`.
+- **Contributing** guide is `CONTRIBUTING.md` (exists) — extend it, don't replace it.
+- Existing package layout is documented in `docs/package_structure.md`; code guidelines in
+  `docs/code_guidelines.md`. Read those before proposing structural changes.
+
+## Repo map
+
+| Repo | Purpose |
+|---|---|
+| `ConduitIO/conduit` | Core engine: pipeline orchestration, plugin runtime, HTTP/gRPC API, built-in UI |
+| `ConduitIO/conduit-connector-protocol` | gRPC protocol between Conduit and connector plugins. **Breaking-change territory — flag loudly, version carefully** |
+| `ConduitIO/conduit-connector-sdk` | Go SDK for building connectors (source + destination), acceptance test harness |
+| `ConduitIO/conduit-processor-sdk` | Go SDK for processors; standalone processors compile to WASM (wazero runtime) |
+| `ConduitIO/conduit-commons` | Shared types: records, schema, config |
+| `ConduitIO/benchi` | Benchmarking framework — use for all performance claims |
+| `ConduitIO/conduit-connector-*` | Individual connectors (Postgres, Kafka, S3, generator, file, log) |
+
+New surfaces come online across Phases 1–3: connector/template registry, MCP server,
+`libconduit` + language bindings, state layer (in-engine), fleet console, K8s operator,
+Terraform provider.
+
+## Data integrity invariants (non-negotiable)
+
+Bugs here corrupt people's pipelines. Corruption-class bugs are sev-0: drop everything, fix,
+postmortem, regression test.
+
+1. **Never acknowledge a record upstream before it is durably handled downstream.** Ack
+   propagation is end-to-end; no intermediate component may ack early for throughput. Any
+   batching/buffering change must prove ack correctness under crash.
+2. **Positions/offsets are monotonic and crash-safe.** A restart must never skip records
+   (at-least-once) or corrupt position state. Position serialization changes require a versioned
+   migration path and an upgrade test.
+3. **At-least-once is the floor.** Any path that could drop a record without delivering it or
+   routing it to a DLQ is a data-loss bug — including error, shutdown, and rebalance paths.
+4. **Ordering guarantees are per-source-partition and documented.** Changes that could reorder
+   records within a partition key require a design doc and explicit sign-off.
+5. **State and checkpoint writes are atomic.** Torn writes on crash must be impossible
+   (write-ahead + rename, or the store's transactional API). Every state feature ships with a
+   kill-mid-write recovery test.
+6. **Schema handling never silently mangles data.** Unknown fields, type mismatches, and drift
+   follow the configured policy (halt/DLQ/evolve) — never silent coercion or truncation.
+7. **Shutdown is graceful by default.** SIGTERM drains in-flight records and checkpoints before
+   exit. `kill -9` at any instant must be recoverable without loss — and we test exactly that.
+
+Where code upholds one of these, say so at the enforcement site:
+`// Invariant 1: ack only after destination confirms durable write`.
+
+## Architecture & design discipline (staff/principal bar)
+
+We're building infrastructure people bet their data on. Design like it.
+
+- **Design doc before code for anything non-trivial.** Non-trivial = touches the data path,
+  changes a public contract (protocol, config schema, CLI, error codes, state format), adds a
+  subsystem, or exceeds ~2 days. The doc goes in `docs/design-documents/` and must cover:
+  problem, constraints, alternatives (≥2, with why they lost), failure modes, upgrade/rollback,
+  observability. A design doc that doesn't enumerate failure modes is not done.
+- **ADRs for decisions.** Every significant architectural decision gets an immutable ADR in
+  `docs/architecture-decision-records/`. Future contributors should reconstruct *why* without
+  archaeology.
+- **Invariants are documented and enforced** — in package docs, with assertions/tests, not
+  comments alone. If you can't state the invariant, the design isn't finished.
+- **Think in failure modes first.** For any data-path change, answer before writing code: crash
+  mid-operation? network partition? duplicate delivery? out-of-order? malformed input? disk
+  full? The happy path is the easy 20%.
+- **Backward compatibility is a design input.** Serialized state, pipeline configs, connector
+  protocol, and registry format must be readable by N+1 versions with an explicit deprecation
+  policy (announce → warn → remove, minimum two minor versions).
+- **No speculative generality.** Interfaces earn their existence with two real implementations
+  or a design doc explaining why the seam matters. YAGNI violations are review blockers.
+- **Simplicity is the review criterion.** If a reviewer can't explain the approach back in two
+  sentences, it's too clever. Prefer boring, obvious code.
+
+## Engineering conventions
+
+- **Language:** Go (latest stable). Match existing code style; run golangci-lint (config is in
+  `.golangci.yml`) before proposing a PR as done. Use the `Makefile` targets.
+- **Errors are API:** every user-facing error gets a stable error code, the failing config path,
+  and a suggested fix. Machine-actionable errors are a product feature (agents consume them).
+- **CLI output:** every command supports `--json`. New commands ship with it, not after.
+- **Commits/PRs:** conventional commits (`feat:`, `fix:`, `docs:`, `refactor:`). Small,
+  reviewable PRs — split large work. PR descriptions state the roadmap item they advance.
+- **Breaking changes:** connector protocol, pipeline config schema, and error codes are public
+  contracts. Breaking changes require a versioning plan and migration notes in the PR.
+- **Releases:** monthly release train. Changelogs from conventional commits; release notes a
+  human would want to read. See `docs/releases.md`.
+- **Performance:** claims require benchi runs, committed configs, reproducible results. Never
+  assert numbers without a benchmark in the repo.
+- **State layer discipline:** local embedded KV state, checkpointed with the pipeline. No
+  distributed snapshots, no pluggable state backends, no event-time watermark machinery. If a
+  design doc starts growing Flink features, stop and flag it.
+- **Docs move with code:** a feature PR without docs is incomplete. Update conduit.io docs
+  source AND `llms.txt` when behavior changes — maintained together, always.
+
+## Testing standards
+
+The test suite is the product's warranty. **Baseline (live now):** unit + integration, race
+detector on in CI, lint clean, conventional-commit check.
+
+Data-path code additionally requires (see *Process maturity* for when each becomes a hard gate):
+
+- **Property-based tests** (rapid or gopter) for serialization, position handling, record
+  transforms — round-trip, ordering, idempotency properties.
+- **Chaos/fault-injection:** SIGKILL (not SIGTERM) mid-snapshot, mid-batch, mid-checkpoint;
+  inject connector errors, slow destinations, network failures. Verify invariants 1–7 on
+  recovery. Lives in `tests/chaos`.
+- **Upgrade/downgrade:** run N, create pipelines with state, upgrade to N+1, verify resume.
+  Serialized-state compat breaks are release blockers.
+- **Soak:** long-running pipeline suite (24h) with memory/goroutine-leak detection.
+- **Fuzzing** on every parser and protocol boundary: pipeline config, record payloads, protocol
+  messages, registry manifests. Native Go fuzzing, CI (short) + scheduled (long).
+- **Coverage floor** 80% on engine packages — a signal, not a goal; review *what's* untested,
+  especially error paths.
+- **Acceptance tests define "connector":** the SDK acceptance suite is the compatibility
+  contract. Expanding it is high-leverage; version it so authors know the bar they passed.
+- **Benchmarks as regression gates:** benchi on reference pipelines; >10% throughput/latency
+  regression fails the build unless waived in the PR with justification.
+- **Every bug fix ships with the test that would have caught it.** No exceptions. Link the issue.
+
+## Documentation & commenting standards
+
+- **Godoc on every exported symbol** — say something the signature doesn't. Document behavior,
+  invariants, error semantics, concurrency safety.
+- **Package-level `doc.go`** for every package: purpose, core types, invariants, relationships
+  to neighbors. A new contributor should navigate the engine by reading `doc.go` files alone.
+- **Comment the why, not the what.** Non-obvious decisions, workarounds (with issue links),
+  performance-motivated shapes, protocol quirks.
+- **Invariant comments at enforcement sites** (see the invariant list above).
+- **Examples that compile:** exported APIs get `Example*` functions run by `go test`.
+- **Architecture docs stay current:** pipeline lifecycle, ack propagation, plugin runtime,
+  state/checkpoint model, with in-repo mermaid diagrams. A PR that changes architectural
+  behavior updates the doc in the same PR.
+- **Runbooks for operators:** every alertable failure mode gets a symptom → diagnosis →
+  remediation entry under `docs/operations/`.
+
+## PR review process
+
+Every PR is risk-tiered; the tier sets the bar and is declared in the PR description.
+
+**Tier 1 — Data path** (record flow, ack/position/checkpoint logic, state layer, connector
+protocol, serialization formats):
+- Design doc or ADR linked (or explicit waiver for small fixes).
+- **Human sign-off always required** — AI-authored or not, no Tier 1 change merges on automated
+  review alone. Solo reality: that human is DeVaris, reviewing with fresh context in a separate
+  session from the author. Author session never approves its own PR.
+- Chaos + upgrade tests updated or explicitly justified as unaffected.
+- PR description includes a **failure-mode analysis**: what could this break, which metric/alert
+  would show it, how do we roll back.
+- Merges freeze 48h before a release cut.
+
+**Tier 2 — Features** (connectors, processors, CLI, UI, registry, docs-adjacent):
+- One reviewer approval; acceptance/integration tests green; new surfaces have `--json` + error
+  codes; docs updated in the same PR.
+
+**Tier 3 — Chore** (deps, CI, typos, comments): one approval, green CI.
+
+**Automated gates:** lint, race detector, unit + integration, coverage floor, benchmark
+regression check, dependency vulnerability scan, conventional-commit check.
+
+**Review conduct:** review the tests first — if they wouldn't catch the bug this PR could
+introduce, request changes before reading the implementation. Check error paths line by line
+(that's where data loss lives). Verify invariant comments at touched enforcement sites still
+hold. "Looks good" is not a review; state what you verified.
+
+**AI-authored code (most of ours):** Claude does an adversarial self-review pass before opening
+any PR — re-read the diff hunting for the bug, specifically error paths, concurrency, resource
+cleanup, and the data-integrity invariants. Findings and resolutions go in the PR description.
+Self-review is not review; a separate session (or human) reviews with fresh context. Any
+uncertainty about behavior under failure is stated, not assumed away.
+
+**Regression response:** any regression that reaches a release triggers a blameless postmortem
+in `docs/postmortems/` and produces at least one new automated check.
+
+### Process maturity (be honest about which gates are actually live)
+
+Do not claim a bar is met when it structurally isn't. Mark PRs against what's real today.
+
+| Gate | Status |
+|---|---|
+| Lint, race detector, unit + integration, conventional commits | **live now** |
+| Design doc / ADR before non-trivial work | **live now** |
+| Adversarial self-review on AI PRs | **live now** |
+| Human (DeVaris) sign-off on Tier 1 | **live now** |
+| Coverage floor enforcement, benchi regression gate | by Phase 1 |
+| Property + fuzz tests on data-path/boundaries | by Phase 1 |
+| Chaos suite (`tests/chaos`) nightly | by Phase 2 (needs the state layer + a second maintainer) |
+| Upgrade/downgrade tests gating releases | by Phase 2 |
+| 24h soak gating every release | by Phase 2 |
+
+When you add a gate to CI, move its row to **live now** in the same PR. The table is the source
+of truth for "is this rule real yet."
+
+## Working style (how DeVaris operates)
+
+- Direct, critical feedback. If a design is weak, say so and propose the alternative — don't
+  hedge.
+- Deployable output over frameworks. Working code, complete files, ready-to-merge PRs,
+  ready-to-publish docs.
+- Concise, human writing in all public-facing text. No AI-polished filler, no "delve," no
+  exclamation-point enthusiasm.
+- When scope is ambiguous, bias toward the two strategic bets (see `STRATEGY.md`) and ask one
+  sharp question rather than five vague ones.
+
+## Definition of done (any task)
+
+- [ ] Risk tier declared; tier-appropriate review completed (Tier 1 = human sign-off +
+      failure-mode analysis)
+- [ ] Compiles, lints clean, race detector clean; all *currently-live* tier-required suites pass
+- [ ] Every bug fix includes the test that would have caught it
+- [ ] Godoc on new exported symbols; invariant comments at touched enforcement sites;
+      architecture docs updated if behavior changed
+- [ ] Docs updated (README, conduit.io source, llms.txt, changelog entry)
+- [ ] `--json` output and stable error codes on any new CLI surface
+- [ ] Adversarial self-review findings documented in the PR (AI-authored code)
+- [ ] Roadmap item referenced in the PR
+- [ ] No new dependencies without justification in the PR description
+- [ ] Breaking changes flagged with a migration note and deprecation plan
+
+## Session workflows
+
+### Issue triage
+1. Pull open issues; group by bug / feature / question / stale.
+2. Per item: reproduce if a bug, label, link to a roadmap item or close with a respectful
+   explanation.
+3. Output a triage report: closed, labeled, needs-maintainer-decision.
+
+### New connector
+1. Scaffold from `conduit-connector-sdk` template (or `conduit connector new` once it exists).
+2. Implement source and/or destination; wire config validation and schema support.
+3. Pass acceptance tests; add integration tests with docker-compose for the target system.
+4. README with config reference, delivery-semantics notes, runnable example pipeline.
+5. Add to the connector list in docs and (once live) the registry.
+
+### New processor
+1. Scaffold from `conduit-processor-sdk`; prefer standalone (WASM) unless perf demands built-in.
+2. Unit tests covering record shapes: raw, structured, tombstones, errors.
+3. Add a cookbook recipe to docs.
+
+### AI-pipeline components (embedding/chunking processors, vector sinks)
+1. Follow the connector/processor workflows.
+2. Embedding processors: pluggable provider (OpenAI, Voyage, local), batching, rate-limit
+   handling, cost-relevant docs (tokens per record).
+3. Vector destinations: upsert semantics, metadata mapping, dimension validation at pipeline
+   start (fail fast, actionable error).
+4. Every AI component ships with a working RAG-sync template update.
+
+### Kafka Connect migration
+- Concept mapping: KC worker → Conduit instance · connector+tasks → pipeline · SMT → processor ·
+  converter → schema/format config.
+- `conduit migrate kafka-connect` must always emit a compatibility report — never silently drop
+  config it can't translate.
+
+### MCP server
+- Tools mirror CLI verbs: scaffold, validate, deploy, inspect, repair. Same code paths as the
+  CLI — no divergent logic.
+- Every tool returns structured results with error codes; test with a real agent session (zero →
+  running pipeline using only MCP + llms.txt) before calling it done. That's a north-star metric.
+
+### State layer
+- Scope check first: dedup, lookup tables, simple windows — nothing else without explicit
+  maintainer sign-off. Checkpoint/recovery tests are mandatory (kill mid-window, verify state).
+
+### Benchmarks
+- Use benchi. Compare against Kafka Connect first. Commit configs and environment specs. Report
+  medians with variance, not best runs.
+
+## Things to never do
+
+- Never introduce a privileged integration for one broker vendor.
+- Never add license restrictions or enterprise-gated features to open-source repos.
+- Never claim Conduit replaces Flink; use the state-layer + streaming-SQL-partner framing.
+- Never introduce a bespoke transformation DSL — transformations are real-language code compiled
+  to WASM.
+- Never change `conduit-connector-protocol` without an explicit versioning discussion.
+- Never publish performance claims without reproducible benchi results.
+- Never mark a connector "supported" without acceptance tests passing in CI.
+- Never start a speculative C#/Ruby/Java-native SDK without documented demand.
+- Never merge a Tier 1 (data-path) change on automated review alone — human sign-off is
+  mandatory.
+- Never trade an ack-correctness, ordering, or crash-safety guarantee for throughput without a
+  design doc and explicit approval.
+- Never change a serialized format (positions, state, checkpoints, protocol) without a versioned
+  migration path and an upgrade test.
+- Never ship a bug fix without the regression test that would have caught it.
+- Never suppress, downgrade, or waive a failing chaos, upgrade, or race-detector check to make a
+  release date.
+- Never add clustering primitives (membership, leader election, gossip, consensus) to the
+  engine — distribution lives in the scheduling layer, per the ADR.
+- Never move anything shipped as open source behind a paywall, and never gate the k8s operator,
+  Helm chart, or fleet console core — the one-way ratchet is absolute.
+- Never claim a review or test gate was satisfied when the *Process maturity* table marks it not
+  yet live — say what was actually run.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,105 @@
+# Conduit Governance
+
+This document describes how the Conduit project is governed: how decisions get made, how
+contributors become maintainers, and the commitments the project makes to everyone who builds on
+it. It is intentionally lightweight and will grow as the community does.
+
+## License commitment
+
+Conduit is licensed under **Apache-2.0**, and the open-source project stays that way — forever.
+
+- The engine, all connectors and processors, all SDKs, the registry and templates, the CLI, the
+  built-in UI, the Helm chart, and the Kubernetes operator are Apache-2.0.
+- **The one-way ratchet:** nothing shipped as open source is ever moved behind a paywall.
+  Commercial features may become open source over time; the reverse never happens.
+- Commercial products (org-scale governance and federation) live in a separate repository, above
+  the open source, never inside it. The line is stated publicly in `ROADMAP.md`.
+
+These are governance commitments, not marketing. A change to any of them would require the
+process described below and could not be made quietly.
+
+## Principles
+
+The project's technical and strategic principles are recorded in `ROADMAP.md` and made durable in
+Architecture Decision Records under `docs/architecture-decision-records/`. Governance exists to
+uphold those principles, not to relitigate them case by case. In particular, decisions already
+recorded as ADRs (single-node engine, no bespoke DSL, WASM component model, local-state-only
+processing, broker neutrality) are settled; changing one requires a superseding ADR, not an
+issue thread.
+
+## Roles
+
+Contribution is a ladder. You move up it by showing sustained, high-quality judgment — not by
+volume alone.
+
+**Users** file issues, ask questions in [Discussions](https://github.com/ConduitIO/conduit/discussions)
+and [Discord](https://discord.meroxa.com), and help others. Every role below starts here.
+
+**Contributors** open pull requests. Anyone who lands a merged PR is a contributor. See
+`CONTRIBUTING.md` for how to start; the scaffolding tooling is designed to make a first
+meaningful PR a single-day effort.
+
+**Reviewers** are trusted to review PRs in an area they know well. A maintainer nominates a
+contributor as a reviewer after a track record of good reviews and merged work. Reviewers can
+approve Tier 2 and Tier 3 changes (see the PR review process in `CLAUDE.md`).
+
+**Maintainers** own the project's direction and have merge rights. They are responsible for
+release quality, the data-integrity invariants, and the review tiers. Maintainers are named
+owners of the regressions they approve — review is a real job here, not a rubber stamp.
+
+### Becoming a maintainer
+
+A reviewer becomes a maintainer by nomination from an existing maintainer and lazy consensus
+(see below) among the current maintainers. The bar is judgment under uncertainty: has this person
+shown they will protect the invariants and say no to the wrong change, not just ship the right
+one? Maintainers are listed in `MAINTAINERS.md` (added as the group grows beyond its founding
+state).
+
+Maintainers who become inactive for an extended period move to emeritus status by their own
+request or by consensus of the active maintainers. This is a recognition of contribution, not a
+demotion.
+
+## Decision process
+
+Most decisions are made through the normal PR and review process. For anything larger, the
+project uses **lazy consensus**: a proposal is made in the open (an issue, a design doc in
+`docs/design-documents/`, or an ADR), and if no maintainer objects within a reasonable review
+window, it is accepted. Silence is assent; objection starts a discussion.
+
+- **Small changes** (bug fixes, docs, chores, connectors): the PR review process in `CLAUDE.md`.
+- **Significant changes** (data path, public contracts, new subsystems): a design doc or ADR
+  first, then lazy consensus among maintainers. Data-path changes always require explicit human
+  maintainer sign-off — they never merge on automated review alone.
+- **Direction and governance changes** (roadmap phases, this document, the license line):
+  proposed in the open, decided by consensus of the maintainers, and recorded so the reasoning
+  survives.
+
+When maintainers disagree and consensus cannot be reached, the change does not proceed until it
+can. The project biases toward *not* shipping a contested change to infrastructure people bet
+their data on.
+
+## Transparency
+
+- Direction lives in `ROADMAP.md` and the public GitHub Project board.
+- Decisions of consequence are recorded as ADRs — immutable once merged, superseded rather than
+  edited, so future contributors can reconstruct *why* without archaeology.
+- Releases follow a monthly train with changelogs generated from conventional commits.
+- Community happens in the open: [Discussions](https://github.com/ConduitIO/conduit/discussions),
+  [Discord](https://discord.meroxa.com), and a monthly community call on a public calendar.
+
+## Code of Conduct
+
+Conduit has adopted the [Contributor Covenant](https://www.contributor-covenant.org/) as its
+[Code of Conduct](https://github.com/ConduitIO/.github/blob/main/CODE_OF_CONDUCT.md). All
+participation is subject to it.
+
+## Security
+
+Security vulnerabilities should be reported privately, not in public issues. The disclosure
+process is documented in `SECURITY.md`.
+
+## Changing this document
+
+This document is itself governed by the process it describes: propose a change in the open, reach
+consensus among maintainers, record the outcome. It is expected to evolve as the project grows
+from its founding state toward a broader maintainer group.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -75,14 +75,14 @@ window, it is accepted. Silence is assent; objection starts a discussion.
   survives.
 
 When maintainers disagree and consensus cannot be reached, the change does not proceed until it
-can. The project biases toward *not* shipping a contested change to infrastructure people bet
+can. The project biases toward _not_ shipping a contested change to infrastructure people bet
 their data on.
 
 ## Transparency
 
 - Direction lives in `ROADMAP.md` and the public GitHub Project board.
 - Decisions of consequence are recorded as ADRs — immutable once merged, superseded rather than
-  edited, so future contributors can reconstruct *why* without archaeology.
+  edited, so future contributors can reconstruct _why_ without archaeology.
 - Releases follow a monthly train with changelogs generated from conventional commits.
 - Community happens in the open: [Discussions](https://github.com/ConduitIO/conduit/discussions),
   [Discord](https://discord.meroxa.com), and a monthly community call on a public calendar.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,7 +46,7 @@ the monthly release cadence is a promise.
 
 ## Phase 0 — Revival (Weeks 0–8)
 
-*Goal: an unmistakable signal that Conduit is active, maintained, and shipping.*
+_Goal: an unmistakable signal that Conduit is active, maintained, and shipping._
 
 - [ ] Triage all open issues and PRs — every item closed, merged, or labeled with a decision
 - [ ] **Cut v0.15.0 stable** off the running nightly train: dependency upgrades, security
@@ -65,10 +65,11 @@ published.
 
 ## Phase 1 — Developer Experience Core (Months 1–4)
 
-*Goal: the best first-hour and first-week experience of any data integration tool — for humans
-and for their agents.*
+_Goal: the best first-hour and first-week experience of any data integration tool — for humans
+and for their agents._
 
 ### The 5-minute wow
+
 - [ ] `brew install conduit` / `curl | sh` / single-binary downloads for all platforms
 - [ ] `conduit init` — scaffolds a working pipeline (e.g., Postgres CDC → file/S3) with zero
       manual config
@@ -77,6 +78,7 @@ and for their agents.*
       inspection, pipeline graph
 
 ### CLI as product
+
 - [ ] `conduit pipeline validate | lint | dry-run`
 - [ ] `conduit doctor` — environment and config diagnostics
 - [ ] Hot-reload of pipeline configs in dev mode
@@ -85,18 +87,21 @@ and for their agents.*
 - [ ] Deterministic, machine-actionable errors: error code + failing config path + suggested fix
 
 ### Agent-native (a Phase 1 priority)
+
 - [ ] Official Conduit MCP server: agents can scaffold, validate, deploy, inspect, and repair
       pipelines
 - [ ] `llms.txt` + single-page condensed documentation dump for LLM context
 - [ ] `conduit generate "<natural language>"` — AI-assisted pipeline generation from plain English
 
 ### Plugin scaffolding
+
 - [ ] `conduit connector new --lang go|python|rust|ts` — full repo: SDK wiring, tests, CI,
       release workflow, acceptance-test harness
 - [ ] `conduit processor new` — same treatment
 - [ ] Target: **first working custom connector in under 30 minutes**
 
 ### WASM everywhere
+
 - [ ] WASM **connectors** (today: WASM processors only) — in-process, sandboxed, single portable
       artifact, no gRPC sidecar
 - [ ] WASI Preview 2 / component model adoption
@@ -109,16 +114,19 @@ and for their agents.*
   - [ ] C# / Ruby: demand-driven only — not speculatively built
 
 ### Connector registry
+
 - [ ] Public registry: `conduit connectors install <name>` pulls signed binaries/WASM artifacts
 - [ ] Community publishing via GitHub Action + signing
 - [ ] Registry web UI with search, verified badges, download stats
 
 ### Templates
+
 - [ ] Template gallery shipped with the registry: `postgres-iceberg`, `mysql-snowflake`,
       `postgres-pgvector-rag`, `shopify-warehouse`, `kafka-clickhouse`, and more
 - [ ] Community-contributed templates with the same publishing flow as connectors
 
 ### Deployment fundamentals (12-factor citizenship — the universal answer)
+
 - [ ] Env-var configuration for all engine settings
 - [ ] `/healthz` and `/readyz` endpoints; Prometheus metrics endpoint
 - [ ] Graceful SIGTERM drain (checkpoint, then exit) — see data-integrity invariants
@@ -129,20 +137,23 @@ and for their agents.*
       Nomad job spec (examples, not supported products — promoted only on demand)
 
 ### Long-lead protocol design (build in Phase 3, design now)
+
 - [ ] Design doc + protocol RFC: **partition claims** — sources declare their partitionable units
       so a scheduler can run one hot pipeline across multiple instances. Touches
       `conduit-connector-protocol`, so the seam ships early to avoid a breaking rev later
 
 ### Embedded v1
+
 - [ ] Stable, documented Go library API for embedding Conduit in applications
 - [ ] C ABI shared library (`libconduit`) as the base for cross-language bindings
 - [ ] Python and Node.js bindings (Java/Ruby to follow on demand)
 
 ## Phase 2 — Kafka Connect Migration, Connector Coverage & AI Pipelines (Months 3–8)
 
-*Goal: switching from Kafka Connect is a command; keeping a RAG index fresh is 10 lines of YAML.*
+_Goal: switching from Kafka Connect is a command; keeping a RAG index fresh is 10 lines of YAML._
 
 ### Migration tooling
+
 - [ ] `conduit migrate kafka-connect` — reads Kafka Connect worker/connector JSON (Debezium,
       JDBC, S3, etc.), emits Conduit pipeline config + compatibility report; never silently drops
       config it can't translate
@@ -151,8 +162,10 @@ and for their agents.*
       catalog parity (also the Java-team on-ramp)
 
 ### CDC (the moat)
+
 Production-grade change data capture — snapshot + streaming, schema evolution, heartbeats,
 tombstones:
+
 - [ ] PostgreSQL (harden existing)
 - [ ] MySQL
 - [ ] MongoDB
@@ -160,7 +173,9 @@ tombstones:
 - [ ] Oracle
 
 ### The AI data pipeline (first-class use case)
+
 The canonical pipeline — CDC → chunk → embed → vector store — as a headline Conduit workload:
+
 - [ ] Chunking processors (document splitting strategies for RAG)
 - [ ] Embedding processors: OpenAI, Voyage, local models
 - [ ] Vector destinations: pgvector, Qdrant, Pinecone, Turbopuffer
@@ -168,11 +183,13 @@ The canonical pipeline — CDC → chunk → embed → vector store — as a hea
 - [ ] Positioning docs: Conduit as the data layer for AI applications
 
 ### Iceberg-first lakehouse story
+
 - [ ] Best-in-class Apache Iceberg destination: upserts, compaction-friendly writes, catalog
       support (REST, Glue, Nessie)
 - [ ] Headline use case: operational DB → lakehouse in real time, no Kafka required
 
 ### Priority native connectors (rough order, after Iceberg)
+
 - [ ] Snowflake
 - [ ] S3 / GCS / Azure Blob with Parquet support
 - [ ] ClickHouse
@@ -188,10 +205,12 @@ The canonical pipeline — CDC → chunk → embed → vector store — as a hea
 - [ ] DuckDB / MotherDuck
 
 ### Kubernetes (static scale-out)
+
 - [ ] Helm chart: Deployment/StatefulSet, pipeline configs via ConfigMap or git-sync, HPA hooks,
       ServiceMonitor — covers static pipeline-to-instance assignment before the operator exists
 
 ### Enterprise correctness
+
 - [ ] Confluent Schema Registry wire compatibility (Avro, Protobuf, JSON Schema)
 - [ ] **Schema contracts & drift policy:** configurable behavior on schema drift — halt, DLQ, or
       auto-evolve — with drift surfaced in the UI
@@ -204,12 +223,14 @@ The canonical pipeline — CDC → chunk → embed → vector store — as a hea
 
 ## Phase 3 — Stateful Processing, Scale & Ecosystem (Months 6–12)
 
-*Goal: capture the 80% of stream-processing workloads that don't need Flink, and run credibly at
-enterprise fleet scale.*
+_Goal: capture the 80% of stream-processing workloads that don't need Flink, and run credibly at
+enterprise fleet scale._
 
 ### Lightweight state layer ("the 80% of Flink")
+
 Right-sized stateful processing — local state (embedded KV store), checkpointed with the
 pipeline, no distributed snapshots or state backends to tune:
+
 - [ ] Deduplication with TTL
 - [ ] Lookup/enrichment tables: cached reference data from a database or topic
 - [ ] Tumbling and sliding window aggregations (counts, sums, simple rollups)
@@ -217,12 +238,15 @@ pipeline, no distributed snapshots or state backends to tune:
       event-time processing)
 
 ### Streaming SQL partnerships (the other 20%)
+
 - [ ] First-class ingest/egress integrations and reference architectures with RisingWave,
       Materialize, and ClickHouse
 - [ ] Documented pattern: "Conduit + streaming SQL engine replaces Kafka Connect + Flink"
 
 ### Scale-out & high availability (open source)
+
 The engine stays single-node (Principle 8); distribution is scheduling:
+
 - [ ] **Kubernetes operator** (Apache-2.0, always): `Pipeline` CRD, bin-packing of pipelines
       across pods, health-based rescheduling, lag-based autoscaling
 - [ ] **Checkpoint-aware rolling upgrades:** drain → checkpoint → reschedule, no data interruption
@@ -235,6 +259,7 @@ The engine stays single-node (Principle 8); distribution is scheduling:
       warm standbys in v1)
 
 ### Fleet control plane (open source core)
+
 - [ ] Lightweight console that registers many Conduit instances: fleet-wide visibility, health,
       versions
 - [ ] GitOps-native: console reads state; pipeline config stays in git
@@ -243,12 +268,14 @@ The engine stays single-node (Principle 8); distribution is scheduling:
 - [ ] Rolling upgrades across a fleet
 
 ### Performance
+
 - [ ] Published, reproducible benchmarks (via [benchi](https://github.com/ConduitIO/benchi)) vs
       Kafka Connect and other stream processors, updated per release
 - [ ] Pipeline-wide batching; allocation reduction; profiling as CI gate
 - [ ] Investigate Arrow-based internal record format for columnar destinations
 
 ### Ecosystem tooling
+
 - [ ] **Terraform provider for the Conduit API:** pipelines, connectors, processors as
       declarative resources. Infrastructure Terraform (EKS modules, etc.) stays in `deploy/` as
       examples, not products
@@ -256,6 +283,7 @@ The engine stays single-node (Principle 8); distribution is scheduling:
 - [ ] OpenTelemetry traces + metrics, prebuilt Grafana dashboards
 
 ### AI-assisted connector development
+
 - [ ] `conduit connector generate --from-openapi <spec>` — AI-assisted connector scaffolding from
       API specs
 
@@ -295,7 +323,7 @@ engine · all connectors and processors · all SDKs · registry and templates ·
 Helm chart · **Kubernetes operator** (scheduling, rescheduling, autoscaling, checkpoint-aware
 rolling upgrades) · fleet console core
 
-**Commercial (separate product, separate repo) — what an *organization* needs to govern Conduit
+**Commercial (separate product, separate repo) — what an _organization_ needs to govern Conduit
 at fleet scale:** multi-cluster/multi-region federation · SSO/SAML/SCIM, RBAC, audit logs · data
 lineage, PII policy packs, org-level schema-contract enforcement, compliance reporting ·
 cross-fleet upgrade orchestration, SLA alerting, cost/throughput analytics · support and SLAs ·

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,322 @@
+# Conduit Roadmap
+
+**Mission:** Make Conduit the default way to move and transform data in real time — a Kafka
+Connect replacement that works with any broker (Kafka, NATS, Redpanda, Hazelcast, Pulsar) or no
+broker at all, runs anywhere from a laptop to Kubernetes to embedded inside your application, and
+lets you build connectors and processors in real programming languages.
+
+This roadmap is a living document. Items move as we learn. Dates are targets, not promises — but
+the monthly release cadence is a promise.
+
+---
+
+## Principles
+
+1. **Apache-2.0, forever.** No relicensing, no enterprise-only connectors, no rug pulls. Open
+   governance with a public contributor ladder.
+2. **Real languages, no bespoke DSL.** Transformations are code you can test, version, and reuse
+   — written in Python, Rust, TypeScript, or Go and compiled to WASM — not a config-language
+   dialect you have to learn. Prebuilt processors cover the common 90% with zero code.
+3. **Broker-neutral.** Conduit is Switzerland. Every streaming provider is a peer; none is
+   privileged. No broker required at all for point-to-point pipelines.
+4. **Boring to operate.** Single static binary, no JVM, no ZooKeeper, no worker cluster.
+   Observability built in. Replay and recovery are first-class verbs, not incident-response
+   archaeology.
+5. **Migration is a product.** Moving off Kafka Connect should be a command, not a quarter-long
+   project.
+6. **Agent-legible by design.** Structured output, deterministic machine-actionable errors, and
+   an MCP server — because the next generation of users includes AI agents building and
+   repairing pipelines.
+7. **Right-sized state.** Conduit handles the stateful processing most pipelines actually need
+   (dedup, enrichment, simple windows) without distributed-snapshot complexity. For heavy
+   stateful workloads, Conduit integrates with streaming SQL engines rather than reinventing
+   them.
+8. **Single-node engine, scale-out by scheduling.** The engine never grows membership protocols,
+   leader election, or consensus. Distribution — running many pipelines across many instances, or
+   one hot pipeline across several — is a scheduling problem solved a layer above
+   (operator/control plane). This keeps the engine embeddable, boring to operate, and free of
+   rebalance-protocol misery.
+9. **Open core with a bright line.** The engine, all connectors, SDKs, registry, CLI, UI, Helm
+   chart, and the Kubernetes operator are Apache-2.0 — a team can run Conduit in production at
+   any scale for free, forever. Commercial products live above the open source (org-scale
+   governance and federation), never inside it, and nothing shipped as open source is ever moved
+   behind a paywall.
+
+---
+
+## Phase 0 — Revival (Weeks 0–8)
+
+*Goal: an unmistakable signal that Conduit is active, maintained, and shipping.*
+
+- [ ] Triage all open issues and PRs — every item closed, merged, or labeled with a decision
+- [ ] **Cut v0.15.0 stable** off the running nightly train: dependency upgrades, security
+      patches, bug fixes, Go version bump
+- [ ] Publish this roadmap + public GitHub Project board with milestones
+- [ ] Governance doc: Apache-2.0 commitment, maintainer ladder, decision process
+- [ ] Seed `docs/architecture-decision-records/` with the foundational decisions already made:
+      single-node engine (distribution via the scheduling layer), no bespoke DSL, WASM component
+      model, local-state-only
+- [ ] Begin CNCF Sandbox application process
+- [ ] Revive Discord; monthly community call on a public calendar
+- [ ] Hold the monthly release train (cadence over scope)
+
+**Definition of done:** zero untriaged issues, v0.15.0 stable shipped, roadmap and governance
+published.
+
+## Phase 1 — Developer Experience Core (Months 1–4)
+
+*Goal: the best first-hour and first-week experience of any data integration tool — for humans
+and for their agents.*
+
+### The 5-minute wow
+- [ ] `brew install conduit` / `curl | sh` / single-binary downloads for all platforms
+- [ ] `conduit init` — scaffolds a working pipeline (e.g., Postgres CDC → file/S3) with zero
+      manual config
+- [ ] `conduit init --template <name>` — template gallery of one-command recipes
+- [ ] Refreshed built-in UI (a rebuild, not a polish — see below): live record flow, per-stage
+      inspection, pipeline graph
+
+### CLI as product
+- [ ] `conduit pipeline validate | lint | dry-run`
+- [ ] `conduit doctor` — environment and config diagnostics
+- [ ] Hot-reload of pipeline configs in dev mode
+- [ ] `conduit pipeline dev` — local dev loop with record inspector
+- [ ] `--json` structured output on every command
+- [ ] Deterministic, machine-actionable errors: error code + failing config path + suggested fix
+
+### Agent-native (a Phase 1 priority)
+- [ ] Official Conduit MCP server: agents can scaffold, validate, deploy, inspect, and repair
+      pipelines
+- [ ] `llms.txt` + single-page condensed documentation dump for LLM context
+- [ ] `conduit generate "<natural language>"` — AI-assisted pipeline generation from plain English
+
+### Plugin scaffolding
+- [ ] `conduit connector new --lang go|python|rust|ts` — full repo: SDK wiring, tests, CI,
+      release workflow, acceptance-test harness
+- [ ] `conduit processor new` — same treatment
+- [ ] Target: **first working custom connector in under 30 minutes**
+
+### WASM everywhere
+- [ ] WASM **connectors** (today: WASM processors only) — in-process, sandboxed, single portable
+      artifact, no gRPC sidecar
+- [ ] WASI Preview 2 / component model adoption
+- [ ] Language SDK rollout, in priority order:
+  - [ ] **Go** — reference SDK (exists; keep current with protocol)
+  - [ ] **Python** — gRPC standalone path first (WASM fast-follow); first `libconduit` binding
+  - [ ] **Rust** — full WASM component-model path; proves the WASM connector architecture
+  - [ ] **TypeScript** — WASM via componentize-js
+  - [ ] Java: served via the Kafka Connect wrapper short-term; native SDK is a Phase 3+ decision
+  - [ ] C# / Ruby: demand-driven only — not speculatively built
+
+### Connector registry
+- [ ] Public registry: `conduit connectors install <name>` pulls signed binaries/WASM artifacts
+- [ ] Community publishing via GitHub Action + signing
+- [ ] Registry web UI with search, verified badges, download stats
+
+### Templates
+- [ ] Template gallery shipped with the registry: `postgres-iceberg`, `mysql-snowflake`,
+      `postgres-pgvector-rag`, `shopify-warehouse`, `kafka-clickhouse`, and more
+- [ ] Community-contributed templates with the same publishing flow as connectors
+
+### Deployment fundamentals (12-factor citizenship — the universal answer)
+- [ ] Env-var configuration for all engine settings
+- [ ] `/healthz` and `/readyz` endpoints; Prometheus metrics endpoint
+- [ ] Graceful SIGTERM drain (checkpoint, then exit) — see data-integrity invariants
+- [ ] Official minimal container image; docker-compose quickstart
+- [ ] systemd unit file for VM deployments
+- [ ] `conduit run --pipelines <dir>` — run a directory of pipeline configs (GitOps-friendly)
+- [ ] `deploy/` directory with documented examples: docker-compose, systemd, ECS task definition,
+      Nomad job spec (examples, not supported products — promoted only on demand)
+
+### Long-lead protocol design (build in Phase 3, design now)
+- [ ] Design doc + protocol RFC: **partition claims** — sources declare their partitionable units
+      so a scheduler can run one hot pipeline across multiple instances. Touches
+      `conduit-connector-protocol`, so the seam ships early to avoid a breaking rev later
+
+### Embedded v1
+- [ ] Stable, documented Go library API for embedding Conduit in applications
+- [ ] C ABI shared library (`libconduit`) as the base for cross-language bindings
+- [ ] Python and Node.js bindings (Java/Ruby to follow on demand)
+
+## Phase 2 — Kafka Connect Migration, Connector Coverage & AI Pipelines (Months 3–8)
+
+*Goal: switching from Kafka Connect is a command; keeping a RAG index fresh is 10 lines of YAML.*
+
+### Migration tooling
+- [ ] `conduit migrate kafka-connect` — reads Kafka Connect worker/connector JSON (Debezium,
+      JDBC, S3, etc.), emits Conduit pipeline config + compatibility report; never silently drops
+      config it can't translate
+- [ ] SMT compatibility pack: 1:1 processor equivalents for standard Kafka Connect SMTs
+- [ ] Hardened Kafka Connect wrapper: run existing KC connector JARs inside Conduit for day-one
+      catalog parity (also the Java-team on-ramp)
+
+### CDC (the moat)
+Production-grade change data capture — snapshot + streaming, schema evolution, heartbeats,
+tombstones:
+- [ ] PostgreSQL (harden existing)
+- [ ] MySQL
+- [ ] MongoDB
+- [ ] SQL Server
+- [ ] Oracle
+
+### The AI data pipeline (first-class use case)
+The canonical pipeline — CDC → chunk → embed → vector store — as a headline Conduit workload:
+- [ ] Chunking processors (document splitting strategies for RAG)
+- [ ] Embedding processors: OpenAI, Voyage, local models
+- [ ] Vector destinations: pgvector, Qdrant, Pinecone, Turbopuffer
+- [ ] "Keep your RAG index fresh from Postgres" quickstart + template
+- [ ] Positioning docs: Conduit as the data layer for AI applications
+
+### Iceberg-first lakehouse story
+- [ ] Best-in-class Apache Iceberg destination: upserts, compaction-friendly writes, catalog
+      support (REST, Glue, Nessie)
+- [ ] Headline use case: operational DB → lakehouse in real time, no Kafka required
+
+### Priority native connectors (rough order, after Iceberg)
+- [ ] Snowflake
+- [ ] S3 / GCS / Azure Blob with Parquet support
+- [ ] ClickHouse
+- [ ] BigQuery
+- [ ] Databricks / Delta Lake
+- [ ] Elasticsearch / OpenSearch
+- [ ] NATS JetStream
+- [ ] Redpanda (native, tuned)
+- [ ] Kinesis / SQS / SNS
+- [ ] Google Pub/Sub
+- [ ] Redis
+- [ ] HTTP / webhooks (source + destination)
+- [ ] DuckDB / MotherDuck
+
+### Kubernetes (static scale-out)
+- [ ] Helm chart: Deployment/StatefulSet, pipeline configs via ConfigMap or git-sync, HPA hooks,
+      ServiceMonitor — covers static pipeline-to-instance assignment before the operator exists
+
+### Enterprise correctness
+- [ ] Confluent Schema Registry wire compatibility (Avro, Protobuf, JSON Schema)
+- [ ] **Schema contracts & drift policy:** configurable behavior on schema drift — halt, DLQ, or
+      auto-evolve — with drift surfaced in the UI
+- [ ] Dead-letter queues
+- [ ] Documented delivery semantics per source/destination pair
+- [ ] Pipeline recovery, retry/backoff policies
+- [ ] **Replay & backfill as first-class verbs:** `conduit pipeline replay --from <position>`,
+      snapshot re-runs, offset inspection and reset in CLI and UI
+- [ ] Secrets management: env, Vault, cloud KMS
+
+## Phase 3 — Stateful Processing, Scale & Ecosystem (Months 6–12)
+
+*Goal: capture the 80% of stream-processing workloads that don't need Flink, and run credibly at
+enterprise fleet scale.*
+
+### Lightweight state layer ("the 80% of Flink")
+Right-sized stateful processing — local state (embedded KV store), checkpointed with the
+pipeline, no distributed snapshots or state backends to tune:
+- [ ] Deduplication with TTL
+- [ ] Lookup/enrichment tables: cached reference data from a database or topic
+- [ ] Tumbling and sliding window aggregations (counts, sums, simple rollups)
+- [ ] Clear documentation of what this is (most real-world jobs) and isn't (large joins, complex
+      event-time processing)
+
+### Streaming SQL partnerships (the other 20%)
+- [ ] First-class ingest/egress integrations and reference architectures with RisingWave,
+      Materialize, and ClickHouse
+- [ ] Documented pattern: "Conduit + streaming SQL engine replaces Kafka Connect + Flink"
+
+### Scale-out & high availability (open source)
+The engine stays single-node (Principle 8); distribution is scheduling:
+- [ ] **Kubernetes operator** (Apache-2.0, always): `Pipeline` CRD, bin-packing of pipelines
+      across pods, health-based rescheduling, lag-based autoscaling
+- [ ] **Checkpoint-aware rolling upgrades:** drain → checkpoint → reschedule, no data interruption
+      during version bumps
+- [ ] **Hot-pipeline parallelism:** scheduler assigns partition claims (protocol seam from Phase
+      1) so one pipeline runs across multiple instances; Kafka-consumer-group sources get this
+      natively
+- [ ] **Active/passive HA:** instance dies → scheduler reassigns → pipeline resumes from
+      checkpoint (correct by construction via the data-integrity invariants; no consensus, no
+      warm standbys in v1)
+
+### Fleet control plane (open source core)
+- [ ] Lightweight console that registers many Conduit instances: fleet-wide visibility, health,
+      versions
+- [ ] GitOps-native: console reads state; pipeline config stays in git
+- [ ] Shared scheduling brain with the operator — the operator is the control plane's Kubernetes
+      backend
+- [ ] Rolling upgrades across a fleet
+
+### Performance
+- [ ] Published, reproducible benchmarks (via [benchi](https://github.com/ConduitIO/benchi)) vs
+      Kafka Connect and other stream processors, updated per release
+- [ ] Pipeline-wide batching; allocation reduction; profiling as CI gate
+- [ ] Investigate Arrow-based internal record format for columnar destinations
+
+### Ecosystem tooling
+- [ ] **Terraform provider for the Conduit API:** pipelines, connectors, processors as
+      declarative resources. Infrastructure Terraform (EKS modules, etc.) stays in `deploy/` as
+      examples, not products
+- [ ] Production reference architectures
+- [ ] OpenTelemetry traces + metrics, prebuilt Grafana dashboards
+
+### AI-assisted connector development
+- [ ] `conduit connector generate --from-openapi <spec>` — AI-assisted connector scaffolding from
+      API specs
+
+## Documentation (parallel track, starts Phase 0)
+
+- [ ] Getting-started rewrite around the 5-minute path; per-broker quickstarts (Kafka, NATS,
+      Redpanda, Hazelcast, none)
+- [ ] "Migrating from Kafka Connect" section: concept mapping (worker→instance, task→pipeline,
+      SMT→processor, converter→schema), per-connector guides for the top 10 KC connectors
+- [ ] "AI data pipelines with Conduit": RAG sync, embedding pipelines, vector store patterns
+- [ ] Connector development tutorial per supported language (Go, Python, Rust, TS)
+- [ ] Processor cookbook: 30+ copy-paste recipes
+- [ ] Embedding guide per language
+- [ ] Honest comparison pages: vs Kafka Connect, vs Redpanda Connect / Bento, vs Flink (when you
+      need it, when you don't), vs batch ELT tools
+- [ ] Architecture deep-dive: ordering guarantees, end-to-end ack propagation, delivery
+      semantics, state & checkpointing model
+- [ ] `llms.txt` and LLM-optimized doc formats maintained alongside human docs
+
+## UI note
+
+Conduit's historical UI was Ember-based and later de-emphasized. "Refreshed built-in UI" means
+**rebuild, not polish** — built modern and agent-friendly from scratch, on the same API the CLI
+and MCP server use (no divergent code paths). UI surfaces by phase: Phase 1 = built-in
+single-instance UI (live record flow, per-stage inspection, pipeline graph) + registry web UI;
+Phase 2 = schema-drift visibility, replay/offset management; Phase 3 = fleet console
+(multi-instance). Deeper org-scale console features are the commercial product.
+
+---
+
+## Open source vs. enterprise (the bright line, stated publicly)
+
+We're an open-core project and we'd rather tell you where the line is than let you guess.
+
+**Apache-2.0, forever — everything a team needs to run Conduit in production at any scale:**
+engine · all connectors and processors · all SDKs · registry and templates · CLI · built-in UI ·
+Helm chart · **Kubernetes operator** (scheduling, rescheduling, autoscaling, checkpoint-aware
+rolling upgrades) · fleet console core
+
+**Commercial (separate product, separate repo) — what an *organization* needs to govern Conduit
+at fleet scale:** multi-cluster/multi-region federation · SSO/SAML/SCIM, RBAC, audit logs · data
+lineage, PII policy packs, org-level schema-contract enforcement, compliance reporting ·
+cross-fleet upgrade orchestration, SLA alerting, cost/throughput analytics · support and SLAs ·
+air-gapped and FIPS-hardened distributions
+
+**The one-way ratchet:** nothing shipped as open source will ever be moved behind a paywall.
+Commercial features may become open source over time; the reverse never happens.
+
+---
+
+## How to contribute
+
+- Check the [GitHub Project board](https://github.com/orgs/ConduitIO/projects) for issues labeled
+  `good first issue` and `help wanted`
+- Build a connector — the scaffolding makes it a weekend project, and the registry gets it
+  distributed
+- Contribute a pipeline template — the gallery is community-driven
+- Join the community call and Discord
+- Everything here is open for discussion; open an issue against this roadmap
+
+**North-star metrics we hold ourselves to:** time-to-first-pipeline < 5 minutes ·
+time-to-first-custom-connector < 30 minutes · an AI agent can go from zero to a running pipeline
+using only the MCP server and llms.txt · monthly release cadence · zero untriaged issues older
+than 14 days.

--- a/docs/architecture-decision-records/20260704-local-state-only.md
+++ b/docs/architecture-decision-records/20260704-local-state-only.md
@@ -1,0 +1,64 @@
+# Local-state-only stateful processing; no distributed snapshots
+
+## Summary
+
+Conduit's stateful processing uses local state — an embedded key-value store, checkpointed
+together with the pipeline. It does not implement distributed snapshots, pluggable state
+backends, or event-time watermark machinery. The scope is deliberately bounded to deduplication
+(with TTL), lookup/enrichment tables, and simple window aggregations. Heavy stateful workloads
+(large joins, complex event-time) are served by integrating with streaming SQL engines, not by
+growing Conduit into one.
+
+## Context
+
+Most real-world stream-processing jobs are read-transform-write with light state: dedup a stream,
+enrich records from a reference table, roll up counts over a window. A small minority need true
+distributed stateful processing — large shuffles/joins, complex event-time with watermarks and
+late-data handling. Flink serves that minority well, at a heavy operational cost.
+
+The temptation is to keep adding "just one more" stateful feature until Conduit is a worse Flink.
+That path destroys the project's core promise (boring to operate, embeddable, single static
+binary) and pulls the engine toward distributed-snapshot machinery that contradicts the
+single-node-engine decision.
+
+We need a bright, defensible scope line for state, and a partnering story for everything past it.
+
+## Decision
+
+Constrain stateful processing to local, checkpointed state.
+
+- **State is a local embedded KV store**, checkpointed atomically with the pipeline. Recovery is
+  resume-from-checkpoint, governed by the data-integrity invariants (atomic checkpoint writes,
+  crash-safe positions). Every state feature ships with a kill-mid-write recovery test.
+- **In scope:** deduplication with TTL, lookup/enrichment tables (cached reference data from a DB
+  or topic), tumbling and sliding window aggregations (counts, sums, simple rollups).
+- **Explicitly out of scope:** distributed snapshots, pluggable/tunable state backends,
+  event-time watermarks, large distributed joins, late-data reprocessing frameworks. If a design
+  doc starts growing these, stop and flag it — scope creep here is an existential risk to the
+  revival.
+- **The other 20% is a partnership, not a build.** Conduit provides best-in-class ingest/egress
+  for RisingWave, Materialize, and ClickHouse. The approved framing is "Conduit + streaming SQL
+  engine replaces Kafka Connect + Flink," never "Conduit replaces Flink."
+- Documentation must state plainly what this state layer is (most real jobs) and is not (large
+  joins, complex event-time), so users self-select correctly.
+
+## Consequences
+
+- The engine stays single-node, embeddable, and operationally boring; state adds no consensus and
+  no snapshot coordinator.
+- Recovery correctness reduces to the existing data-integrity invariants rather than a new
+  distributed-snapshot protocol.
+- Users with genuinely heavy stateful needs must run a streaming SQL engine alongside Conduit;
+  we make that integration excellent instead of pretending to replace it.
+- We give up the "single tool for all stream processing" pitch by choice; the payoff is a tool
+  that is trustworthy and simple for the workloads it does claim.
+- Every proposed state feature is measured against the scope line above; "add a pluggable state
+  backend" or "add watermarks" requires explicit maintainer sign-off and, realistically, a
+  superseding ADR — not a design-doc footnote.
+
+## Related
+
+- `ROADMAP.md` — Principle 7 (right-sized state); Phase 3 lightweight state layer and streaming
+  SQL partnerships
+- [20260704-single-node-engine.md](20260704-single-node-engine.md) — local-only state is what
+  keeps checkpoint/recovery correct without consensus

--- a/docs/architecture-decision-records/20260704-no-bespoke-dsl.md
+++ b/docs/architecture-decision-records/20260704-no-bespoke-dsl.md
@@ -1,0 +1,59 @@
+# No bespoke transformation DSL; transformations are real-language code
+
+## Summary
+
+Conduit will never introduce a bespoke transformation or configuration DSL (a Bloblang-style
+config language). Transformations are written in real programming languages — Go, Python, Rust,
+TypeScript — and, for standalone processors, compiled to WASM. Prebuilt processors cover the
+common 90% with zero code; anything beyond that is code you can test, version, and reuse.
+
+## Context
+
+Competing tools (Benthos / Redpanda Connect, and its Bento fork) center on Bloblang, a custom
+mapping language. A DSL is attractive early — it makes simple transforms terse and keeps them in
+config — but it carries permanent costs: users must learn a new language, it is hard to test and
+debug, tooling (editors, linters, type checkers) has to be built from scratch, and the surface
+grows without bound as users push it past its design point.
+
+Conduit already has a WASM processor runtime (wazero) and an SDK model that decouples plugins
+from the engine. Real languages are therefore available to us as the transformation substrate
+without inventing anything.
+
+This is also a stated public principle, not merely an implementation preference — users and
+contributors should be able to rely on it.
+
+## Decision
+
+Reject bespoke DSLs as a category. Specifically:
+
+- Transformations are real-language code. Standalone processors compile to WASM and run in the
+  wazero runtime, sandboxed and portable; built-in processors are Go compiled into the binary.
+- Prebuilt, configuration-only processors cover the common cases (field extraction, renaming,
+  filtering, format conversion, common SMT equivalents) so that most users write no code at all.
+- When configuration is not enough, the escalation path is a real language with real tests and
+  real tooling — never a new config-language dialect.
+- Kafka Connect SMTs are matched with 1:1 processor equivalents, not by building an SMT
+  expression language.
+
+This decision is settled and is not relitigated in design docs.
+
+## Consequences
+
+- Transformations are testable, versionable, and reusable with ordinary language tooling; no
+  bespoke editor/linter/debugger investment is required from us.
+- The learning curve for advanced transforms is "a language you already know," not "our DSL."
+- Terse one-line mappings are slightly more verbose than a DSL would make them; the prebuilt
+  processor library must be good enough that users rarely feel this.
+- We commit to maintaining the WASM component toolchain and per-language SDKs as the
+  transformation path — that is a real, ongoing cost we accept in exchange for never owning a
+  language runtime.
+- Any PR proposing an expression/config language is a review blocker on principle.
+
+## Related
+
+- `ROADMAP.md` — Principle 2 (real languages, no bespoke DSL); Phase 1 WASM connectors and SDK
+  rollout; Phase 2 SMT compatibility pack
+- [20231117-better-processors.md](../design-documents/20231117-better-processors.md) — processor
+  design
+- [20260704-wasm-component-model.md](20260704-wasm-component-model.md) — the WASM substrate that
+  makes real-language plugins portable

--- a/docs/architecture-decision-records/20260704-single-node-engine.md
+++ b/docs/architecture-decision-records/20260704-single-node-engine.md
@@ -1,0 +1,71 @@
+# Single-node engine; distribution lives in the scheduling layer
+
+## Summary
+
+The Conduit engine is single-node by design. It will never grow cluster-membership protocols,
+leader election, gossip, or consensus (Raft/etcd). Distribution — running many pipelines across
+many instances, or one hot pipeline across several — is a scheduling concern solved a layer above
+the engine (Kubernetes operator / control plane), not inside it.
+
+## Context
+
+Data-integration systems that put distribution *inside* the engine pay for it forever. Kafka
+Connect's rebalance protocol is the canonical example: worker-cluster membership and task
+rebalancing are a persistent source of operational pain, stop-the-world pauses, and subtle
+correctness bugs. We want Conduit to be boring to operate (Principle 4), embeddable as a library
+(a differentiator), and free of that class of failure.
+
+At the same time, real deployments need scale-out and high availability. The question is not
+*whether* Conduit distributes, but *where the distribution logic lives*.
+
+Two forces are in tension:
+
+- Users will eventually run fleets of pipelines and expect rescheduling, autoscaling, and HA.
+- Every distributed primitive added to the engine makes it heavier, harder to embed, and harder
+  to reason about under failure.
+
+## Decision
+
+Keep the engine single-node and place all distribution in a scheduling layer above it.
+
+- **No membership, no leader election, no gossip, no consensus in the engine.** Well-meaning
+  clustering PRs are rejected and pointed at this ADR. If a design doc starts growing
+  engine-level rebalancing, that is a stop-and-flag signal.
+- **Level 1 scale-out = fleet sharding.** A scheduler bin-packs pipelines onto instances.
+  "Who runs what" state lives in the control plane (Postgres- or Kubernetes-lease-backed), not in
+  the engine.
+- **Level 2 scale-out = hot-pipeline parallelism via partition claims.** Sources declare their
+  partitionable units in the connector protocol; the scheduler assigns claims to instances. Kafka
+  consumer-group sources get this natively. CDC is single-writer per replication slot and scales
+  per-table, which is acceptable. The partition-claim protocol RFC is a Phase 1 deliverable even
+  though the scheduler itself is Phase 3, so the protocol seam ships before it would need a
+  breaking revision.
+- **High availability = active/passive, resume-from-checkpoint.** An instance dies, the scheduler
+  reassigns its pipelines, and each pipeline resumes from its last checkpoint. This is correct by
+  construction given the data-integrity invariants (crash-safe positions, atomic checkpoints,
+  at-least-once). No consensus and no warm standbys in v1.
+
+The operator and the control plane share one scheduling brain; the operator is the control
+plane's Kubernetes backend. Scheduling stays open source; org-scale governance and federation are
+the commercial layer.
+
+## Consequences
+
+- The engine stays small, embeddable, and easy to reason about under failure.
+- We inherit none of Kafka Connect's rebalance-protocol failure surface.
+- HA correctness reduces to the data-integrity invariants rather than a bespoke consensus
+  implementation we would have to prove correct.
+- We take on a dependency on the scheduling layer for anything beyond a single instance; static
+  pipeline-to-instance assignment (Helm, `conduit run --pipelines <dir>`) must cover users well
+  before the operator exists.
+- The connector protocol must carry a partition-claim concept earlier than the scheduler needs
+  it, to avoid a later breaking change.
+- We explicitly forgo in-engine dynamic rebalancing of a running pipeline across instances; that
+  capability, if ever needed, is the scheduler's job, not the engine's.
+
+## Related
+
+- `ROADMAP.md` — Principle 8 (single-node engine, scale-out by scheduling); Phase 1 partition-
+  claim RFC; Phase 3 operator, hot-pipeline parallelism, and active/passive HA
+- [20220121-conduit-plugin-architecture.md](20220121-conduit-plugin-architecture.md) — the
+  built-in/standalone plugin model the engine already assumes

--- a/docs/architecture-decision-records/20260704-single-node-engine.md
+++ b/docs/architecture-decision-records/20260704-single-node-engine.md
@@ -9,14 +9,14 @@ the engine (Kubernetes operator / control plane), not inside it.
 
 ## Context
 
-Data-integration systems that put distribution *inside* the engine pay for it forever. Kafka
+Data-integration systems that put distribution _inside_ the engine pay for it forever. Kafka
 Connect's rebalance protocol is the canonical example: worker-cluster membership and task
 rebalancing are a persistent source of operational pain, stop-the-world pauses, and subtle
 correctness bugs. We want Conduit to be boring to operate (Principle 4), embeddable as a library
 (a differentiator), and free of that class of failure.
 
 At the same time, real deployments need scale-out and high availability. The question is not
-*whether* Conduit distributes, but *where the distribution logic lives*.
+_whether_ Conduit distributes, but _where the distribution logic lives_.
 
 Two forces are in tension:
 
@@ -67,5 +67,5 @@ the commercial layer.
 
 - `ROADMAP.md` — Principle 8 (single-node engine, scale-out by scheduling); Phase 1 partition-
   claim RFC; Phase 3 operator, hot-pipeline parallelism, and active/passive HA
-- [20220121-conduit-plugin-architecture.md](20220121-conduit-plugin-architecture.md) — the
+- [20220121-Conduit-plugin-architecture.md](20220121-conduit-plugin-architecture.md) — the
   built-in/standalone plugin model the engine already assumes

--- a/docs/architecture-decision-records/20260704-wasm-component-model.md
+++ b/docs/architecture-decision-records/20260704-wasm-component-model.md
@@ -1,0 +1,65 @@
+# WASM component model for any-language plugins
+
+## Summary
+
+Conduit's path to any-language connectors and processors is WebAssembly using the WASI Preview 2
+component model, run in-process in the wazero runtime. WASM is the target for standalone plugins
+across languages; the existing gRPC/go-plugin standalone path remains supported, and is the
+first-ship path for languages whose WASM component tooling is still immature (notably Python).
+
+## Context
+
+A core differentiator is that connectors and processors can be written in real languages, and
+that the community — not a central team — builds the long tail of the catalog. Two plugin
+transports are available to us:
+
+- **gRPC via go-plugin** (today's standalone model): a separate process, language-agnostic,
+  mature, but requires a sidecar process and its lifecycle, and pays serialization and IPC costs.
+- **WASM**: a single portable, sandboxed artifact that runs in-process with no sidecar. The WASI
+  Preview 2 component model gives us typed interfaces (WIT) across languages, which fits a
+  multi-language SDK strategy far better than raw core WASM.
+
+Standalone processors already run as WASM in wazero. Connectors do not yet — they use the
+gRPC/go-plugin path. The component model is maturing at different rates per language: Rust and
+Go/TinyGo are ready, TypeScript via componentize-js is workable, Python's component tooling lags.
+
+## Decision
+
+Adopt the WASI Preview 2 component model as the primary any-language plugin architecture.
+
+- **Interfaces are defined in WIT** and shared across language SDKs, giving typed, portable
+  contracts rather than per-language ad hoc bindings.
+- **wazero is the runtime** — pure-Go, no CGo, embeddable, consistent with the single static
+  binary and library-embedding goals.
+- **WASM connectors** extend the model that WASM processors already use: in-process, sandboxed,
+  a single portable artifact, no gRPC sidecar.
+- **gRPC/go-plugin stays supported** and is the pragmatic first-ship path where WASM component
+  tooling is immature. Python ships on the gRPC standalone path first, with WASM as a
+  fast-follow; Rust proves the full component-model connector path.
+- The connector protocol changes this implies are breaking-change territory and follow the
+  protocol versioning discipline.
+
+## Consequences
+
+- One portable, sandboxed artifact per plugin, distributable through a registry with signing —
+  no per-platform binaries or sidecar process management for WASM plugins.
+- In-process execution removes IPC/serialization overhead relative to the gRPC path and
+  simplifies the plugin lifecycle.
+- The sandbox gives us a security boundary for community-published plugins by default.
+- We depend on the maturity of per-language component tooling; the SDK rollout order is
+  constrained by it (Rust and Go lead, Python starts on gRPC). This is an accepted, temporary
+  asymmetry, not a permanent two-transport strategy.
+- Maintaining WIT interfaces and multiple SDK toolchains is an ongoing cost; it is the cost of
+  the any-language differentiator and is accepted.
+- Plugins needing host capabilities beyond what WASI Preview 2 exposes may be blocked until the
+  relevant WASI proposals land; such gaps are documented rather than worked around with bespoke
+  host escapes.
+
+## Related
+
+- `ROADMAP.md` — Phase 1 "WASM everywhere," WASI Preview 2 / component model adoption, SDK
+  rollout order
+- [20220121-conduit-plugin-architecture.md](20220121-conduit-plugin-architecture.md) — the
+  built-in vs. standalone dispenser model this builds on
+- [20260704-no-bespoke-dsl.md](20260704-no-bespoke-dsl.md) — WASM is what makes real-language
+  transformations portable, so no DSL is needed

--- a/docs/architecture-decision-records/20260704-wasm-component-model.md
+++ b/docs/architecture-decision-records/20260704-wasm-component-model.md
@@ -59,7 +59,7 @@ Adopt the WASI Preview 2 component model as the primary any-language plugin arch
 
 - `ROADMAP.md` — Phase 1 "WASM everywhere," WASI Preview 2 / component model adoption, SDK
   rollout order
-- [20220121-conduit-plugin-architecture.md](20220121-conduit-plugin-architecture.md) — the
+- [20220121-Conduit-plugin-architecture.md](20220121-conduit-plugin-architecture.md) — the
   built-in vs. standalone dispenser model this builds on
 - [20260704-no-bespoke-dsl.md](20260704-no-bespoke-dsl.md) — WASM is what makes real-language
   transformations portable, so no DSL is needed


### PR DESCRIPTION
Establishes the operating context and public direction for the Conduit revival. Docs-only; no code changes.

## What's here
- **CLAUDE.md** — operational context for contributors and agents: repo conventions (matched to the existing `docs/architecture-decision-records/` and `docs/design-documents/` layout), the data-integrity invariants, testing standards, a risk-tiered PR process, workflows, and definition of done. The PR-process gates are explicitly tiered to the current maintainer reality via a "Process maturity" table (live-now vs. by-Phase), so the doc stays honestly enforceable rather than aspirational. Points to a gitignored `STRATEGY.md` for internal positioning material (not in this PR by design).
- **ROADMAP.md** — public phased roadmap (Phase 0 revival → Phase 3 stateful processing & scale), principles, and the open-source/enterprise line stated in the open.
- **GOVERNANCE.md** — Apache-2.0 commitment with the one-way ratchet, the contributor→reviewer→maintainer ladder, and a lazy-consensus decision process.
- **docs/architecture-decision-records/2026070*.md** — four foundational ADRs in the repo's existing date-prefixed format, recording decisions already made: single-node engine (distribution via the scheduling layer), no bespoke DSL, WASM component model, and local-state-only processing.

## Risk tier
Tier 3 (docs). No runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)