### PR TITLE
fix(connector): stay backwards compatible with pre-lifecycle connectors (#1999)

### DIFF
--- a/pkg/connector/destination.go
+++ b/pkg/connector/destination.go
@@ -315,7 +315,12 @@ func (d *Destination) triggerLifecycleEvent(ctx context.Context, oldConfig, newC
 	}
 
 	defer func() {
-		if cerrors.Is(err, plugin.ErrUnimplemented) {
+		// Older connectors that predate the lifecycle methods return an
+		// "Unimplemented" gRPC status, which the protocol client unwraps into
+		// pconnector.ErrUnimplemented (a distinct sentinel from plugin.ErrUnimplemented,
+		// despite the identical message). Match pconnector's sentinel so we stay
+		// backwards compatible instead of fatally erroring. See issue #1999.
+		if cerrors.Is(err, pconnector.ErrUnimplemented) {
 			d.Instance.logger.Trace(ctx).Msg("lifecycle events not implemented on destination connector plugin (it's probably an older connector)")
 			err = nil // ignore error to stay backwards compatible
 		}

--- a/pkg/connector/destination_test.go
+++ b/pkg/connector/destination_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/conduitio/conduit-connector-protocol/pconnector"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/log"
-	"github.com/conduitio/conduit/pkg/plugin"
 	"github.com/conduitio/conduit/pkg/plugin/connector/builtin"
 	"github.com/conduitio/conduit/pkg/plugin/connector/mock"
 	"github.com/matryer/is"
@@ -156,6 +155,33 @@ func TestDestination_LifecycleOnDeleted_Success(t *testing.T) {
 	is.NoErr(err)
 }
 
+func TestDestination_LifecycleOnCreated_BackwardsCompatibility(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	dest, destinationMock := newTestDestination(ctx, t, ctrl)
+
+	// before plugin is started we expect LastActiveConfig to be empty
+	is.Equal(dest.Instance.LastActiveConfig, Config{})
+
+	_ = expectDestinationOpen(dest, destinationMock)
+
+	// An older connector that predates lifecycle events returns
+	// pconnector.ErrUnimplemented (the "Unimplemented" gRPC status, unwrapped by
+	// the protocol client). Conduit must treat this as backwards compatible and
+	// open the destination without a fatal error. Regression test for #1999 —
+	// this is the exact path (created event during Open) that was crashing real
+	// pipelines against older connectors.
+	destinationMock.EXPECT().LifecycleOnCreated(
+		gomock.Any(),
+		pconnector.DestinationLifecycleOnCreatedRequest{Config: dest.Instance.Config.Settings},
+	).Return(pconnector.DestinationLifecycleOnCreatedResponse{}, pconnector.ErrUnimplemented)
+
+	err := dest.Open(ctx)
+	is.NoErr(err)
+}
+
 func TestDestination_LifecycleOnDeleted_BackwardsCompatibility(t *testing.T) {
 	is := is.New(t)
 	ctx := context.Background()
@@ -166,11 +192,13 @@ func TestDestination_LifecycleOnDeleted_BackwardsCompatibility(t *testing.T) {
 	// assume that there was a config already active, but with different settings
 	dest.Instance.LastActiveConfig.Settings = map[string]string{"last-active": "yes"}
 
-	// we should ignore the error if the plugin does not implement lifecycle events
+	// we should ignore the error if the plugin does not implement lifecycle
+	// events. Older connectors surface this as pconnector.ErrUnimplemented (see
+	// the trigger in destination.go and issue #1999).
 	destinationMock.EXPECT().LifecycleOnDeleted(
 		gomock.Any(),
 		pconnector.DestinationLifecycleOnDeletedRequest{Config: dest.Instance.LastActiveConfig.Settings},
-	).Return(pconnector.DestinationLifecycleOnDeletedResponse{}, plugin.ErrUnimplemented)
+	).Return(pconnector.DestinationLifecycleOnDeletedResponse{}, pconnector.ErrUnimplemented)
 
 	destinationMock.EXPECT().Teardown(gomock.Any(), pconnector.DestinationTeardownRequest{}).Return(pconnector.DestinationTeardownResponse{}, nil)
 

--- a/pkg/connector/source.go
+++ b/pkg/connector/source.go
@@ -330,7 +330,12 @@ func (s *Source) triggerLifecycleEvent(ctx context.Context, oldConfig, newConfig
 	}
 
 	defer func() {
-		if cerrors.Is(err, plugin.ErrUnimplemented) {
+		// Older connectors that predate the lifecycle methods return an
+		// "Unimplemented" gRPC status, which the protocol client unwraps into
+		// pconnector.ErrUnimplemented (a distinct sentinel from plugin.ErrUnimplemented,
+		// despite the identical message). Match pconnector's sentinel so we stay
+		// backwards compatible instead of fatally erroring. See issue #1999.
+		if cerrors.Is(err, pconnector.ErrUnimplemented) {
 			s.Instance.logger.Trace(ctx).Msg("lifecycle events not implemented on source connector plugin (it's probably an older connector)")
 			err = nil // ignore error to stay backwards compatible
 		}

--- a/pkg/connector/source_test.go
+++ b/pkg/connector/source_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/conduitio/conduit-connector-protocol/pconnector"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/log"
-	"github.com/conduitio/conduit/pkg/plugin"
 	"github.com/conduitio/conduit/pkg/plugin/connector/builtin"
 	"github.com/conduitio/conduit/pkg/plugin/connector/mock"
 	"github.com/matryer/is"
@@ -157,6 +156,33 @@ func TestSource_LifecycleOnDeleted_Success(t *testing.T) {
 	is.NoErr(err)
 }
 
+func TestSource_LifecycleOnCreated_BackwardsCompatibility(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	src, sourceMock := newTestSource(ctx, t, ctrl)
+
+	// before plugin is started we expect LastActiveConfig to be empty
+	is.Equal(src.Instance.LastActiveConfig, Config{})
+
+	_ = expectSourceOpen(src, sourceMock)
+
+	// An older connector that predates lifecycle events returns
+	// pconnector.ErrUnimplemented (the "Unimplemented" gRPC status, unwrapped by
+	// the protocol client). Conduit must treat this as backwards compatible and
+	// open the source without a fatal error. Regression test for #1999 — this is
+	// the exact path (created event during Open) that was crashing real
+	// pipelines against older connectors.
+	sourceMock.EXPECT().LifecycleOnCreated(
+		gomock.Any(),
+		pconnector.SourceLifecycleOnCreatedRequest{Config: src.Instance.Config.Settings},
+	).Return(pconnector.SourceLifecycleOnCreatedResponse{}, pconnector.ErrUnimplemented)
+
+	err := src.Open(ctx)
+	is.NoErr(err)
+}
+
 func TestSource_LifecycleOnDeleted_BackwardsCompatibility(t *testing.T) {
 	is := is.New(t)
 	ctx := context.Background()
@@ -167,11 +193,13 @@ func TestSource_LifecycleOnDeleted_BackwardsCompatibility(t *testing.T) {
 	// assume that there was a config already active, but with different settings
 	src.Instance.LastActiveConfig.Settings = map[string]string{"last-active": "yes"}
 
-	// we should ignore the error if the plugin does not implement lifecycle events
+	// we should ignore the error if the plugin does not implement lifecycle
+	// events. Older connectors surface this as pconnector.ErrUnimplemented (see
+	// the trigger in source.go and issue #1999).
 	sourceMock.EXPECT().LifecycleOnDeleted(
 		gomock.Any(),
 		pconnector.SourceLifecycleOnDeletedRequest{Config: src.Instance.LastActiveConfig.Settings},
-	).Return(pconnector.SourceLifecycleOnDeletedResponse{}, plugin.ErrUnimplemented)
+	).Return(pconnector.SourceLifecycleOnDeletedResponse{}, pconnector.ErrUnimplemented)
 
 	sourceMock.EXPECT().Teardown(gomock.Any(), pconnector.SourceTeardownRequest{}).Return(pconnector.SourceTeardownResponse{}, nil)
 


### PR DESCRIPTION
Fixes #1999.

## The bug
Older connectors that predate the lifecycle methods (`OnCreated`/`OnUpdated`/`OnDeleted`) return an `Unimplemented` gRPC status. Conduit is meant to treat that as backwards compatible and continue — but the guard in `triggerLifecycleEvent` checked the wrong sentinel:

```go
if cerrors.Is(err, plugin.ErrUnimplemented) { ... } // never matches
```

Since the connector-protocol v2 migration (commit `06bd6e5`), the standalone gRPC client unwraps an `Unimplemented` status into **`pconnector.ErrUnimplemented`** — a distinct value from `plugin.ErrUnimplemented`, despite the identical `"method not implemented"` message. `errors.Is` compares by identity, so the guard never matched and every real pre-lifecycle connector hit the fatal path on `Open`:

```
could not open destination connector: error while triggering lifecycle event
"created": unknown method LifecycleOnCreated ... method not implemented
```

This crashed real pipelines (the reporter hit it on postgres → elasticsearch with an older elasticsearch connector).

## The fix
Match `pconnector.ErrUnimplemented`, the sentinel that actually flows on the connector path, in both `source.go` and `destination.go`. A comment at each site documents the two-sentinel trap so it can't regress on the next protocol bump.

## Why not match both sentinels?
`plugin.ErrUnimplemented` is not returned anywhere under `pkg/plugin/connector/` (verified by grep), and the built-in path is a no-op through the SDK — so it can't reach this guard. Matching only `pconnector.ErrUnimplemented` is complete for this path and keeps the intent unambiguous.

## Tests
- The existing `*_LifecycleOnDeleted_BackwardsCompatibility` tests mocked the **dead** `plugin.ErrUnimplemented` sentinel — which is exactly why they passed while the bug shipped. They now exercise `pconnector.ErrUnimplemented`.
- Added `Test{Source,Destination}_LifecycleOnCreated_BackwardsCompatibility` covering the exact reported path (created event during `Open`).
- **Verified the regression tests fail against the old sentinel and pass with the fix** (reverted the production change locally; all four backward-compat tests failed reproducing the #1999 symptom — connector tears down instead of opening — then passed once restored).
- `go test -race ./pkg/connector/` green; `go vet` and `gofmt` clean.

## Risk tier
Tier 2 (connector-protocol backwards-compat), but it leans Tier 1 in impact — `triggerLifecycleEvent` fires on every `Open`/config-update, so this can fatally crash a connector node mid-restart. Requesting human maintainer sign-off accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)