### PR TITLE
fix(provisioning): don't delete embedder-provisioned pipelines on restart (#1274)

### DIFF
--- a/pkg/provisioning/import.go
+++ b/pkg/provisioning/import.go
@@ -25,14 +25,26 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
-// Import takes a pipeline config and imports it into Conduit.
+// Import takes a pipeline config and imports it into Conduit. Pipelines imported
+// this way are tagged with ProvisionTypeAPI, so they are treated as
+// programmatically provisioned and are NOT removed by the config-file
+// reconciliation on restart (see #1274). The config-file provisioning path uses
+// importPipeline with ProvisionTypeConfig instead.
 func (s *Service) Import(ctx context.Context, newConfig config.Pipeline) error {
+	return s.importPipeline(ctx, newConfig, pipeline.ProvisionTypeAPI)
+}
+
+// importPipeline imports a pipeline config, tagging any newly created pipeline
+// with the given provision type.
+func (s *Service) importPipeline(ctx context.Context, newConfig config.Pipeline, provisionedBy pipeline.ProvisionType) error {
 	oldConfig, err := s.Export(ctx, newConfig.ID)
 	if err != nil && !cerrors.Is(err, pipeline.ErrInstanceNotFound) {
 		return cerrors.Errorf("could not export pipeline with ID %v, this could mean the Conduit state is corrupted: %w", err)
 	}
 
-	actions := s.newActionsBuilder().Build(oldConfig, newConfig)
+	builder := s.newActionsBuilder()
+	builder.pipelineProvisionType = provisionedBy
+	actions := builder.Build(oldConfig, newConfig)
 
 	failedActionIndex, err := s.executeActions(ctx, actions)
 	if err != nil {
@@ -80,6 +92,9 @@ func (s *Service) rollbackActions(ctx context.Context, actions []action) bool {
 
 func (s *Service) newActionsBuilder() actionsBuilder {
 	return actionsBuilder{
+		// default to config-file provisioning; importPipeline overrides this for
+		// programmatic (API) imports. See #1274.
+		pipelineProvisionType:  pipeline.ProvisionTypeConfig,
 		pipelineService:        s.pipelineService,
 		connectorService:       s.connectorService,
 		processorService:       s.processorService,
@@ -88,6 +103,7 @@ func (s *Service) newActionsBuilder() actionsBuilder {
 }
 
 type actionsBuilder struct {
+	pipelineProvisionType  pipeline.ProvisionType
 	pipelineService        PipelineService
 	connectorService       ConnectorService
 	processorService       ProcessorService
@@ -200,6 +216,7 @@ func (ab actionsBuilder) preparePipelineActions(oldConfig, newConfig config.Pipe
 		// no old config, it's a brand new pipeline
 		return []action{createPipelineAction{
 			cfg:             newConfig,
+			provisionedBy:   ab.pipelineProvisionType,
 			pipelineService: ab.pipelineService,
 		}}
 	} else if newConfig.ID == "" {

--- a/pkg/provisioning/import.go
+++ b/pkg/provisioning/import.go
@@ -220,9 +220,12 @@ func (ab actionsBuilder) preparePipelineActions(oldConfig, newConfig config.Pipe
 			pipelineService: ab.pipelineService,
 		}}
 	} else if newConfig.ID == "" {
-		// no new config, it's an old pipeline that needs to be deleted
+		// no new config, it's an old pipeline that needs to be deleted.
+		// provisionedBy is carried so that a rollback of this delete recreates the
+		// pipeline with its original provision type (the zero value would be API).
 		return []action{deletePipelineAction{
 			cfg:             oldConfig,
+			provisionedBy:   ab.pipelineProvisionType,
 			pipelineService: ab.pipelineService,
 		}}
 	}

--- a/pkg/provisioning/import_actions.go
+++ b/pkg/provisioning/import_actions.go
@@ -40,6 +40,11 @@ type action interface {
 
 type createPipelineAction struct {
 	cfg config.Pipeline
+	// provisionedBy records how the pipeline was provisioned. Config-file
+	// provisioning uses ProvisionTypeConfig (subject to reconciliation/deletion
+	// on restart); programmatic callers of Import use ProvisionTypeAPI so their
+	// pipelines survive restarts (see #1274).
+	provisionedBy pipeline.ProvisionType
 
 	pipelineService PipelineService
 }
@@ -52,7 +57,7 @@ func (a createPipelineAction) Do(ctx context.Context) error {
 	_, err := a.pipelineService.Create(ctx, a.cfg.ID, pipeline.Config{
 		Name:        a.cfg.Name,
 		Description: a.cfg.Description,
-	}, pipeline.ProvisionTypeConfig)
+	}, a.provisionedBy)
 	if err != nil {
 		return cerrors.Errorf("failed to create pipeline: %w", err)
 	}

--- a/pkg/provisioning/import_actions_test.go
+++ b/pkg/provisioning/import_actions_test.go
@@ -68,6 +68,7 @@ func TestCreatePipelineAction_Do(t *testing.T) {
 
 	a := createPipelineAction{
 		cfg:             haveCfg,
+		provisionedBy:   pipeline.ProvisionTypeConfig,
 		pipelineService: pipSrv,
 	}
 	err := a.Do(ctx)
@@ -254,6 +255,7 @@ func TestDeletePipelineAction_Rollback(t *testing.T) {
 
 	a := deletePipelineAction{
 		cfg:             haveCfg,
+		provisionedBy:   pipeline.ProvisionTypeConfig,
 		pipelineService: pipSrv,
 	}
 	err := a.Rollback(ctx)

--- a/pkg/provisioning/import_test.go
+++ b/pkg/provisioning/import_test.go
@@ -402,6 +402,25 @@ func TestService_Import_ProvisionType(t *testing.T) {
 	}
 }
 
+// TestService_deleteOldPipelines_SkipsNonConfig pins the other half of #1274: the
+// restart reconciliation sweep must not delete a pipeline that isn't config-file
+// provisioned (e.g. one created by an embedder via Import, tagged API), even when
+// it is absent from the current config files. gomock fails if Delete is called.
+func TestService_deleteOldPipelines_SkipsNonConfig(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	srv, pipSrv, _, _, _, _ := newTestService(ctrl, log.Nop())
+
+	pipSrv.EXPECT().List(ctx).Return(map[string]*pipeline.Instance{
+		"embedder-pl": {ID: "embedder-pl", ProvisionedBy: pipeline.ProvisionTypeAPI},
+	})
+
+	// keepIDs is empty: the pipeline is in no config file, yet must survive.
+	deleted := srv.deleteOldPipelines(ctx, nil)
+	is.Equal(len(deleted), 0)
+}
+
 func TestActionsBuilder_PreparePipelineActions_Delete(t *testing.T) {
 	is := is.New(t)
 	logger := log.Nop()
@@ -413,7 +432,10 @@ func TestActionsBuilder_PreparePipelineActions_Delete(t *testing.T) {
 	newConfig := config.Pipeline{}
 
 	want := []action{deletePipelineAction{
-		cfg:             oldConfig,
+		cfg: oldConfig,
+		// the delete action must carry the builder's provision type so a rollback
+		// recreates the pipeline with the correct type (not the API zero value)
+		provisionedBy:   pipeline.ProvisionTypeConfig,
 		pipelineService: pipSrv,
 	}}
 

--- a/pkg/provisioning/import_test.go
+++ b/pkg/provisioning/import_test.go
@@ -19,8 +19,10 @@ import (
 	"testing"
 
 	"github.com/conduitio/conduit-commons/database/inmemory"
+	"github.com/conduitio/conduit-commons/lang"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/pipeline"
 	"github.com/conduitio/conduit/pkg/processor"
 	"github.com/conduitio/conduit/pkg/provisioning/config"
 	"github.com/conduitio/conduit/pkg/provisioning/mock"
@@ -342,11 +344,62 @@ func TestActionsBuilder_PreparePipelineActions_Create(t *testing.T) {
 
 	want := []action{createPipelineAction{
 		cfg:             newConfig,
+		provisionedBy:   pipeline.ProvisionTypeConfig,
 		pipelineService: pipSrv,
 	}}
 
 	got := srv.newActionsBuilder().preparePipelineActions(oldConfig, newConfig)
 	is.Equal(got, want)
+}
+
+// TestService_Import_ProvisionType is the regression test for #1274: pipelines
+// created via the public Import method (used by embedders) must be tagged
+// ProvisionTypeAPI so the config-file reconciliation does not delete them on
+// restart, while the config-file path keeps tagging as ProvisionTypeConfig.
+// Previously Import hardcoded ProvisionTypeConfig, so embedder-provisioned
+// pipelines were swept on restart.
+func TestService_Import_ProvisionType(t *testing.T) {
+	newCfg := func() config.Pipeline {
+		return config.Pipeline{
+			ID:   "p-" + uuid.NewString(),
+			Name: "test",
+			DLQ:  config.DLQ{WindowSize: lang.Ptr(1), WindowNackThreshold: lang.Ptr(0)},
+		}
+	}
+	testCases := []struct {
+		name string
+		do   func(s *Service, ctx context.Context, cfg config.Pipeline) error
+		want pipeline.ProvisionType
+	}{
+		{
+			"public Import tags API",
+			func(s *Service, ctx context.Context, cfg config.Pipeline) error { return s.Import(ctx, cfg) },
+			pipeline.ProvisionTypeAPI,
+		},
+		{
+			"config-file path tags Config",
+			func(s *Service, ctx context.Context, cfg config.Pipeline) error {
+				return s.importPipeline(ctx, cfg, pipeline.ProvisionTypeConfig)
+			},
+			pipeline.ProvisionTypeConfig,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			ctx := context.Background()
+			ctrl := gomock.NewController(t)
+			srv, pipSrv, _, _, _, _ := newTestService(ctrl, log.Nop())
+			cfg := newCfg()
+
+			pipSrv.EXPECT().Get(ctx, cfg.ID).Return(nil, pipeline.ErrInstanceNotFound)
+			// gomock fails the test if Create is called with any other provision type.
+			pipSrv.EXPECT().Create(ctx, cfg.ID, gomock.Any(), tc.want)
+			pipSrv.EXPECT().UpdateDLQ(ctx, cfg.ID, gomock.Any())
+
+			is.NoErr(tc.do(srv, ctx, cfg))
+		})
+	}
 }
 
 func TestActionsBuilder_PreparePipelineActions_Delete(t *testing.T) {

--- a/pkg/provisioning/service.go
+++ b/pkg/provisioning/service.go
@@ -288,7 +288,9 @@ func (s *Service) provisionPipeline(ctx context.Context, cfg config.Pipeline) er
 	}
 	defer txn.Discard()
 
-	err = s.Import(importCtx, cfg)
+	// config-file provisioning tags pipelines as ProvisionTypeConfig so they are
+	// reconciled (and removed if they disappear from the config files) on restart.
+	err = s.importPipeline(importCtx, cfg, pipeline.ProvisionTypeConfig)
 	if err != nil {
 		return cerrors.Errorf("could not import pipeline: %w", err)
 	}


### PR DESCRIPTION
Closes #1274.

## Problem
`createPipelineAction` hardcoded `pipeline.ProvisionTypeConfig`, so **every** pipeline created through `Import` — including programmatic calls by applications **embedding** Conduit — was tagged as config-file-provisioned. On restart, `Init`'s `deleteOldPipelines` deletes any `ProvisionTypeConfig` pipeline not present in the config files, so embedder-provisioned pipelines were silently removed. (The HTTP/gRPC API path was fine — it tags `ProvisionTypeAPI` directly.)

## Fix
Thread the provision type through the import path:
- `createPipelineAction` gains a `provisionedBy` field, used in `Do()` instead of the hardcoded constant; `deletePipelineAction` (a type alias of it) reuses it on rollback.
- `actionsBuilder` carries the pipeline provision type; `newActionsBuilder` **defaults to `ProvisionTypeConfig`** so all existing behavior is preserved.
- The **public `Import`** now tags `ProvisionTypeAPI` (programmatic pipelines survive restart); the **config-file path** (`provisionPipeline`) calls the internal `importPipeline` with `ProvisionTypeConfig` so reconciliation still works.

Only the *pipeline* provision type matters: there's no independent connector/processor reconciliation sweep, and deleting a pipeline cascades to its connectors — so tagging the pipeline is sufficient (minimal blast radius).

## Tests
- `TestService_Import_ProvisionType` — table-driven: the public `Import` tags `API`, the config-file path tags `Config`. **Verified to fail against the previous hardcoded behavior** (the API case) and pass with the fix.
- Existing action-level tests updated for the new field; full `pkg/provisioning/...` suite passes; `golangci-lint` clean.

## Risk tier
Tier 2 (provisioning path, not the runtime record path). Behavior-preserving for config-file provisioning (still `Config`); the only change is that programmatic `Import` callers now correctly get `API`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)