### PR TITLE
fix(provisioning): honor status:stopped for a previously-running pipeline (#2061)

### DIFF
--- a/pkg/provisioning/import_test.go
+++ b/pkg/provisioning/import_test.go
@@ -421,6 +421,38 @@ func TestService_deleteOldPipelines_SkipsNonConfig(t *testing.T) {
 	is.Equal(len(deleted), 0)
 }
 
+// TestService_provisionPipeline_StatusStopped is the regression test for #2061: a
+// pipeline whose config says `status: stopped` must not be resumed on restart. A
+// pipeline that was running before the restart is marked StatusSystemStopped (the
+// lifecycle auto-resume marker); provisioning must convert it to StatusUserStopped
+// so the lifecycle service leaves it stopped, and must never call Start.
+func TestService_provisionPipeline_StatusStopped(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	srv, pipSrv, _, _, _, _ := newTestService(ctrl, log.Nop())
+
+	// existing pipeline, was running before the restart -> now SystemStopped, with
+	// a config identical to the incoming one so the import produces no actions.
+	instance := &pipeline.Instance{
+		ID:            "p1",
+		Config:        pipeline.Config{Name: "p1"},
+		DLQ:           pipeline.DefaultDLQ,
+		ProvisionedBy: pipeline.ProvisionTypeConfig,
+	}
+	instance.SetStatus(pipeline.StatusSystemStopped)
+	cfg := config.Pipeline{ID: "p1", Status: config.StatusStopped}
+
+	pipSrv.EXPECT().Get(gomock.Any(), "p1").Return(instance, nil).AnyTimes()
+	// the fix: convert the SystemStopped marker to UserStopped so lifecycle.Init
+	// does not resume it. gomock has no Start expectation on lifecycleService, so
+	// the test fails if the pipeline is (wrongly) started.
+	pipSrv.EXPECT().UpdateStatus(gomock.Any(), "p1", pipeline.StatusUserStopped, "")
+
+	err := srv.provisionPipeline(ctx, cfg)
+	is.NoErr(err)
+}
+
 func TestActionsBuilder_PreparePipelineActions_Delete(t *testing.T) {
 	is := is.New(t)
 	logger := log.Nop()

--- a/pkg/provisioning/import_test.go
+++ b/pkg/provisioning/import_test.go
@@ -422,35 +422,51 @@ func TestService_deleteOldPipelines_SkipsNonConfig(t *testing.T) {
 }
 
 // TestService_provisionPipeline_StatusStopped is the regression test for #2061: a
-// pipeline whose config says `status: stopped` must not be resumed on restart. A
-// pipeline that was running before the restart is marked StatusSystemStopped (the
-// lifecycle auto-resume marker); provisioning must convert it to StatusUserStopped
-// so the lifecycle service leaves it stopped, and must never call Start.
+// pipeline whose config says `status: stopped` must not be resumed on restart.
+// Only the StatusSystemStopped auto-resume marker is converted to StatusUserStopped
+// (the necessary-and-sufficient state); other statuses are left as-is. In every
+// case the pipeline must not be started (lifecycleService has no Start expectation,
+// so gomock fails the test if Start is called).
 func TestService_provisionPipeline_StatusStopped(t *testing.T) {
-	is := is.New(t)
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-	srv, pipSrv, _, _, _, _ := newTestService(ctrl, log.Nop())
-
-	// existing pipeline, was running before the restart -> now SystemStopped, with
-	// a config identical to the incoming one so the import produces no actions.
-	instance := &pipeline.Instance{
-		ID:            "p1",
-		Config:        pipeline.Config{Name: "p1"},
-		DLQ:           pipeline.DefaultDLQ,
-		ProvisionedBy: pipeline.ProvisionTypeConfig,
+	testCases := []struct {
+		name          string
+		status        pipeline.Status
+		wantConverted bool // whether UpdateStatus(UserStopped) is expected
+	}{
+		// was running before restart -> SystemStopped -> must be converted so
+		// lifecycle.Init does not auto-resume it (the #2061 bug)
+		{"SystemStopped is converted to UserStopped", pipeline.StatusSystemStopped, true},
+		// already user-stopped: nothing to do, guard must skip
+		{"UserStopped is left alone", pipeline.StatusUserStopped, false},
+		// crashed while degraded: functionally stopped already, guard must skip
+		{"Degraded is left alone", pipeline.StatusDegraded, false},
 	}
-	instance.SetStatus(pipeline.StatusSystemStopped)
-	cfg := config.Pipeline{ID: "p1", Status: config.StatusStopped}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			ctx := context.Background()
+			ctrl := gomock.NewController(t)
+			srv, pipSrv, _, _, _, _ := newTestService(ctrl, log.Nop())
 
-	pipSrv.EXPECT().Get(gomock.Any(), "p1").Return(instance, nil).AnyTimes()
-	// the fix: convert the SystemStopped marker to UserStopped so lifecycle.Init
-	// does not resume it. gomock has no Start expectation on lifecycleService, so
-	// the test fails if the pipeline is (wrongly) started.
-	pipSrv.EXPECT().UpdateStatus(gomock.Any(), "p1", pipeline.StatusUserStopped, "")
+			// existing pipeline with a config identical to the incoming one, so the
+			// import produces no actions and the test isolates the status handling.
+			instance := &pipeline.Instance{
+				ID:            "p1",
+				Config:        pipeline.Config{Name: "p1"},
+				DLQ:           pipeline.DefaultDLQ,
+				ProvisionedBy: pipeline.ProvisionTypeConfig,
+			}
+			instance.SetStatus(tc.status)
+			cfg := config.Pipeline{ID: "p1", Status: config.StatusStopped}
 
-	err := srv.provisionPipeline(ctx, cfg)
-	is.NoErr(err)
+			pipSrv.EXPECT().Get(gomock.Any(), "p1").Return(instance, nil).AnyTimes()
+			if tc.wantConverted {
+				pipSrv.EXPECT().UpdateStatus(gomock.Any(), "p1", pipeline.StatusUserStopped, "")
+			}
+
+			is.NoErr(srv.provisionPipeline(ctx, cfg))
+		})
+	}
 }
 
 func TestActionsBuilder_PreparePipelineActions_Delete(t *testing.T) {

--- a/pkg/provisioning/interfaces.go
+++ b/pkg/provisioning/interfaces.go
@@ -31,6 +31,7 @@ type PipelineService interface {
 	List(ctx context.Context) map[string]*pipeline.Instance
 	Create(ctx context.Context, id string, cfg pipeline.Config, p pipeline.ProvisionType) (*pipeline.Instance, error)
 	Update(ctx context.Context, pipelineID string, cfg pipeline.Config) (*pipeline.Instance, error)
+	UpdateStatus(ctx context.Context, pipelineID string, status pipeline.Status, errMsg string) error
 	Delete(ctx context.Context, pipelineID string) error
 	UpdateDLQ(ctx context.Context, pipelineID string, cfg pipeline.DLQ) (*pipeline.Instance, error)
 

--- a/pkg/provisioning/mock/provisioning.go
+++ b/pkg/provisioning/mock/provisioning.go
@@ -433,6 +433,44 @@ func (c *PipelineServiceUpdateDLQCall) DoAndReturn(f func(context.Context, strin
 	return c
 }
 
+// UpdateStatus mocks base method.
+func (m *PipelineService) UpdateStatus(ctx context.Context, pipelineID string, status pipeline.Status, errMsg string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateStatus", ctx, pipelineID, status, errMsg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateStatus indicates an expected call of UpdateStatus.
+func (mr *PipelineServiceMockRecorder) UpdateStatus(ctx, pipelineID, status, errMsg any) *PipelineServiceUpdateStatusCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStatus", reflect.TypeOf((*PipelineService)(nil).UpdateStatus), ctx, pipelineID, status, errMsg)
+	return &PipelineServiceUpdateStatusCall{Call: call}
+}
+
+// PipelineServiceUpdateStatusCall wrap *gomock.Call
+type PipelineServiceUpdateStatusCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *PipelineServiceUpdateStatusCall) Return(arg0 error) *PipelineServiceUpdateStatusCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *PipelineServiceUpdateStatusCall) Do(f func(context.Context, string, pipeline.Status, string) error) *PipelineServiceUpdateStatusCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *PipelineServiceUpdateStatusCall) DoAndReturn(f func(context.Context, string, pipeline.Status, string) error) *PipelineServiceUpdateStatusCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ConnectorService is a mock of ConnectorService interface.
 type ConnectorService struct {
 	ctrl     *gomock.Controller

--- a/pkg/provisioning/service.go
+++ b/pkg/provisioning/service.go
@@ -302,10 +302,26 @@ func (s *Service) provisionPipeline(ctx context.Context, cfg config.Pipeline) er
 	}
 
 	// check if pipeline should be running
-	if cfg.Status == config.StatusRunning {
+	switch cfg.Status {
+	case config.StatusRunning:
 		err := s.lifecycleService.Start(ctx, cfg.ID)
 		if err != nil {
 			return cerrors.Errorf("could not start the pipeline %q: %w", cfg.ID, err)
+		}
+	case config.StatusStopped:
+		// The config says this pipeline should be stopped. If it was running
+		// before the restart it is now marked StatusSystemStopped (the marker the
+		// lifecycle service uses to auto-resume pipelines on startup). Convert it
+		// to StatusUserStopped so it is NOT resumed, honoring the config. See #2061.
+		pl, err := s.pipelineService.Get(ctx, cfg.ID)
+		if err != nil {
+			return cerrors.Errorf("could not get pipeline %q: %w", cfg.ID, err)
+		}
+		if pl.GetStatus() == pipeline.StatusSystemStopped {
+			err = s.pipelineService.UpdateStatus(ctx, cfg.ID, pipeline.StatusUserStopped, "")
+			if err != nil {
+				return cerrors.Errorf("could not mark pipeline %q as stopped: %w", cfg.ID, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Closes #2061.

## Problem
When Conduit loads a pipeline persisted as `StatusRunning`, it flips it to `StatusSystemStopped` — the marker the lifecycle service uses to **auto-resume** pipelines that were running before a restart. `provisionPipeline` handled a config `status: running` by starting the pipeline, but had **no handling for `status: stopped`**: it correctly skipped `Start`, yet left the pipeline as `StatusSystemStopped`. The subsequent `lifecycle.Init` then resumed it anyway — so a pipeline the operator marked `stopped` kept running and **writing to its destination** after a restart.

Flow:
1. `pipeline.Service.Init`: `StatusRunning` → `StatusSystemStopped`.
2. `provisionPipeline`: `cfg.Status == stopped` → no `Start`, but the marker is left as `SystemStopped`.
3. `lifecycle.Service.Init`: resumes **all** `SystemStopped` pipelines → runs it despite `status: stopped`.

## Fix
Handle the stopped case in `provisionPipeline`: when the config says `stopped` and the pipeline is `StatusSystemStopped`, convert it to `StatusUserStopped` so `lifecycle.Init` leaves it stopped. Done after the import transaction commits, alongside the existing start-on-running logic. Added `UpdateStatus` to the provisioning `PipelineService` interface (already implemented by `pipeline.Service`) and regenerated the mock.

Only the `SystemStopped` marker is converted — new/already-user-stopped pipelines are untouched, and `running` behavior is unchanged.

## Tests
- `TestService_provisionPipeline_StatusStopped` — a `SystemStopped` pipeline with a `stopped` config is converted to `UserStopped` and **never started** (gomock fails if `Start` is called). **Verified to fail without the fix** (missing `UpdateStatus` call).
- Full `pkg/provisioning/...` suite passes with `-race`; `golangci-lint` clean; generated mock committed.

## Risk tier
**Tier 1** — the bug caused unintended writes to a destination on the data path. The change is narrow (a status-marker conversion during provisioning, after commit, before lifecycle resume) and behavior-preserving for `running` and already-stopped pipelines. Requesting human maintainer sign-off per CLAUDE.md.

## Failure-mode analysis
- Crash between commit and `UpdateStatus`: the pipeline stays `SystemStopped` and would be resumed on the *next* restart — same as today's behavior, no worse; the next successful provision converts it. No data loss (at-least-once is unaffected; this only governs whether a stopped pipeline auto-resumes).
- `UpdateStatus` failure: returns an error from `provisionPipeline`, surfaced by `Init`'s per-pipeline error aggregation; the pipeline is not silently started.
- Does not touch ack/position/checkpoint logic or serialized formats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)