### PR TITLE
docs: bump README install examples to v0.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Download the right `.deb` file for your machine architecture from the
 [latest release](https://github.com/conduitio/conduit/releases/latest), then run:
 
 ```sh
-dpkg -i conduit_0.14.0_Linux_x86_64.deb
+dpkg -i conduit_0.15.0_Linux_x86_64.deb
 ```
 
 ### RPM
@@ -93,7 +93,7 @@ Download the right `.rpm` file for your machine architecture from the
 [latest release](https://github.com/conduitio/conduit/releases/latest), then run:
 
 ```sh
-rpm -i conduit_0.14.0_Linux_x86_64.rpm
+rpm -i conduit_0.15.0_Linux_x86_64.rpm
 ```
 
 ### Build from source


### PR DESCRIPTION
Updates the `.deb`/`.rpm` install-command examples in the README from `0.14.0` to `0.15.0` for the release (the "search and replace the latest version in README.md" step of the release checklist).

Docs-only, Tier 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)