### PR TITLE
fix(docker): update base image to Go 1.25 to unbreak the release Docker build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,15 @@ jobs:
 
       - name: Build linux/386
         run: GOOS=linux GOARCH=386 go build ./...
+
+  docker-build:
+    # Build the release Docker image. The image is otherwise only built by the
+    # release workflow, so a Dockerfile issue (e.g. a base image whose Go version
+    # is older than the go.mod directive) would only surface at release time.
+    name: docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t conduit:ci .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start with a golang base
-FROM golang:1.24-bullseye AS base
+FROM golang:1.25-bookworm AS base
 
 # Build the full app binary
 WORKDIR /app


### PR DESCRIPTION
**The v0.15.0 release Docker build failed on this.** Second (and final) piece of the release blocker.

## What broke
The Dockerfile pinned `golang:1.24-bullseye`, but the go.mod directive is now `1.25` (from the Go 1.25 upgrade in #2507). So `CGO_ENABLED=0 make build` inside the image failed:

```
process "/bin/sh -c CGO_ENABLED=0 make build" did not complete successfully: exit code: 2
```

Regular CI reads `go-version-file: go.mod` (so it installs Go 1.25) **and never builds the Docker image** — the image is only built by the release workflow — so this only surfaced at release time.

## Fix
Bump the base image to **`golang:1.25-bookworm`**. (The `bullseye` variant was dropped for Go 1.25; bookworm is the current Debian base. `CGO_ENABLED=0` produces a static binary copied into the alpine final stage, so the build-stage Debian version doesn't affect the runtime image.)

**Verified end-to-end locally:** ran the exact `docker build .` — the image builds (`Build complete`) and the resulting binary runs (`conduit version` → `v0.15.0`).

## Guard (postmortem follow-up)
Added a **`docker build`** job to `test.yml` so the release image is built on every PR — catching Dockerfile/go.mod mismatches in CI instead of at release. Same class of fix as the `build (linux/386)` guard from #2515. The job passing here is the proof.

## Risk tier
Tier 3 (build infrastructure). No code or dependency change.

## v0.15.0
Once this merges, re-cut the tag on the fixed `main` again — this is the last known release-build issue (binaries fixed in #2515, Docker fixed here; both now guarded in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)