### PR TITLE
feat(api): wire ConduitError into the API error boundary

### DIFF
--- a/pkg/http/api/status/status.go
+++ b/pkg/http/api/status/status.go
@@ -17,6 +17,7 @@ package status
 import (
 	"github.com/conduitio/conduit/pkg/connector"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/orchestrator"
 	"github.com/conduitio/conduit/pkg/pipeline"
 	conn_plugin "github.com/conduitio/conduit/pkg/plugin/connector"
@@ -25,7 +26,24 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 )
 
+// conduitErrorStatus returns the structured gRPC status for a ConduitError in err's
+// chain — its gRPC category plus a google.rpc.ErrorInfo detail carrying the stable
+// reason and any configPath/suggestion/fix — and true if one was found. This is the
+// single point where the ConduitError model reaches the API; boundaries that have
+// not yet been migrated fall through to the sentinel-based code mapping below,
+// unchanged.
+func conduitErrorStatus(err error) (error, bool) {
+	if ce, ok := conduiterr.Get(err); ok {
+		return conduiterr.ToStatus(ce).Err(), true
+	}
+	return nil, false
+}
+
 func PipelineError(err error) error {
+	if s, ok := conduitErrorStatus(err); ok {
+		return s
+	}
+
 	var code codes.Code
 
 	switch {
@@ -41,6 +59,10 @@ func PipelineError(err error) error {
 }
 
 func ConnectorError(err error) error {
+	if s, ok := conduitErrorStatus(err); ok {
+		return s
+	}
+
 	var code codes.Code
 
 	switch {
@@ -56,6 +78,10 @@ func ConnectorError(err error) error {
 }
 
 func ProcessorError(err error) error {
+	if s, ok := conduitErrorStatus(err); ok {
+		return s
+	}
+
 	var code codes.Code
 
 	switch {
@@ -71,6 +97,9 @@ func ProcessorError(err error) error {
 }
 
 func PluginError(err error) error {
+	if s, ok := conduitErrorStatus(err); ok {
+		return s
+	}
 	return grpcstatus.Error(codeFromError(err), err.Error())
 }
 

--- a/pkg/http/api/status/status_test.go
+++ b/pkg/http/api/status/status_test.go
@@ -19,10 +19,12 @@ import (
 
 	"github.com/conduitio/conduit/pkg/connector"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/orchestrator"
 	"github.com/conduitio/conduit/pkg/pipeline"
 	"github.com/conduitio/conduit/pkg/processor"
 	"github.com/matryer/is"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 )
@@ -124,6 +126,45 @@ func TestProcessorError(t *testing.T) {
 			is.Equal(tt.want, ProcessorError(tt.args.err))
 		})
 	}
+}
+
+// TestConduitErrorFlowsThroughBoundary proves the ConduitError foundation reaches
+// the API: a ConduitError (even wrapped) yields a gRPC status with the code's
+// category and an additive google.rpc.ErrorInfo detail carrying the stable reason,
+// configPath, and suggestion.
+func TestConduitErrorFlowsThroughBoundary(t *testing.T) {
+	is := is.New(t)
+
+	ce := conduiterr.New(conduiterr.CodeConnectorPluginNotFound, "connector plugin not found")
+	ce.ConfigPath = "/connectors/0/plugin"
+	ce.Suggestion = "run `conduit connectors install <name>`"
+
+	// wrapped, to prove errors.As finds it through the chain
+	got := PipelineError(cerrors.Errorf("provisioning failed: %w", ce))
+
+	st, ok := grpcstatus.FromError(got)
+	is.True(ok)
+	is.Equal(st.Code(), codes.NotFound) // the code's gRPC category
+
+	var info *errdetails.ErrorInfo
+	for _, d := range st.Details() {
+		if ei, ok := d.(*errdetails.ErrorInfo); ok {
+			info = ei
+		}
+	}
+	is.True(info != nil) // the structured detail is present
+	is.Equal(info.GetReason(), conduiterr.CodeConnectorPluginNotFound.Reason())
+	is.Equal(info.GetDomain(), "conduit")
+	is.Equal(info.GetMetadata()["configPath"], "/connectors/0/plugin")
+	is.Equal(info.GetMetadata()["suggestion"], "run `conduit connectors install <name>`")
+}
+
+// TestNonConduitErrorUnchanged confirms the wiring is additive: a plain sentinel
+// error still maps exactly as before, with no detail.
+func TestNonConduitErrorUnchanged(t *testing.T) {
+	is := is.New(t)
+	got := PipelineError(pipeline.ErrInstanceNotFound)
+	is.Equal(grpcstatus.Error(codes.NotFound, pipeline.ErrInstanceNotFound.Error()), got)
 }
 
 func TestCodeFromError(t *testing.T) {


### PR DESCRIPTION
**Step 2 of the structured-error rollout** (design: `docs/design-documents/20260705-conduit-error-and-structured-output.md`; foundation landed in #2524).

The `ConduitError` foundation now reaches the API. When an error returned to a handler carries a `*ConduitError` anywhere in its chain, `status.go` emits its gRPC category **plus an additive `google.rpc.ErrorInfo` detail** (stable reason, configPath, suggestion, fix) — so an API/MCP/UI consumer gets a machine-actionable error.

## Purely additive
A single integration point (`conduitErrorStatus`, checked at the top of `PipelineError`/`ConnectorError`/`ProcessorError`/`PluginError`). Any error that is **not** a ConduitError falls through to the existing sentinel→code mapping, byte-for-byte unchanged — all existing tests pass. Individual error sources get migrated to emit ConduitError codes incrementally from here (step 3).

## Tests
- A wrapped `ConduitError` → correct gRPC code + `ErrorInfo` detail (reason/configPath/suggestion). Proves the compat path end-to-end at the boundary.
- A sentinel error → maps exactly as before (no detail).

Tier 2 (API boundary, additive, no behavior change for existing errors). Advances #2451 (error codes in the API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)