### PR TITLE
feat: emit pipeline/connector instance_not_found ConduitError codes

### DIFF
--- a/pkg/connector/codes.go
+++ b/pkg/connector/codes.go
@@ -1,0 +1,29 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connector
+
+import (
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"google.golang.org/grpc/codes"
+)
+
+// Connector error codes. Every error carries one of these codes plus a
+// suggested fix, so an API, MCP, or UI consumer knows what happened without
+// parsing message text.
+var (
+	// CodeConnectorNotFound is raised when a referenced connector instance
+	// cannot be located.
+	CodeConnectorNotFound = conduiterr.Register("connector.instance_not_found", codes.NotFound)
+)

--- a/pkg/connector/service.go
+++ b/pkg/connector/service.go
@@ -16,12 +16,14 @@ package connector
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
 
 	"github.com/conduitio/conduit-commons/database"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/foundation/metrics/measure"
 )
@@ -104,7 +106,15 @@ func (s *Service) List(context.Context) map[string]*Instance {
 func (s *Service) Get(_ context.Context, id string) (*Instance, error) {
 	ins, ok := s.connectors[id]
 	if !ok {
-		return nil, cerrors.Errorf("%w (ID: %s)", ErrInstanceNotFound, id)
+		// Invariant: errors.Is(err, ErrInstanceNotFound) still holds — the sentinel
+		// is wrapped, and the ConduitError adds the machine-actionable code.
+		err := conduiterr.Wrap(
+			CodeConnectorNotFound,
+			fmt.Sprintf("connector %q not found", id),
+			ErrInstanceNotFound,
+		)
+		err.Suggestion = "run `conduit connectors list` to see existing connectors"
+		return nil, err
 	}
 	return ins, nil
 }

--- a/pkg/connector/service_test.go
+++ b/pkg/connector/service_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/conduitio/conduit-commons/database/mock"
 	"github.com/conduitio/conduit-commons/opencdc"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	pmock "github.com/conduitio/conduit/pkg/plugin/connector/mock"
 	"github.com/google/uuid"
@@ -423,7 +424,11 @@ func TestService_GetInstanceNotFound(t *testing.T) {
 	// get connector that does not exist
 	got, err := service.Get(ctx, uuid.NewString())
 	is.True(err != nil)
-	is.True(cerrors.Is(err, ErrInstanceNotFound))
+	is.True(cerrors.Is(err, ErrInstanceNotFound)) // sentinel still in the chain
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // now also carries a machine-actionable ConduitError code
+	is.Equal(ce.Code.Reason(), CodeConnectorNotFound.Reason())
+	is.True(ce.Suggestion != "") // with a suggested fix
 	is.Equal(got, nil)
 }
 

--- a/pkg/pipeline/codes.go
+++ b/pkg/pipeline/codes.go
@@ -1,0 +1,29 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"google.golang.org/grpc/codes"
+)
+
+// Pipeline error codes. Every error carries one of these codes plus a
+// suggested fix, so an API, MCP, or UI consumer knows what happened without
+// parsing message text.
+var (
+	// CodePipelineNotFound is raised when a referenced pipeline instance
+	// cannot be located.
+	CodePipelineNotFound = conduiterr.Register("pipeline.instance_not_found", codes.NotFound)
+)

--- a/pkg/pipeline/service.go
+++ b/pkg/pipeline/service.go
@@ -16,12 +16,14 @@ package pipeline
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
 
 	"github.com/conduitio/conduit-commons/database"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/foundation/metrics/measure"
 )
@@ -104,7 +106,15 @@ func (s *Service) List(context.Context) map[string]*Instance {
 func (s *Service) Get(_ context.Context, id string) (*Instance, error) {
 	p, ok := s.instances[id]
 	if !ok {
-		return nil, cerrors.Errorf("%w (ID: %s)", ErrInstanceNotFound, id)
+		// Invariant: errors.Is(err, ErrInstanceNotFound) still holds — the sentinel
+		// is wrapped, and the ConduitError adds the machine-actionable code.
+		err := conduiterr.Wrap(
+			CodePipelineNotFound,
+			fmt.Sprintf("pipeline %q not found", id),
+			ErrInstanceNotFound,
+		)
+		err.Suggestion = "run `conduit pipelines list` to see existing pipelines"
+		return nil, err
 	}
 	return p, nil
 }

--- a/pkg/pipeline/service_test.go
+++ b/pkg/pipeline/service_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/conduitio/conduit-commons/database/inmemory"
 	"github.com/conduitio/conduit-commons/database/mock"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/google/uuid"
 	"github.com/matryer/is"
@@ -312,7 +313,11 @@ func TestService_GetInstanceNotFound(t *testing.T) {
 	// get pipeline instance that does not exist
 	got, err := service.Get(ctx, uuid.NewString())
 	is.True(err != nil)
-	is.True(cerrors.Is(err, ErrInstanceNotFound))
+	is.True(cerrors.Is(err, ErrInstanceNotFound)) // sentinel still in the chain
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // now also carries a machine-actionable ConduitError code
+	is.Equal(ce.Code.Reason(), CodePipelineNotFound.Reason())
+	is.True(ce.Suggestion != "") // with a suggested fix
 	is.Equal(got, nil)
 }
 


### PR DESCRIPTION
## Summary

Step 4 of the structured-error rollout (follows #2528, #2527, #2524). Migrates two more error sources to emit `ConduitError` codes, exercising the API boundary wired in #2527, following the exact pattern used for `connector.plugin_not_found`.

- **`pipeline.ErrInstanceNotFound`** — raised in `pipeline.Service.Get`, the sole construction site (every other method — `Update`, `Delete`, `AddConnector`, `AddProcessor`, etc. — calls `Get` internally, so this single choke point covers all not-found paths). Now wraps with a new code `pipeline.instance_not_found` (`codes.NotFound`, registered in new `pkg/pipeline/codes.go`) and a suggestion to run `conduit pipelines list`.
- **`connector.ErrInstanceNotFound`** — same treatment in `connector.Service.Get` (same choke-point property). New code `connector.instance_not_found` (`codes.NotFound`, registered in new `pkg/connector/codes.go`), suggestion to run `conduit connectors list`.

Both sentinels remain in the error chain via `conduiterr.Wrap(code, msg, sentinel)`, so this is additive and backward-compatible: any error that is *not* one of these two sentinels is unaffected, and existing `errors.Is(err, ErrInstanceNotFound)` checks across `pkg/provisioning`, `pkg/orchestrator`, and `pkg/http/api/status` continue to hold unchanged — no behavior change for consumers that only check `errors.Is`. Consumers reading the error through `conduiterr.Get` now additionally get a stable machine-actionable code + suggestion.

**Deliberately out of scope:** `processor.ErrInstanceNotFound` (`pkg/processor/service.go`) is a separate, un-migrated error source with the same shape — left for a follow-up PR to keep this change's blast radius tight (single choke point in each of two packages, not a third).

## Self-review (adversarial pass, per CLAUDE.md)

- `conduiterr.Wrap`'s "inner ConduitError code wins" branch doesn't fire here — both sentinels are plain `cerrors.New(...)` values, not existing `*ConduitError`s, so the new code is always the one that lands. Confirmed via `Wrap`'s `cerrors.As(cause, &inner)` check.
- No duplicate-registration panic risk: grepped the registry for `instance_not_found` — each reason (`pipeline.instance_not_found`, `connector.instance_not_found`) is registered exactly once.
- No test or call site asserts on the exact `Get`-produced message text (old: `"pipeline instance not found (ID: %s)"`, new: `"pipeline %q not found"`) — everywhere else uses `errors.Is`, not string comparison, so the wording change is safe.
- `pkg/http/api/status/status_test.go`'s existing `TestPipelineError`/`TestConnectorError`/`TestNonConduitErrorUnchanged` cases pass the bare sentinel directly into `PipelineError`/`ConnectorError` (not through `Service.Get`), so they're unaffected by this change and remain green as regression coverage for the "non-ConduitError" fallback path.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/pipeline/... ./pkg/connector/... ./pkg/http/api/status/... -count=1` — green
- [x] `go test ./pkg/orchestrator/... ./pkg/provisioning/... ./pkg/lifecycle/... ./pkg/lifecycle-poc/... -count=1` — green (confirms no downstream `errors.Is` regressions)
- [x] `golangci-lint run ./pkg/pipeline/... ./pkg/connector/...` (v2.12.2) — 0 issues
- [x] `TestService_GetInstanceNotFound` augmented in both `pkg/pipeline` and `pkg/connector` to assert the sentinel `errors.Is` check AND `conduiterr.Get(err)` returns the new code with a non-empty `Suggestion`, mirroring the `connector.plugin_not_found` test augmentation

Design: `docs/design-documents/20260705-conduit-error-and-structured-output.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tapg9dLWXKMZJoL65R24vd