### PR TITLE
refactor: make flaky tests hermetic (sleep sync, fixed port, env leak)

### DIFF
--- a/pkg/conduit/runtime_test.go
+++ b/pkg/conduit/runtime_test.go
@@ -60,18 +60,30 @@ func TestRuntime(t *testing.T) {
 	is.NoErr(err)
 	is.True(r != nil)
 
-	// set a cancel on a trigger to kill the context after THRESHOLD duration.
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		time.Sleep(500 * time.Millisecond)
-		cancel()
-	}()
 
-	errC := make(chan error)
+	errC := make(chan error, 1)
 	go func() {
 		errC <- r.Run(ctx)
 	}()
-	err, got, recvErr := cchan.ChanOut[error](errC).RecvTimeout(context.Background(), time.Second)
+
+	// Wait for the gRPC API to report ready before triggering graceful
+	// shutdown, instead of racing a fixed 500ms sleep. The old sleep was a
+	// double race: too short and the "grpc API started" assertion below hadn't
+	// been logged yet; longer than the receive budget and the runtime hadn't
+	// shut down in time. Polling the readiness marker synchronously (then
+	// cancelling) removes both races without changing any assertion.
+	startupDeadline := time.Now().Add(10 * time.Second)
+	for !strings.Contains(logs.String(), "grpc API started") {
+		if time.Now().After(startupDeadline) {
+			cancel()
+			t.Fatal("grpc API did not start within timeout")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+
+	err, got, recvErr := cchan.ChanOut[error](errC).RecvTimeout(context.Background(), 10*time.Second)
 	is.NoErr(recvErr)
 	is.True(got)
 	if !cerrors.Is(err, context.Canceled) {

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -15,6 +15,7 @@
 package orchestrator
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -169,8 +170,22 @@ func TestPipelineSimple(t *testing.T) {
 	err = orc.Pipelines.Start(ctx, pl.ID)
 	is.NoErr(err)
 
-	// give the pipeline time to run through
-	time.Sleep(time.Second)
+	// Wait until all 5 source records have been written to the destination file
+	// before stopping, instead of racing a fixed 1s sleep. A fixed sleep flaked
+	// on slow CI: if the pipeline hadn't drained all records yet, Stop cut it
+	// short and the file-content assertion below saw a truncated file.
+	const wantRecords = 5
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		got, readErr := os.ReadFile(destinationPath)
+		if readErr == nil && bytes.Count(got, []byte("\n")) >= wantRecords {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d records in %s", wantRecords, destinationPath)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 
 	t.Log("stopping pipeline")
 	err = orc.Pipelines.Stop(ctx, pl.ID, false)

--- a/pkg/plugin/processor/builtin/impl/webhook/http_examples_test.go
+++ b/pkg/plugin/processor/builtin/impl/webhook/http_examples_test.go
@@ -153,12 +153,9 @@ The response will be written under the record's ` + "`.Payload.After.response`."
 
 func newTestServer() *httptest.Server {
 	var lc net.ListenConfig
-	// Bind to an OS-assigned port (:0) instead of a fixed one so parallel test
-	// runs never collide on the same port. The caller reads back the real
-	// address via srv.URL, so the concrete port does not matter.
-	l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:54321")
 	if err != nil {
-		log.Fatalf("failed starting test server: %v", err)
+		log.Fatalf("failed starting test server on port 54321: %v", err)
 	}
 
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {

--- a/pkg/plugin/processor/builtin/impl/webhook/http_examples_test.go
+++ b/pkg/plugin/processor/builtin/impl/webhook/http_examples_test.go
@@ -153,9 +153,12 @@ The response will be written under the record's ` + "`.Payload.After.response`."
 
 func newTestServer() *httptest.Server {
 	var lc net.ListenConfig
-	l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:54321")
+	// Bind to an OS-assigned port (:0) instead of a fixed one so parallel test
+	// runs never collide on the same port. The caller reads back the real
+	// address via srv.URL, so the concrete port does not matter.
+	l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
-		log.Fatalf("failed starting test server on port 54321: %v", err)
+		log.Fatalf("failed starting test server: %v", err)
 	}
 
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {

--- a/pkg/provisioning/config/yaml/parser_test.go
+++ b/pkg/provisioning/config/yaml/parser_test.go
@@ -199,19 +199,12 @@ func TestParser_V1_EnvVars(t *testing.T) {
 	parser := NewParser(log.Nop())
 	filepath := "./v1/testdata/pipelines5-env-vars.yml"
 
-	// set env variables
-	err := os.Setenv("TEST_PARSER_AWS_SECRET", "my-aws-secret")
-	if err != nil {
-		t.Fatalf("Failed to write env var: $TEST_PARSER_AWS_SECRET")
-	}
-	err = os.Setenv("TEST_PARSER_AWS_KEY", "my-aws-key")
-	if err != nil {
-		t.Fatalf("Failed to write env var: $TEST_PARSER_AWS_KEY")
-	}
-	err = os.Setenv("TEST_PARSER_AWS_URL", "aws-url")
-	if err != nil {
-		t.Fatalf("Failed to write env var: $TEST_PARSER_AWS_URL")
-	}
+	// set env variables; t.Setenv restores the previous value (and clears vars
+	// that were unset) when the test finishes, so they never leak into other
+	// tests in this package.
+	t.Setenv("TEST_PARSER_AWS_SECRET", "my-aws-secret")
+	t.Setenv("TEST_PARSER_AWS_KEY", "my-aws-key")
+	t.Setenv("TEST_PARSER_AWS_URL", "aws-url")
 
 	want := Configurations{
 		v1.Configuration{
@@ -577,19 +570,12 @@ func TestParser_V2_EnvVars(t *testing.T) {
 	parser := NewParser(log.Nop())
 	filepath := "./v2/testdata/pipelines5-env-vars.yml"
 
-	// set env variables
-	err := os.Setenv("TEST_PARSER_AWS_SECRET", "my-aws-secret")
-	if err != nil {
-		t.Fatalf("Failed to write env var: $TEST_PARSER_AWS_SECRET")
-	}
-	err = os.Setenv("TEST_PARSER_AWS_KEY", "my-aws-key")
-	if err != nil {
-		t.Fatalf("Failed to write env var: $TEST_PARSER_AWS_KEY")
-	}
-	err = os.Setenv("TEST_PARSER_AWS_URL", "aws-url")
-	if err != nil {
-		t.Fatalf("Failed to write env var: $TEST_PARSER_AWS_URL")
-	}
+	// set env variables; t.Setenv restores the previous value (and clears vars
+	// that were unset) when the test finishes, so they never leak into other
+	// tests in this package.
+	t.Setenv("TEST_PARSER_AWS_SECRET", "my-aws-secret")
+	t.Setenv("TEST_PARSER_AWS_KEY", "my-aws-key")
+	t.Setenv("TEST_PARSER_AWS_URL", "aws-url")
 
 	want := Configurations{
 		v2.Configuration{

--- a/pkg/provisioning/service_test.go
+++ b/pkg/provisioning/service_test.go
@@ -546,8 +546,23 @@ func TestService_IntegrationTestServices(t *testing.T) {
 	err = service.Init(context.Background())
 	is.NoErr(err)
 
-	// give the pipeline time to run through
-	time.Sleep(1 * time.Second)
+	// Wait until the running pipeline (p4.P1) has actually delivered records to
+	// its destination file before asserting, rather than racing a fixed 1s
+	// sleep. This is the condition the final assertion (destFile is non-empty)
+	// depends on, and by the time records are written P1 has reached
+	// StatusRunning, so all the status/config assertions below become
+	// deterministic. A fixed sleep flaked under CI load.
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		data, readErr := os.ReadFile(destFile)
+		if readErr == nil && len(data) != 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for records to be written to %s", destFile)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 
 	// checking pipelines
 	pipelines := []*pipeline.Instance{p4.P1, p4.P2, p4.P3}


### PR DESCRIPTION
## What

Test-only refactor: make several structurally-flaky tests hermetic. Follow-up to the flaky-CI pain in #2534 (that PR needed 4 CI rerun cycles). A separate effort is fixing the *known* flakes in `pkg/lifecycle/`, `pkg/schemaregistry/`, `pkg/plugin/.../diff/lcs/`, and `pkg/.../avro/internal/` — this PR deliberately stays out of those packages and fixes the *other* latent offenders.

**Risk tier: Tier 3 (chore — tests only).** No production code changed, no assertions weakened. Every change alters only *how* a test isolates or synchronizes.

## Fixes by anti-pattern

### 1. Sleep-based synchronization (the top CI-load flakes)

Fixed-duration `time.Sleep` that races a real condition → poll-until-condition with a generous timeout.

**`pkg/conduit/runtime_test.go`** — `TestRuntime` slept 500ms then cancelled, then received the run error with a 1s budget. Double race: too short and the `"grpc API started"` assertion hadn't logged; longer than 1s and the runtime hadn't shut down in time.
```go
// before
go func() {
    time.Sleep(500 * time.Millisecond)
    cancel()
}()
errC := make(chan error)
go func() { errC <- r.Run(ctx) }()
err, got, recvErr := cchan.ChanOut[error](errC).RecvTimeout(context.Background(), time.Second)
// after
errC := make(chan error, 1)
go func() { errC <- r.Run(ctx) }()
startupDeadline := time.Now().Add(10 * time.Second)
for !strings.Contains(logs.String(), "grpc API started") {
    if time.Now().After(startupDeadline) {
        cancel()
        t.Fatal("grpc API did not start within timeout")
    }
    time.Sleep(5 * time.Millisecond)
}
cancel()
err, got, recvErr := cchan.ChanOut[error](errC).RecvTimeout(context.Background(), 10*time.Second)
```

**`pkg/orchestrator/orchestrator_test.go`** — `TestPipelineSimple` slept 1s then stopped, then asserted the destination file equals 5 records. If the pipeline hadn't drained, `Stop` truncated the file. Now polls the destination file until all 5 records are present, then stops.
```go
// before
time.Sleep(time.Second)
// after
const wantRecords = 5
deadline := time.Now().Add(30 * time.Second)
for {
    got, readErr := os.ReadFile(destinationPath)
    if readErr == nil && bytes.Count(got, []byte("\n")) >= wantRecords {
        break
    }
    if time.Now().After(deadline) {
        t.Fatalf("timed out waiting for %d records in %s", wantRecords, destinationPath)
    }
    time.Sleep(5 * time.Millisecond)
}
```

**`pkg/provisioning/service_test.go`** — `TestService_IntegrationTestServices` slept 1s then asserted (among other things) the destination file is non-empty. Now polls until records are actually delivered.
```go
// before
time.Sleep(1 * time.Second)
// after
deadline := time.Now().Add(30 * time.Second)
for {
    data, readErr := os.ReadFile(destFile)
    if readErr == nil && len(data) != 0 {
        break
    }
    if time.Now().After(deadline) {
        t.Fatalf("timed out waiting for records to be written to %s", destFile)
    }
    time.Sleep(5 * time.Millisecond)
}
```

### 2. Hardcoded network port

**`pkg/plugin/processor/builtin/impl/webhook/http_examples_test.go`** — the example test server bound to the fixed port `127.0.0.1:54321`. `srv.URL` is read back dynamically, so the concrete port never mattered; a fixed port only creates collisions under parallel runs.
```go
// before
l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:54321")
// after
l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
```

### 3. Global mutable state (env leak)

**`pkg/provisioning/config/yaml/parser_test.go`** — `TestParser_V1_EnvVars` / `TestParser_V2_EnvVars` set three `TEST_PARSER_AWS_*` vars with `os.Setenv` and never unset them, leaking process state into every later test in the package. Switched to `t.Setenv`, which restores prior values on cleanup. (Neither test uses `t.Parallel`, so `t.Setenv` is valid.)

## Verification

- `go build ./...` clean.
- Per changed package, `go test -count=20 -race` green (provisioning integration at `-count=15`):
  - `pkg/plugin/processor/builtin/impl/webhook` ok
  - `pkg/provisioning/config/yaml` ok
  - `pkg/orchestrator` ok
  - `pkg/provisioning` ok
  - `pkg/conduit` (`TestRuntime`) ok
- `golangci-lint run` (v2.12.2) on all changed packages: 0 issues.

## Adversarial self-review

- Initial `runtime_test.go` attempt put the marker-poll in a goroutine running *concurrently* with the 1s `RecvTimeout` — that just moved the race (slow startup would blow the receive budget). Caught in self-review and restructured to poll synchronously before cancelling, and widened the receive budget to 10s. The final `is.True(strings.Contains(logs, "grpc API started"))` is now guaranteed by construction (the loop only exits when the marker is present or the test fails).
- The orchestrator and provisioning polls key off the *same* condition their downstream assertions depend on (record delivery), so they can't pass prematurely.
- Concurrent log reads in `runtime_test.go` go through the existing mutex-protected `safeBuffer`; no new race.

## Reported-only (not fixed here)

- **`pkg/lifecycle-poc/service_test.go`** (2 sleeps): the 100ms sleeps wait for full record delivery + ack, not just for a status transition — hard-concurrency territory, and this POC package mirrors the owned `pkg/lifecycle/`. Left to the lifecycle owner.
- **`pkg/connector/persister_test.go`**: sleeps + tight `time.Since` tolerances are the persister's own timing/debounce *contract* under test; making them hermetic would mean loosening assertions. Left as-is.
- **`pkg/conduit/entrypoint_test.go`** (`TestEntrypoint_CancelOnInterrupt_SIGTERM`): fails only under `-count>1` because `CancelOnInterrupt` installs a process-global signal handler that `os.Exit`s on a second signal (documented in the test itself). Passes under normal CI (`count=1`); a real fix needs a production change to `CancelOnInterrupt`.
- **`pkg/plugin/processor/builtin/internal/diff/diff_test.go`** (`rand.Seed(1)`): deterministic fixed seed and adjacent to the owned `diff/lcs/` package; left to avoid colliding with the concurrent effort.

Refs #2534

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tapg9dLWXKMZJoL65R24vd
