### PR TITLE
test: deflake known-flaky tests (#2534), add nightly flake-hunt job

### DIFF
--- a/.github/workflows/flake-hunt.yml
+++ b/.github/workflows/flake-hunt.yml
@@ -1,0 +1,45 @@
+name: flake hunt
+
+# Issue #2534: the PR-gating `test` workflow runs the suite once per PR
+# (-count=1), which is fast but gives order/timing-dependent flakes very few
+# chances to show up before they've already cost someone a rerun cycle. This
+# workflow repeats the same suite multiple times on a schedule, off the
+# critical path, so flakes surface here instead of on a contributor's PR.
+#
+# Deliberately not wired into branch protection: a red run here is a signal
+# to go fix a flaky test, not a reason to block merges.
+
+on:
+  schedule:
+    # Nightly, off-peak. Cron minute/hour offset from trigger-nightly.yml so
+    # the two scheduled workflows don't contend for runners at the same time.
+    - cron: '30 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  flake-hunt:
+    name: repeat test suite (-count=3 -race)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Test (repeated x3, shuffled)
+        # -count=3 runs every test three times in the same process, which is
+        # exactly the kind of repetition that catches tests relying on
+        # process-global state (e.g. the math/rand and shared-fixture bugs
+        # fixed for #2534). -shuffle=on randomizes ordering on top of that;
+        # go test prints the seed it used so a failure here is reproducible
+        # locally with `-shuffle=<seed>`.
+        run: make test-integration GOTEST_FLAGS="-v -count=3 -shuffle=on"
+
+      - name: Report outcome
+        if: failure()
+        run: |
+          echo "::warning::Flake hunt found a failure. This does not block merges, but a real flake was caught - investigate and either fix it or file/update a tracking issue referencing ConduitIO/conduit#2534."

--- a/pkg/plugin/processor/builtin/internal/diff/lcs/common_test.go
+++ b/pkg/plugin/processor/builtin/internal/diff/lcs/common_test.go
@@ -105,12 +105,16 @@ func lcslen(l lcs) int {
 	return ans
 }
 
-// return a random string of length n made of characters from s
-func randstr(s string, n int) string {
+// randstr returns a random string of length n made of characters from s,
+// drawing from rng. Callers must pass their own *rand.Rand (rather than the
+// global math/rand functions) so that seeding one test's generator can never
+// perturb another test's sequence when tests run in the same process
+// (parallel tests, or repeated runs via `-count`). See issue #2534.
+func randstr(rng *rand.Rand, s string, n int) string {
 	src := []rune(s)
 	x := make([]rune, n)
 	for i := 0; i < n; i++ {
-		x[i] = src[rand.Intn(len(src))]
+		x[i] = src[rng.Intn(len(src))]
 	}
 	return string(x)
 }

--- a/pkg/plugin/processor/builtin/internal/diff/lcs/old_test.go
+++ b/pkg/plugin/processor/builtin/internal/diff/lcs/old_test.go
@@ -106,12 +106,18 @@ func TestRegressionOld003(t *testing.T) {
 }
 
 func TestRandOld(t *testing.T) {
-	rand.Seed(1)
+	// Issue #2534: use a local generator seeded deterministically instead of
+	// reseeding the global math/rand source. The global source is
+	// process-wide, so calling rand.Seed(1) here made this test's "fixed
+	// seed" a lie as soon as any other test running in the same process
+	// (parallel, or a later -count iteration) also drew from the global
+	// source and advanced or reset its state.
+	rng := rand.New(rand.NewSource(1))
 	for i := 0; i < 1000; i++ {
 		// TODO(adonovan): use ASCII and bytesSeqs here? The use of
 		// non-ASCII isn't relevant to the property exercised by the test.
-		a := []rune(randstr("abω", 16))
-		b := []rune(randstr("abωc", 16))
+		a := []rune(randstr(rng, "abω", 16))
+		b := []rune(randstr(rng, "abωc", 16))
 		seq := runesSeqs{a, b}
 
 		const lim = 24 // large enough to get true lcs
@@ -184,15 +190,16 @@ func BenchmarkForwOld(b *testing.B) {
 func genBench(set string, n int) []struct{ before, after string } {
 	// before and after for benchmarks. 24 strings of length n with
 	// before and after differing at least once, and about 5%
-	rand.Seed(3)
+	// Local generator (see TestRandOld) so this doesn't touch global state.
+	rng := rand.New(rand.NewSource(3))
 	var ans []struct{ before, after string }
 	for i := 0; i < 24; i++ {
 		// maybe b should have an approximately known number of diffs
-		a := randstr(set, n)
+		a := randstr(rng, set, n)
 		cnt := 0
 		bb := make([]rune, 0, n)
 		for _, r := range a {
-			if rand.Float64() < .05 {
+			if rng.Float64() < .05 {
 				cnt++
 				r = 'N'
 			}

--- a/pkg/schemaregistry/schemaregistrytest/inmemory.go
+++ b/pkg/schemaregistry/schemaregistrytest/inmemory.go
@@ -94,7 +94,26 @@ func inMemorySchemaRegistryURL(name string, logger *slog.Logger, port int) (stri
 
 		srv.Start()
 		serverByTest[name] = srv
-		cleanup = srv.Close
+
+		// Issue #2534: the server is keyed by test name so that multiple
+		// TestSchemaRegistryURL calls from the *same* test (e.g. one to seed
+		// data directly, one via the client under test) share one backing
+		// registry. But if we only ever closed the server and left the
+		// stale, now-dead entry in the map, any later call with the same
+		// name (a second `-count` iteration in the same test binary, or any
+		// other re-entrant call) would be handed back a closed listener and
+		// fail with "connection refused" instead of getting a fresh server.
+		// Removing the entry on cleanup keeps sharing within one test while
+		// guaranteeing every new logical test run gets an isolated registry.
+		srvToClose := srv
+		cleanup = func() {
+			serverByTestLock.Lock()
+			if serverByTest[name] == srvToClose {
+				delete(serverByTest, name)
+			}
+			serverByTestLock.Unlock()
+			srvToClose.Close()
+		}
 	}
 	return srv.URL, cleanup
 }

--- a/test/compose-schemaregistry.yaml
+++ b/test/compose-schemaregistry.yaml
@@ -6,6 +6,19 @@ services:
       ZOOKEEPER_ADMIN_ENABLE_SERVER: 'false'
     networks:
       - confluent
+    # Root cause (issue #2534): `docker compose up --wait` only waits for a
+    # HEALTHY status if a healthcheck is defined. Without one, Compose treats
+    # "container is running" as ready and returns immediately, so tests race
+    # zookeeper accepting client connections on 2181.
+    healthcheck:
+      # `ruok` isn't in the default 4lw whitelist on this image (only `srvr`
+      # is); `srvr` returns server info and only succeeds once zookeeper is
+      # actually serving the client port.
+      test: ["CMD-SHELL", "echo srvr | nc -w 2 localhost 2181 | grep -q Mode || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
 
   kafka:
     image: confluentinc/cp-kafka:7.9.1
@@ -16,13 +29,25 @@ services:
       KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:9092'
     links:
       - zookeeper
+    depends_on:
+      zookeeper:
+        condition: service_healthy
     networks:
       - confluent
+    # Same as above: gate on the broker actually answering the Kafka protocol,
+    # not just the container process being alive.
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-broker-api-versions --bootstrap-server localhost:9092 > /dev/null 2>&1 || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 15s
 
   schema-registry:
     image: confluentinc/cp-schema-registry:7.9.1
     depends_on:
-      - kafka
+      kafka:
+        condition: service_healthy
     ports:
       - '8085:8085'
     environment:
@@ -32,6 +57,20 @@ services:
       SCHEMA_REGISTRY_LOG4J_ROOT_LOGLEVEL: 'INFO'
     networks:
       - confluent
+    # This is the fix for the schema-registry flakes tracked in #2534
+    # (TestClient_NotFound/CacheMiss/CacheHit, avro encode/decode strategy
+    # tests): `docker compose up --wait` returned as soon as the container
+    # started, ~3-4s before the Jetty HTTP listener actually came up, so the
+    # first requests from the Go test suite got "connection refused" or, once
+    # a connection succeeded, a still-initializing registry occasionally
+    # returned unexpected error shapes instead of a clean 404. Gating on the
+    # REST API responding makes `--wait` mean what the tests need it to mean.
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8085/subjects || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 15s
 
 networks:
   confluent:


### PR DESCRIPTION
## Summary

Fixes three of the four flakes tracked in #2534. Tier: 3 (chore/CI — test-only and CI-config changes, no product code touched).

Scope note: I own `pkg/plugin/processor/builtin/internal/diff/lcs/`, `pkg/schemaregistry/`, and `pkg/plugin/processor/builtin/impl/avro/internal/` for this fix; a parallel effort is handling the rest of the suite. The lifecycle flake (`TestServiceLifecycle_Stop/user_stop:_forceful`, #2521/#1659) is **not touched** — see below.

### 1. `TestRandOld` (`pkg/plugin/processor/builtin/internal/diff/lcs`)

**Root cause:** `rand.Seed(1)` reseeds the process-global `math/rand` source. Any other test in the same binary that draws from the global source (directly, or via a shared helper) can perturb the sequence `TestRandOld` thinks is deterministic. Same issue in `genBench` (used by the benchmarks in the same file), reseeding with `rand.Seed(3)`.

**Fix:** both now use a local `rand.New(rand.NewSource(seed))`, threaded through `randstr` as an explicit parameter instead of a hidden global.

**Proof:**
```
go test ./pkg/plugin/processor/builtin/internal/diff/lcs/... -run TestRandOld -race -count=50   # 50/50 PASS
go test ./pkg/plugin/processor/builtin/internal/diff/lcs/... -race -shuffle=on -count=20         # PASS
go test ./pkg/plugin/processor/builtin/internal/diff/lcs/... -bench=. -benchtime=1x -run '^$'    # benchmarks still compile/run
```

### 2. `TestClient_NotFound` / `TestClient_CacheMiss` / `TestClient_CacheHit` (`pkg/schemaregistry`) + `TestEncodeDecode_ExtractAndUploadSchemaStrategy` / `TestEncodeDecode_DownloadStrategy_Avro` (`avro/internal`)

**Root cause (the actual one, confirmed by reproduction — not the fake-registry cache I originally suspected):** the `test` CI job runs `make test-integration` (`--tags=integration`), which points these tests at the **real** Confluent stack in `test/compose-schemaregistry.yaml`. None of the three services (zookeeper, kafka, schema-registry) had a `healthcheck`, so `docker compose up --wait` returned as soon as the containers *started* — not once they were actually serving. Schema-registry's Jetty listener takes ~3-4s after container start to come up, so the first HTTP requests from the Go suite raced that window and got connection-refused/reset, or a still-initializing registry returned unexpected error shapes instead of a clean 404.

I reproduced this directly: reverted to the old compose file, and in a loop (fresh containers, `up --wait`, run the tests immediately, no artificial delay) got **6/6 failures** with the *exact* failure signatures from the issue:
```
client_test.go:54: not true: cerrors.As(err, &respErr)                     # TestClient_NotFound
...read tcp [::1]:xxxxx->[::1]:8085: read: connection reset by peer        # TestClient_CacheMiss / CacheHit
```
With healthchecks added (gating on zookeeper `srvr` responding, kafka `kafka-broker-api-versions`, schema-registry `curl .../subjects`, and `depends_on: condition: service_healthy` chaining them) and the same immediate-run loop: **6/6 PASS**, `up --wait` now takes ~23s (an honest wait) instead of a fake ~1.3s.

**Secondary fix (not the CI root cause, but a real bug):** `pkg/schemaregistry/schemaregistrytest/inmemory.go` (used when tests run *without* `--tags=integration`) caches the fake in-memory registry server by test name but never evicted the entry on cleanup. A second call with the same test name in the same process — e.g. `-count>1`, which the new flake-hunt job below uses — got handed back a *closed* listener and failed with connection-refused. Fixed by deleting the map entry in the cleanup func.

**Proof:**
```
# schemaregistry package
go test ./pkg/schemaregistry/... -run TestClient_NotFound      -race -count=50   # 50/50 PASS (was 0/1 without the -count=20 stress before the fix)
go test ./pkg/schemaregistry/... -run TestClient_CacheMiss      -race -count=50   # 50/50 PASS
go test ./pkg/schemaregistry/... -run TestClient_CacheHit        -race -count=50   # 50/50 PASS
go test ./pkg/schemaregistry/...                                 -race -shuffle=on -count=20  # PASS

# avro internal
go test ./pkg/plugin/processor/builtin/impl/avro/internal/... -run TestEncodeDecode_ExtractAndUploadSchemaStrategy -race -count=50  # 50/50 PASS
go test ./pkg/plugin/processor/builtin/impl/avro/internal/... -run TestEncodeDecode_DownloadStrategy_Avro          -race -count=50  # 50/50 PASS
go test ./pkg/plugin/processor/builtin/impl/avro/internal/... -race -shuffle=on -count=20                                            # PASS

# real docker-compose stack, before/after, immediate-hit loop (no artificial warm-up delay)
# old compose file: 0/6 pass
# new compose file with healthchecks: 6/6 pass
```

### Lifecycle flake (#2521/#1659) — left alone

Ran `TestServiceLifecycle_Stop` under `-race -count=50` locally: 50/50 clean here. I couldn't reproduce the flake in this environment, and per the task scope this one is entangled with forceful-stop timing semantics that need dedicated attention, not a bolt-on fix. Leaving `pkg/lifecycle` untouched; it's already tracked in #2521.

## CI hardening (additive, non-blocking)

- **New scheduled workflow** `.github/workflows/flake-hunt.yml`: nightly (+ `workflow_dispatch`) run of `make test-integration GOTEST_FLAGS="-v -count=3 -shuffle=on"`. Not wired into branch protection — a red run here is a signal to fix a flaky test, not a reason to block merges. `-count=3` catches process-global-state bugs like the two above; `-shuffle=on` catches ordering assumptions, and `go test` prints the seed it used so a failure is reproducible locally.
- **Did not add `-shuffle=on` to the PR-gating `test` workflow.** I ran the full suite (`go test -race -shuffle=on -count=1 ./...`) locally first, per the task's ask. It surfaced two failures **outside this PR's owned files**:
  - `pkg/foundation/log`: `TestCtxLoggerWithHooks` / `TestCtxLoggerWithoutHooks`
  - `pkg/plugin/processor/builtin/internal/diff/difftest`: `TestVerifyUnified`

  I confirmed both are **pre-existing, environment-specific, and unrelated to shuffle/ordering** — they fail identically with `-shuffle` off, and on unmodified `main`. `TestVerifyUnified` fails with `diff tool not available: exit status 2` (looks like a `diff(1)` availability/flag assumption that may not hold in this sandbox the way it does on `ubuntu-latest`); the log ones look like a stack-trace-format assumption in the test unrelated to test ordering. Flagging both for whoever owns those files (the parallel refactor effort) rather than fixing them here since they're out of scope — but they mean I can't currently claim the full suite is green under shuffle, so I gated shuffle to the new non-blocking nightly job instead of the blocking one, per the task's instructions.

## Adversarial self-review

- Checked the `inmemory.go` fix for a race: cleanup takes the same mutex before deleting the map entry, and `srv.Close()` happens on a locally-captured pointer outside the lock — no new race, verified under `-race`.
- Checked that the intra-test sharing behavior `TestClient_CacheMiss` depends on (two `TestSchemaRegistryURL(t)` calls with the *same* `t` need to hit the *same* backing server) is preserved — the cache entry is only removed in the `t.Cleanup` callback, which runs after the test body (both calls) completes.
- Confirmed the compose healthcheck fix doesn't change any test-visible behavior beyond timing — same images, same ports, same env vars.
- Confirmed `-race`, `go build ./...`, and `golangci-lint run` are clean on every package I touched (scoped run; did not attempt to fix pre-existing lint debt in sibling packages I didn't touch, e.g. `pkg/plugin/processor/builtin/internal/diff/*.go`).

## Test plan

- [x] `go build ./...`
- [x] `golangci-lint run ./pkg/plugin/processor/builtin/internal/diff/lcs/... ./pkg/schemaregistry/... ./pkg/plugin/processor/builtin/impl/avro/...` — 0 issues
- [x] Per-test `-race -count=50` verification (all 5 fixed tests, 50/50 clean each)
- [x] `-shuffle=on -count=20` on each owned package — clean
- [x] Real docker-compose stack before/after comparison (0/6 → 6/6)
- [ ] Not merging — leaving for review per repo process (Tier 3, but flagging the shuffle-revealed out-of-scope failures for a human look)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>