### PR TITLE
feat: emit precondition/invalid-argument ConduitError codes across pipeline, connector, orchestrator

### DIFF
--- a/pkg/connector/codes.go
+++ b/pkg/connector/codes.go
@@ -26,4 +26,11 @@ var (
 	// CodeConnectorNotFound is raised when a referenced connector instance
 	// cannot be located.
 	CodeConnectorNotFound = conduiterr.Register("connector.instance_not_found", codes.NotFound)
+	// CodeConnectorRunning is raised when an operation requires the
+	// connector to not be running, but a connector instance for it already
+	// exists.
+	CodeConnectorRunning = conduiterr.Register("connector.running", codes.FailedPrecondition)
+	// CodeConnectorInvalidType is raised when a connector type is neither
+	// "source" nor "destination".
+	CodeConnectorInvalidType = conduiterr.Register("connector.invalid_type", codes.InvalidArgument)
 )

--- a/pkg/connector/instance.go
+++ b/pkg/connector/instance.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/inspector"
 	connectorPlugin "github.com/conduitio/conduit/pkg/plugin/connector"
@@ -117,7 +118,11 @@ func (i *Instance) Inspect(ctx context.Context) *inspector.Session {
 func (i *Instance) Connector(_ context.Context, dispenserFetcher PluginDispenserFetcher) (Connector, error) {
 	if i.connector != nil {
 		// connector is already running, might be a bug where an old connector is stuck
-		return nil, ErrConnectorRunning
+		// Invariant: errors.Is(err, ErrConnectorRunning) still holds — sentinel
+		// wrapped, ConduitError adds the code.
+		err := conduiterr.Wrap(CodeConnectorRunning, "connector is running", ErrConnectorRunning)
+		err.Suggestion = "wait for the current connector operation to finish, or restart the pipeline"
+		return nil, err
 	}
 
 	pluginDispenser, err := dispenserFetcher.NewDispenser(i.logger, i.Plugin, i.ID)

--- a/pkg/connector/instance_test.go
+++ b/pkg/connector/instance_test.go
@@ -15,9 +15,15 @@
 package connector
 
 import (
+	"context"
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/plugin"
 	connectorPlugin "github.com/conduitio/conduit/pkg/plugin/connector"
+	"github.com/matryer/is"
 )
 
 // fakePluginFetcher fulfills the PluginFetcher interface.
@@ -29,4 +35,34 @@ func (fpf fakePluginFetcher) NewDispenser(_ log.CtxLogger, name string, _ string
 		return nil, plugin.ErrPluginNotFound
 	}
 	return plug, nil
+}
+
+// fakeConnector fulfills the Connector interface, used to simulate an
+// already-running connector on an Instance.
+type fakeConnector struct{}
+
+func (fakeConnector) OnDelete(context.Context) error { return nil }
+
+// TestInstance_Connector_AlreadyRunning proves Instance.Connector still
+// returns ErrConnectorRunning (the sentinel every errors.Is(err,
+// ErrConnectorRunning) check throughout the codebase relies on) when a
+// connector is already running, and that the error now also carries a
+// machine-actionable ConduitError code + suggestion.
+func TestInstance_Connector_AlreadyRunning(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	i := &Instance{ID: "conn1", Type: TypeSource}
+	i.Init(log.Nop(), nil)
+	i.connector = fakeConnector{}
+
+	got, err := i.Connector(ctx, fakePluginFetcher{})
+	is.Equal(got, nil)
+	is.True(err != nil)
+	is.True(cerrors.Is(err, ErrConnectorRunning)) // sentinel still in the chain
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // also carries a machine-actionable ConduitError code
+	is.Equal(ce.Code.Reason(), CodeConnectorRunning.Reason())
+	is.True(ce.Suggestion != "") // with a suggested fix
 }

--- a/pkg/connector/service.go
+++ b/pkg/connector/service.go
@@ -142,7 +142,11 @@ func (s *Service) Create(
 		return nil, cerrors.New("must provide a pipeline ID")
 	}
 	if t != TypeSource && t != TypeDestination {
-		return nil, ErrInvalidConnectorType
+		// Invariant: errors.Is(err, ErrInvalidConnectorType) still holds — sentinel
+		// wrapped, ConduitError adds the code.
+		err := conduiterr.Wrap(CodeConnectorInvalidType, "invalid connector type", ErrInvalidConnectorType)
+		err.Suggestion = `set the connector type to either "source" or "destination"`
+		return nil, err
 	}
 
 	now := time.Now().UTC()

--- a/pkg/connector/service_test.go
+++ b/pkg/connector/service_test.go
@@ -247,6 +247,8 @@ func TestService_CreateError(t *testing.T) {
 		connType   Type
 		plugin     string
 		pipelineID string
+		wantErr    error           // non-nil means also assert errors.Is(err, wantErr)
+		wantCode   conduiterr.Code // zero value means "don't check the ConduitError code"
 		data       Config
 	}{
 		{
@@ -254,6 +256,8 @@ func TestService_CreateError(t *testing.T) {
 			connType:   0,
 			plugin:     "test-plugin",
 			pipelineID: uuid.NewString(),
+			wantErr:    ErrInvalidConnectorType,
+			wantCode:   CodeConnectorInvalidType,
 			data: Config{
 				Name:     "test-connector",
 				Settings: map[string]string{"foo": "bar"},
@@ -292,6 +296,16 @@ func TestService_CreateError(t *testing.T) {
 			)
 			is.True(err != nil)
 			is.Equal(got, nil)
+
+			if tt.wantErr != nil {
+				is.True(cerrors.Is(err, tt.wantErr)) // sentinel still in the chain
+			}
+			if !tt.wantCode.IsZero() {
+				ce, ok := conduiterr.Get(err)
+				is.True(ok) // also carries a machine-actionable ConduitError code
+				is.Equal(ce.Code.Reason(), tt.wantCode.Reason())
+				is.True(ce.Suggestion != "") // with a suggested fix
+			}
 		})
 	}
 }

--- a/pkg/lifecycle/service.go
+++ b/pkg/lifecycle/service.go
@@ -28,6 +28,7 @@ import (
 	"github.com/conduitio/conduit-commons/csync"
 	"github.com/conduitio/conduit/pkg/connector"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/foundation/metrics"
 	"github.com/conduitio/conduit/pkg/foundation/metrics/measure"
@@ -174,7 +175,15 @@ func (s *Service) Start(
 	}
 
 	if pl.GetStatus() == pipeline.StatusRunning {
-		return cerrors.Errorf("can't start pipeline %s: %w", pl.ID, pipeline.ErrPipelineRunning)
+		// Invariant: errors.Is(err, ErrPipelineRunning) still holds — sentinel
+		// wrapped, ConduitError adds the code.
+		err := conduiterr.Wrap(
+			pipeline.CodePipelineRunning,
+			fmt.Sprintf("can't start pipeline %s: %s", pl.ID, pipeline.ErrPipelineRunning),
+			pipeline.ErrPipelineRunning,
+		)
+		err.Suggestion = "the pipeline is already running; stop it first if you need to restart it"
+		return err
 	}
 
 	s.logger.Debug(ctx).Str(log.PipelineIDField, pl.ID).Msg("starting pipeline")
@@ -253,11 +262,27 @@ func (s *Service) Stop(ctx context.Context, pipelineID string, force bool) error
 	rp, ok := s.runningPipelines.Get(pipelineID)
 
 	if !ok {
-		return cerrors.Errorf("pipeline %s is not running: %w", pipelineID, pipeline.ErrPipelineNotRunning)
+		// Invariant: errors.Is(err, ErrPipelineNotRunning) still holds — sentinel
+		// wrapped, ConduitError adds the code.
+		err := conduiterr.Wrap(
+			pipeline.CodePipelineNotRunning,
+			fmt.Sprintf("pipeline %s is not running: %s", pipelineID, pipeline.ErrPipelineNotRunning),
+			pipeline.ErrPipelineNotRunning,
+		)
+		err.Suggestion = "start the pipeline before trying to stop it"
+		return err
 	}
 
 	if rp.pipeline.GetStatus() != pipeline.StatusRunning && rp.pipeline.GetStatus() != pipeline.StatusRecovering {
-		return cerrors.Errorf("can't stop pipeline with status %q: %w", rp.pipeline.GetStatus(), pipeline.ErrPipelineNotRunning)
+		// Invariant: errors.Is(err, ErrPipelineNotRunning) still holds — sentinel
+		// wrapped, ConduitError adds the code.
+		err := conduiterr.Wrap(
+			pipeline.CodePipelineNotRunning,
+			fmt.Sprintf("can't stop pipeline with status %q: %s", rp.pipeline.GetStatus(), pipeline.ErrPipelineNotRunning),
+			pipeline.ErrPipelineNotRunning,
+		)
+		err.Suggestion = "start the pipeline before trying to stop it"
+		return err
 	}
 
 	switch force {

--- a/pkg/lifecycle/service_test.go
+++ b/pkg/lifecycle/service_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/conduitio/conduit-commons/opencdc"
 	"github.com/conduitio/conduit/pkg/connector"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/lifecycle/stream"
 	"github.com/conduitio/conduit/pkg/pipeline"
@@ -353,6 +354,66 @@ func TestServiceLifecycle_PipelineError(t *testing.T) {
 		strings.Contains(pl.Error, wantErr.Error()),
 	)
 	is.True(cerrors.Is(event.Error, wantErr))
+}
+
+// TestServiceLifecycle_Start_AlreadyRunning proves Service.Start still returns
+// pipeline.ErrPipelineRunning (the sentinel every errors.Is(err,
+// pipeline.ErrPipelineRunning) check throughout the codebase relies on) when
+// the pipeline is already running, and that the error now also carries a
+// machine-actionable ConduitError code + suggestion.
+func TestServiceLifecycle_Start_AlreadyRunning(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	logger := log.New(zerolog.Nop())
+
+	pl := &pipeline.Instance{ID: uuid.NewString(), Config: pipeline.Config{Name: "test-pipeline"}}
+	pl.SetStatus(pipeline.StatusRunning)
+
+	ls := NewService(
+		logger,
+		testErrRecoveryCfg(),
+		testConnectorService{},
+		testProcessorService{},
+		testConnectorPluginService{},
+		testPipelineService{pl.ID: pl},
+	)
+
+	err := ls.Start(ctx, pl.ID)
+	is.True(err != nil)
+	is.True(cerrors.Is(err, pipeline.ErrPipelineRunning)) // sentinel still in the chain
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // also carries a machine-actionable ConduitError code
+	is.Equal(ce.Code.Reason(), pipeline.CodePipelineRunning.Reason())
+	is.True(ce.Suggestion != "") // with a suggested fix
+}
+
+// TestServiceLifecycle_Stop_NotRunning proves Service.Stop still returns
+// pipeline.ErrPipelineNotRunning when no pipeline is running for the given
+// ID, and that the error now also carries a machine-actionable ConduitError
+// code + suggestion.
+func TestServiceLifecycle_Stop_NotRunning(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	logger := log.New(zerolog.Nop())
+
+	ls := NewService(
+		logger,
+		testErrRecoveryCfg(),
+		testConnectorService{},
+		testProcessorService{},
+		testConnectorPluginService{},
+		testPipelineService{},
+	)
+
+	err := ls.Stop(ctx, uuid.NewString(), false)
+	is.True(err != nil)
+	is.True(cerrors.Is(err, pipeline.ErrPipelineNotRunning)) // sentinel still in the chain
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // also carries a machine-actionable ConduitError code
+	is.Equal(ce.Code.Reason(), pipeline.CodePipelineNotRunning.Reason())
+	is.True(ce.Suggestion != "") // with a suggested fix
 }
 
 func TestServiceLifecycle_Stop(t *testing.T) {

--- a/pkg/orchestrator/codes.go
+++ b/pkg/orchestrator/codes.go
@@ -1,0 +1,82 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/pipeline"
+	"google.golang.org/grpc/codes"
+)
+
+// Orchestrator error codes. Every error carries one of these codes plus a
+// suggested fix, so an API, MCP, or UI consumer knows what happened without
+// parsing message text.
+var (
+	// CodeInvalidProcessorParentType is raised when a processor's parent is
+	// neither a pipeline nor a connector.
+	CodeInvalidProcessorParentType = conduiterr.Register("orchestrator.invalid_processor_parent_type", codes.InvalidArgument)
+	// CodePipelineHasProcessorsAttached is raised when a pipeline cannot be
+	// deleted because it still has processors attached.
+	CodePipelineHasProcessorsAttached = conduiterr.Register("orchestrator.pipeline_has_processors_attached", codes.FailedPrecondition)
+	// CodePipelineHasConnectorsAttached is raised when a pipeline cannot be
+	// deleted because it still has connectors attached.
+	CodePipelineHasConnectorsAttached = conduiterr.Register("orchestrator.pipeline_has_connectors_attached", codes.FailedPrecondition)
+	// CodeConnectorHasProcessorsAttached is raised when a connector cannot
+	// be deleted because it still has processors attached.
+	CodeConnectorHasProcessorsAttached = conduiterr.Register("orchestrator.connector_has_processors_attached", codes.FailedPrecondition)
+	// CodeImmutableProvisionedByConfig is raised when a pipeline, connector,
+	// or processor provisioned by a config file is mutated through the API
+	// instead of the config file.
+	CodeImmutableProvisionedByConfig = conduiterr.Register("orchestrator.immutable_provisioned_by_config", codes.FailedPrecondition)
+)
+
+// pipelineRunningErr wraps pipeline.ErrPipelineRunning with the
+// pipeline.CodePipelineRunning code and a suggestion. msg is the
+// boundary-level, human-readable message (Wrap replaces, not concatenates,
+// the wrapped cause's text).
+//
+// Invariant: errors.Is(err, pipeline.ErrPipelineRunning) still holds — the
+// sentinel is wrapped, and the ConduitError adds the machine-actionable code.
+func pipelineRunningErr(msg string) error {
+	e := conduiterr.Wrap(pipeline.CodePipelineRunning, msg, pipeline.ErrPipelineRunning)
+	e.Suggestion = "the pipeline is running; stop it before making this change"
+	return e
+}
+
+// immutableProvisionedByConfigErr wraps ErrImmutableProvisionedByConfig with
+// the CodeImmutableProvisionedByConfig code and a suggestion. msg is the
+// boundary-level, human-readable message.
+//
+// Invariant: errors.Is(err, ErrImmutableProvisionedByConfig) still holds —
+// the sentinel is wrapped, and the ConduitError adds the machine-actionable
+// code.
+func immutableProvisionedByConfigErr(msg string) error {
+	e := conduiterr.Wrap(CodeImmutableProvisionedByConfig, msg, ErrImmutableProvisionedByConfig)
+	e.Suggestion = "change the corresponding pipeline configuration file instead"
+	return e
+}
+
+// invalidProcessorParentTypeErr wraps ErrInvalidProcessorParentType with the
+// CodeInvalidProcessorParentType code and a suggestion. msg is the
+// boundary-level, human-readable message.
+//
+// Invariant: errors.Is(err, ErrInvalidProcessorParentType) still holds — the
+// sentinel is wrapped, and the ConduitError adds the machine-actionable
+// code.
+func invalidProcessorParentTypeErr(msg string) error {
+	e := conduiterr.Wrap(CodeInvalidProcessorParentType, msg, ErrInvalidProcessorParentType)
+	e.Suggestion = `set the processor parent type to either "pipeline" or "connector"`
+	return e
+}

--- a/pkg/orchestrator/connectors.go
+++ b/pkg/orchestrator/connectors.go
@@ -16,10 +16,12 @@ package orchestrator
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/conduitio/conduit-commons/rollback"
 	"github.com/conduitio/conduit/pkg/connector"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/inspector"
 	"github.com/conduitio/conduit/pkg/pipeline"
 	"github.com/google/uuid"
@@ -59,10 +61,14 @@ func (c *ConnectorOrchestrator) Create(
 	}
 
 	if pl.ProvisionedBy != pipeline.ProvisionTypeAPI {
-		return nil, cerrors.Errorf("cannot add a connector to the pipeline %q: %w", pl.ID, ErrImmutableProvisionedByConfig)
+		// Invariant: errors.Is(err, ErrImmutableProvisionedByConfig) still holds —
+		// sentinel wrapped, ConduitError adds the code.
+		return nil, immutableProvisionedByConfigErr(fmt.Sprintf("cannot add a connector to the pipeline %q", pl.ID))
 	}
 	if pl.GetStatus() == pipeline.StatusRunning {
-		return nil, cerrors.Errorf("cannot create connector: %w", pipeline.ErrPipelineRunning)
+		// Invariant: errors.Is(err, ErrPipelineRunning) still holds — sentinel
+		// wrapped, ConduitError adds the code.
+		return nil, pipelineRunningErr("cannot create connector: " + pipeline.ErrPipelineRunning.Error())
 	}
 
 	err = c.Validate(ctx, t, plugin, config)
@@ -115,17 +121,25 @@ func (c *ConnectorOrchestrator) Delete(ctx context.Context, id string) error {
 		return err
 	}
 	if conn.ProvisionedBy != connector.ProvisionTypeAPI {
-		return cerrors.Errorf("connector %q cannot be deleted: %w", conn.ID, ErrImmutableProvisionedByConfig)
+		// Invariant: errors.Is(err, ErrImmutableProvisionedByConfig) still holds —
+		// sentinel wrapped, ConduitError adds the code.
+		return immutableProvisionedByConfigErr(fmt.Sprintf("connector %q cannot be deleted", conn.ID))
 	}
 	if len(conn.ProcessorIDs) != 0 {
-		return ErrConnectorHasProcessorsAttached
+		// Invariant: errors.Is(err, ErrConnectorHasProcessorsAttached) still holds —
+		// sentinel wrapped, ConduitError adds the code.
+		err := conduiterr.Wrap(CodeConnectorHasProcessorsAttached, ErrConnectorHasProcessorsAttached.Error(), ErrConnectorHasProcessorsAttached)
+		err.Suggestion = "remove the connector's processors first, then delete the connector"
+		return err
 	}
 	pl, err := c.pipelines.Get(ctx, conn.PipelineID)
 	if err != nil {
 		return err
 	}
 	if pl.GetStatus() == pipeline.StatusRunning {
-		return pipeline.ErrPipelineRunning
+		// Invariant: errors.Is(err, ErrPipelineRunning) still holds — sentinel
+		// wrapped, ConduitError adds the code.
+		return pipelineRunningErr(pipeline.ErrPipelineRunning.Error())
 	}
 	err = c.connectors.Delete(ctx, id, c.connectorPlugins)
 	if err != nil {
@@ -164,7 +178,9 @@ func (c *ConnectorOrchestrator) Update(ctx context.Context, id string, plugin st
 		return nil, err
 	}
 	if conn.ProvisionedBy != connector.ProvisionTypeAPI {
-		return nil, cerrors.Errorf("connector %q cannot be updated: %w", conn.ID, ErrImmutableProvisionedByConfig)
+		// Invariant: errors.Is(err, ErrImmutableProvisionedByConfig) still holds —
+		// sentinel wrapped, ConduitError adds the code.
+		return nil, immutableProvisionedByConfigErr(fmt.Sprintf("connector %q cannot be updated", conn.ID))
 	}
 
 	pl, err := c.pipelines.Get(ctx, conn.PipelineID)
@@ -172,7 +188,9 @@ func (c *ConnectorOrchestrator) Update(ctx context.Context, id string, plugin st
 		return nil, err
 	}
 	if pl.GetStatus() == pipeline.StatusRunning {
-		return nil, pipeline.ErrPipelineRunning
+		// Invariant: errors.Is(err, ErrPipelineRunning) still holds — sentinel
+		// wrapped, ConduitError adds the code.
+		return nil, pipelineRunningErr(pipeline.ErrPipelineRunning.Error())
 	}
 
 	err = c.Validate(ctx, conn.Type, conn.Plugin, config)

--- a/pkg/orchestrator/connectors_test.go
+++ b/pkg/orchestrator/connectors_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/conduitio/conduit-commons/database/inmemory"
 	"github.com/conduitio/conduit/pkg/connector"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/pipeline"
 	"github.com/google/uuid"
@@ -331,7 +332,12 @@ func TestConnectorOrchestrator_Delete_PipelineRunning(t *testing.T) {
 	orc := NewOrchestrator(db, log.Nop(), plsMock, consMock, procsMock, connPluginMock, procPluginMock, lifecycleMock)
 	err := orc.Connectors.Delete(ctx, conn.ID)
 	is.True(err != nil)
-	is.Equal(pipeline.ErrPipelineRunning, err)
+	is.True(cerrors.Is(err, pipeline.ErrPipelineRunning)) // sentinel still in the chain
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // also carries a machine-actionable ConduitError code
+	is.Equal(ce.Code.Reason(), pipeline.CodePipelineRunning.Reason())
+	is.True(ce.Suggestion != "") // with a suggested fix
 }
 
 func TestConnectorOrchestrator_Delete_ProcessorAttached(t *testing.T) {
@@ -540,7 +546,12 @@ func TestConnectorOrchestrator_Update_PipelineRunning(t *testing.T) {
 	got, err := orc.Connectors.Update(ctx, conn.ID, conn.Plugin, connector.Config{})
 	is.True(got == nil)
 	is.True(err != nil)
-	is.Equal(pipeline.ErrPipelineRunning, err)
+	is.True(cerrors.Is(err, pipeline.ErrPipelineRunning)) // sentinel still in the chain
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // also carries a machine-actionable ConduitError code
+	is.Equal(ce.Code.Reason(), pipeline.CodePipelineRunning.Reason())
+	is.True(ce.Suggestion != "") // with a suggested fix
 }
 
 func TestConnectorOrchestrator_Update_Fail(t *testing.T) {

--- a/pkg/orchestrator/pipelines.go
+++ b/pkg/orchestrator/pipelines.go
@@ -16,9 +16,10 @@ package orchestrator
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/conduitio/conduit/pkg/connector"
-	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/pipeline"
 	"github.com/google/uuid"
 )
@@ -54,11 +55,15 @@ func (po *PipelineOrchestrator) Update(ctx context.Context, id string, cfg pipel
 	}
 
 	if pl.ProvisionedBy != pipeline.ProvisionTypeAPI {
-		return nil, cerrors.Errorf("pipeline %q cannot be updated: %w", pl.ID, ErrImmutableProvisionedByConfig)
+		// Invariant: errors.Is(err, ErrImmutableProvisionedByConfig) still holds —
+		// sentinel wrapped, ConduitError adds the code.
+		return nil, immutableProvisionedByConfigErr(fmt.Sprintf("pipeline %q cannot be updated", pl.ID))
 	}
 	// TODO lock pipeline
 	if pl.GetStatus() == pipeline.StatusRunning {
-		return nil, pipeline.ErrPipelineRunning
+		// Invariant: errors.Is(err, ErrPipelineRunning) still holds — sentinel
+		// wrapped, ConduitError adds the code.
+		return nil, pipelineRunningErr(pipeline.ErrPipelineRunning.Error())
 	}
 	return po.pipelines.Update(ctx, pl.ID, cfg)
 }
@@ -70,16 +75,28 @@ func (po *PipelineOrchestrator) Delete(ctx context.Context, id string) error {
 	}
 
 	if pl.ProvisionedBy != pipeline.ProvisionTypeAPI {
-		return cerrors.Errorf("pipeline %q cannot be deleted: %w", pl.ID, ErrImmutableProvisionedByConfig)
+		// Invariant: errors.Is(err, ErrImmutableProvisionedByConfig) still holds —
+		// sentinel wrapped, ConduitError adds the code.
+		return immutableProvisionedByConfigErr(fmt.Sprintf("pipeline %q cannot be deleted", pl.ID))
 	}
 	if pl.GetStatus() == pipeline.StatusRunning {
-		return pipeline.ErrPipelineRunning
+		// Invariant: errors.Is(err, ErrPipelineRunning) still holds — sentinel
+		// wrapped, ConduitError adds the code.
+		return pipelineRunningErr(pipeline.ErrPipelineRunning.Error())
 	}
 	if len(pl.ConnectorIDs) != 0 {
-		return ErrPipelineHasConnectorsAttached
+		// Invariant: errors.Is(err, ErrPipelineHasConnectorsAttached) still holds —
+		// sentinel wrapped, ConduitError adds the code.
+		err := conduiterr.Wrap(CodePipelineHasConnectorsAttached, ErrPipelineHasConnectorsAttached.Error(), ErrPipelineHasConnectorsAttached)
+		err.Suggestion = "remove the pipeline's connectors first, then delete the pipeline"
+		return err
 	}
 	if len(pl.ProcessorIDs) != 0 {
-		return ErrPipelineHasProcessorsAttached
+		// Invariant: errors.Is(err, ErrPipelineHasProcessorsAttached) still holds —
+		// sentinel wrapped, ConduitError adds the code.
+		err := conduiterr.Wrap(CodePipelineHasProcessorsAttached, ErrPipelineHasProcessorsAttached.Error(), ErrPipelineHasProcessorsAttached)
+		err.Suggestion = "remove the pipeline's processors first, then delete the pipeline"
+		return err
 	}
 	return po.pipelines.Delete(ctx, pl.ID)
 }
@@ -91,11 +108,15 @@ func (po *PipelineOrchestrator) UpdateDLQ(ctx context.Context, id string, dlq pi
 	}
 
 	if pl.ProvisionedBy != pipeline.ProvisionTypeAPI {
-		return nil, cerrors.Errorf("pipeline %q cannot be updated: %w", pl.ID, ErrImmutableProvisionedByConfig)
+		// Invariant: errors.Is(err, ErrImmutableProvisionedByConfig) still holds —
+		// sentinel wrapped, ConduitError adds the code.
+		return nil, immutableProvisionedByConfigErr(fmt.Sprintf("pipeline %q cannot be updated", pl.ID))
 	}
 	// TODO lock pipeline
 	if pl.GetStatus() == pipeline.StatusRunning {
-		return nil, pipeline.ErrPipelineRunning
+		// Invariant: errors.Is(err, ErrPipelineRunning) still holds — sentinel
+		// wrapped, ConduitError adds the code.
+		return nil, pipelineRunningErr(pipeline.ErrPipelineRunning.Error())
 	}
 
 	// cast orchestrator to a ConnectorOrchestrator to get access to the plugin

--- a/pkg/orchestrator/pipelines_test.go
+++ b/pkg/orchestrator/pipelines_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/conduitio/conduit-commons/database/inmemory"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/pipeline"
 	"github.com/google/uuid"
@@ -163,7 +164,12 @@ func TestPipelineOrchestrator_Update_PipelineRunning(t *testing.T) {
 
 	got, err := orc.Pipelines.Update(ctx, plBefore.ID, newConfig)
 	is.Equal(got, nil)
-	is.Equal(err, pipeline.ErrPipelineRunning)
+	is.True(cerrors.Is(err, pipeline.ErrPipelineRunning)) // sentinel still in the chain
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // also carries a machine-actionable ConduitError code
+	is.Equal(ce.Code.Reason(), pipeline.CodePipelineRunning.Reason())
+	is.True(ce.Suggestion != "") // with a suggested fix
 }
 
 func TestPipelineOrchestrator_Update_PipelineProvisionedByConfig(t *testing.T) {
@@ -231,7 +237,12 @@ func TestPipelineOrchestrator_Delete_PipelineRunning(t *testing.T) {
 		Return(plBefore, nil)
 
 	err := orc.Pipelines.Delete(ctx, plBefore.ID)
-	is.Equal(pipeline.ErrPipelineRunning, err)
+	is.True(cerrors.Is(err, pipeline.ErrPipelineRunning)) // sentinel still in the chain
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // also carries a machine-actionable ConduitError code
+	is.Equal(ce.Code.Reason(), pipeline.CodePipelineRunning.Reason())
+	is.True(ce.Suggestion != "") // with a suggested fix
 }
 
 func TestPipelineOrchestrator_Delete_PipelineProvisionedByConfig(t *testing.T) {
@@ -273,7 +284,12 @@ func TestPipelineOrchestrator_Delete_PipelineHasProcessorsAttached(t *testing.T)
 		Return(plBefore, nil)
 
 	err := orc.Pipelines.Delete(ctx, plBefore.ID)
-	is.Equal(err, ErrPipelineHasProcessorsAttached)
+	is.True(cerrors.Is(err, ErrPipelineHasProcessorsAttached)) // sentinel still in the chain
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // also carries a machine-actionable ConduitError code
+	is.Equal(ce.Code.Reason(), CodePipelineHasProcessorsAttached.Reason())
+	is.True(ce.Suggestion != "") // with a suggested fix
 }
 
 func TestPipelineOrchestrator_Delete_PipelineHasConnectorsAttached(t *testing.T) {
@@ -294,7 +310,12 @@ func TestPipelineOrchestrator_Delete_PipelineHasConnectorsAttached(t *testing.T)
 		Return(plBefore, nil)
 
 	err := orc.Pipelines.Delete(ctx, plBefore.ID)
-	is.Equal(err, ErrPipelineHasConnectorsAttached)
+	is.True(cerrors.Is(err, ErrPipelineHasConnectorsAttached)) // sentinel still in the chain
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // also carries a machine-actionable ConduitError code
+	is.Equal(ce.Code.Reason(), CodePipelineHasConnectorsAttached.Reason())
+	is.True(ce.Suggestion != "") // with a suggested fix
 }
 
 func TestPipelineOrchestrator_Delete_PipelineDoesntExist(t *testing.T) {
@@ -377,8 +398,13 @@ func TestPipelineOrchestrator_UpdateDLQ_PipelineRunning(t *testing.T) {
 		Return(plBefore, nil)
 
 	got, err := orc.Pipelines.UpdateDLQ(ctx, plBefore.ID, pipeline.DLQ{})
-	is.Equal(err, pipeline.ErrPipelineRunning)
+	is.True(cerrors.Is(err, pipeline.ErrPipelineRunning)) // sentinel still in the chain
 	is.Equal(got, nil)
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // also carries a machine-actionable ConduitError code
+	is.Equal(ce.Code.Reason(), pipeline.CodePipelineRunning.Reason())
+	is.True(ce.Suggestion != "") // with a suggested fix
 }
 
 func TestPipelineOrchestrator_UpdateDLQ_PipelineProvisionedByConfig(t *testing.T) {

--- a/pkg/orchestrator/processors.go
+++ b/pkg/orchestrator/processors.go
@@ -16,6 +16,7 @@ package orchestrator
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/conduitio/conduit-commons/rollback"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
@@ -50,11 +51,15 @@ func (p *ProcessorOrchestrator) Create(
 
 	// check if pipeline was provisioned by config
 	if pl.ProvisionedBy != pipeline.ProvisionTypeAPI {
-		return nil, cerrors.Errorf("cannot add a processor to the pipeline %q: %w", pl.ID, ErrImmutableProvisionedByConfig)
+		// Invariant: errors.Is(err, ErrImmutableProvisionedByConfig) still holds —
+		// sentinel wrapped, ConduitError adds the code.
+		return nil, immutableProvisionedByConfigErr(fmt.Sprintf("cannot add a processor to the pipeline %q", pl.ID))
 	}
 
 	if pl.GetStatus() == pipeline.StatusRunning {
-		return nil, pipeline.ErrPipelineRunning
+		// Invariant: errors.Is(err, ErrPipelineRunning) still holds — sentinel
+		// wrapped, ConduitError adds the code.
+		return nil, pipelineRunningErr(pipeline.ErrPipelineRunning.Error())
 	}
 
 	// create processor and add to pipeline or connector
@@ -92,7 +97,9 @@ func (p *ProcessorOrchestrator) Create(
 			return err
 		})
 	default:
-		return nil, cerrors.Errorf("%w: %s", ErrInvalidProcessorParentType, parent.Type)
+		// Invariant: errors.Is(err, ErrInvalidProcessorParentType) still holds —
+		// sentinel wrapped, ConduitError adds the code.
+		return nil, invalidProcessorParentTypeErr(fmt.Sprintf("%s: %s", ErrInvalidProcessorParentType, parent.Type))
 	}
 
 	// commit db transaction and skip rollback
@@ -154,7 +161,9 @@ func (p *ProcessorOrchestrator) Update(ctx context.Context, id string, plugin st
 
 	// check if processor was provisioned by config
 	if proc.ProvisionedBy != processor.ProvisionTypeAPI {
-		return nil, cerrors.Errorf("processor %q cannot be updated: %w", proc.ID, ErrImmutableProvisionedByConfig)
+		// Invariant: errors.Is(err, ErrImmutableProvisionedByConfig) still holds —
+		// sentinel wrapped, ConduitError adds the code.
+		return nil, immutableProvisionedByConfigErr(fmt.Sprintf("processor %q cannot be updated", proc.ID))
 	}
 	// provisioned by API
 	oldPlugin := proc.Plugin
@@ -166,7 +175,9 @@ func (p *ProcessorOrchestrator) Update(ctx context.Context, id string, plugin st
 	}
 
 	if pl.GetStatus() == pipeline.StatusRunning {
-		return nil, pipeline.ErrPipelineRunning
+		// Invariant: errors.Is(err, ErrPipelineRunning) still holds — sentinel
+		// wrapped, ConduitError adds the code.
+		return nil, pipelineRunningErr(pipeline.ErrPipelineRunning.Error())
 	}
 
 	proc, err = p.processors.Update(ctx, id, plugin, cfg)
@@ -205,7 +216,9 @@ func (p *ProcessorOrchestrator) Delete(ctx context.Context, id string) error {
 
 	// check if processor was provisioned by config
 	if proc.ProvisionedBy != processor.ProvisionTypeAPI {
-		return cerrors.Errorf("processor %q cannot be deleted: %w", proc.ID, ErrImmutableProvisionedByConfig)
+		// Invariant: errors.Is(err, ErrImmutableProvisionedByConfig) still holds —
+		// sentinel wrapped, ConduitError adds the code.
+		return immutableProvisionedByConfigErr(fmt.Sprintf("processor %q cannot be deleted", proc.ID))
 	}
 
 	pl, err := p.getProcessorsPipeline(ctx, proc.Parent)
@@ -214,7 +227,9 @@ func (p *ProcessorOrchestrator) Delete(ctx context.Context, id string) error {
 	}
 
 	if pl.GetStatus() == pipeline.StatusRunning {
-		return pipeline.ErrPipelineRunning
+		// Invariant: errors.Is(err, ErrPipelineRunning) still holds — sentinel
+		// wrapped, ConduitError adds the code.
+		return pipelineRunningErr(pipeline.ErrPipelineRunning.Error())
 	}
 
 	err = p.processors.Delete(ctx, id)
@@ -246,7 +261,9 @@ func (p *ProcessorOrchestrator) Delete(ctx context.Context, id string) error {
 			return err
 		})
 	default:
-		return cerrors.Errorf("%w: %s", ErrInvalidProcessorParentType, proc.Parent.Type)
+		// Invariant: errors.Is(err, ErrInvalidProcessorParentType) still holds —
+		// sentinel wrapped, ConduitError adds the code.
+		return invalidProcessorParentTypeErr(fmt.Sprintf("%s: %s", ErrInvalidProcessorParentType, proc.Parent.Type))
 	}
 
 	// commit db transaction and skip rollback
@@ -270,6 +287,8 @@ func (p *ProcessorOrchestrator) getProcessorsPipeline(ctx context.Context, paren
 		}
 		return p.pipelines.Get(ctx, conn.PipelineID)
 	default:
-		return nil, cerrors.Errorf("%w: %s", ErrInvalidProcessorParentType, parent.Type)
+		// Invariant: errors.Is(err, ErrInvalidProcessorParentType) still holds —
+		// sentinel wrapped, ConduitError adds the code.
+		return nil, invalidProcessorParentTypeErr(fmt.Sprintf("%s: %s", ErrInvalidProcessorParentType, parent.Type))
 	}
 }

--- a/pkg/orchestrator/processors_test.go
+++ b/pkg/orchestrator/processors_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/conduitio/conduit-commons/database/inmemory"
 	"github.com/conduitio/conduit/pkg/connector"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/pipeline"
 	"github.com/conduitio/conduit/pkg/processor"
@@ -124,7 +125,12 @@ func TestProcessorOrchestrator_CreateOnPipeline_PipelineRunning(t *testing.T) {
 	orc := NewOrchestrator(db, log.Nop(), plsMock, consMock, procsMock, connPluginMock, procPluginMock, lifecycleMock)
 	got, err := orc.Processors.Create(ctx, "test-processor", parent, processor.Config{}, "")
 	is.True(err != nil)
-	is.Equal(pipeline.ErrPipelineRunning, err)
+	is.True(cerrors.Is(err, pipeline.ErrPipelineRunning)) // sentinel still in the chain
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // also carries a machine-actionable ConduitError code
+	is.Equal(ce.Code.Reason(), pipeline.CodePipelineRunning.Reason())
+	is.True(ce.Suggestion != "") // with a suggested fix
 	is.True(got == nil)
 }
 
@@ -460,7 +466,12 @@ func TestProcessorOrchestrator_UpdateOnPipeline_PipelineRunning(t *testing.T) {
 	orc := NewOrchestrator(db, log.Nop(), plsMock, consMock, procsMock, connPluginMock, procPluginMock, lifecycleMock)
 	got, err := orc.Processors.Update(ctx, before.ID, before.Plugin, newConfig)
 	is.True(err != nil)
-	is.Equal(pipeline.ErrPipelineRunning, err)
+	is.True(cerrors.Is(err, pipeline.ErrPipelineRunning)) // sentinel still in the chain
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // also carries a machine-actionable ConduitError code
+	is.Equal(ce.Code.Reason(), pipeline.CodePipelineRunning.Reason())
+	is.True(ce.Suggestion != "") // with a suggested fix
 	is.True(got == nil)
 }
 
@@ -702,7 +713,12 @@ func TestProcessorOrchestrator_DeleteOnPipeline_PipelineRunning(t *testing.T) {
 	orc := NewOrchestrator(db, log.Nop(), plsMock, consMock, procsMock, connPluginMock, procPluginMock, lifecycleMock)
 	err := orc.Processors.Delete(ctx, want.ID)
 	is.True(err != nil)
-	is.Equal(pipeline.ErrPipelineRunning, err)
+	is.True(cerrors.Is(err, pipeline.ErrPipelineRunning)) // sentinel still in the chain
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // also carries a machine-actionable ConduitError code
+	is.Equal(ce.Code.Reason(), pipeline.CodePipelineRunning.Reason())
+	is.True(ce.Suggestion != "") // with a suggested fix
 }
 
 func TestProcessorOrchestrator_DeleteOnPipeline_Fail(t *testing.T) {

--- a/pkg/pipeline/codes.go
+++ b/pkg/pipeline/codes.go
@@ -26,4 +26,16 @@ var (
 	// CodePipelineNotFound is raised when a referenced pipeline instance
 	// cannot be located.
 	CodePipelineNotFound = conduiterr.Register("pipeline.instance_not_found", codes.NotFound)
+	// CodePipelineRunning is raised when an operation requires the pipeline
+	// to be stopped, but it is currently running.
+	CodePipelineRunning = conduiterr.Register("pipeline.running", codes.FailedPrecondition)
+	// CodePipelineNotRunning is raised when an operation requires the
+	// pipeline to be running, but it is currently stopped.
+	CodePipelineNotRunning = conduiterr.Register("pipeline.not_running", codes.FailedPrecondition)
+	// CodePipelineNameAlreadyExists is raised when a pipeline config's name
+	// collides with an existing pipeline's name.
+	CodePipelineNameAlreadyExists = conduiterr.Register("pipeline.name_already_exists", codes.AlreadyExists)
+	// CodePipelineNameMissing is raised when a pipeline config is missing
+	// the required name field.
+	CodePipelineNameMissing = conduiterr.Register("pipeline.name_missing", codes.InvalidArgument)
 )

--- a/pkg/pipeline/service.go
+++ b/pkg/pipeline/service.go
@@ -158,13 +158,21 @@ func (s *Service) Update(ctx context.Context, pipelineID string, cfg Config) (*I
 		return nil, err
 	}
 	if cfg.Name == "" {
-		return nil, ErrNameMissing
+		// Invariant: errors.Is(err, ErrNameMissing) still holds — sentinel
+		// wrapped, ConduitError adds the code.
+		err := conduiterr.Wrap(CodePipelineNameMissing, "must provide a pipeline name", ErrNameMissing)
+		err.Suggestion = "provide a non-empty pipeline name"
+		return nil, err
 	}
 
 	// delete the old name from the names set
 	exists := s.instanceNames[cfg.Name]
 	if exists && pl.Config.Name != cfg.Name {
-		return nil, ErrNameAlreadyExists
+		// Invariant: errors.Is(err, ErrNameAlreadyExists) still holds — sentinel
+		// wrapped, ConduitError adds the code.
+		err := conduiterr.Wrap(CodePipelineNameAlreadyExists, "pipeline name already exists", ErrNameAlreadyExists)
+		err.Suggestion = "choose a different pipeline name"
+		return nil, err
 	}
 
 	delete(s.instanceNames, pl.Config.Name) // delete the old name
@@ -322,10 +330,18 @@ func (s *Service) validatePipeline(cfg Config, id string) error {
 	var errs []error
 
 	if cfg.Name == "" {
-		errs = append(errs, ErrNameMissing)
+		// Invariant: errors.Is(err, ErrNameMissing) still holds — sentinel
+		// wrapped, ConduitError adds the code.
+		nameMissingErr := conduiterr.Wrap(CodePipelineNameMissing, "must provide a pipeline name", ErrNameMissing)
+		nameMissingErr.Suggestion = "provide a non-empty pipeline name"
+		errs = append(errs, nameMissingErr)
 	}
 	if s.instanceNames[cfg.Name] {
-		errs = append(errs, ErrNameAlreadyExists)
+		// Invariant: errors.Is(err, ErrNameAlreadyExists) still holds — sentinel
+		// wrapped, ConduitError adds the code.
+		nameExistsErr := conduiterr.Wrap(CodePipelineNameAlreadyExists, "pipeline name already exists", ErrNameAlreadyExists)
+		nameExistsErr.Suggestion = "choose a different pipeline name"
+		errs = append(errs, nameExistsErr)
 	}
 	if len(cfg.Name) > NameLengthLimit {
 		errs = append(errs, ErrNameOverLimit)

--- a/pkg/pipeline/service_test.go
+++ b/pkg/pipeline/service_test.go
@@ -198,14 +198,16 @@ func TestService_Create_ValidateError(t *testing.T) {
 	service := NewService(logger, db)
 
 	testCases := []struct {
-		name    string
-		id      string
-		errType error
-		data    Config
+		name     string
+		id       string
+		errType  error
+		wantCode conduiterr.Code // zero value means "don't check the ConduitError code"
+		data     Config
 	}{{
-		name:    "empty config name",
-		id:      uuid.NewString(),
-		errType: ErrNameMissing,
+		name:     "empty config name",
+		id:       uuid.NewString(),
+		errType:  ErrNameMissing,
+		wantCode: CodePipelineNameMissing,
 		data: Config{
 			Name:        "",
 			Description: "",
@@ -252,8 +254,15 @@ func TestService_Create_ValidateError(t *testing.T) {
 				tt.data,
 				ProvisionTypeAPI,
 			)
-			is.True(cerrors.Is(err, tt.errType))
+			is.True(cerrors.Is(err, tt.errType)) // sentinel still in the chain
 			is.Equal(got, nil)
+
+			if !tt.wantCode.IsZero() {
+				ce, ok := conduiterr.Get(err)
+				is.True(ok) // also carries a machine-actionable ConduitError code
+				is.Equal(ce.Code.Reason(), tt.wantCode.Reason())
+				is.True(ce.Suggestion != "") // with a suggested fix
+			}
 		})
 	}
 }
@@ -273,6 +282,12 @@ func TestService_Create_PipelineNameExists(t *testing.T) {
 	got, err = service.Create(ctx, uuid.NewString(), conf, ProvisionTypeAPI)
 	is.Equal(got, nil)
 	is.True(err != nil)
+	is.True(cerrors.Is(err, ErrNameAlreadyExists)) // sentinel still in the chain
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // also carries a machine-actionable ConduitError code
+	is.Equal(ce.Code.Reason(), CodePipelineNameAlreadyExists.Reason())
+	is.True(ce.Suggestion != "") // with a suggested fix
 }
 
 func TestService_CreateEmptyName(t *testing.T) {
@@ -285,6 +300,12 @@ func TestService_CreateEmptyName(t *testing.T) {
 	got, err := service.Create(ctx, uuid.NewString(), Config{Name: ""}, ProvisionTypeAPI)
 	is.True(err != nil)
 	is.Equal(got, nil)
+	is.True(cerrors.Is(err, ErrNameMissing)) // sentinel still in the chain
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // also carries a machine-actionable ConduitError code
+	is.Equal(ce.Code.Reason(), CodePipelineNameMissing.Reason())
+	is.True(ce.Suggestion != "") // with a suggested fix
 }
 
 func TestService_GetSuccess(t *testing.T) {
@@ -398,6 +419,12 @@ func TestService_Update_PipelineNameExists(t *testing.T) {
 	got, err := service.Update(ctx, instance2.ID, want)
 	is.True(err != nil)
 	is.Equal(got, nil)
+	is.True(cerrors.Is(err, ErrNameAlreadyExists)) // sentinel still in the chain
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // also carries a machine-actionable ConduitError code
+	is.Equal(ce.Code.Reason(), CodePipelineNameAlreadyExists.Reason())
+	is.True(ce.Suggestion != "") // with a suggested fix
 }
 
 func TestService_UpdateInvalidConfig(t *testing.T) {
@@ -415,4 +442,10 @@ func TestService_UpdateInvalidConfig(t *testing.T) {
 	got, err := service.Update(ctx, instance.ID, config)
 	is.True(err != nil)
 	is.Equal(got, nil)
+	is.True(cerrors.Is(err, ErrNameMissing)) // sentinel still in the chain
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // also carries a machine-actionable ConduitError code
+	is.Equal(ce.Code.Reason(), CodePipelineNameMissing.Reason())
+	is.True(ce.Suggestion != "") // with a suggested fix
 }


### PR DESCRIPTION
## Summary

Continues the structured-error rollout (item 2). Steps 1-4 (#2524, #2527, #2528, #2530,
#2532) wired the `ConduitError` foundation into the API boundary and migrated every
not-found sentinel. This PR migrates the non-not-found sentinels that guard pipeline
lifecycle and mutation preconditions, following the exact `conduiterr.Wrap` pattern from
those PRs.

Purely additive: `pkg/http/api/status/status.go`'s `conduitErrorStatus` already turns any
`*ConduitError` into the right gRPC status + `ErrorInfo` detail; the sentinel-based
`codeFromError`/`PipelineError`/`ConnectorError` switches are untouched and remain the
fallback for anything not yet migrated. Every sentinel stays in the error chain via
`conduiterr.Wrap`, so `errors.Is(err, ErrX)` checks throughout the codebase are
unaffected — verified below.

### Codes added

| Code (reason) | gRPC code | Sentinel | Package |
| --- | --- | --- | --- |
| `pipeline.running` | FailedPrecondition | `ErrPipelineRunning` | pipeline (`CodePipelineRunning`) |
| `pipeline.not_running` | FailedPrecondition | `ErrPipelineNotRunning` | pipeline (`CodePipelineNotRunning`) |
| `pipeline.name_already_exists` | AlreadyExists | `ErrNameAlreadyExists` | pipeline (`CodePipelineNameAlreadyExists`) |
| `pipeline.name_missing` | InvalidArgument | `ErrNameMissing` | pipeline (`CodePipelineNameMissing`) |
| `connector.running` | FailedPrecondition | `ErrConnectorRunning` | connector (`CodeConnectorRunning`) |
| `connector.invalid_type` | InvalidArgument | `ErrInvalidConnectorType` | connector (`CodeConnectorInvalidType`) |
| `orchestrator.invalid_processor_parent_type` | InvalidArgument | `ErrInvalidProcessorParentType` | orchestrator (new `codes.go`) |
| `orchestrator.pipeline_has_processors_attached` | FailedPrecondition | `ErrPipelineHasProcessorsAttached` | orchestrator |
| `orchestrator.pipeline_has_connectors_attached` | FailedPrecondition | `ErrPipelineHasConnectorsAttached` | orchestrator |
| `orchestrator.connector_has_processors_attached` | FailedPrecondition | `ErrConnectorHasProcessorsAttached` | orchestrator |
| `orchestrator.immutable_provisioned_by_config` | FailedPrecondition | `ErrImmutableProvisionedByConfig` | orchestrator |

### Per-sentinel raise sites: migrated vs deferred

- **`ErrPipelineRunning` / `ErrPipelineNotRunning`** — sentinel is defined in `pkg/pipeline`
  but raised in `pkg/lifecycle` and `pkg/orchestrator`. Migrated the clean control-plane
  sites: `lifecycle.Service.Start`/`Stop` (the authoritative check) and every
  `orchestrator.{Pipeline,Connector,Processor}Orchestrator` CRUD guard (9 sites for
  `ErrPipelineRunning`, 2 for `ErrPipelineNotRunning`).
  **Deferred** (reported, not touched): the `lifecycle-poc` (`PipelineArchV2` preview
  engine) mirror of both Start/Stop checks, and the internal
  `lifecycle.Service.runPipeline` tomb-alive defensive check (redundant with `Start`'s
  check, several layers below the API boundary). Both remain bare sentinels — no
  behavior change, `errors.Is` still holds.
- **`ErrNameAlreadyExists` / `ErrNameMissing`** (pipeline package only —
  `connector.ErrNameMissing` is a distinct sentinel, out of scope per the task) —
  migrated both raise sites: `Service.Update` (direct return) and `validatePipeline`
  (joined via `cerrors.Join`, same pattern already proven in
  `pkg/provisioning/config/validate.go`'s `fieldError` helper).
- **`ErrConnectorRunning`** — single choke point, `connector.Instance.Connector`.
  Migrated.
- **`ErrInvalidConnectorType`** — 4 raise sites total. Migrated the one user-facing site,
  `connector.Service.Create` (validates a caller-supplied type). **Deferred**: the three
  `default:` branches in `Service.SetState`, `Store.decode`, and
  `Instance.Connector` — all guard against a `Type` value already validated at `Create`
  time (storage-layer/defensive, effectively unreachable in practice); left as bare
  sentinels.
- **`ErrInvalidProcessorParentType`**, **`ErrPipelineHasProcessorsAttached`**,
  **`ErrPipelineHasConnectorsAttached`**, **`ErrConnectorHasProcessorsAttached`**,
  **`ErrImmutableProvisionedByConfig`** — all defined and raised entirely within
  `pkg/orchestrator` (3, 1, 1, 1, and 9 sites respectively). Migrated every site; added
  small unexported helpers (`pipelineRunningErr`, `immutableProvisionedByConfigErr`,
  `invalidProcessorParentTypeErr` in the new `pkg/orchestrator/codes.go`) to avoid
  repeating the wrap+suggestion boilerplate across the 9 `ErrImmutableProvisionedByConfig`
  sites.

### Adversarial self-review

- Re-checked every `conduiterr.Wrap` call: `Wrap`'s `msg` *replaces* (does not
  concatenate with) the cause's `Error()` text, so for sites that previously did
  `cerrors.Errorf("<prefix>: %w", sentinel)` I reconstructed the equivalent text via
  `fmt.Sprintf`/string-concat with `sentinel.Error()` so the human-readable message is
  unchanged.
- Confirmed `pkg/pipeline/service.go`'s `validatePipeline` joins multiple wrapped
  `*ConduitError`s via `cerrors.Join`; `conduiterr.Get` (via `errors.As`) still finds the
  first one, matching the existing `pkg/provisioning/config/validate.go` precedent (Go
  1.20+ `Unwrap() []error` support).
- Found four existing tests that asserted **strict identity** (`is.Equal(err, sentinel)`,
  stronger than `errors.Is`) on sentinels that used to be returned bare:
  `TestPipelineOrchestrator_{Update,Delete,UpdateDLQ}_PipelineRunning`,
  `TestPipelineOrchestrator_Delete_PipelineHas{Processors,Connectors}Attached`,
  `TestConnectorOrchestrator_{Delete,Update}_PipelineRunning`,
  `TestProcessorOrchestrator_{CreateOnPipeline,UpdateOnPipeline,DeleteOnPipeline}_PipelineRunning`.
  Wrapping necessarily breaks `is.Equal` identity (the concrete error value changes from
  the sentinel to a `*ConduitError`); updated these to `errors.Is` + a new
  `conduiterr.Get` check for the code and suggestion — this is not a weakened
  assertion, it verifies the same fact (this exact sentinel is in the chain) the way
  every other migrated site's test does.
- Added minimal new tests where no test previously exercised the raise site directly:
  `TestInstance_Connector_AlreadyRunning` (connector), `TestServiceLifecycle_Start_AlreadyRunning`
  / `TestServiceLifecycle_Stop_NotRunning` (lifecycle).
- Did not touch `pkg/http/api/status/status.go` — its sentinel-based fallback switches
  are intentionally left alone per the established pattern (they still catch the
  deferred/bare-sentinel sites above).

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/pipeline/... ./pkg/connector/... ./pkg/orchestrator/... ./pkg/http/api/... ./pkg/provisioning/... -count=1` — all green
- [x] `go test -race` on the same packages plus `./pkg/lifecycle/...` — all green, no data races
- [x] `golangci-lint run ./pkg/pipeline/... ./pkg/connector/... ./pkg/orchestrator/...` — 0 issues
- [x] `GOOS=linux GOARCH=386 go build ./...` — OK
- [x] Verified every `errors.Is(err, ErrX)` check across the repo still holds for all
      migrated and deferred sentinels (grepped for `Is(` usages before and after)

Risk tier: **Tier 2** (API/orchestrator error surface, not a data-path/serialization
change — no wire format, no protocol, no state layer touched). One reviewer approval
required per `CLAUDE.md`; not merging this myself per the task instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tapg9dLWXKMZJoL65R24vd
