### PR TITLE
fix(lifecycle): guard all four ForceStop nodes against startup nil-panic (#2539)

### DIFF
--- a/pkg/lifecycle/stream/destination.go
+++ b/pkg/lifecycle/stream/destination.go
@@ -36,7 +36,9 @@ type DestinationNode struct {
 	base   pubSubNodeBase
 	logger log.CtxLogger
 
-	connectorCtxCancel context.CancelFunc
+	// stopper force-stops the connector context, coordinating with Run so a
+	// force-stop that races startup is neither lost nor a nil-panic. See #2539.
+	stopper forceStopper
 }
 
 type Destination interface {
@@ -63,10 +65,10 @@ func (n *DestinationNode) Run(ctx context.Context) (err error) {
 	defer cleanup()
 
 	// start a fresh connector context to make sure the connector is running
-	// until this method returns
-	var connectorCtx context.Context
-	connectorCtx, n.connectorCtxCancel = context.WithCancel(context.Background())
-	defer n.connectorCtxCancel()
+	// until this method returns. stopper.start also applies a force-stop that
+	// arrived before now (raced startup).
+	connectorCtx, connectorCtxCancel := n.stopper.start()
+	defer connectorCtxCancel()
 
 	var (
 		// lastPosition stores the position of the last successfully processed record
@@ -137,7 +139,7 @@ func (n *DestinationNode) Run(ctx context.Context) (err error) {
 
 func (n *DestinationNode) ForceStop(ctx context.Context) {
 	n.logger.Warn(ctx).Msg("force stopping destination connector")
-	n.connectorCtxCancel()
+	n.stopper.stop()
 }
 
 // Sub will subscribe this node to an incoming channel.

--- a/pkg/lifecycle/stream/destination_acker.go
+++ b/pkg/lifecycle/stream/destination_acker.go
@@ -36,13 +36,12 @@ type DestinationAckerNode struct {
 
 	queueMutex sync.Mutex
 
-	// mctx guards access to the contextCtxCancel function
-	mctx sync.Mutex
-
 	base   subNodeBase
 	logger log.CtxLogger
 
-	connectorCtxCancel context.CancelFunc
+	// stopper force-stops the connector context, coordinating with Run so a
+	// force-stop that races startup is neither lost nor a nil-panic. See #2539.
+	stopper forceStopper
 }
 
 func (n *DestinationAckerNode) ID() string {
@@ -51,12 +50,10 @@ func (n *DestinationAckerNode) ID() string {
 
 func (n *DestinationAckerNode) Run(ctx context.Context) (err error) {
 	// start a fresh connector context to make sure the connector is running
-	// until this method returns
-	var connectorCtx context.Context
-	n.mctx.Lock()
-	connectorCtx, n.connectorCtxCancel = context.WithCancel(context.Background())
-	n.mctx.Unlock()
-	defer n.connectorCtxCancel()
+	// until this method returns. stopper.start also applies a force-stop that
+	// arrived before now (raced startup).
+	connectorCtx, connectorCtxCancel := n.stopper.start()
+	defer connectorCtxCancel()
 
 	// signalChan is buffered to ensure signals don't get lost if worker is busy
 	signalChan := make(chan struct{}, 1)
@@ -253,7 +250,5 @@ func (n *DestinationAckerNode) SetLogger(logger log.CtxLogger) {
 
 func (n *DestinationAckerNode) ForceStop(ctx context.Context) {
 	n.logger.Warn(ctx).Msg("force stopping destination acker node")
-	n.mctx.Lock()
-	n.connectorCtxCancel()
-	n.mctx.Unlock()
+	n.stopper.stop()
 }

--- a/pkg/lifecycle/stream/dlq.go
+++ b/pkg/lifecycle/stream/dlq.go
@@ -59,7 +59,9 @@ type DLQHandlerNode struct {
 	// m guards access to Handler and window
 	m sync.Mutex
 
-	handlerCtxCancel context.CancelFunc
+	// stopper force-stops the handler context, coordinating with Run so a
+	// force-stop that races startup is neither lost nor a nil-panic. See #2539.
+	stopper forceStopper
 }
 
 func (n *DLQHandlerNode) ID() string {
@@ -73,10 +75,10 @@ func (n *DLQHandlerNode) Run(ctx context.Context) error {
 	n.window = newDLQWindow(n.WindowSize, n.WindowNackThreshold)
 
 	// start a fresh connector context to make sure the handler is running until
-	// this method returns
-	var handlerCtx context.Context
-	handlerCtx, n.handlerCtxCancel = context.WithCancel(context.Background())
-	defer n.handlerCtxCancel()
+	// this method returns. stopper.start also applies a force-stop that arrived
+	// before now (raced startup).
+	handlerCtx, handlerCtxCancel := n.stopper.start()
+	defer handlerCtxCancel()
 
 	err := n.Handler.Open(handlerCtx)
 	if err != nil {
@@ -207,7 +209,7 @@ func (n *DLQHandlerNode) SetLogger(logger log.CtxLogger) {
 
 func (n *DLQHandlerNode) ForceStop(ctx context.Context) {
 	n.logger.Warn(ctx).Msg("force stopping DLQ handler node")
-	n.handlerCtxCancel()
+	n.stopper.stop()
 }
 
 // dlqWindow is responsible for tracking the last N nacks/acks and enforce a

--- a/pkg/lifecycle/stream/force_stop.go
+++ b/pkg/lifecycle/stream/force_stop.go
@@ -39,6 +39,10 @@ import (
 // invariant 7: force at any instant must be recoverable, not crash), and it was
 // previously reimplemented per node — one of four correctly, the rest with a
 // nil-deref panic and, for two, an unsynchronized field. See #2539.
+//
+// A forceStopper is single-shot: once stopped it stays stopped, matching a node's
+// single-use lifecycle (a new pipeline run builds fresh nodes). It is not designed
+// to be reset and reused.
 type forceStopper struct {
 	mu      sync.Mutex
 	cancel  context.CancelFunc

--- a/pkg/lifecycle/stream/force_stop.go
+++ b/pkg/lifecycle/stream/force_stop.go
@@ -1,0 +1,74 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stream
+
+import (
+	"context"
+	"sync"
+)
+
+// forceStopper coordinates force-stopping a node's connector context with the
+// node's Run initialization. A force-stoppable node holds one, calls start() when
+// Run sets up its connector context, and calls stop() from ForceStop.
+//
+// The two can race: force-stop is gated only on the pipeline status being
+// "running", which is set as the node goroutines launch, so ForceStop may run
+// before Run has created the connector context. forceStopper makes that safe in
+// both orderings:
+//
+//   - stop() after start(): cancels the connector context immediately.
+//   - stop() before start(): latches the request; start() cancels the context the
+//     moment it is created, so the force-stop is neither lost nor a nil-panic.
+//
+// All state is guarded by mu, so the cancel func written by start() (in the Run
+// goroutine) and read by stop() (in the force-stop goroutine) never race.
+//
+// This exists because force-stop is a crash-safety guarantee (data-integrity
+// invariant 7: force at any instant must be recoverable, not crash), and it was
+// previously reimplemented per node — one of four correctly, the rest with a
+// nil-deref panic and, for two, an unsynchronized field. See #2539.
+type forceStopper struct {
+	mu      sync.Mutex
+	cancel  context.CancelFunc
+	stopped bool
+}
+
+// start returns a fresh cancelable context for the node's connector and records
+// its cancel func. If stop() already ran, the returned context is already
+// canceled. The caller must defer the returned cancel func so the connector
+// context is released when Run returns.
+func (f *forceStopper) start() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cancel = cancel
+	if f.stopped {
+		cancel()
+	}
+	return ctx, cancel
+}
+
+// stop cancels the connector context. If start() has not run yet, it latches the
+// request so start() cancels immediately when it does.
+func (f *forceStopper) stop() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.cancel != nil {
+		f.cancel()
+		return
+	}
+	f.stopped = true
+}

--- a/pkg/lifecycle/stream/force_stop_test.go
+++ b/pkg/lifecycle/stream/force_stop_test.go
@@ -1,0 +1,98 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stream
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+func TestForceStopper_StopAfterStart(t *testing.T) {
+	is := is.New(t)
+	var fs forceStopper
+
+	ctx, cancel := fs.start()
+	defer cancel()
+	is.NoErr(ctx.Err()) // running: not canceled yet
+
+	fs.stop()
+	is.True(ctx.Err() != nil) // stop cancels the connector context
+}
+
+// TestForceStopper_StopBeforeStart is the #2539 case: a force-stop that arrives
+// before Run initialized the context must not be lost or panic — it latches, and
+// start() returns an already-canceled context.
+func TestForceStopper_StopBeforeStart(t *testing.T) {
+	is := is.New(t)
+	var fs forceStopper
+
+	fs.stop() // no context yet — must latch, not panic
+
+	ctx, cancel := fs.start()
+	defer cancel()
+	is.True(ctx.Err() != nil) // start applies the latched force-stop immediately
+}
+
+func TestForceStopper_StopIsIdempotent(t *testing.T) {
+	is := is.New(t)
+	var fs forceStopper
+
+	fs.stop()
+	fs.stop() // latched twice — no panic
+	ctx, cancel := fs.start()
+	defer cancel()
+	is.True(ctx.Err() != nil)
+
+	fs.stop() // after start — no panic
+	fs.stop()
+}
+
+// TestForceStopper_ConcurrentStartStop proves the invariant that matters: no
+// matter how start() (Run goroutine) and stop() (force-stop goroutine) interleave,
+// the connector context always ends canceled — the force-stop is never lost — and
+// the field access is race-free (run under -race).
+func TestForceStopper_ConcurrentStartStop(t *testing.T) {
+	is := is.New(t)
+
+	for i := 0; i < 500; i++ {
+		var fs forceStopper
+		var (
+			ctx    context.Context
+			cancel context.CancelFunc
+		)
+
+		release := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-release
+			ctx, cancel = fs.start()
+		}()
+		go func() {
+			defer wg.Done()
+			<-release
+			fs.stop()
+		}()
+		close(release)
+		wg.Wait()
+
+		is.True(ctx.Err() != nil) // force-stop is honored regardless of ordering
+		cancel()
+	}
+}

--- a/pkg/lifecycle/stream/source.go
+++ b/pkg/lifecycle/stream/source.go
@@ -248,8 +248,17 @@ func (n *SourceNode) stopGraceful(ctx context.Context, reason error) (err error)
 func (n *SourceNode) ForceStop(ctx context.Context) {
 	n.logger.Warn(ctx).Msg("force stopping source connector")
 	n.mctx.Lock()
-	n.connectorCtxCancel()
-	n.mctx.Unlock()
+	defer n.mctx.Unlock()
+	// connectorCtxCancel is nil if Run has not yet reached its initialization
+	// (force-stop raced source startup). Skipping the cancel is safe: stopForceful
+	// kills the pipeline tomb before calling ForceStop, so Run will observe the
+	// canceled node context and stop as soon as it starts. Canceling the connector
+	// context here only interrupts an in-flight Read faster — which by definition
+	// isn't happening yet. Guarding avoids a nil-deref panic (invariant 7: force
+	// at any instant must be recoverable, not crash). See issue #2539.
+	if n.connectorCtxCancel != nil {
+		n.connectorCtxCancel()
+	}
 }
 
 func (n *SourceNode) Pub() <-chan *Message {

--- a/pkg/lifecycle/stream/source.go
+++ b/pkg/lifecycle/stream/source.go
@@ -44,11 +44,11 @@ type SourceNode struct {
 	base   pubNodeBase
 	logger log.CtxLogger
 
-	state              csync.ValueWatcher[nodeState]
-	connectorCtxCancel context.CancelFunc
+	state csync.ValueWatcher[nodeState]
 
-	// mctx guards access to the connector context
-	mctx sync.Mutex
+	// stopper force-stops the connector context, coordinating with Run so a
+	// force-stop that races startup is neither lost nor a nil-panic. See #2539.
+	stopper forceStopper
 
 	stop struct {
 		sync.Mutex
@@ -103,13 +103,11 @@ func (n *SourceNode) Run(ctx context.Context) (err error) {
 	defer cleanup()
 
 	// start a fresh connector context to make sure the connector is running
-	// until this method returns
-	var connectorCtx context.Context
-
-	n.mctx.Lock()
-	connectorCtx, n.connectorCtxCancel = context.WithCancel(context.Background())
-	n.mctx.Unlock()
-	defer n.connectorCtxCancel()
+	// until this method returns. stopper.start also applies a force-stop that
+	// arrived before now (raced startup), so the connector context is canceled
+	// immediately in that case.
+	connectorCtx, connectorCtxCancel := n.stopper.start()
+	defer connectorCtxCancel()
 
 	// openMsgTracker tracks open messages until they are acked or nacked
 	var openMsgTracker OpenMessagesTracker
@@ -247,18 +245,7 @@ func (n *SourceNode) stopGraceful(ctx context.Context, reason error) (err error)
 
 func (n *SourceNode) ForceStop(ctx context.Context) {
 	n.logger.Warn(ctx).Msg("force stopping source connector")
-	n.mctx.Lock()
-	defer n.mctx.Unlock()
-	// connectorCtxCancel is nil if Run has not yet reached its initialization
-	// (force-stop raced source startup). Skipping the cancel is safe: stopForceful
-	// kills the pipeline tomb before calling ForceStop, so Run will observe the
-	// canceled node context and stop as soon as it starts. Canceling the connector
-	// context here only interrupts an in-flight Read faster — which by definition
-	// isn't happening yet. Guarding avoids a nil-deref panic (invariant 7: force
-	// at any instant must be recoverable, not crash). See issue #2539.
-	if n.connectorCtxCancel != nil {
-		n.connectorCtxCancel()
-	}
+	n.stopper.stop()
 }
 
 func (n *SourceNode) Pub() <-chan *Message {

--- a/pkg/lifecycle/stream/source_test.go
+++ b/pkg/lifecycle/stream/source_test.go
@@ -221,6 +221,21 @@ func TestSourceNode_StopWhileNextNodeIsStuck(t *testing.T) {
 	is.True(!ok)  // expected node to close outgoing channel
 }
 
+// TestSourceNode_ForceStop_BeforeRun guards #2539: force-stopping a source node
+// before Run has initialized its connector-context cancel must not panic. Before
+// the fix, ForceStop nil-dereferenced connectorCtxCancel and crashed the process
+// (invariant 7: force at any instant must be recoverable, not crash).
+func TestSourceNode_ForceStop_BeforeRun(t *testing.T) {
+	node := &SourceNode{
+		Name:          "source-node",
+		PipelineTimer: noop.Timer{},
+	}
+
+	// connectorCtxCancel is nil here — Run was never called. This must be a no-op,
+	// not a panic.
+	node.ForceStop(context.Background())
+}
+
 func TestSourceNode_ForceStop(t *testing.T) {
 	ctrl := gomock.NewController(t)
 


### PR DESCRIPTION
**Tier 1 — lifecycle/shutdown (invariant 7). Requires your sign-off; not self-merged.**

Fixes #2539. **Scope expanded after adversarial review** — the initial fix covered only `SourceNode`; review found the identical crash in the three other force-stoppable nodes.

## The bug (all four nodes)
`stopForceful` force-stops **every** node, and node goroutines start concurrently with force-stop gated only on pipeline status = running. So a force-stop racing startup nil-derefs the node's connector-cancel func. Confirmed in all four `ForceStoppableNode`s:
- `SourceNode` — nil-panic (had a mutex)
- `DestinationNode` — nil-panic **+ data race** (cancel field had no mutex)
- `DestinationAckerNode` — nil-panic
- `DLQHandlerNode` — nil-panic **+ data race**

Review also noted the first patch's "skip cancel if nil" left a **hang** if the connector's `Open` blocks (the connector ctx is decoupled from the tomb).

## The fix — one primitive, not four copies
Replaced the four hand-rolled implementations with a single mutex-guarded `forceStopper`:
- `start()` (Run) records the cancel and, if a force-stop already arrived, **cancels immediately** — closing the hang, not just the panic.
- `stop()` (ForceStop) cancels, or **latches** if `start()` hasn't run yet — force-stop is never lost, never nil-panics.

## Failure modes
- *Lost force-stop if it races startup?* No — latched and applied by `start()`. Proven by a `-race` concurrent test asserting the context **always ends canceled**.
- *Hang on blocking `Open`?* Closed — `start()` cancels immediately when a force-stop is already latched.
- *Data race?* All cancel-field access under `forceStopper.mu`.
- *Rollback:* revert the diff; no contracts/formats touched.

## Tests
- `forceStopper` directly: stop-before-start latch, idempotency, and a 500× `-race` concurrent-interleaving invariant test.
- Per-node `ForceStop` suites + `TestSourceNode_ForceStop_BeforeRun` pass.
- Full `pkg/lifecycle` + `stream` green under `-race -shuffle=on`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
