### PR TITLE
test: clear remaining #2534 flaky-test backlog, enable -shuffle=on on blocking test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,15 @@ jobs:
 
       - name: Test
         # The test coverate and the test report are needed for the SonarCloud analysis
-        run: make test-integration GOTEST_FLAGS="-v -count=1"
+        #
+        # Issue #2534: -shuffle=on randomizes test (and subtest) execution
+        # order within each package, which catches tests that depend on
+        # process-global state or execution order without needing -count>1.
+        # It was deferred until the two order/env-dependent failures it
+        # surfaced (pkg/foundation/log and
+        # pkg/plugin/processor/builtin/internal/diff/difftest) were fixed;
+        # both are now hermetic and this can gate merges.
+        run: make test-integration GOTEST_FLAGS="-v -count=1 -shuffle=on"
 
   build-cross:
     # Cross-compile for the 32-bit release target. Regular CI only builds on

--- a/pkg/foundation/log/ctxlogger_test.go
+++ b/pkg/foundation/log/ctxlogger_test.go
@@ -20,11 +20,26 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"runtime"
 	"testing"
 
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/matryer/is"
 	"github.com/rs/zerolog"
+)
+
+// Issue #2534: the stack frame's file path is asserted against the actual
+// location of this file (captured via runtime.Caller) rather than a
+// hardcoded "<...>/conduit/pkg/foundation/log/ctxlogger_test.go" pattern.
+// The hardcoded pattern only matches when the repository checkout has
+// "conduit" as the immediate parent directory of "pkg" (e.g. a plain
+// clone); it breaks under any other checkout layout, such as a nested git
+// worktree, a renamed clone directory, or a fork - a real env-dependent
+// failure, not a test-ordering one, and reproducible independent of
+// -shuffle.
+var (
+	_, thisFile, _, _ = runtime.Caller(0)
+	thisFilePattern   = regexp.QuoteMeta(thisFile)
 )
 
 func TestCtxLoggerComponent(t *testing.T) {
@@ -193,13 +208,13 @@ func TestCtxLoggerWithoutHooks(t *testing.T) {
 		logfunc: func(logger CtxLogger) {
 			logger.Err(ctx, cerrors.New("foo")).Msg("")
 		},
-		want: `{"level":"error","stack":\[{"func":"github.com/conduitio/conduit/pkg/foundation/log.TestCtxLoggerWithoutHooks.func\d*","file":".*/conduit/pkg/foundation/log/ctxlogger_test.go","line":\d*}\],"error":"foo"}`,
+		want: `{"level":"error","stack":\[{"func":"github.com/conduitio/conduit/pkg/foundation/log.TestCtxLoggerWithoutHooks.func\d*","file":"` + thisFilePattern + `","line":\d*}\],"error":"foo"}`,
 	}, {
 		name: "err one-field with error",
 		logfunc: func(logger CtxLogger) {
 			logger.Err(ctx, cerrors.New("foo")).Str("foo", "bar").Msg("")
 		},
-		want: `{"level":"error","stack":\[{"func":"github.com/conduitio/conduit/pkg/foundation/log.TestCtxLoggerWithoutHooks.func\d*","file":".*/conduit/pkg/foundation/log/ctxlogger_test.go","line":\d*}\],"error":"foo","foo":"bar"}\n`,
+		want: `{"level":"error","stack":\[{"func":"github.com/conduitio/conduit/pkg/foundation/log.TestCtxLoggerWithoutHooks.func\d*","file":"` + thisFilePattern + `","line":\d*}\],"error":"foo","foo":"bar"}\n`,
 	}, {
 		name: "err two-field with error",
 		logfunc: func(logger CtxLogger) {
@@ -208,7 +223,7 @@ func TestCtxLoggerWithoutHooks(t *testing.T) {
 				Int("n", 123).
 				Msg("")
 		},
-		want: `{"level":"error","stack":\[{"func":"github.com/conduitio/conduit/pkg/foundation/log.TestCtxLoggerWithoutHooks.func\d*","file":".*/conduit/pkg/foundation/log/ctxlogger_test.go","line":\d*}\],"error":"foo","foo":"bar","n":123}\n`,
+		want: `{"level":"error","stack":\[{"func":"github.com/conduitio/conduit/pkg/foundation/log.TestCtxLoggerWithoutHooks.func\d*","file":"` + thisFilePattern + `","line":\d*}\],"error":"foo","foo":"bar","n":123}\n`,
 	}, {
 		name: "err empty without error",
 		logfunc: func(logger CtxLogger) {
@@ -416,13 +431,13 @@ func TestCtxLoggerWithHooks(t *testing.T) {
 		logfunc: func(logger CtxLogger) {
 			logger.Err(ctx, cerrors.New("foo")).Msg("")
 		},
-		want: `{"level":"error","stack":\[{"func":"github.com/conduitio/conduit/pkg/foundation/log.TestCtxLoggerWithHooks.func\d*","file":".*/conduit/pkg/foundation/log/ctxlogger_test.go","line":\d*}\],"error":"foo","strval":"bar","intval":123}\n`,
+		want: `{"level":"error","stack":\[{"func":"github.com/conduitio/conduit/pkg/foundation/log.TestCtxLoggerWithHooks.func\d*","file":"` + thisFilePattern + `","line":\d*}\],"error":"foo","strval":"bar","intval":123}\n`,
 	}, {
 		name: "err one-field with error",
 		logfunc: func(logger CtxLogger) {
 			logger.Err(ctx, cerrors.New("foo")).Str("foo", "bar").Msg("")
 		},
-		want: `{"level":"error","stack":\[{"func":"github.com/conduitio/conduit/pkg/foundation/log.TestCtxLoggerWithHooks.func\d*","file":".*/conduit/pkg/foundation/log/ctxlogger_test.go","line":\d*}],"error":"foo","foo":"bar","strval":"bar","intval":123}\n`,
+		want: `{"level":"error","stack":\[{"func":"github.com/conduitio/conduit/pkg/foundation/log.TestCtxLoggerWithHooks.func\d*","file":"` + thisFilePattern + `","line":\d*}],"error":"foo","foo":"bar","strval":"bar","intval":123}\n`,
 	}, {
 		name: "err two-field with error",
 		logfunc: func(logger CtxLogger) {
@@ -431,7 +446,7 @@ func TestCtxLoggerWithHooks(t *testing.T) {
 				Int("n", 123).
 				Msg("")
 		},
-		want: `{"level":"error","stack":\[{"func":"github.com/conduitio/conduit/pkg/foundation/log.TestCtxLoggerWithHooks.func\d*","file":".*/conduit/pkg/foundation/log/ctxlogger_test.go","line":\d*}\],"error":"foo","foo":"bar","n":123,"strval":"bar","intval":123}\n`,
+		want: `{"level":"error","stack":\[{"func":"github.com/conduitio/conduit/pkg/foundation/log.TestCtxLoggerWithHooks.func\d*","file":"` + thisFilePattern + `","line":\d*}\],"error":"foo","foo":"bar","n":123,"strval":"bar","intval":123}\n`,
 	}, {
 		name: "err empty without error",
 		logfunc: func(logger CtxLogger) {

--- a/pkg/plugin/processor/builtin/impl/avro/decode_examples_test.go
+++ b/pkg/plugin/processor/builtin/impl/avro/decode_examples_test.go
@@ -31,7 +31,11 @@ import (
 )
 
 func ExampleDecodeProcessor() {
-	url, cleanup := schemaregistrytest.ExampleSchemaRegistryURL("ExampleDecodeProcessor", 54322)
+	// Issue #2534: use an OS-assigned port (0) instead of a hardcoded one to
+	// avoid flakes when the port is already in use. The port/URL is not
+	// captured in the generated example spec (pkg/plugin/processor/builtin/internal/exampleutil/specs),
+	// only Summary/Description/Config/Have/Want are, so this is safe to change.
+	url, cleanup := schemaregistrytest.ExampleSchemaRegistryURL("ExampleDecodeProcessor", 0)
 	defer cleanup()
 
 	client, err := schemaregistry.NewClient(log.Nop(), sr.URLs(url))

--- a/pkg/plugin/processor/builtin/impl/avro/encode_examples_test.go
+++ b/pkg/plugin/processor/builtin/impl/avro/encode_examples_test.go
@@ -31,7 +31,11 @@ import (
 )
 
 func ExampleEncodeProcessor_autoRegister() {
-	url, cleanup := schemaregistrytest.ExampleSchemaRegistryURL("ExampleEncodeProcessor_autoRegister", 54322)
+	// Issue #2534: use an OS-assigned port (0) instead of a hardcoded one to
+	// avoid flakes when the port is already in use. The port/URL is not
+	// captured in the generated example spec (pkg/plugin/processor/builtin/internal/exampleutil/specs),
+	// only Summary/Description/Config/Have/Want are, so this is safe to change.
+	url, cleanup := schemaregistrytest.ExampleSchemaRegistryURL("ExampleEncodeProcessor_autoRegister", 0)
 	defer cleanup()
 
 	client, err := schemaregistry.NewClient(log.Nop(), sr.URLs(url))
@@ -115,7 +119,7 @@ and registered on the fly under the subject ` + "`example-autoRegister`" + `.`,
 }
 
 func ExampleEncodeProcessor_preRegistered() {
-	url, cleanup := schemaregistrytest.ExampleSchemaRegistryURL("ExampleEncodeProcessor_preRegistered", 54322)
+	url, cleanup := schemaregistrytest.ExampleSchemaRegistryURL("ExampleEncodeProcessor_preRegistered", 0)
 	defer cleanup()
 
 	client, err := schemaregistry.NewClient(log.Nop(), sr.URLs(url))

--- a/pkg/plugin/processor/builtin/internal/diff/testenv/testenv.go
+++ b/pkg/plugin/processor/builtin/internal/diff/testenv/testenv.go
@@ -166,9 +166,24 @@ func allowMissingTool(tool string) bool {
 			return true
 		}
 	case "diff":
-		if os.Getenv("GO_BUILDER_NAME") != "" {
-			return true
-		}
+		// Issue #2534: this package is vendored from the Go project's
+		// internal testenv, where a missing/non-GNU "diff" is only
+		// tolerated on known builders (GO_BUILDER_NAME) or when running as
+		// a dependency (packageMainIsDevel() == false). Conduit has neither
+		// concept: it isn't a Go-toolchain builder, and TestVerifyUnified
+		// runs the module directly (packageMainIsDevel() == true) in every
+		// environment that matters (local dev, CI). That combination made
+		// this test-environment fall through to a hard t.Fatalf instead of
+		// a skip on any host lacking GNU diffutils - e.g. macOS, whose
+		// system "diff" is BSD-based and doesn't support "-version" the
+		// same way, causing a deterministic failure independent of test
+		// order/shuffle. The GNU diff comparison here is an optional
+		// cross-check against a real external tool, not a requirement for
+		// the diff algorithm's correctness (which is asserted elsewhere
+		// without external tools), so always allow skipping when it's
+		// unavailable rather than making the pass/fail outcome depend on
+		// unrelated build metadata.
+		return true
 	case "patch":
 		if os.Getenv("GO_BUILDER_NAME") != "" {
 			return true


### PR DESCRIPTION
## Summary

Closes out the three remaining items from #2534's backlog comment so the suite is deterministic enough to gate merges on `-shuffle=on`.

## Task 1 — avro `Example*` fixed port 54322

`impl/avro/{encode,decode}_examples_test.go` bound `schemaregistrytest.ExampleSchemaRegistryURL(name, 54322)` to a hardcoded port — same flake class as the compose healthcheck fix in #2537, but for the in-process fake registry used by non-integration example tests.

**Fix:** pass `0` instead of `54322` so the OS assigns a free port; the function already returns the real listener URL (`srv.URL`), which the tests already read back and use — no other code changes needed.

**Golden-file check (the caveat called out in the task):** grepped the whole repo for `54322` — only the two test files reference it. Inspected `pkg/plugin/processor/builtin/internal/exampleutil/specs/avro.{decode,encode}.json` (the generated golden specs `validate-generated-files` CI diffs against) — they only capture `Summary`, `Description`, `Config`, `Have`, `Want`; the schema-registry URL/port never appears in the `Output:` comments either (those diff canonical JSON, not connection info). Confirmed empirically: ran `go generate` in `pkg/plugin/processor/builtin/impl/avro` (which runs `EXPORT_PROCESSORS=true go test -tags export_processors .` and rewrites the spec JSON) — `git diff` against the specs directory is empty. Unlike the earlier webhook regression, this port is not golden-captured, so the dynamic-port change is safe.

## Task 2 — the two `-shuffle`-revealed failures

Both turned out to be genuine **environment** bugs (not test-ordering bugs) — they fail identically with shuffle on or off, and I could reproduce them deterministically on this machine even at `-count=1`.

**`pkg/foundation/log` `TestCtxLoggerWithHooks` / `TestCtxLoggerWithoutHooks`:**
Root cause: the "err ... with error" subtests assert the logged stack frame's file field against a hardcoded regex `".*/conduit/pkg/foundation/log/ctxlogger_test.go"`. That only matches when the checkout has `conduit` as the *immediate* parent directory of `pkg` (a plain `git clone`). Any other layout — e.g. a nested git worktree (`.../conduit/.claude/worktrees/<hash>/pkg/foundation/log/...`, which is literally this repo's own agent-worktree convention) — breaks the match, causing a hard, deterministic failure unrelated to ordering.
Fix: capture this file's real path via `runtime.Caller(0)` (same pattern already used in `pkg/foundation/cerrors/cerrors_test.go`) and build the expected regex from `regexp.QuoteMeta(thisFile)` instead of a hardcoded partial path.
Before: fails 100% of the time when run from a nested worktree, on unmodified `main`, shuffle on or off. After: `go test ./pkg/foundation/log/... -run 'TestCtxLoggerWithHooks$|TestCtxLoggerWithoutHooks$' -shuffle=on -count=50 -race` → `ok` (0 failures), and `-shuffle=off -count=50` → `ok` (0 failures). Full package: `-shuffle=on -count=20 -race` → `ok`.

**`pkg/plugin/processor/builtin/internal/diff/difftest` `TestVerifyUnified`:**
Root cause: `internal/diff/testenv` is vendored from the Go project's own `internal/testenv`. Its `allowMissingTool("diff")` only tolerates a missing/non-GNU `diff` when `GO_BUILDER_NAME` is set (a Go-toolchain-builder concept Conduit doesn't have) or when `packageMainIsDevel()` is false (running as a dependency, not the main module under test). Since Conduit's own test run is always `packageMainIsDevel() == true`, any host whose system `diff` isn't GNU (e.g. macOS ships BSD diff, which doesn't support `-version` the way the check expects) makes `NeedsTool` call `t.Fatalf` instead of `t.Skip` — a hard, deterministic failure, again independent of shuffle.
Fix: `allowMissingTool` now always permits skipping the "diff" case. The GNU-diff comparison is an optional cross-check against a real external tool (the algorithm's correctness is asserted independently, without external tools); the pass/fail/skip decision shouldn't hinge on unrelated build metadata.
Verified the fix doesn't paper over a real regression: with a `PATH`-shimmed `diff` that reports a GNU version string and delegates real invocations to the system diff, the subtests actually execute and pass/skip exactly as before (GNU-diff-only quirks still `t.Skip` per-subtest as designed) — confirmed the comparison logic still runs for real when the tool is present, this only fixes the skip-vs-fail decision when it's absent.
Before: fails 100% on this host (no GNU diffutils), shuffle on or off, `-count` irrelevant. After: `-shuffle=on -count=50 -race` → `ok`, `-shuffle=off -count=50` → `ok`. Full package (`diff`, `difftest`, `lcs`): `-shuffle=on -count=20 -race` → `ok`.

## Task 3 — enable `-shuffle=on` on the blocking `test` job

Added `-shuffle=on` to `.github/workflows/test.yml`'s `GOTEST_FLAGS` for the `test` job (which runs `make test-integration`, i.e. `go test -race --tags=integration ./...`).

Before enabling it, ran the full suite with shuffle on, excluding `pkg/lifecycle/` and `pkg/lifecycle-poc/` (owned by the concurrent #2521/#1659 effort per instructions):

- `go test -shuffle=on -count=1 $(90 packages)` → 0 failures (ran twice)
- `go test -race -shuffle=on -count=1 $(90 packages)` → 0 failures

I could not run the actual dockerized `make test-integration -shuffle=on` locally end-to-end — `docker compose up` for `test/compose-postgres.yaml` failed with `port is already allocated` on 5432 (a pre-existing local process outside my control, not something this branch touches). This doesn't affect the validity of the fix: neither `ctxlogger_test.go` nor `difftest_test.go` (the two files with `-shuffle`-revealed bugs) carry `//go:build integration` constraints, so they compile and run identically under `--tags=integration`; the avro example-port fix is in files with `//go:build !integration` and so isn't part of the `test-integration` invocation at all (it only matters for `make test` / `go generate` / local unit runs).

Known **out-of-scope** failures (per the issue's own remaining-backlog list, explicitly not touched here, and not owned by this branch):
- `pkg/lifecycle` / `pkg/lifecycle-poc` sleep-based waits (#2521/#1659 — a concurrent effort's domain, per instructions I did not touch `pkg/lifecycle/`)
- `pkg/connector/persister_test.go` debounce-tolerance sleeps (flagged in the issue as needing a rethink, not a mechanical fix)
- `entrypoint_test.go` `TestEntrypoint_CancelOnInterrupt_SIGTERM` under `-count>1` (global signal-handler `os.Exit`, needs a production change)

None of these are gated by this PR's `-shuffle=on` change at `-count=1` scope.

## Adversarial self-review

- Re-checked the avro port change doesn't silently change any comparison surface: the tests already read back `url` (the real `srv.URL`) rather than reconstructing it from the port constant, so no other code path assumed port `54322`.
- Re-checked the `ctxlogger_test.go` fix doesn't weaken the assertion: `regexp.QuoteMeta(thisFile)` still requires an exact match against this file's real absolute path — it's strictly more precise than the old wildcard-prefixed partial-path match, not looser.
- Re-checked the `testenv.go` fix doesn't cause `TestVerifyUnified` to become a silent no-op: verified with a `diff` shim that reports a GNU version banner that the real per-case comparisons still execute (and one subtest still legitimately `t.Skip`s for reasons unrelated to my change — "diff tool produces expected different results").
- Considered whether to also loosen the `"patch"` case in `allowMissingTool` for consistency — left it untouched since it's out of this issue's scope and the local `patch` binary already satisfies the GNU check on this machine, so I have no failure to reproduce or regression-test against for it.

## Risk tier

Tier 3 (chore/test-infra) — no production code path touched, only test hermeticity and CI config. One approval + green CI applies per the repo's process-maturity table.

Refs #2534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)