### PR TITLE
fix(cerrors): make conduiterr.New/Wrap capture caller-accurate frames

### DIFF
--- a/pkg/foundation/cerrors/cerrors.go
+++ b/pkg/foundation/cerrors/cerrors.go
@@ -24,6 +24,7 @@ package cerrors
 
 import (
 	"errors" //nolint:depguard // the std. errors package is allowed only in this package
+	"fmt"
 	"reflect"
 	"runtime"
 
@@ -39,6 +40,38 @@ var (
 	Unwrap = errors.Unwrap
 	Join   = errors.Join
 )
+
+// stackError is a cerrors-native equivalent of xerrors' unexported
+// errorString, used by NewWithStackDepth. It exists only because xerrors.New
+// hardcodes its caller depth (always attributes the frame to its immediate
+// caller) and exposes no way to skip additional frames. hasStackTrace and
+// getRuntimeFrame recognize it structurally (a "frame" field of type
+// xerrors.Frame), the same way they walk xerrors' own error type.
+type stackError struct {
+	s     string
+	frame xerrors.Frame
+}
+
+func (e *stackError) Error() string { return e.s }
+
+func (e *stackError) Format(s fmt.State, v rune) { xerrors.FormatError(e, s, v) }
+
+func (e *stackError) FormatError(p xerrors.Printer) (next error) {
+	p.Print(e.s)
+	e.frame.Format(p)
+	return nil
+}
+
+// NewWithStackDepth is like New, but lets the caller skip additional stack
+// frames when attributing the captured frame. New (equivalent to skip=0)
+// always attributes the frame to its own immediate caller; a function that
+// itself wraps New (e.g. conduiterr.New) needs skip=1 so the frame lands on
+// *its* caller instead of on the wrapper. skip counts wrapper layers between
+// the real call site and this function, analogous to runtime.Caller's skip
+// but relative to New's existing (fixed) depth.
+func NewWithStackDepth(skip int, msg string) error {
+	return &stackError{s: msg, frame: xerrors.Caller(1 + skip)}
+}
 
 type Frame struct {
 	Func string `json:"func,omitempty"`
@@ -107,9 +140,20 @@ func ForEach(err error, fn func(error)) {
 	}
 }
 
+// frameType is the reflect.Type of xerrors.Frame, used to recognize any
+// error carrying one structurally, regardless of which package defined the
+// concrete error type. This lets hasStackTrace/getRuntimeFrame walk both
+// xerrors' own error type and cerrors' stackError (see NewWithStackDepth)
+// without hardcoding "golang.org/x/xerrors" as the only allowed origin.
+var frameType = reflect.TypeOf(xerrors.Frame{})
+
 func hasStackTrace(err error) bool {
 	errT := reflect.TypeOf(err)
-	return errT != nil && errT.Elem().PkgPath() == "golang.org/x/xerrors"
+	if errT == nil || errT.Kind() != reflect.Pointer {
+		return false
+	}
+	f, ok := errT.Elem().FieldByName("frame")
+	return ok && f.Type == frameType
 }
 
 func getRuntimeFrame(err error) Frame {

--- a/pkg/foundation/cerrors/conduiterr/conduiterr.go
+++ b/pkg/foundation/cerrors/conduiterr/conduiterr.go
@@ -141,13 +141,11 @@ func (e *ConduitError) Unwrap() error { return e.err }
 // New creates a leaf ConduitError with no wrapped cause. It guarantees a non-empty
 // stack trace so the error is never trace-less.
 //
-// Caveat: because cerrors.New attributes the frame to its immediate caller, the
-// captured frame points into this constructor, not the site that called New. For
-// accurate call-site attribution, build the cause with cerrors.New/Errorf at the
-// real origination point and pass it to Wrap. A skip-aware helper in cerrors that
-// would let New capture the true caller is tracked as a follow-up.
+// The captured frame points at New's caller (the real origination site), not at
+// New itself: New calls cerrors.NewWithStackDepth(1, msg), which skips one extra
+// wrapper frame beyond what cerrors.New/Errorf capture on their own.
 func New(code Code, msg string) *ConduitError {
-	return &ConduitError{Code: code, Message: msg, err: cerrors.New(msg)}
+	return &ConduitError{Code: code, Message: msg, err: cerrors.NewWithStackDepth(1, msg)}
 }
 
 // Wrap creates a ConduitError around an existing cause, adding context.
@@ -183,7 +181,9 @@ func Wrap(code Code, msg string, cause error) *ConduitError {
 	}
 
 	if e.err == nil {
-		e.err = cerrors.New(msg) // guarantee a frame even if cause was nil
+		// Guarantee a frame even if cause was nil. Skip=1 for the same reason as
+		// New: attribute the frame to Wrap's caller, not to Wrap itself.
+		e.err = cerrors.NewWithStackDepth(1, msg)
 	}
 	return e
 }

--- a/pkg/foundation/cerrors/conduiterr/conduiterr_test.go
+++ b/pkg/foundation/cerrors/conduiterr/conduiterr_test.go
@@ -15,12 +15,16 @@
 package conduiterr_test
 
 import (
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/matryer/is"
 )
+
+var _, thisFile, _, _ = runtime.Caller(0)
 
 func frameCount(err error) int {
 	frames, _ := cerrors.GetStackTrace(err).([]cerrors.Frame)
@@ -96,4 +100,46 @@ func TestRegistry_FoundationalCodesPresent(t *testing.T) {
 	is.True(ok)
 	is.Equal(c.Reason(), "connector.plugin_not_found")
 	is.True(len(conduiterr.Codes()) >= 5)
+}
+
+// TestNew_FrameIsCallerAccurate is the regression test for #2526: the frame
+// captured by New must point at the real call site (this test function, the
+// line that calls conduiterr.New below), not at New's own definition in
+// conduiterr.go. Before the fix, fr.File/fr.Line pointed into conduiterr.go
+// and fr.Func was "...conduiterr.New" instead of this test.
+func TestNew_FrameIsCallerAccurate(t *testing.T) {
+	is := is.New(t)
+
+	err := conduiterr.New(conduiterr.CodeInvalidArgument, "boom") // <-- line under test
+	const wantLine = 113                                          // line of the statement above
+
+	frames, ok := cerrors.GetStackTrace(err).([]cerrors.Frame)
+	is.True(ok)
+	is.True(len(frames) > 0)
+
+	fr := frames[0]
+	is.Equal(fr.File, thisFile)
+	is.Equal(fr.Line, wantLine)
+	is.True(!strings.Contains(fr.Func, "conduiterr.New"))
+	is.True(strings.HasSuffix(fr.Func, "conduiterr_test.TestNew_FrameIsCallerAccurate"))
+}
+
+// TestWrap_FrameIsCallerAccurate is the same regression guard for Wrap's
+// nil-cause fallback path (Wrap(code, msg, nil)), which also used to
+// attribute its guaranteed frame to Wrap itself rather than to the caller.
+func TestWrap_FrameIsCallerAccurate(t *testing.T) {
+	is := is.New(t)
+
+	err := conduiterr.Wrap(conduiterr.CodeInternal, "boom", nil) // <-- line under test
+	const wantLine = 133                                         // line of the statement above
+
+	frames, ok := cerrors.GetStackTrace(err).([]cerrors.Frame)
+	is.True(ok)
+	is.True(len(frames) > 0)
+
+	fr := frames[0]
+	is.Equal(fr.File, thisFile)
+	is.Equal(fr.Line, wantLine)
+	is.True(!strings.Contains(fr.Func, "conduiterr.Wrap"))
+	is.True(strings.HasSuffix(fr.Func, "conduiterr_test.TestWrap_FrameIsCallerAccurate"))
 }


### PR DESCRIPTION
## Summary

Fixes the caller-attribution part of #2526. `conduiterr.New` and `Wrap`'s
nil-cause fallback both called `cerrors.New(msg)`, which attributes its
captured stack frame to its immediate caller — `conduiterr.New`/`Wrap`
themselves, not the real call site. This was documented as a known caveat
rather than fixed, since `xerrors.New` hardcodes its caller depth and
exposes no skip parameter.

- Added `cerrors.NewWithStackDepth(skip, msg)`: a skip-aware constructor
  that calls `xerrors.Caller(1+skip)` directly (bypassing `xerrors.New`)
  via a small cerrors-native `stackError` type that carries an
  `xerrors.Frame` the same way xerrors' own (unexported) `errorString`
  does. `New`/`Errorf` are unchanged — they remain effectively `skip=0`.
- Loosened `hasStackTrace` to recognize any error with a `"frame"` field of
  type `xerrors.Frame` structurally, instead of gating on the concrete
  error type's defining package being exactly `"golang.org/x/xerrors"`.
  This lets `GetStackTrace`/`getRuntimeFrame`'s existing reflection-based
  walk pick up `stackError` too, with no change to how xerrors' own type is
  handled.
- `conduiterr.New` and `Wrap` now call `NewWithStackDepth(1, msg)`. `skip=1`
  accounts for the single wrapper layer between the real call site and
  `cerrors` (`caller -> conduiterr.New/Wrap -> cerrors.NewWithStackDepth ->
  xerrors.Caller`), landing the frame on the actual caller instead of on
  the constructor.

## How the skip depth was determined and verified

Traced `xerrors.Caller`/`runtime.Callers` skip semantics by reading the
vendored `xerrors` source (`Caller(skip)` → `runtime.Callers(skip+1, ...)`,
and `getRuntimeFrame` in `cerrors.go` discards the first `CallersFrames.Next()`
and reports the second). Worked through the call chain algebraically:
`user code -> conduiterr.New -> cerrors.NewWithStackDepth -> xerrors.Caller`
is one indirection layer beyond `xerrors.New`'s own `Caller(1)`, so
`skip=1` → `xerrors.Caller(2)` should land the reported frame back on the
user's call site.

Verified empirically, not just by derivation — added
`TestNew_FrameIsCallerAccurate` and `TestWrap_FrameIsCallerAccurate` in
`conduiterr_test.go`, which call `conduiterr.New`/`Wrap` from a known line
in the test file and assert the top frame from `cerrors.GetStackTrace`
reports that exact file/line/func — not `conduiterr.go`. Confirmed the
tests fail (frame pointing into `conduiterr.go`, `fr.Func` ending in
`conduiterr.New`) against the pre-fix code and pass against the fix.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/foundation/cerrors/... -count=1 -race -v` — all green,
      including new regression tests
- [x] Confirmed new regression tests fail without the fix (reverted
      `conduiterr.go` only, reran the two new tests, saw them fail with
      frame pointing into `conduiterr.go`)
- [x] `golangci-lint run ./pkg/foundation/cerrors/...` — 0 issues
- [x] `go vet ./...` — clean except a pre-existing, unrelated
      `unreachable code` warning in `pkg/lifecycle-poc/funnel/worker.go`
      (confirmed present on `main` before this change too)

## Adversarial self-review

- Checked `hasStackTrace`'s loosened check isn't *weaker* than before: it
  now requires a `"frame"` field whose reflect type equals
  `xerrors.Frame{}`'s type exactly, which is at least as specific as the
  old "defined in package golang.org/x/xerrors" check — no unrelated error
  type accidentally starts round-tripping through the stack walk.
- Confirmed `New`/`Errorf` (skip=0 callers) are byte-for-byte unchanged;
  only `conduiterr.New`/`Wrap` change behavior.
- `NewWithStackDepth`/`stackError` hold no shared mutable state and are
  race-free (test run with `-race`).
- No serialized-format, protocol, or data-path involvement — this only
  affects in-memory Go stack-trace attribution for error observability, so
  none of the data-integrity invariants apply here.

## Scope note (per issue #2526)

Issue #2526 also asked for (1) a `forbidigo` guard against raw
`&ConduitError{}` literals and (2) an explicit code-override escape hatch
for `Wrap`. Left both as follow-ups — they're independent, additive
changes and mixing them in here would blur this PR's single, verifiable
fix. Happy to pick either up in a follow-up PR if wanted.

## Risk tier

Tier 2 (internal error-handling foundation, not the data path) — this
package underlies the machine-actionable error surface the CLAUDE.md
"errors are API" convention calls out, but touches no record flow,
ack/position/checkpoint logic, connector protocol, or serialization
formats.

Fixes #2526

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01Tapg9dLWXKMZJoL65R24vd