### PR TITLE
test(connector): inject a clock into Persister to deflake delay-threshold test

### DIFF
--- a/pkg/connector/persister.go
+++ b/pkg/connector/persister.go
@@ -39,14 +39,48 @@ type Persister struct {
 	delayThreshold       time.Duration
 	bundleCountThreshold int
 
+	// clock abstracts time so tests can control the passage of time
+	// deterministically instead of relying on real sleeps and timing
+	// tolerances. NewPersister sets this to a realClock; tests in this
+	// package may swap it for a fakeClock before exercising delay-based
+	// behavior.
+	clock clock
+
 	connWg sync.WaitGroup
 
 	// m guards all private variables below it.
 	m           sync.Mutex
 	bundleCount int
 	batch       map[string]persistData
-	flushTimer  *time.Timer
+	flushTimer  stoppableTimer
 	flushWg     sync.WaitGroup
+}
+
+// clock abstracts the two time operations the persister needs in order to
+// debounce flushes: reading the current time and scheduling a callback after
+// a delay. It exists purely to make the delay-threshold behavior
+// deterministically testable; NewPersister always wires up a realClock.
+type clock interface {
+	Now() time.Time
+	AfterFunc(d time.Duration, f func()) stoppableTimer
+}
+
+// stoppableTimer is the subset of *time.Timer's API the persister relies on.
+type stoppableTimer interface {
+	// Stop prevents the timer from firing, matching the semantics of
+	// *time.Timer.Stop: it returns true if the call stops the timer, false
+	// if the timer has already expired or been stopped.
+	Stop() bool
+}
+
+// realClock is the production clock implementation, backed directly by the
+// time package.
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+func (realClock) AfterFunc(d time.Duration, f func()) stoppableTimer {
+	return time.AfterFunc(d, f)
 }
 
 // PersistCallback is a function that's called when a connector is persisted.
@@ -73,6 +107,8 @@ func NewPersister(
 
 		delayThreshold:       delayThreshold,
 		bundleCountThreshold: bundleCountThreshold,
+
+		clock: realClock{},
 	}
 }
 
@@ -126,7 +162,7 @@ func (p *Persister) Persist(ctx context.Context, conn *Instance, callback Persis
 	}
 
 	if p.flushTimer == nil {
-		p.flushTimer = time.AfterFunc(p.delayThreshold, func() {
+		p.flushTimer = p.clock.AfterFunc(p.delayThreshold, func() {
 			p.Flush(context.Background()) // use a new context because action happens in background
 		})
 	}
@@ -173,7 +209,7 @@ func (p *Persister) triggerFlush(ctx context.Context) {
 // flushNow will flush the state to the store.
 func (p *Persister) flushNow(ctx context.Context, batch map[string]persistData) {
 	defer p.flushWg.Done()
-	start := time.Now()
+	start := p.clock.Now()
 
 	tx, ctx, err := p.db.NewTransaction(ctx, true)
 	if err != nil {
@@ -202,6 +238,6 @@ func (p *Persister) flushNow(ctx context.Context, batch map[string]persistData) 
 	p.logger.Debug(ctx).
 		Err(err).
 		Int("count", len(batch)).
-		Dur(log.DurationField, time.Since(start)).
+		Dur(log.DurationField, p.clock.Now().Sub(start)).
 		Msg("persisted connectors")
 }

--- a/pkg/connector/persister_test.go
+++ b/pkg/connector/persister_test.go
@@ -40,33 +40,54 @@ func TestPersister_EmptyFlushDoesNothing(t *testing.T) {
 	is.Equal(0, len(got))
 }
 
+// TestPersister_PersistFlushesAfterDelayThreshold verifies the delay-based
+// side of the flush contract described on Persist: a batch is flushed once
+// delayThreshold has elapsed (as long as the bundle-count threshold wasn't
+// hit first). It uses a fakeClock instead of real sleeps so the assertions
+// are exact rather than tolerance-based: advancing by less than the
+// threshold must never flush, and advancing to (or past) the threshold must
+// always flush. This replaces a previous version of the test that measured
+// real wall-clock delay against a fixed tolerance window, which flaked under
+// load when the timer fired later than the tolerance allowed.
 func TestPersister_PersistFlushesAfterDelayThreshold(t *testing.T) {
 	is := is.New(t)
 	ctx := context.Background()
 	delayThreshold := time.Millisecond * 100
 
 	persister, store := initPersisterTest(delayThreshold, 2)
+	clk := newFakeClock()
+	persister.clock = clk
 
 	conn := &Instance{ID: uuid.NewString(), Type: TypeDestination}
 	callbackCalled := make(chan struct{})
-	persistAt := time.Now()
 	err := persister.Persist(ctx, conn, func(err error) {
 		if err != nil {
-			t.Fatalf("expected nil error, got: %v", err)
+			t.Errorf("expected nil error, got: %v", err)
 		}
 		close(callbackCalled)
 	})
 	is.NoErr(err)
 
-	// we are testing a delay which is not exact, this is the acceptable margin
-	maxDelay := delayThreshold + time.Millisecond*10
+	// Advancing by less than the threshold must not schedule a flush.
+	// fakeClock.Advance fires any due timers synchronously before
+	// returning, so this check is deterministic: there is no window in
+	// which the flush could still be "in flight".
+	clk.Advance(delayThreshold - time.Millisecond)
 	select {
 	case <-callbackCalled:
-		if gotDelay := time.Since(persistAt); gotDelay < delayThreshold || gotDelay > maxDelay {
-			t.Fatalf("flush delay should be between %s and %s, actual delay: %s", delayThreshold, maxDelay, gotDelay)
-		}
-	case <-time.After(maxDelay):
-		t.Fatalf("expected callback to be called in a certain time frame")
+		t.Fatal("flush was triggered before the delay threshold elapsed")
+	default:
+	}
+
+	// Advancing past the threshold must trigger the flush. The flush itself
+	// still runs in a background goroutine (flushNow, and the callback
+	// invocation within it), so we wait on the channel rather than asserting
+	// immediately - but with a generous timeout, not a tight tolerance.
+	clk.Advance(time.Millisecond * 2)
+	select {
+	case <-callbackCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected callback to be called after the delay threshold elapsed")
 	}
 
 	got, err := store.Get(ctx, conn.ID)
@@ -199,4 +220,99 @@ func initPersisterTest(
 
 	persister := NewPersister(logger, db, delayThreshold, bundleCountThreshold)
 	return persister, NewStore(db, logger)
+}
+
+// fakeClock is a test-only implementation of the connector package's clock
+// interface. It gives tests explicit, synchronous control over time so that
+// delay-threshold behavior (see Persister.Persist) can be asserted exactly
+// instead of within a real-time tolerance window.
+//
+// Advance fires any due timers synchronously, in the calling goroutine,
+// before returning. That means a call to Advance which does not cross a
+// timer's deadline is guaranteed to have triggered no side effects by the
+// time it returns - callers don't need to sleep or poll to check that
+// "nothing happened yet".
+type fakeClock struct {
+	mu     sync.Mutex
+	now    time.Time
+	timers []*fakeTimer
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{now: time.Now()}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) AfterFunc(d time.Duration, f func()) stoppableTimer {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	t := &fakeTimer{fireAt: c.now.Add(d), fn: f}
+	c.timers = append(c.timers, t)
+	return t
+}
+
+// Advance moves the fake clock forward by d and synchronously fires any
+// timers whose deadline is now due, in the order they were scheduled. Firing
+// happens after releasing the clock's internal lock (but before Advance
+// returns), so timer callbacks are free to call back into the clock (e.g.
+// schedule a new AfterFunc) without deadlocking.
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(d)
+	now := c.now
+
+	remaining := make([]*fakeTimer, 0, len(c.timers))
+	var due []*fakeTimer
+	for _, t := range c.timers {
+		if !t.fireAt.After(now) {
+			due = append(due, t)
+		} else {
+			remaining = append(remaining, t)
+		}
+	}
+	c.timers = remaining
+	c.mu.Unlock()
+
+	for _, t := range due {
+		t.fire()
+	}
+}
+
+// fakeTimer is the fakeClock counterpart to *time.Timer, tracked by the
+// clock so Advance can fire it once its deadline is due.
+type fakeTimer struct {
+	fireAt time.Time
+	fn     func()
+
+	mu      sync.Mutex
+	stopped bool
+	fired   bool
+}
+
+// Stop mirrors *time.Timer.Stop: it returns true if this call is the one
+// that prevents the timer from firing, false if it had already fired or
+// been stopped.
+func (t *fakeTimer) Stop() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	stoppedNow := !t.stopped && !t.fired
+	t.stopped = true
+	return stoppedNow
+}
+
+func (t *fakeTimer) fire() {
+	t.mu.Lock()
+	if t.stopped || t.fired {
+		t.mu.Unlock()
+		return
+	}
+	t.fired = true
+	t.mu.Unlock()
+
+	t.fn()
 }


### PR DESCRIPTION
## Summary

- Deflakes `TestPersister_PersistFlushesAfterDelayThreshold` (part of the #2534 flaky-test backlog) by injecting a `clock` seam into `Persister` instead of calling `time.AfterFunc`/`time.Now` directly.
- The test previously asserted a flush landed within a tight real-time window (`delayThreshold`..`delayThreshold+10ms`); under load the timer fires late and the assertion trips. That tolerance is the actual contract being tested, so it can't just be loosened — the fix is to make time controllable instead.

## What changed

- `pkg/connector/persister.go`: added an unexported `clock` interface (`Now() time.Time`, `AfterFunc(d, f) stoppableTimer`) and a `realClock` implementation that delegates straight to the `time` package. `Persister` gets an unexported `clock` field, defaulted to `realClock{}` in `NewPersister` — **the public `NewPersister` signature is unchanged**. `flushTimer`'s type changed from `*time.Timer` to the new `stoppableTimer` interface (just `Stop() bool`, which `*time.Timer` already satisfies).
- `pkg/connector/persister_test.go`: added a test-only `fakeClock`/`fakeTimer` (advances time synchronously, fires due timers deterministically, no goroutines, no dependency added) and rewrote `TestPersister_PersistFlushesAfterDelayThreshold` to advance the fake clock instead of sleeping: advancing less than `delayThreshold` must never flush (checked with a non-blocking `select`, since `Advance` fires due timers before returning), advancing to `delayThreshold` must always flush (awaited on the callback channel with a generous 5s timeout, not a tight tolerance).

No existing fake-clock dependency (`clockwork`, `benbjohnson/clock`, etc.) was found in `go.mod`/`go.sum`/`pkg/`, so this adds a minimal in-repo interface rather than a new third-party dependency, per the "no new dependencies without justification" rule.

## Other Persister tests — left as-is, and why

- `TestPersister_PersistFlushesAfterBundleCountThreshold`, `TestPersister_EmptyFlushDoesNothing`: don't depend on `clock.AfterFunc` at all (bundle-count path flushes immediately).
- `TestPersister_FlushStoresRightAway`, `TestPersister_WaitsForOpenConnectorsAndFlush`: use real timing, but neither exercises `clock.AfterFunc` — the first tests explicit `Flush()` latency, the second tests `Wait()` blocking on a test-driven `time.Sleep` in a goroutine, unrelated to the persister's internal timer. Rewriting these wasn't in scope for this fix and would risk touching unrelated behavior.

## Self-review (data-path adjacent, `pkg/connector`)

- **Behavior preserved:** `clock.AfterFunc`/`stoppableTimer.Stop` delegate directly to `time.AfterFunc`/`*time.Timer.Stop` in production (`realClock`) — no change to flush semantics (bundle-count OR delay, whichever comes first), no change to `Stop()` idempotency/return-value semantics.
- **Concurrency:** `clock` field is set once at construction (like `delayThreshold`/`bundleCountThreshold`) and never mutated concurrently in production; test only swaps it before starting any goroutines. `fakeClock`/`fakeTimer` guard their own state with mutexes; `Advance` releases its lock before firing due timers so a fired callback can safely call back into the clock (e.g. schedule a new `AfterFunc`) without deadlocking.
- **No typed-nil risk:** `stoppableTimer` interface is only ever assigned a valid `*time.Timer` or `*fakeTimer`, never a nil concrete pointer, so the `p.flushTimer == nil` interface check behaves the same as before.
- Confirmed no other file in the repo constructs `Persister{}` directly or touches `flushTimer` (`grep -rn "flushTimer|Persister{"` over `pkg/` outside `persister.go` returns nothing), so the field-type change is contained.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/connector/... -count=50 -race` — green; `TestPersister_PersistFlushesAfterDelayThreshold` now completes in ~0ms per iteration (deterministic) instead of racing a wall-clock window
- [x] `go test ./pkg/connector/... -count=20 -shuffle=on -race` — green
- [x] `golangci-lint run ./pkg/connector/...` — 0 issues
- [x] `go vet ./pkg/connector/...`

Refs #2534.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01Tapg9dLWXKMZJoL65R24vd