### PR TITLE
feat(conduit): add /readyz readiness endpoint + document 12-factor essentials

### DIFF
--- a/docs/health_check.md
+++ b/docs/health_check.md
@@ -1,8 +1,20 @@
-# Health check
+# Health and readiness
 
-Conduit’s health check can be used to determine if Conduit is running correctly. What it does is to check if Conduit
-can successfully connect to the database which it was configured with (which can be BadgerDB, PostgreSQL or the
-in-memory one). The health check is available at the `/healthz` path. Here’s an example:
+Conduit exposes two distinct probes, following the standard liveness/readiness split
+used by orchestrators such as Kubernetes:
+
+- **`/healthz` (liveness)** — is the Conduit process alive and able to reach its state
+  store? Use it to decide whether to restart the process.
+- **`/readyz` (readiness)** — is the engine finished starting up and able to serve? Use
+  it to decide whether to route traffic. A pipeline being _degraded_ does **not** make
+  Conduit "not ready" — the engine can still serve; degraded pipelines are reported in
+  the response body instead.
+
+## Liveness — `/healthz`
+
+The liveness check verifies that Conduit can successfully connect to the database it was
+configured with (BadgerDB, PostgreSQL, SQLite, or the in-memory one). It is available at
+the `/healthz` path. Here’s an example:
 
 ```bash
 $ curl "http://localhost:8080/healthz"
@@ -18,3 +30,47 @@ $ curl "http://localhost:8080/healthz?service=PipelineService"
 
 The services which can be checked for health are: `PipelineService`, `ConnectorService`, `ProcessorService`, and
 `PluginService`.
+
+## Readiness — `/readyz`
+
+The readiness check reports whether the engine can serve requests. It returns:
+
+- **`503 Service Unavailable`** with `{"status":"starting"}` while the engine is still
+  starting up (services initializing, pipelines provisioning, API coming online).
+- **`503 Service Unavailable`** with `{"status":"unavailable","reason":"…"}` if the engine
+  has started but its state store is unreachable.
+- **`200 OK`** with `{"status":"ready", …}` once the engine can serve. Degraded pipelines
+  are listed in the body but do **not** make Conduit not-ready.
+
+```bash
+$ curl "http://localhost:8080/readyz"
+{
+  "status": "ready",
+  "pipelines": {
+    "total": 3,
+    "running": 2,
+    "degraded": 1,
+    "degradedPipelines": [
+      {"id": "pg-to-kafka", "status": "degraded", "error": "source connector error"}
+    ]
+  }
+}
+```
+
+Use `/readyz` as the readiness probe and `/healthz` as the liveness probe.
+
+## Metrics
+
+Prometheus metrics are exposed at `/metrics`.
+
+## Configuration
+
+Every engine setting is configurable three ways, in order of precedence
+(**flag > environment variable > config file**):
+
+- a CLI flag, e.g. `--api.http.address=:8080`;
+- an environment variable with the `CONDUIT_` prefix and the flag path upper-cased with
+  `.`/`-` replaced by `_`, e.g. `CONDUIT_API_HTTP_ADDRESS=:8080`;
+- a key in the `conduit.yaml` config file.
+
+`conduit run` with no configuration starts with sensible defaults (zero-config).

--- a/pkg/conduit/readyz.go
+++ b/pkg/conduit/readyz.go
@@ -1,0 +1,112 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conduit
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/conduitio/conduit/pkg/pipeline"
+	json "github.com/goccy/go-json"
+)
+
+// readinessStatus is the top-level state reported by /readyz.
+const (
+	readinessStarting    = "starting"    // engine has not finished starting up
+	readinessUnavailable = "unavailable" // engine started but a dependency is down
+	readinessReady       = "ready"       // engine can serve
+)
+
+// ReadinessResponse is the JSON body returned by /readyz.
+type ReadinessResponse struct {
+	Status    string              `json:"status"`
+	Reason    string              `json:"reason,omitempty"`
+	Pipelines *PipelinesReadiness `json:"pipelines,omitempty"`
+}
+
+// PipelinesReadiness summarizes pipeline health. Degraded pipelines are reported
+// here but do NOT make the engine "not ready" — a degraded pipeline is an
+// operational condition, not an inability of the engine to serve requests.
+type PipelinesReadiness struct {
+	Total    int                 `json:"total"`
+	Running  int                 `json:"running"`
+	Degraded int                 `json:"degraded"`
+	Detail   []PipelineReadiness `json:"degradedPipelines,omitempty"`
+}
+
+// PipelineReadiness identifies a degraded pipeline and its recorded error.
+type PipelineReadiness struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
+// readyzHandler serves the /readyz readiness endpoint. It is distinct from the
+// liveness/health check: readiness answers "can the engine serve?" and is used by
+// orchestrators to gate traffic. It returns 503 only while the engine is still
+// starting up or if its state store is unavailable; once the engine can serve it
+// returns 200, with any degraded pipelines listed in the body rather than treated
+// as not-ready. See docs/design-documents/20260704-phase-1-execution-plan.md.
+func (r *Runtime) readyzHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		resp, code := r.readiness(req.Context())
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(code)
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+func (r *Runtime) readiness(ctx context.Context) (ReadinessResponse, int) {
+	// The engine has not finished starting up (services initialized, pipelines
+	// provisioned, API served) until Ready is closed.
+	select {
+	case <-r.Ready:
+	default:
+		return ReadinessResponse{Status: readinessStarting}, http.StatusServiceUnavailable
+	}
+
+	// The state store must be reachable for the engine to serve.
+	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := r.DB.Ping(pingCtx); err != nil {
+		return ReadinessResponse{
+			Status: readinessUnavailable,
+			Reason: "state store unavailable: " + err.Error(),
+		}, http.StatusServiceUnavailable
+	}
+
+	// Ready. Summarize pipeline health in the body; degraded pipelines do not
+	// affect readiness.
+	pls := r.pipelineService.List(ctx)
+	p := &PipelinesReadiness{Total: len(pls)}
+	for _, pl := range pls {
+		switch pl.GetStatus() {
+		case pipeline.StatusRunning:
+			p.Running++
+		case pipeline.StatusDegraded:
+			p.Degraded++
+			p.Detail = append(p.Detail, PipelineReadiness{
+				ID:     pl.ID,
+				Status: pl.GetStatus().String(),
+				Error:  pl.Error,
+			})
+		case pipeline.StatusSystemStopped, pipeline.StatusUserStopped, pipeline.StatusRecovering:
+			// Count toward Total but are neither running nor degraded for the
+			// readiness summary.
+		}
+	}
+	return ReadinessResponse{Status: readinessReady, Pipelines: p}, http.StatusOK
+}

--- a/pkg/conduit/readyz_test.go
+++ b/pkg/conduit/readyz_test.go
@@ -1,0 +1,90 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conduit
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/conduitio/conduit-commons/database/inmemory"
+	dbmock "github.com/conduitio/conduit-commons/database/mock"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/pipeline"
+	"github.com/matryer/is"
+	"go.uber.org/mock/gomock"
+)
+
+func TestRuntime_readiness_Starting(t *testing.T) {
+	is := is.New(t)
+	// Ready is not closed -> still starting up.
+	r := &Runtime{Ready: make(chan struct{})}
+
+	resp, code := r.readiness(context.Background())
+	is.Equal(code, http.StatusServiceUnavailable)
+	is.Equal(resp.Status, readinessStarting)
+	is.Equal(resp.Pipelines, nil)
+}
+
+func TestRuntime_readiness_StoreUnavailable(t *testing.T) {
+	is := is.New(t)
+	ctrl := gomock.NewController(t)
+
+	db := dbmock.NewDB(ctrl)
+	db.EXPECT().Ping(gomock.Any()).Return(cerrors.New("connection refused"))
+
+	ready := make(chan struct{})
+	close(ready)
+	r := &Runtime{Ready: ready, DB: db}
+
+	resp, code := r.readiness(context.Background())
+	is.Equal(code, http.StatusServiceUnavailable)
+	is.Equal(resp.Status, readinessUnavailable)
+	is.True(strings.Contains(resp.Reason, "connection refused"))
+}
+
+func TestRuntime_readiness_Ready(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	db := &inmemory.DB{}
+	ps := pipeline.NewService(log.Nop(), db)
+
+	running, err := ps.Create(ctx, "p-running", pipeline.Config{Name: "running"}, pipeline.ProvisionTypeAPI)
+	is.NoErr(err)
+	running.SetStatus(pipeline.StatusRunning)
+
+	degraded, err := ps.Create(ctx, "p-degraded", pipeline.Config{Name: "degraded"}, pipeline.ProvisionTypeAPI)
+	is.NoErr(err)
+	degraded.SetStatus(pipeline.StatusDegraded)
+	degraded.Error = "source connector error"
+
+	ready := make(chan struct{})
+	close(ready)
+	r := &Runtime{Ready: ready, DB: db, pipelineService: ps}
+
+	resp, code := r.readiness(ctx)
+	// Degraded pipelines do NOT make the engine not-ready.
+	is.Equal(code, http.StatusOK)
+	is.Equal(resp.Status, readinessReady)
+	is.True(resp.Pipelines != nil)
+	is.Equal(resp.Pipelines.Total, 2)
+	is.Equal(resp.Pipelines.Running, 1)
+	is.Equal(resp.Pipelines.Degraded, 1)
+	is.Equal(len(resp.Pipelines.Detail), 1)
+	is.Equal(resp.Pipelines.Detail[0].ID, "p-degraded")
+	is.Equal(resp.Pipelines.Detail[0].Error, "source connector error")
+}

--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -710,6 +710,18 @@ func (r *Runtime) serveHTTPAPI(
 		return nil, cerrors.Errorf("failed to register metrics handler: %w", err)
 	}
 
+	readyzHandler := r.readyzHandler()
+	err = gwmux.HandlePath(
+		"GET",
+		"/readyz",
+		func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+			readyzHandler.ServeHTTP(w, req)
+		},
+	)
+	if err != nil {
+		return nil, cerrors.Errorf("failed to register readyz handler: %w", err)
+	}
+
 	handler := grpcutil.WithWebsockets(
 		ctx,
 		grpcutil.WithDefaultGatewayMiddleware(allowCORS(gwmux, "http://localhost:4200")),


### PR DESCRIPTION
Part of the v0.16 **12-factor essentials** (deployment fundamentals).

## What already existed
`/healthz` (gRPC health via gateway — liveness), `/metrics` (Prometheus), and `CONDUIT_`-prefixed env config with **flag > env > file** precedence. So most of the 12-factor surface was already there — this fills the gaps and documents it.

## New: `/readyz` readiness probe
Distinct from liveness. It answers "can the engine serve?":
- `503` `{"status":"starting"}` while starting up (services init, pipelines provisioning, API coming online).
- `503` `{"status":"unavailable","reason":"…"}` if the state store is unreachable.
- `200` `{"status":"ready", …}` once it can serve. **A degraded pipeline does NOT make Conduit not-ready** — degraded pipelines are reported in the body (total/running/degraded + per-pipeline id/status/error), per the execution plan's AC. Mounted on the gateway mux next to `/metrics`.

## Docs
`docs/health_check.md` now documents the liveness/readiness split, `/readyz` semantics + example body, `/metrics`, and the **env-config precedence** — verified live (`CONDUIT_API_GRPC_ADDRESS` bound gRPC to the supplied address).

## Tests
`readiness()` covers starting (503), store-unavailable (503, via a mock DB failing Ping), and ready-with-a-degraded-pipeline-in-body (200). Build + lint clean.

## Deferred (follow-up)
The `conduit run --pipelines <dir>` alias for `--pipelines.path`: a flag literally named `pipelines` collides with the `Pipelines` config **struct** key in viper (`'Pipelines' expected a map or struct, got "string"`). Doing it right needs a cobra-level flag outside ecdysis's config binding — filed separately rather than shipping broken config parsing.

Tier 2 (additive API surface). Design: execution-plan §1.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)