### PR TITLE
test(connector): deflake TestPersister_WaitsForOpenConnectorsAndFlush

### DIFF
--- a/pkg/connector/persister_test.go
+++ b/pkg/connector/persister_test.go
@@ -179,36 +179,75 @@ func TestPersister_FlushStoresRightAway(t *testing.T) {
 	is.Equal(conn, got)
 }
 
+// TestPersister_WaitsForOpenConnectorsAndFlush verifies that Wait blocks
+// until every started connector has been stopped and the flush triggered by
+// the last stop has actually completed. It used to simulate "connectors are
+// still open" by having a background goroutine time.Sleep(100ms) before
+// calling ConnectorStopped, then asserting Wait() unblocked within a
+// delay..delay+10ms wall-clock window. Under load the goroutine could be
+// descheduled past the 10ms tolerance (or, on a fast/idle machine, Wait()
+// could unblock suspiciously close to the sleep boundary), so the test
+// flaked independently of the fakeClock work in #2544 - it never went
+// through clock.AfterFunc (ConnectorStopped triggers an immediate flush, not
+// the delay-threshold timer), so there is no timer to fake here.
+//
+// Instead of tightening an already-flaky tolerance, this drops wall-clock
+// timing entirely: it synchronizes the goroutine and the Wait() call with
+// channels, and proves the "and flush" half of the contract by asserting the
+// persisted state is already visible in the store by the time Wait()
+// returns - which is only possible if Wait() actually blocked on flushWg
+// until the automatic flush triggered by the final ConnectorStopped call
+// finished. A 5s timeout guards against a genuine deadlock; it is not part
+// of the assertion.
 func TestPersister_WaitsForOpenConnectorsAndFlush(t *testing.T) {
 	is := is.New(t)
 	ctx := context.Background()
-	persister, _ := initPersisterTest(time.Millisecond*100, 2)
+	persister, store := initPersisterTest(time.Millisecond*100, 2)
 
 	conn := &Instance{ID: uuid.NewString(), Type: TypeDestination}
 	persister.ConnectorStarted()
 	persister.ConnectorStarted()
 	persister.ConnectorStarted()
 
-	timeAtStart := time.Now()
-	delay := time.Millisecond * 100
+	stoppedAll := make(chan struct{})
 	go func() {
-		time.Sleep(delay)
+		defer close(stoppedAll)
 		persister.ConnectorStopped()
 		persister.ConnectorStopped()
-		// before last stop we persist another change which should be flushed
-		// automatically when the connector is stopped
+		// before the last stop we persist another change which should be
+		// flushed automatically when the last connector is stopped
 		err := persister.Persist(ctx, conn, func(err error) {})
 		is.NoErr(err)
 		persister.ConnectorStopped()
 	}()
 
-	persister.Wait()
+	waitReturned := make(chan struct{})
+	go func() {
+		persister.Wait()
+		close(waitReturned)
+	}()
 
-	// we are testing a delay which is not exact, this is the acceptable margin
-	maxDelay := delay + time.Millisecond*10
-	if gotDelay := time.Since(timeAtStart); gotDelay > maxDelay {
-		t.Fatalf("wait delay should be between %s and %s, actual delay: %s", delay, maxDelay, gotDelay)
+	select {
+	case <-waitReturned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected Wait to return once all connectors stopped and the final flush completed")
 	}
+
+	// connWg.Wait() (inside Wait) cannot unblock until all three
+	// ConnectorStopped calls have run, so the goroutine above must already
+	// be done - deterministically, not by timing.
+	select {
+	case <-stoppedAll:
+	default:
+		t.Fatal("Wait returned before the connector-stop goroutine finished")
+	}
+
+	// Wait also blocks on flushWg, so the flush triggered by the last
+	// ConnectorStopped must have completed by the time Wait returns - no
+	// polling or sleeping needed to observe the persisted state.
+	got, err := store.Get(ctx, conn.ID)
+	is.NoErr(err)
+	is.Equal(conn, got)
 }
 
 func initPersisterTest(


### PR DESCRIPTION
## Summary

Extends the injected-clock deflaking pattern from #2544 to the other real-timing Persister test that was reddening CI. Refs #2534.

- `TestPersister_WaitsForOpenConnectorsAndFlush` simulated "connectors still open" with a background goroutine that did `time.Sleep(100ms)` before calling `ConnectorStopped`, then asserted `Persister.Wait()` unblocked within a `delay..delay+10ms` wall-clock window. Under CI load the goroutine could be descheduled past the 10ms tolerance, which is exactly what reddened an unrelated PR's `test` job.
- **This test does not touch `clock.AfterFunc`** — `ConnectorStopped` triggers an immediate flush via `triggerFlush`, not the delay-threshold timer — so there's no timer to hand to `fakeClock`. Per the task's fallback instruction, I diagnosed the actual flake cause (a tight wall-clock tolerance around goroutine scheduling) and fixed it hermetically instead: the test now synchronizes the background goroutine and `Wait()` with channels (a 5s timeout is a deadlock guard, not part of the assertion), and proves the "and flush" half of the contract by asserting the persisted connector state is visible in the store by the time `Wait()` returns — only possible if `Wait()` actually blocked on `flushWg` until the automatic flush from the final `ConnectorStopped` completed.
- I also stress-tested the other two Persister tests that still carry wall-clock tolerances (`TestPersister_FlushStoresRightAway`, `TestPersister_PersistFlushesAfterBundleCountThreshold`) under `-shuffle=on -count=500 -race` with concurrent CPU load. Neither flaked and neither uses `time.Sleep` to simulate a delay (both trigger flush synchronously/via bundle-count, not the timer), so both are left untouched — converting them would add fakeClock plumbing with no flakiness to fix.

## Risk tier

Tier 3 (test-only change, no production code touched). `pkg/connector/persister.go` is unmodified.

## Adversarial self-review

- Re-read the diff for the usual suspects: the `is.NoErr`/`t.Fatal` calls inside the background goroutine are pre-existing patterns from the original test (not introduced here) — a failure there fails the whole test binary via `is`'s panic-based mechanism, same as before.
- Confirmed `Wait()`'s two internal waits (`connWg.Wait()` then `flushWg.Wait()`) are exactly what make the post-`waitReturned` assertions deterministic: `stoppedAll` must already be closed (connWg semantics), and the store read must already reflect the flush (flushWg semantics). No sleep/poll needed for either.
- Verified the test still exercises the same behavioral contract as before (Wait blocks until all connectors stop and the final flush lands) — only the mechanism for observing "did it wait long enough" changed, from timing to synchronization + persisted-state proof.
- No production code changed; flush semantics (bundle-count OR delay, whichever first) are untouched.

## Verification

- `go build ./...`
- `go test ./pkg/connector/... -count=50 -race` — green
- `go test ./pkg/connector/... -shuffle=on -count=30 -race` — green
- Re-ran at `-shuffle=on -count=200 -race` under artificial CPU contention (`yes > /dev/null` on every core) — still green
- `golangci-lint run ./pkg/connector/...` — 0 issues
- Before: the converted test took ~100ms per run (real sleep) and carried a 10ms flake margin. After: ~0ms per run, no timing assumption at all.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>