### PR TITLE
feat(cli): add conduit run --pipelines <dir> alias for --pipelines.path

### DIFF
--- a/cmd/conduit/root/run/run.go
+++ b/cmd/conduit/root/run/run.go
@@ -32,6 +32,11 @@ var (
 	_ ecdysis.CommandWithConfig  = (*RunCommand)(nil)
 )
 
+// pipelinesFlagName is the --pipelines alias for --pipelines.path. It is excluded
+// from the viper config binding (name collides with the Pipelines struct) and
+// applied in Execute.
+const pipelinesFlagName = "pipelines"
+
 type RunFlags struct {
 	conduit.Config
 }
@@ -39,9 +44,19 @@ type RunFlags struct {
 type RunCommand struct {
 	flags RunFlags
 	Cfg   conduit.Config
+	// pipelinesAlias backs the --pipelines flag, a GitOps-friendly alias for
+	// --pipelines.path. It can't be bound to the config struct via viper (the name
+	// collides with the Pipelines struct key), so it's excluded from the config
+	// binding (see Config) and applied in Execute.
+	pipelinesAlias string
 }
 
-func (c *RunCommand) Execute(_ context.Context) error {
+func (c *RunCommand) Execute(ctx context.Context) error {
+	// --pipelines is an alias for --pipelines.path; apply it when explicitly set.
+	if cmd := ecdysis.CobraCmdFromContext(ctx); cmd != nil && cmd.Flags().Changed(pipelinesFlagName) {
+		c.Cfg.Pipelines.Path = c.pipelinesAlias
+	}
+
 	e := &conduit.Entrypoint{}
 
 	if !c.Cfg.API.Enabled {
@@ -57,9 +72,12 @@ func (c *RunCommand) Config() ecdysis.Config {
 	path := filepath.Dir(c.flags.ConduitCfg.Path)
 
 	return ecdysis.Config{
-		EnvPrefix:     "CONDUIT",
-		Parsed:        &c.Cfg,
-		Path:          c.flags.ConduitCfg.Path,
+		EnvPrefix: "CONDUIT",
+		Parsed:    &c.Cfg,
+		Path:      c.flags.ConduitCfg.Path,
+		// --pipelines collides with the Pipelines config struct key; exclude it from
+		// the viper binding and apply it in Execute (see pipelinesAlias).
+		ExcludedFlags: []string{pipelinesFlagName},
 		DefaultValues: conduit.DefaultConfigWithBasePath(path),
 	}
 }
@@ -101,6 +119,17 @@ func (c *RunCommand) Flags() []ecdysis.Flag {
 	flags.SetDefault("schema-registry.confluent.connection-string", c.Cfg.SchemaRegistry.Confluent.ConnectionString)
 	flags.SetDefault("preview.pipeline-arch-v2", c.Cfg.Preview.PipelineArchV2)
 	flags.SetDefault("preview.pipeline-arch-v2-disable-metrics", c.Cfg.Preview.PipelineArchV2DisableMetrics)
+
+	// --pipelines is a GitOps-friendly alias for --pipelines.path (point Conduit at
+	// a directory of pipeline configs). It's excluded from the viper config binding
+	// (see Config) because its name collides with the Pipelines struct; Execute
+	// copies it into Cfg.Pipelines.Path when set.
+	flags = append(flags, ecdysis.Flag{
+		Long:    pipelinesFlagName,
+		Usage:   "alias for --pipelines.path: path to a pipelines' directory or a pipeline configuration file",
+		Ptr:     &c.pipelinesAlias,
+		Default: c.Cfg.Pipelines.Path,
+	})
 	return flags
 }
 

--- a/cmd/conduit/root/run/run_test.go
+++ b/cmd/conduit/root/run/run_test.go
@@ -46,6 +46,7 @@ func TestRunCommandFlags(t *testing.T) {
 		{longName: "connectors.path", usage: "path to standalone connectors' directory"},
 		{longName: "processors.path", usage: "path to standalone processors' directory"},
 		{longName: "pipelines.path", usage: "path to a pipelines' directory or a pipeline configuration file"},
+		{longName: "pipelines", usage: "alias for --pipelines.path: path to a pipelines' directory or a pipeline configuration file"},
 		{longName: "pipelines.exit-on-degraded", usage: "exit Conduit if a pipeline is degraded"},
 		{longName: "pipelines.error-recovery.min-delay", usage: "minimum delay before restart"},
 		{longName: "pipelines.error-recovery.max-delay", usage: "maximum delay before restart"},

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/conduitio/conduit-connector-sdk v0.14.2
 	github.com/conduitio/conduit-processor-sdk v0.5.1
 	github.com/conduitio/conduit-schema-registry v0.2.6
-	github.com/conduitio/ecdysis v0.5.0
+	github.com/conduitio/ecdysis v0.6.0
 	github.com/conduitio/yaml/v3 v3.3.0
 	github.com/dop251/goja v0.0.0-20240806095544-3491d4a58fbe
 	github.com/dop251/goja_nodejs v0.0.0-20231122114759-e84d9a924c5c

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,8 @@ github.com/conduitio/conduit-processor-sdk v0.5.1 h1:MeZw0smfE5MONQJD+SolMczcTEA
 github.com/conduitio/conduit-processor-sdk v0.5.1/go.mod h1:GCbaiprjw+8Q3hDodZx47oXjcENRcLQyKcQLLVyGeQg=
 github.com/conduitio/conduit-schema-registry v0.2.6 h1:39a7AUp3ZM6Hq1vKKpVTmwSTvKbwKC2kxsnkP6H9qrQ=
 github.com/conduitio/conduit-schema-registry v0.2.6/go.mod h1:1A1FUC3SZeU8tBEtSY35Xzfrw7k3Z6FHA0XWyROkbyE=
-github.com/conduitio/ecdysis v0.5.0 h1:MsEqPei0woD4Ecl7kMAXSoW+9D5nHTt8HNxzLS5OuEM=
-github.com/conduitio/ecdysis v0.5.0/go.mod h1:NnWv7W3fa5TXqlP2tuiOcbHMUyGRH6FcW1pjooRvSfE=
+github.com/conduitio/ecdysis v0.6.0 h1:sSvB6wMXoBOya96dpAEJxOV7VvvVFEokQavKsG61tcM=
+github.com/conduitio/ecdysis v0.6.0/go.mod h1:NnWv7W3fa5TXqlP2tuiOcbHMUyGRH6FcW1pjooRvSfE=
 github.com/conduitio/evolviconf v0.1.0 h1:rcG+hs6tlrYlX9qomOQJz+K+OnDhbMbioGx3ci55yo0=
 github.com/conduitio/evolviconf v0.1.0/go.mod h1:RnbnSqDDYarKgG2p+krP71svG6qLms3+/TnKrPKWk+0=
 github.com/conduitio/evolviconf/evolviyaml v0.1.0 h1:nMW7CROIMtHhscm/QLMpMs7uCPp6O2dS4CfU9bhugd4=


### PR DESCRIPTION
Completes the last v0.16 **12-factor essential**: a GitOps-friendly `conduit run --pipelines <dir>` alias for `--pipelines.path`.

## The blocker (from #2549) and the fix
A flag literally named `pipelines` collides with the `Pipelines` config **struct** key in viper. Fixed via a new **`ecdysis.Config.ExcludedFlags`** (ecdysis v0.6.0, ConduitIO/ecdysis#44): `--pipelines` is registered with cobra but **excluded from the viper binding**, and `RunCommand.Execute` copies it into `Cfg.Pipelines.Path` when explicitly set (`Changed`). Setting either flag has the same effect.

- Bumps `conduitio/ecdysis` → v0.6.0.
- Verified end-to-end: `conduit run --pipelines /dir` provisions from `/dir` (`pipelines_path=/dir` in the log); default run + config parsing unaffected; lint clean.
- Test asserts the flag is registered with the right usage.

Closes #2549. Tier 2 (additive CLI surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)