### PR TITLE
test: fix racy watermark tracking in TestParallelNode_Processor

### DIFF
--- a/pkg/lifecycle/stream/parallel_test.go
+++ b/pkg/lifecycle/stream/parallel_test.go
@@ -570,7 +570,27 @@ func TestParallelNode_Processor(t *testing.T) {
 		Process(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, records []opencdc.Record) []sdk.ProcessedRecord {
 			current := atomic.AddInt32(&workersCurrent, 1)
-			atomic.CompareAndSwapInt32(&workersHighWatermark, current-1, current)
+			// Ratchet the high watermark up to current using a CAS retry loop.
+			// A single-shot CAS(workersHighWatermark, current-1, current) is
+			// racy: it only succeeds if the goroutines that received lower
+			// "current" values from AddInt32 above have already applied their
+			// CAS, which the scheduler does not guarantee. Under real
+			// concurrency a goroutine holding a higher value can run its CAS
+			// before goroutines holding lower values, causing it to fail and
+			// permanently under-report the watermark (it does not retry). The
+			// loop below instead compares against the live value and retries
+			// until it either wins the update or observes a value already >=
+			// current, which correctly computes the max regardless of the
+			// order in which goroutines execute.
+			for {
+				hw := atomic.LoadInt32(&workersHighWatermark)
+				if current <= hw {
+					break
+				}
+				if atomic.CompareAndSwapInt32(&workersHighWatermark, hw, current) {
+					break
+				}
+			}
 			time.Sleep(time.Millisecond) // sleep to let other workers catch up
 			atomic.AddInt32(&workersCurrent, -1)
 


### PR DESCRIPTION
## Summary

`TestParallelNode_Processor` (pkg/lifecycle/stream/parallel_test.go) flaked under `go test -shuffle=on` in the full-package run (observed ~1/5), while passing reliably in isolation. Root cause turned out to be a genuine concurrency bug in the test's own instrumentation, not cross-test shared state — confirmed by reproducing the failure even in isolation (1/50 with `-run TestParallelNode_Processor -race -count=1`, repeated).

**Root cause** (`pkg/lifecycle/stream/parallel_test.go:572-573`, pre-fix):

```go
current := atomic.AddInt32(&workersCurrent, 1)
atomic.CompareAndSwapInt32(&workersHighWatermark, current-1, current)
```

This "high watermark" tracker used a single-shot CAS that only succeeds if goroutines apply their CAS in the *exact* order matching the sequential values handed out by `atomic.AddInt32`. The Go scheduler makes no such guarantee — a goroutine that received a higher `current` value can run its CAS before a goroutine holding a lower value has run its own. When that happens the CAS fails and, since there's no retry, the update is silently dropped — permanently under-reporting the watermark (it frequently got stuck at 1). That then fails the `is.True(workersHighWatermark >= 2)` assertion at the end of the test.

This is timing/scheduling-sensitive rather than a pure logic bug, which is why it reproduced far more often under `-shuffle=on` in the full package run (more goroutine/GC pressure from preceding tests perturbs scheduling) than alone, but it is not actually dependent on any shared or global package state — no package-level vars are mutated across tests in this package.

**Fix:** replace the one-shot CAS with a standard atomic "update-max" retry loop that reads the live value and retries until it either wins the update or observes a value already `>= current`. This computes the true max regardless of the order in which goroutines happen to execute, eliminating the race. Assertions were not weakened.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/lifecycle/stream/ -shuffle=on -count=50 -race` — before fix this failed intermittently (2/20 observed at that volume during investigation); after fix, 100% green
- [x] `go test ./pkg/lifecycle/stream/ -shuffle=off -count=50 -race` — 100% green
- [x] Isolated stress: `go test ./pkg/lifecycle/stream/ -run TestParallelNode_Processor -race -count=50` (looped 50x with `-count=1`) — went from 1/50 failures (pre-fix) to 0/50 (post-fix)
- [x] `golangci-lint run ./pkg/lifecycle/stream/...` — 0 issues

Refs #2534

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>