### PR TITLE
conduiterr: forbidigo guard against raw literals + WithCode escape hatch

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - errcheck
     - errname
     - exhaustive
+    - forbidigo
     - goconst
     - gocritic
     - gocyclo
@@ -45,6 +46,24 @@ linters:
               desc: github.com/golang/mock is deprecated, use go.uber.org/mock instead.
             - pkg: encoding/json
               desc: github.com/goccy/go-json is preferred for performance reasons.
+    forbidigo:
+      forbid:
+        # conduiterr#2526 follow-up: construction must go through New/Wrap (or the
+        # WithCode escape hatch), which guarantee a stack frame and a validated,
+        # registered Code. A raw literal skips both.
+        #
+        # Caveat: forbidigo only matches Ident/SelectorExpr node text, not the
+        # enclosing composite literal, so it cannot distinguish "constructing
+        # ConduitError{}" from "naming the ConduitError type" (e.g. as a var, param,
+        # or return type). In this codebase the type is meant to be reached via
+        # New/Wrap/Get, not named directly outside the package, so forbidding the
+        # bare identifier is the closest enforceable guard and today has zero known
+        # legitimate hits outside the package/tests (verified by grep). It also
+        # will not catch the literal if conduiterr is imported under a different
+        # local name.
+        - pattern: '^conduiterr\.ConduitError$'
+          msg: construct via conduiterr.New, conduiterr.Wrap, or conduiterr.WithCode instead of a raw ConduitError{} literal - see package doc.
+      exclude-godoc-examples: true
     gocyclo:
       min-complexity: 20
     goheader:
@@ -82,7 +101,13 @@ linters:
           - dogsled
           - gosec
           - goconst
+          - forbidigo
         path: (.+)_test\.go
+      - linters:
+          - forbidigo
+        # conduiterr's own constructors (New/Wrap/WithCode) are the only place
+        # allowed to build a ConduitError{} literal directly.
+        path: ^pkg/foundation/cerrors/conduiterr/
 formatters:
   enable:
     - gofmt

--- a/pkg/foundation/cerrors/cerrors.go
+++ b/pkg/foundation/cerrors/cerrors.go
@@ -32,9 +32,12 @@ import (
 )
 
 var (
-	// xerrors is used, since it provides the stack traces too
-	New    = xerrors.New    //nolint:forbidigo // xerrors.New is allowed here, but not anywhere else
-	Errorf = xerrors.Errorf //nolint:forbidigo // xerrors.Errorf is allowed here, but not anywhere else
+	// xerrors is used, since it provides the stack traces too. xerrors.New/Errorf
+	// are allowed here, but not anywhere else: the depguard rule above blocks
+	// importing golang.org/x/xerrors outside this file, so this is the only place
+	// that can call them at all.
+	New    = xerrors.New
+	Errorf = xerrors.Errorf
 	Is     = errors.Is
 	As     = errors.As
 	Unwrap = errors.Unwrap

--- a/pkg/foundation/cerrors/conduiterr/conduiterr.go
+++ b/pkg/foundation/cerrors/conduiterr/conduiterr.go
@@ -22,8 +22,10 @@
 // with a google.rpc.ErrorInfo detail) and the mapping between the two live in
 // status.go, with a round-trip test that keeps the two encodings from drifting.
 //
-// Construction is only via New or Wrap; a bare &ConduitError{} literal carries no
-// stack trace (ConduitError is not itself an xerrors value) and is forbidden.
+// Construction is only via New, Wrap, or the WithCode escape hatch; a bare
+// &ConduitError{} literal carries no stack trace (ConduitError is not itself an
+// xerrors value) and is forbidden — enforced outside this package (and outside
+// _test.go files) by the forbidigo rule in .golangci.yml.
 package conduiterr
 
 import (
@@ -158,8 +160,9 @@ func New(code Code, msg string) *ConduitError {
 // *ConduitError, the returned error takes that inner Code (and inherits its
 // structured fields where the wrap does not set them), so errors.As never surfaces
 // a code that hides a more specific inner one. Note this means Wrap's own code
-// argument is ignored when an inner ConduitError is present — an explicit-override
-// escape hatch is a tracked follow-up.
+// argument is ignored when an inner ConduitError is present. A boundary that
+// genuinely needs to reclassify — the explicit-override escape hatch — should
+// use WithCode instead.
 func Wrap(code Code, msg string, cause error) *ConduitError {
 	e := &ConduitError{Code: code, Message: msg, err: cause}
 
@@ -183,6 +186,49 @@ func Wrap(code Code, msg string, cause error) *ConduitError {
 	if e.err == nil {
 		// Guarantee a frame even if cause was nil. Skip=1 for the same reason as
 		// New: attribute the frame to Wrap's caller, not to Wrap itself.
+		e.err = cerrors.NewWithStackDepth(1, msg)
+	}
+	return e
+}
+
+// WithCode is the explicit code-override escape hatch. Wrap intentionally
+// refuses to shadow an inner ConduitError's code (the no-shadow invariant); that
+// is correct for ordinary wrapping, but a boundary that genuinely needs to
+// reclassify an error — e.g. surface a generic lower-level code as a more
+// specific one at an API boundary — has no way to signal that intent through
+// Wrap. WithCode is that signal: it always adopts code, even when err already
+// is, or wraps, a *ConduitError with its own code. Use it sparingly and only
+// when the override is deliberate; reach for Wrap for ordinary context-adding.
+//
+// err becomes the wrapped cause (via Unwrap), so errors.Is/As and Get still
+// reach it and any inner ConduitError through the chain — only the Code
+// on the returned, outermost error changes. The returned error's Message is
+// err.Error() (for a *ConduitError cause, ConduitError.Error() returns just the
+// inner Message, not the full chain text, so the displayed message is
+// unchanged; only the classification is). Structured fields (ConfigPath,
+// Suggestion, Fix, DocsURL) are inherited from an inner ConduitError, if any,
+// since WithCode overrides the code, not the remediation data.
+//
+// Like New and Wrap, WithCode guarantees a non-empty stack trace: it captures a
+// frame at its caller (via cerrors.NewWithStackDepth) when err is nil or itself
+// carries none.
+func WithCode(err error, code Code) *ConduitError {
+	var msg string
+	if err != nil {
+		msg = err.Error()
+	}
+	e := &ConduitError{Code: code, Message: msg, err: err}
+
+	var inner *ConduitError
+	if err != nil && cerrors.As(err, &inner) {
+		e.ConfigPath = inner.ConfigPath
+		e.Suggestion = inner.Suggestion
+		e.Fix = inner.Fix
+		e.DocsURL = inner.DocsURL
+	}
+
+	if e.err == nil {
+		// Guarantee a frame even if err was nil, same reasoning as New/Wrap.
 		e.err = cerrors.NewWithStackDepth(1, msg)
 	}
 	return e

--- a/pkg/foundation/cerrors/conduiterr/conduiterr_test.go
+++ b/pkg/foundation/cerrors/conduiterr/conduiterr_test.go
@@ -143,3 +143,48 @@ func TestWrap_FrameIsCallerAccurate(t *testing.T) {
 	is.True(!strings.Contains(fr.Func, "conduiterr.Wrap"))
 	is.True(strings.HasSuffix(fr.Func, "conduiterr_test.TestWrap_FrameIsCallerAccurate"))
 }
+
+// TestWithCode_OverridesInnerCode is the guard for the #2526 escape-hatch
+// follow-up: unlike Wrap, which passes an inner ConduitError's code through
+// untouched (no-shadow invariant), WithCode must always adopt the code it is
+// given, even when err already carries a more specific inner ConduitError code.
+func TestWithCode_OverridesInnerCode(t *testing.T) {
+	is := is.New(t)
+	inner := conduiterr.New(conduiterr.CodeConnectorPluginNotFound, "no such plugin")
+	inner.ConfigPath = "/connectors/0/plugin"
+
+	recoded := conduiterr.WithCode(inner, conduiterr.CodeInternal)
+
+	is.Equal(recoded.Code.Reason(), conduiterr.CodeInternal.Reason())
+	is.Equal(recoded.Code.GRPCCode(), conduiterr.CodeInternal.GRPCCode())
+	// Structured fields still come along even though the code was overridden.
+	is.Equal(recoded.ConfigPath, "/connectors/0/plugin")
+	// The displayed message is unchanged; only the classification is.
+	is.Equal(recoded.Error(), "no such plugin")
+}
+
+// TestWithCode_CausePreservedInChain ensures the escape hatch does not sever
+// the chain: errors.Is/Get must still be able to reach through to the original
+// cause and the new code after WithCode reclassifies it.
+func TestWithCode_CausePreservedInChain(t *testing.T) {
+	is := is.New(t)
+	sentinel := cerrors.New("plugin missing")
+	inner := conduiterr.Wrap(conduiterr.CodeConnectorPluginNotFound, "no such plugin", sentinel)
+
+	recoded := conduiterr.WithCode(inner, conduiterr.CodeInternal)
+
+	is.True(cerrors.Is(recoded, sentinel))
+
+	ce, ok := conduiterr.Get(recoded)
+	is.True(ok)
+	is.Equal(ce.Code.Reason(), conduiterr.CodeInternal.Reason())
+}
+
+// TestWithCode_GuaranteesFrameWithNilCause mirrors Wrap's nil-cause guarantee:
+// WithCode(nil, code) must still carry a non-empty stack trace.
+func TestWithCode_GuaranteesFrameWithNilCause(t *testing.T) {
+	is := is.New(t)
+	err := conduiterr.WithCode(nil, conduiterr.CodeInternal)
+	is.True(frameCount(err) > 0)
+	is.Equal(err.Code.Reason(), conduiterr.CodeInternal.Reason())
+}


### PR DESCRIPTION
## Summary

Two of the three `conduiterr` follow-ups from #2526 (the third — caller-accurate
stack frames — already landed in #2543 and is not touched here):

- **forbidigo guard.** Enables `forbidigo` (previously only ever commented out
  in `.golangci.yml`, never actually running) with a pattern forbidding
  `conduiterr.ConduitError{...}` construction outside the `conduiterr` package
  and outside `_test.go` files, so production code can't bypass `New`/`Wrap`
  and skip the guaranteed stack frame + validated `Code`.
- **`WithCode` escape hatch.** Adds `WithCode(err error, code Code) *ConduitError`,
  the explicit code-override hatch `Wrap`'s godoc named as a tracked follow-up.

## Risk tier

**Tier 2 — Features/tooling.** No data-path, protocol, or serialization-format
change. `conduiterr` itself is new (landed via #2524) and not yet wired into any
boundary's ack/position/checkpoint logic.

## forbidigo rule + proof it fires

Added to `.golangci.yml`:

```yaml
forbidigo:
  forbid:
    - pattern: '^conduiterr\.ConduitError$'
      msg: construct via conduiterr.New, conduiterr.Wrap, or conduiterr.WithCode instead of a raw ConduitError{} literal - see package doc.
```
with exclusion rules for `_test.go` files (repo-wide, matching the existing
test-file exclusion style already used for `dogsled`/`gosec`/`goconst`) and for
`pkg/foundation/cerrors/conduiterr/` itself (New/Wrap/WithCode legitimately
build the struct).

**Expressiveness limitation, documented in the config comment:** forbidigo
only inspects `*ast.Ident`/`*ast.SelectorExpr` node text — it never sees the
enclosing `*ast.CompositeLit`, so a pattern can't distinguish "constructing
`ConduitError{}`" from "naming the `ConduitError` type" (e.g. as a var/param/
return type). I verified this two ways against forbidigo v1.6.0 (the version
golangci-lint v2.12.2 bundles) in a scratch module:
- A pattern with a trailing brace (`conduiterr\.ConduitError\{`, the fallback
  the issue itself suggested) never matches anything — the matched node's
  printed text never includes the brace.
- A bare-identifier pattern (`^conduiterr\.ConduitError$`) matches *every*
  occurrence of the selector, including legitimate type references (`var e
  *sub.ConduitError`, `func f(x *sub.ConduitError)`), not just literals.

Given that, I used the bare-identifier pattern as "the closest enforceable
guard" (per the issue's own fallback language). Blast-radius check: grepped
the whole repo — the only occurrence of `conduiterr.ConduitError` outside the
package today is the one raw literal in `conduiterr_test.go` (already
covered by the `_test.go` exclusion), so this has zero false positives right
now. Future callers that legitimately want to *name* the type (rather than
construct one) outside the package will also get flagged — that's arguably
consistent with the package's own doc ("construction is only via New/Wrap"),
but it's a real, documented limitation, not a silent one. A caveat also
called out in the config: this is source-text matching, so it's blind to a
non-standard import alias for `conduiterr`.

**Proof it fires:** added a scratch package (`pkg/foundation/lintprobe`,
never committed) with `var _ = &conduiterr.ConduitError{}` and ran
`golangci-lint run ./pkg/foundation/lintprobe/...`:

```
pkg/foundation/lintprobe/probe.go:5:10: use of `conduiterr.ConduitError` forbidden because
"construct via conduiterr.New, conduiterr.Wrap, or conduiterr.WithCode instead of a raw
ConduitError{} literal - see package doc." (forbidigo)
var _ = &conduiterr.ConduitError{}
         ^
```
removed the probe afterward; `git status` confirms it's gone from this diff.

**Side effect of enabling forbidigo for the first time:** two pre-existing
`//nolint:forbidigo` markers on `cerrors.go`'s `xerrors.New`/`Errorf`
assignments predated any active forbidigo rule (forbidigo was always
commented out) and became genuinely unused once the linter actually runs,
failing `nolintlint`. Removed them rather than inventing a new forbid rule
for `xerrors.*` to keep them "alive" — the depguard rule already fully
enforces "xerrors only importable in cerrors.go", so no coverage is lost,
and adding unrelated enforcement policy in this PR would be scope creep.

## `WithCode` semantics

`Wrap(code, msg, cause)` intentionally *never* shadows an inner
`ConduitError`'s code (the no-shadow invariant) — correct for ordinary
context-adding wraps, but it means a boundary that genuinely needs to
reclassify has no way to signal that intent.

`WithCode(err, code)` is the opposite, deliberate hatch: it always adopts
`code`, even when `err` already is, or wraps, a `*ConduitError` with its own
code.

- `err` becomes the wrapped cause (`Unwrap`), so `errors.Is`/`As` and `Get`
  still reach it and any inner `ConduitError` through the chain — only the
  `Code` on the returned, outermost error changes.
- `Message` is `err.Error()` (for a `*ConduitError` cause, that's just the
  inner `Message`, since `ConduitError.Error()` doesn't include the chain) —
  so the displayed text is unchanged; only the classification is.
- Structured fields (`ConfigPath`, `Suggestion`, `Fix`, `DocsURL`) are
  inherited from an inner `ConduitError`, if any, since `WithCode` overrides
  the code, not the remediation data.
- Same nil-cause stack-frame guarantee as `New`/`Wrap`, via
  `cerrors.NewWithStackDepth`.

Tests added in `conduiterr_test.go`:
- `TestWithCode_OverridesInnerCode` — code changes even over an inner
  `ConduitError`'s code; structured fields and displayed message survive.
- `TestWithCode_CausePreservedInChain` — `errors.Is` still reaches the
  original sentinel cause; `Get` returns the *new* code.
- `TestWithCode_GuaranteesFrameWithNilCause` — mirrors `Wrap`'s nil-cause
  frame guarantee.

## Adversarial self-review

- `WithCode(nil, code)`: guarantees a frame (mirrors `Wrap`'s nil-cause
  fallback), `Message` is `""` in that case — documented, not silently
  assumed.
- No new concurrency surface — `WithCode` doesn't touch the code registry or
  any shared mutable state.
- Confirmed the forbidigo rule does *not* fire on `conduiterr.go`'s own
  `New`/`Wrap`/`WithCode` literal, nor on `conduiterr_test.go`'s existing
  `TestBareLiteral_HasNoStackTrace` (both covered by the path exclusion).
- Confirmed removing the two `nolint:forbidigo` markers doesn't weaken
  enforcement (verified depguard still blocks importing `x/xerrors` outside
  `cerrors.go` — that rule is unchanged).
- Not a data-path change: `conduiterr` isn't wired into any ack/position/
  checkpoint/protocol code yet, so invariants 1-7 are unaffected.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/foundation/cerrors/... -count=1 -race` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] forbidigo rule verified to fire against a deliberately-added raw
      literal in a scratch package (removed before commit)

Refs #2526.