### PR TITLE
feat(cli): add conduit quickstart — the 5-minute wow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,16 @@ Conduit was created and open-sourced by [Meroxa](https://meroxa.io).
 
 ## Quick start
 
-<https://conduit.io/docs/getting-started>
+The fastest way to see Conduit working — scaffold and run a demo pipeline with a
+single command:
+
+```sh
+conduit quickstart
+```
+
+Sample records flow to your console within seconds. State is in-memory and nothing
+is written to your working directory; press Ctrl-C to stop. For a full walkthrough,
+see <https://conduit.io/docs/getting-started>.
 
 ## Installation guide
 

--- a/cmd/conduit/root/quickstart/quickstart.go
+++ b/cmd/conduit/root/quickstart/quickstart.go
@@ -1,0 +1,147 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package quickstart implements `conduit quickstart`, the zero-config 5-minute-wow
+// command: it scaffolds an ephemeral demo pipeline (built-in generator -> built-in
+// log) and runs it in-process so a new user sees records flowing within seconds,
+// with nothing written to their working directory.
+package quickstart
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/conduitio/conduit/pkg/conduit"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/ecdysis"
+)
+
+var (
+	_ ecdysis.CommandWithExecute = (*QuickstartCommand)(nil)
+	_ ecdysis.CommandWithDocs    = (*QuickstartCommand)(nil)
+	_ ecdysis.CommandWithFlags   = (*QuickstartCommand)(nil)
+)
+
+// demoPipeline is a self-contained generator->log pipeline. The generator produces
+// structured sample records at 1/s and the log destination prints them, so records
+// visibly flow with no setup. The generator settings match the no-flag demo used by
+// `conduit pipelines init` so the two stay consistent.
+const demoPipeline = `version: "2.2"
+pipelines:
+  - id: quickstart
+    status: running
+    description: Demo pipeline — generates sample records and logs them.
+    connectors:
+      - id: source
+        type: source
+        plugin: builtin:generator
+        settings:
+          format.type: structured
+          format.options.scheduledDeparture: time
+          format.options.airline: string
+          rate: "1"
+          # the sample records use unstructured keys; skip key-schema encoding so
+          # the demo output stays clean.
+          sdk.schema.extract.key.enabled: "false"
+      - id: destination
+        type: destination
+        plugin: builtin:log
+        settings:
+          sdk.schema.extract.key.enabled: "false"
+`
+
+// logFormatJSON is the config string for JSON-formatted logs.
+const logFormatJSON = "json"
+
+type QuickstartFlags struct {
+	JSON bool `long:"json" usage:"Emit logs and records as JSON instead of human-readable text."`
+}
+
+type QuickstartCommand struct {
+	flags QuickstartFlags
+}
+
+func (c *QuickstartCommand) Flags() []ecdysis.Flag { return ecdysis.BuildFlags(&c.flags) }
+
+func (c *QuickstartCommand) Usage() string { return "quickstart" }
+
+func (c *QuickstartCommand) Docs() ecdysis.Docs {
+	return ecdysis.Docs{
+		Short: "Run a demo pipeline to see Conduit working in under a minute.",
+		Long: `Scaffold an ephemeral demo pipeline — a built-in generator streaming sample
+records to the built-in log destination — and run it immediately. Records flow to
+your console within seconds, with no configuration and nothing written to your
+working directory.
+
+State is in-memory and the scaffolded config lives in a temporary directory that is
+removed on exit. Press Ctrl-C to stop. To build your own pipeline, see
+'conduit pipelines init'.`,
+	}
+}
+
+// setup scaffolds the ephemeral demo workspace and builds the runtime config. It is
+// separated from Execute so it can be tested without starting the blocking server.
+// On any error it removes anything it created.
+func (c *QuickstartCommand) setup() (dir string, cfg conduit.Config, err error) {
+	dir, err = os.MkdirTemp("", "conduit-quickstart-*")
+	if err != nil {
+		return "", conduit.Config{}, cerrors.Errorf("failed to create temp workspace: %w", err)
+	}
+	// Create all workspace dirs the runtime scans, so it doesn't warn about missing
+	// connectors/processors directories during a clean demo.
+	for _, sub := range []string{"pipelines", "connectors", "processors"} {
+		if err := os.Mkdir(filepath.Join(dir, sub), 0o750); err != nil {
+			_ = os.RemoveAll(dir)
+			return "", conduit.Config{}, cerrors.Errorf("failed to create %s dir: %w", sub, err)
+		}
+	}
+	pipelinesDir := filepath.Join(dir, "pipelines")
+	if err := os.WriteFile(filepath.Join(pipelinesDir, "quickstart.yaml"), []byte(demoPipeline), 0o600); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", conduit.Config{}, cerrors.Errorf("failed to write demo pipeline: %w", err)
+	}
+
+	cfg = conduit.DefaultConfigWithBasePath(dir)
+	cfg.DB.Type = conduit.DBTypeInMemory // zero disk footprint
+	cfg.Pipelines.Path = pipelinesDir
+	cfg.Connectors.Path = filepath.Join(dir, "connectors")
+	cfg.Processors.Path = filepath.Join(dir, "processors")
+	cfg.API.Enabled = true
+	if c.flags.JSON {
+		cfg.Log.Format = logFormatJSON
+	}
+	return dir, cfg, nil
+}
+
+func (c *QuickstartCommand) Execute(_ context.Context) error {
+	dir, cfg, err := c.setup()
+	if err != nil {
+		return err
+	}
+	// Serve returns on a graceful (single) Ctrl-C/SIGTERM, at which point we clean
+	// up. A second signal or a fatal error calls os.Exit, skipping this — the temp
+	// dir is then reclaimed by the OS, and the in-memory store means nothing to
+	// corrupt.
+	defer os.RemoveAll(dir)
+
+	if cfg.Log.Format != logFormatJSON {
+		fmt.Fprint(os.Stdout, "Starting a demo pipeline (generator → log). "+
+			"Records will flow below — press Ctrl-C to stop.\n\n")
+	}
+
+	(&conduit.Entrypoint{}).Serve(cfg)
+	return nil
+}

--- a/cmd/conduit/root/quickstart/quickstart_test.go
+++ b/cmd/conduit/root/quickstart/quickstart_test.go
@@ -1,0 +1,64 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package quickstart
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/conduit"
+	"github.com/matryer/is"
+)
+
+func TestQuickstartCommand_setup(t *testing.T) {
+	is := is.New(t)
+	c := &QuickstartCommand{}
+
+	dir, cfg, err := c.setup()
+	is.NoErr(err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	// Ephemeral workspace scaffolded: all three dirs + the demo pipeline file.
+	for _, sub := range []string{"pipelines", "connectors", "processors"} {
+		info, statErr := os.Stat(filepath.Join(dir, sub))
+		is.NoErr(statErr)
+		is.True(info.IsDir())
+	}
+	content, err := os.ReadFile(filepath.Join(dir, "pipelines", "quickstart.yaml"))
+	is.NoErr(err)
+	is.True(strings.Contains(string(content), "builtin:generator")) // source
+	is.True(strings.Contains(string(content), "builtin:log"))       // destination
+
+	// Config: in-memory store, points at the temp pipelines dir, API on, human logs.
+	is.Equal(cfg.DB.Type, conduit.DBTypeInMemory)
+	is.Equal(cfg.Pipelines.Path, filepath.Join(dir, "pipelines"))
+	is.Equal(cfg.Connectors.Path, filepath.Join(dir, "connectors"))
+	is.Equal(cfg.Processors.Path, filepath.Join(dir, "processors"))
+	is.True(cfg.API.Enabled)
+	is.True(cfg.Log.Format != "json") // default human-readable
+}
+
+func TestQuickstartCommand_setup_JSON(t *testing.T) {
+	is := is.New(t)
+	c := &QuickstartCommand{flags: QuickstartFlags{JSON: true}}
+
+	dir, cfg, err := c.setup()
+	is.NoErr(err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	is.Equal(cfg.Log.Format, logFormatJSON)
+}

--- a/cmd/conduit/root/root.go
+++ b/cmd/conduit/root/root.go
@@ -27,6 +27,7 @@ import (
 	"github.com/conduitio/conduit/cmd/conduit/root/pipelines"
 	"github.com/conduitio/conduit/cmd/conduit/root/processorplugins"
 	"github.com/conduitio/conduit/cmd/conduit/root/processors"
+	"github.com/conduitio/conduit/cmd/conduit/root/quickstart"
 	"github.com/conduitio/conduit/cmd/conduit/root/run"
 	"github.com/conduitio/conduit/cmd/conduit/root/version"
 	"github.com/conduitio/conduit/pkg/conduit"
@@ -98,6 +99,7 @@ func (c *RootCommand) SubCommands() []ecdysis.Command {
 		&pipelines.PipelinesCommand{},
 		&processors.ProcessorsCommand{},
 		&processorplugins.ProcessorPluginsCommand{},
+		&quickstart.QuickstartCommand{},
 		&version.VersionCommand{},
 		runCmd,
 	}

--- a/docs/design-documents/20260706-quickstart-command.md
+++ b/docs/design-documents/20260706-quickstart-command.md
@@ -1,0 +1,81 @@
+# `conduit quickstart` — the 5-minute wow
+
+## Summary
+
+A single command that scaffolds an ephemeral demo pipeline (built-in generator →
+built-in log) and runs it in-process, so a brand-new user sees records flowing in
+under a minute with **zero flags and zero footprint**. It leaves `conduit init` and
+`conduit pipelines init` untouched. Tier 2 (additive CLI surface; no data-path or
+protocol change).
+
+## Context
+
+The Phase-1 execution plan (§1.2) calls for a "5-minute wow": a first-run
+experience where records visibly flow with no configuration. The plan's original
+shape merged this into `conduit init` (deprecating `conduit pipelines init`); that
+was reconsidered in #2535, which kept `init` (workspace) and `pipelines init`
+(pipeline scaffold) separate. Rather than reverse that split, `quickstart` is a
+dedicated, purely additive command: it delivers the wow without changing either
+existing command.
+
+## Decision
+
+Add `conduit quickstart`. It:
+
+1. Creates an **ephemeral** workspace — a temp directory for the pipeline config and
+   an **in-memory** state store (`db.type=inmemory`). Nothing is written to the
+   user's working directory; the temp dir is removed on graceful exit.
+2. Writes a demo pipeline: **`builtin:generator`** (structured sample records at
+   1/s) → **`builtin:log`** (records printed to the console). Both are compiled-in,
+   so there is nothing to install.
+3. Runs it in the foreground via the **same `Entrypoint.Serve` path as
+   `conduit run`** — no divergent run logic. SIGINT/SIGTERM drains and exits
+   gracefully (invariant 7); a second signal hard-exits.
+4. Enables the HTTP/gRPC API on the default addresses and prints the URLs, so the
+   user can immediately explore `/readyz`, `/metrics`, and `/openapi`.
+5. Supports `--json`, which sets the log format to JSON so the streamed records and
+   logs are machine-consumable.
+
+The demo generator settings are the same known-good ones `conduit pipelines init`
+uses for its no-flag demo (a flight-record shape), so the two stay consistent.
+
+## Alternatives
+
+- **Merge into `conduit init` (the plan's original shape).** Rejected: reverses the
+  #2535 decision and deprecates `pipelines init` — more churn and user-facing
+  breakage than a new additive command, for no extra capability.
+- **`conduit pipelines init --run`.** Rejected: overloads a scaffolding command with
+  run-and-block semantics, and couples the wow to the workspace layout. Quickstart's
+  ephemeral, zero-footprint nature is a distinct concern.
+
+## Failure modes
+
+- **Port collision** (8080/8084 already bound, e.g. another Conduit running).
+  `NewRuntime`/`Serve` surfaces an actionable bind error and exits non-zero. v1 uses
+  the default ports for predictability; automatic free-port selection is a noted
+  future enhancement.
+- **`kill -9` / second ctrl-C.** `Serve` calls `os.Exit`, skipping temp cleanup — the
+  temp dir leaks into the OS temp location (reclaimed by the OS). The in-memory store
+  means there is no state to corrupt. A single, graceful ctrl-C returns from `Serve`
+  and cleans up.
+- **Missing plugins.** generator and log are built-in — always present.
+- **Existing `conduit.yaml` in the cwd.** Irrelevant: quickstart uses its own temp
+  workspace and never reads cwd configuration.
+
+## Rollback / compatibility
+
+Purely additive: a new command package plus one entry in the root command's
+subcommand list. No serialized formats, no protocol, no changes to existing
+commands. Rollback is deleting the package and the registration.
+
+## Observability
+
+Records are visible in the console via the log destination. The API exposes
+`/readyz`, `/metrics`, and `/openapi`. `--json` makes the stream machine-readable.
+
+## Related
+
+- Execution plan §1.2 (the 5-minute wow).
+- Reuses `builtin:generator`, `builtin:log`, and `pkg/conduit` `Entrypoint.Serve`.
+- Bundled-template-manifest schema (§1.2, registry) is a separate follow-up; the
+  quickstart demo is a self-contained embedded config for now.


### PR DESCRIPTION
The v0.16 **5-minute wow** (execution plan §1.2), as a dedicated command.

## What it does
`conduit quickstart` scaffolds an ephemeral demo pipeline (built-in **generator → log**) and runs it in-process. Sample records flow to the console within seconds — **zero flags, zero footprint**.

```
$ conduit quickstart
Starting a demo pipeline (generator → log). Records will flow below — press Ctrl-C to stop.
...
INF  ... plugin_name=builtin:log  record={"payload":{"after":{"airline":"...","scheduledDeparture":"..."}}...}
```

## Design
- **Ephemeral:** temp workspace + **in-memory** state store, removed on graceful exit. Nothing touches the user's cwd.
- **No divergent run logic:** reuses the same `Entrypoint.Serve` path as `conduit run`; SIGINT/SIGTERM drains gracefully (invariant 7); a second signal hard-exits.
- **API enabled** on default addresses; the runtime prints the `/openapi` URL so the user can explore `/readyz`, `/metrics`.
- **`--json`** → JSON log format for machine-consumable output.
- **Leaves `conduit init` + `conduit pipelines init` untouched** — this sidesteps the #2535 split entirely (chosen over merging into `init`).

## Verification
Ran end-to-end: 7 records in 7s at 1/s, **no schema warnings, no config errors**, graceful shutdown on SIGTERM. Unit test covers scaffolding + config (in-memory DB, temp pipelines path, API on, `--json` → json format). Build + lint clean; `go generate` produces no diff.

## Follow-up (noted in the design doc)
Port-collision uses default ports for predictability (free-port auto-select is a future enhancement); bundled-template-manifest schema (§1.2 registry) is a separate concern — the demo is a self-contained embedded config for now.

Design doc: `docs/design-documents/20260706-quickstart-command.md`. Tier 2 (additive CLI surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)