### PR TITLE
chore: gitignore Claude Code local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ pkg/plugin/processor/standalone/test/wasm_processors/*/processor.wasm
 !pkg/provisioning/test/source-file.txt
 
 golangci-report.xml
+# Claude Code local state
+.claude/worktrees/
+.claude/settings.local.json


### PR DESCRIPTION
`.claude/worktrees/` and `.claude/settings.local.json` are session-local Claude Code state, never committed. Ignoring them keeps the working tree clean — the untracked `.claude/` directory was blocking `scripts/tag.sh` (which refuses to tag a dirty tree) ahead of the v0.16.0 cut.

Tier 3 (chore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)