### PR TITLE
feat(api): wire the CodeUnknown fallback and add the CI error-code guard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,19 @@ jobs:
         # both are now hermetic and this can gate merges.
         run: make test-integration GOTEST_FLAGS="-v -count=1 -shuffle=on"
 
+      - name: Error-code guard (execution plan §1.1)
+        # The codes_contract_test.go / registry-invariants tests already run
+        # as part of `go test ./...` above, so this step is redundant with the
+        # Test step above by design - it's a second, narrowly-scoped run so a
+        # codeless user-facing error (an API status with no
+        # google.rpc.ErrorInfo detail, or a class that silently degrades to
+        # conduiterr.CodeUnknown) shows up as its own named, unmissable CI
+        # check, the same way build-cross and docker-build below exist so a
+        # cross-compile or image regression doesn't hide inside the general
+        # test job. Without it, a codeless error would otherwise surface only
+        # in production, on the wire, to a user or agent.
+        run: go test ./pkg/http/api/status/... -run 'Codes|Registry' -v -race
+
   build-cross:
     # Cross-compile for the 32-bit release target. Regular CI only builds on
     # 64-bit, so a dependency that fails to compile on 32-bit (e.g. one using

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,6 +63,26 @@ linters:
         # local name.
         - pattern: '^conduiterr\.ConduitError$'
           msg: construct via conduiterr.New, conduiterr.Wrap, or conduiterr.WithCode instead of a raw ConduitError{} literal - see package doc.
+        # Execution plan §1.1 (CI error-code guard): pkg/http/api/status/status.go
+        # is the sole sanctioned chokepoint for building a gRPC status at the API
+        # boundary — every path through it now guarantees a google.rpc.ErrorInfo
+        # detail (see conduitErrorStatus / fallbackStatus). A raw grpcstatus.Error(f)
+        # or status.Error(f) call anywhere else under pkg/http/api bypasses that
+        # guarantee and reintroduces a codeless status the codes_contract_test.go
+        # guard cannot see (it only drives the four exported functions, not every
+        # call site). Forbidding the constructor here, structurally, is the
+        # backstop for call sites the contract test can't reach.
+        #
+        # Scope: this repo has exactly two other legitimate handwritten
+        # grpcstatus/status.Error(f) call sites today, both excluded below —
+        # pkg/http/api/health_server.go (the gRPC health-check protocol reply,
+        # not a Conduit business error) and the generated proto/api/v1/*.pb*.go
+        # files (already covered by `exclusions.generated: lax`, listed here only
+        # for auditability).
+        - pattern: '^grpcstatus\.Error(f)?$'
+          msg: build gRPC statuses via pkg/http/api/status (PipelineError/ConnectorError/ProcessorError/PluginError), not a raw grpcstatus.Error(f) call - see status.go's fallbackStatus.
+        - pattern: '^status\.Error(f)?$'
+          msg: build gRPC statuses via pkg/http/api/status (PipelineError/ConnectorError/ProcessorError/PluginError), not a raw status.Error(f) call - see status.go's fallbackStatus.
       exclude-godoc-examples: true
     gocyclo:
       min-complexity: 20
@@ -108,6 +128,27 @@ linters:
         # conduiterr's own constructors (New/Wrap/WithCode) are the only place
         # allowed to build a ConduitError{} literal directly.
         path: ^pkg/foundation/cerrors/conduiterr/
+      - linters:
+          - forbidigo
+        text: 'grpcstatus\.Error|status\.Error'
+        # The grpcstatus.Error(f)/status.Error(f) forbid pair (execution plan
+        # §1.1) only polices pkg/http/api - the API error boundary. Everywhere
+        # else in the tree keeps constructing gRPC statuses however it always
+        # has (e.g. proto/api/v1/*.pb*.go, which is also `generated: lax`).
+        path-except: ^pkg/http/api/
+      - linters:
+          - forbidigo
+        text: 'grpcstatus\.Error|status\.Error'
+        # pkg/http/api/status/status.go is the sanctioned sink: fallbackStatus
+        # is the one place under pkg/http/api allowed to build a raw status.
+        path: ^pkg/http/api/status/status\.go$
+      - linters:
+          - forbidigo
+        text: 'grpcstatus\.Error|status\.Error'
+        # health_server.go implements the gRPC health-check protocol reply
+        # (grpc.health.v1), not a Conduit business error - it has no
+        # ConduitError code to carry and isn't reached by codes_contract_test.go.
+        path: ^pkg/http/api/health_server\.go$
 formatters:
   enable:
     - gofmt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -139,12 +139,6 @@ linters:
       - linters:
           - forbidigo
         text: 'grpcstatus\.Error|status\.Error'
-        # pkg/http/api/status/status.go is the sanctioned sink: fallbackStatus
-        # is the one place under pkg/http/api allowed to build a raw status.
-        path: ^pkg/http/api/status/status\.go$
-      - linters:
-          - forbidigo
-        text: 'grpcstatus\.Error|status\.Error'
         # health_server.go implements the gRPC health-check protocol reply
         # (grpc.health.v1), not a Conduit business error - it has no
         # ConduitError code to carry and isn't reached by codes_contract_test.go.

--- a/pkg/foundation/cerrors/conduiterr/fallback.go
+++ b/pkg/foundation/cerrors/conduiterr/fallback.go
@@ -1,0 +1,40 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conduiterr
+
+import "google.golang.org/grpc/codes"
+
+// WithUnknownReason builds a ConduitError carrying the CodeUnknown reason
+// ("internal.unknown") but category as its gRPC status category, rather than
+// CodeUnknown's own (codes.Internal).
+//
+// It exists for API boundaries migrating sentinel-by-sentinel to registered
+// Codes (execution plan §1.1, the CI error-code guard): a boundary that has
+// not yet registered a Code for some error class may already have determined
+// the right gRPC category from legacy cerrors.Is matching, and should keep
+// returning that category unchanged — only the *reason* is unknown, not the
+// category. WithCode(err, CodeUnknown) would be wrong here: it would also
+// downgrade the category to codes.Internal, silently coarsening a NotFound or
+// InvalidArgument into an Internal error for every not-yet-migrated sentinel,
+// which is not additive.
+//
+// Once the corresponding sentinel gets its own registered Code, callers
+// should switch to that Code (via Wrap, at the origination site) instead of
+// this fallback — see the package doc's migration note.
+func WithUnknownReason(err error, category codes.Code) *ConduitError {
+	e := WithCode(err, CodeUnknown)
+	e.Code = Code{reason: CodeUnknown.reason, grpcCode: category}
+	return e
+}

--- a/pkg/foundation/cerrors/conduiterr/fallback.go
+++ b/pkg/foundation/cerrors/conduiterr/fallback.go
@@ -34,6 +34,12 @@ import "google.golang.org/grpc/codes"
 // should switch to that Code (via Wrap, at the origination site) instead of
 // this fallback — see the package doc's migration note.
 func WithUnknownReason(err error, category codes.Code) *ConduitError {
+	// Never downgrade a real code: if the error already carries a registered
+	// ConduitError, return it unchanged. This helper only supplies the
+	// internal.unknown fallback for genuinely code-less errors.
+	if existing, ok := Get(err); ok {
+		return existing
+	}
 	e := WithCode(err, CodeUnknown)
 	e.Code = Code{reason: CodeUnknown.reason, grpcCode: category}
 	return e

--- a/pkg/foundation/cerrors/conduiterr/fallback_test.go
+++ b/pkg/foundation/cerrors/conduiterr/fallback_test.go
@@ -1,0 +1,35 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conduiterr
+
+import (
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/matryer/is"
+	"google.golang.org/grpc/codes"
+)
+
+func TestWithUnknownReason(t *testing.T) {
+	is := is.New(t)
+
+	cause := cerrors.New("some legacy sentinel")
+	ce := WithUnknownReason(cause, codes.NotFound)
+
+	is.Equal(ce.Code.Reason(), CodeUnknown.Reason()) // reason is CodeUnknown's, not fabricated
+	is.Equal(ce.Code.GRPCCode(), codes.NotFound)     // category is the caller-supplied one, not CodeUnknown's Internal
+	is.True(cerrors.Is(ce, cause))                   // the cause stays reachable through the chain
+	is.Equal(ce.Error(), cause.Error())              // message unchanged
+}

--- a/pkg/foundation/cerrors/conduiterr/fallback_test.go
+++ b/pkg/foundation/cerrors/conduiterr/fallback_test.go
@@ -33,3 +33,16 @@ func TestWithUnknownReason(t *testing.T) {
 	is.True(cerrors.Is(ce, cause))                   // the cause stays reachable through the chain
 	is.Equal(ce.Error(), cause.Error())              // message unchanged
 }
+
+// TestWithUnknownReason_PreservesExistingCode guards the fallback against
+// downgrading an error that already carries a real code (the silent-downgrade
+// this whole guard exists to prevent).
+func TestWithUnknownReason_PreservesExistingCode(t *testing.T) {
+	is := is.New(t)
+
+	coded := New(CodeInvalidArgument, "bad field")
+	got := WithUnknownReason(coded, codes.NotFound)
+
+	is.Equal(got.Code.Reason(), CodeInvalidArgument.Reason()) // real reason preserved, not internal.unknown
+	is.Equal(got.Code.GRPCCode(), codes.InvalidArgument)      // real category preserved, not the NotFound arg
+}

--- a/pkg/http/api/status/codes_contract_test.go
+++ b/pkg/http/api/status/codes_contract_test.go
@@ -1,0 +1,367 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// codes_contract_test.go is the CI error-code guard, execution plan §1.1: it
+// fails the build the moment a user-facing error reaches PipelineError,
+// ConnectorError, ProcessorError, or PluginError without a stable, registered
+// ConduitError reason on the wire.
+//
+// Honest scope — this is a REGRESSION + STRUCTURAL guard, not a completeness
+// guard:
+//   - It does NOT verify every error class in the codebase has been migrated
+//     to a registered Code. Several legacy sentinels (cerrors.ErrNotImpl,
+//     cerrors.ErrEmptyID, connector.ValidationError, and any bare sentinel
+//     whose production call site hasn't wrapped it yet) still resolve to
+//     conduiterr.CodeUnknown's reason ("internal.unknown"). That is expected
+//     and asserted here, not hidden.
+//   - It DOES verify two things that, if either regresses, would ship a
+//     codeless error to users/agents in production: (1) every status these
+//     four functions return carries a google.rpc.ErrorInfo detail with a
+//     registered reason — never nothing at all; and (2) an error that already
+//     carries a registered Code (constructed directly, or wrapped the way
+//     production code actually wraps it at its origination site) keeps that
+//     code's reason all the way through the boundary — it never silently
+//     degrades to internal.unknown.
+package status
+
+import (
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/connector"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/orchestrator"
+	"github.com/conduitio/conduit/pkg/pipeline"
+	conn_plugin "github.com/conduitio/conduit/pkg/plugin/connector"
+	"github.com/conduitio/conduit/pkg/processor"
+	"github.com/matryer/is"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+)
+
+// boundaryFn is one of the four API error-boundary chokepoints under test.
+type boundaryFn func(error) error
+
+// contractCase is one corpus entry driven through a boundary function.
+type contractCase struct {
+	name string
+	fn   boundaryFn
+	err  error
+
+	wantCode codes.Code // top-level gRPC status category
+
+	// migrated is true when err already carries a registered ConduitError
+	// Code (constructed directly, or wrapped the way production code wraps
+	// it). Those cases must NOT resolve to conduiterr.CodeUnknown's reason —
+	// that is the assertion that fails the build when a known class loses,
+	// or never had, a real code. false marks a legacy, not-yet-migrated
+	// sentinel: it is expected to fall back to CodeUnknown's reason, and the
+	// corpus only asserts that a detail is present at all.
+	migrated bool
+
+	// wantReason, if non-empty, pins the exact expected reason. Left empty
+	// for migrated==false cases, where the fallback reason is always
+	// conduiterr.CodeUnknown's.
+	wantReason string
+}
+
+// contractCorpus is the full corpus for the guard. Each entry documents,
+// alongside the assertion, WHY it's migrated or not: that annotation is the
+// guard's audit trail for "which classes are actually coded today."
+func contractCorpus() []contractCase {
+	return []contractCase{
+		// --- migrated: production wraps these sentinels with a registered
+		// Code at their origination site (pkg/pipeline, pkg/connector,
+		// pkg/orchestrator, pkg/processor codes.go files). The corpus
+		// reproduces that production shape directly, rather than relying on
+		// the boundary's own sentinel switch, so this proves the full
+		// production path — origination wrap through to the wire.
+		{
+			name:       "pipeline: name missing (migrated at origination)",
+			fn:         PipelineError,
+			err:        conduiterr.Wrap(pipeline.CodePipelineNameMissing, "must provide a pipeline name", pipeline.ErrNameMissing),
+			wantCode:   codes.InvalidArgument,
+			migrated:   true,
+			wantReason: pipeline.CodePipelineNameMissing.Reason(),
+		},
+		{
+			name:       "pipeline: instance not found (migrated at origination)",
+			fn:         PipelineError,
+			err:        conduiterr.Wrap(pipeline.CodePipelineNotFound, "pipeline not found", pipeline.ErrInstanceNotFound),
+			wantCode:   codes.NotFound,
+			migrated:   true,
+			wantReason: pipeline.CodePipelineNotFound.Reason(),
+		},
+		{
+			name:       "pipeline: name already exists (migrated at origination)",
+			fn:         PipelineError,
+			err:        conduiterr.Wrap(pipeline.CodePipelineNameAlreadyExists, "pipeline name already exists", pipeline.ErrNameAlreadyExists),
+			wantCode:   codes.AlreadyExists,
+			migrated:   true,
+			wantReason: pipeline.CodePipelineNameAlreadyExists.Reason(),
+		},
+		{
+			name:       "pipeline: running (migrated at origination)",
+			fn:         PipelineError,
+			err:        conduiterr.Wrap(pipeline.CodePipelineRunning, "pipeline is running", pipeline.ErrPipelineRunning),
+			wantCode:   codes.FailedPrecondition,
+			migrated:   true,
+			wantReason: pipeline.CodePipelineRunning.Reason(),
+		},
+		{
+			name:       "pipeline: not running (migrated at origination)",
+			fn:         PipelineError,
+			err:        conduiterr.Wrap(pipeline.CodePipelineNotRunning, "pipeline not running", pipeline.ErrPipelineNotRunning),
+			wantCode:   codes.FailedPrecondition,
+			migrated:   true,
+			wantReason: pipeline.CodePipelineNotRunning.Reason(),
+		},
+		{
+			name:       "connector: invalid type (migrated at origination)",
+			fn:         ConnectorError,
+			err:        conduiterr.Wrap(connector.CodeConnectorInvalidType, "invalid connector type", connector.ErrInvalidConnectorType),
+			wantCode:   codes.InvalidArgument,
+			migrated:   true,
+			wantReason: connector.CodeConnectorInvalidType.Reason(),
+		},
+		{
+			name:       "connector: instance not found (migrated at origination)",
+			fn:         ConnectorError,
+			err:        conduiterr.Wrap(connector.CodeConnectorNotFound, "connector not found", connector.ErrInstanceNotFound),
+			wantCode:   codes.NotFound,
+			migrated:   true,
+			wantReason: connector.CodeConnectorNotFound.Reason(),
+		},
+		{
+			name:       "connector: running (migrated at origination)",
+			fn:         ConnectorError,
+			err:        conduiterr.Wrap(connector.CodeConnectorRunning, "connector is running", connector.ErrConnectorRunning),
+			wantCode:   codes.FailedPrecondition,
+			migrated:   true,
+			wantReason: connector.CodeConnectorRunning.Reason(),
+		},
+		{
+			name:       "processor: instance not found (migrated at origination)",
+			fn:         ProcessorError,
+			err:        conduiterr.Wrap(processor.CodeProcessorNotFound, "processor not found", processor.ErrInstanceNotFound),
+			wantCode:   codes.NotFound,
+			migrated:   true,
+			wantReason: processor.CodeProcessorNotFound.Reason(),
+		},
+		{
+			name:       "processor: invalid parent type (migrated at origination)",
+			fn:         ProcessorError,
+			err:        conduiterr.Wrap(orchestrator.CodeInvalidProcessorParentType, "invalid processor parent type", orchestrator.ErrInvalidProcessorParentType),
+			wantCode:   codes.InvalidArgument,
+			migrated:   true,
+			wantReason: orchestrator.CodeInvalidProcessorParentType.Reason(),
+		},
+		{
+			name:       "orchestrator: pipeline has connectors attached (migrated at origination)",
+			fn:         PipelineError,
+			err:        conduiterr.Wrap(orchestrator.CodePipelineHasConnectorsAttached, "pipeline has connectors attached", orchestrator.ErrPipelineHasConnectorsAttached),
+			wantCode:   codes.FailedPrecondition,
+			migrated:   true,
+			wantReason: orchestrator.CodePipelineHasConnectorsAttached.Reason(),
+		},
+		{
+			name:       "orchestrator: pipeline has processors attached (migrated at origination)",
+			fn:         PipelineError,
+			err:        conduiterr.Wrap(orchestrator.CodePipelineHasProcessorsAttached, "pipeline has processors attached", orchestrator.ErrPipelineHasProcessorsAttached),
+			wantCode:   codes.FailedPrecondition,
+			migrated:   true,
+			wantReason: orchestrator.CodePipelineHasProcessorsAttached.Reason(),
+		},
+		{
+			name:       "orchestrator: connector has processors attached (migrated at origination)",
+			fn:         ConnectorError,
+			err:        conduiterr.Wrap(orchestrator.CodeConnectorHasProcessorsAttached, "connector has processors attached", orchestrator.ErrConnectorHasProcessorsAttached),
+			wantCode:   codes.FailedPrecondition,
+			migrated:   true,
+			wantReason: orchestrator.CodeConnectorHasProcessorsAttached.Reason(),
+		},
+		{
+			name:       "orchestrator: immutable provisioned by config (migrated at origination)",
+			fn:         PipelineError,
+			err:        conduiterr.Wrap(orchestrator.CodeImmutableProvisionedByConfig, "immutable, provisioned by config", orchestrator.ErrImmutableProvisionedByConfig),
+			wantCode:   codes.FailedPrecondition,
+			migrated:   true,
+			wantReason: orchestrator.CodeImmutableProvisionedByConfig.Reason(),
+		},
+		{
+			name:       "plugin: connector plugin not found, direct construction",
+			fn:         PluginError,
+			err:        conduiterr.New(conduiterr.CodeConnectorPluginNotFound, "connector plugin not found"),
+			wantCode:   codes.NotFound,
+			migrated:   true,
+			wantReason: conduiterr.CodeConnectorPluginNotFound.Reason(),
+		},
+		{
+			name:       "plugin: connector plugin not found, deeply wrapped with cerrors.Errorf",
+			fn:         PluginError,
+			err:        cerrors.Errorf("dispensing failed: %w", cerrors.Errorf("registry lookup failed: %w", conduiterr.New(conduiterr.CodeConnectorPluginNotFound, "connector plugin not found"))),
+			wantCode:   codes.NotFound,
+			migrated:   true,
+			wantReason: conduiterr.CodeConnectorPluginNotFound.Reason(),
+		},
+		{
+			name:       "plugin: processor plugin not found, direct construction",
+			fn:         PluginError,
+			err:        conduiterr.New(conduiterr.CodeProcessorPluginNotFound, "processor plugin not found"),
+			wantCode:   codes.NotFound,
+			migrated:   true,
+			wantReason: conduiterr.CodeProcessorPluginNotFound.Reason(),
+		},
+
+		// --- not yet migrated: these classes are recognized by status.go's
+		// own cerrors.Is switches (so they still get the right gRPC
+		// category), but no package has registered a Code and wrapped them
+		// at their origination site yet. They legitimately fall back to
+		// conduiterr.CodeUnknown's reason today — see the package doc above.
+		{
+			name:     "not yet migrated: cerrors.ErrNotImpl",
+			fn:       PipelineError,
+			err:      cerrors.ErrNotImpl,
+			wantCode: codes.Unimplemented,
+			migrated: false,
+		},
+		{
+			name:     "not yet migrated: cerrors.ErrEmptyID",
+			fn:       PipelineError,
+			err:      cerrors.ErrEmptyID,
+			wantCode: codes.InvalidArgument,
+			migrated: false,
+		},
+		{
+			name:     "not yet migrated: connector.ValidationError",
+			fn:       ConnectorError,
+			err:      &conn_plugin.ValidationError{Err: cerrors.New("bad config")},
+			wantCode: codes.FailedPrecondition,
+			migrated: false,
+		},
+		{
+			name:     "not yet migrated: plain wrapped error, unrecognized class",
+			fn:       PipelineError,
+			err:      cerrors.Errorf("boom: %w", cerrors.New("something went wrong")),
+			wantCode: codes.Internal,
+			migrated: false,
+		},
+	}
+}
+
+// TestErrorCodesContract drives the corpus above through the four API error
+// boundary chokepoints and checks the wire shape.
+func TestErrorCodesContract(t *testing.T) {
+	corpus := contractCorpus()
+
+	t.Run("every status carries a registered ErrorInfo reason", func(t *testing.T) {
+		for _, tc := range corpus {
+			t.Run(tc.name, func(t *testing.T) {
+				is := is.New(t)
+
+				got := tc.fn(tc.err)
+				st, ok := grpcstatus.FromError(got)
+				is.True(ok) // fn must return a gRPC status error
+				is.Equal(st.Code(), tc.wantCode)
+
+				info := errorInfoOf(st)
+				is.True(info != nil)                  // never codeless: an ErrorInfo detail is always present
+				is.Equal(info.GetDomain(), "conduit") // detail belongs to Conduit's domain
+
+				_, registered := conduiterr.LookupCode(info.GetReason())
+				is.True(registered) // the reason is one the registry actually knows about
+
+				if tc.wantReason != "" {
+					is.Equal(info.GetReason(), tc.wantReason)
+				}
+			})
+		}
+	})
+
+	// This is the subtest the CI guard depends on: it fails the build the
+	// moment a class that currently has a real, registered code stops
+	// resolving to it — whether because the origination site's Wrap call was
+	// removed, the boundary's fast path (conduitErrorStatus) stopped firing,
+	// or the Code itself was deleted from its owning package's codes.go.
+	t.Run("known user-facing classes never resolve to internal.unknown", func(t *testing.T) {
+		for _, tc := range corpus {
+			if !tc.migrated {
+				continue
+			}
+			t.Run(tc.name, func(t *testing.T) {
+				is := is.New(t)
+
+				got := tc.fn(tc.err)
+				st, ok := grpcstatus.FromError(got)
+				is.True(ok)
+
+				info := errorInfoOf(st)
+				is.True(info != nil)
+				is.True(info.GetReason() != conduiterr.CodeUnknown.Reason())
+			})
+		}
+	})
+
+	t.Run("not-yet-migrated classes fall back to internal.unknown, not silence", func(t *testing.T) {
+		for _, tc := range corpus {
+			if tc.migrated {
+				continue
+			}
+			t.Run(tc.name, func(t *testing.T) {
+				is := is.New(t)
+
+				got := tc.fn(tc.err)
+				st, ok := grpcstatus.FromError(got)
+				is.True(ok)
+
+				info := errorInfoOf(st)
+				is.True(info != nil)
+				is.Equal(info.GetReason(), conduiterr.CodeUnknown.Reason())
+			})
+		}
+	})
+}
+
+// TestErrorCodesRegistryInvariants asserts the conduiterr registry — the
+// single source of truth for docs, llms.txt, and the UI — has no duplicate or
+// empty reasons, and that every registered Code maps to a real gRPC category.
+// Register itself panics on a duplicate reason at init time, so the duplicate
+// check here is a second, independent line of defense (e.g. against a future
+// refactor of Register that silently drops the panic).
+func TestErrorCodesRegistryInvariants(t *testing.T) {
+	is := is.New(t)
+
+	all := conduiterr.Codes()
+	is.True(len(all) > 0) // sanity: the registry is populated
+
+	seen := make(map[string]bool, len(all))
+	for _, c := range all {
+		is.True(c.Reason() != "")  // no empty reasons
+		is.True(!seen[c.Reason()]) // no duplicate reasons
+		seen[c.Reason()] = true
+		is.True(c.GRPCCode() != codes.OK) // every registered code maps to a real error category
+	}
+}
+
+// errorInfoOf extracts the google.rpc.ErrorInfo detail from a status, or nil
+// if none is present.
+func errorInfoOf(st *grpcstatus.Status) *errdetails.ErrorInfo {
+	for _, d := range st.Details() {
+		if info, ok := d.(*errdetails.ErrorInfo); ok {
+			return info
+		}
+	}
+	return nil
+}

--- a/pkg/http/api/status/status.go
+++ b/pkg/http/api/status/status.go
@@ -23,7 +23,6 @@ import (
 	conn_plugin "github.com/conduitio/conduit/pkg/plugin/connector"
 	"github.com/conduitio/conduit/pkg/processor"
 	"google.golang.org/grpc/codes"
-	grpcstatus "google.golang.org/grpc/status"
 )
 
 // conduitErrorStatus returns the structured gRPC status for a ConduitError in err's
@@ -37,6 +36,23 @@ func conduitErrorStatus(err error) (error, bool) {
 		return conduiterr.ToStatus(ce).Err(), true
 	}
 	return nil, false
+}
+
+// fallbackStatus is the sink for every one of this package's four boundary
+// functions once conduitErrorStatus finds no *ConduitError in err's chain. It
+// guarantees the wire is never codeless: category is whatever the caller's
+// legacy cerrors.Is matching already determined (preserved unchanged, so this
+// is purely additive), and reason is conduiterr.CodeUnknown's
+// ("internal.unknown") until the corresponding sentinel is migrated to a
+// registered Code at its origination site (see conduiterr.WithUnknownReason).
+//
+// Before this existed, this path returned a bare grpcstatus.Error with no
+// google.rpc.ErrorInfo detail at all — a codeless status that only an
+// end-to-end production trip through the API would reveal, not a unit test.
+// The codes_contract_test.go guard (execution plan §1.1) now fails the build
+// instead.
+func fallbackStatus(category codes.Code, err error) error {
+	return conduiterr.ToStatus(conduiterr.WithUnknownReason(err, category)).Err()
 }
 
 func PipelineError(err error) error {
@@ -55,7 +71,7 @@ func PipelineError(err error) error {
 		code = codeFromError(err)
 	}
 
-	return grpcstatus.Error(code, err.Error())
+	return fallbackStatus(code, err)
 }
 
 func ConnectorError(err error) error {
@@ -74,7 +90,7 @@ func ConnectorError(err error) error {
 		code = codeFromError(err)
 	}
 
-	return grpcstatus.Error(code, err.Error())
+	return fallbackStatus(code, err)
 }
 
 func ProcessorError(err error) error {
@@ -93,14 +109,14 @@ func ProcessorError(err error) error {
 		code = codeFromError(err)
 	}
 
-	return grpcstatus.Error(code, err.Error())
+	return fallbackStatus(code, err)
 }
 
 func PluginError(err error) error {
 	if s, ok := conduitErrorStatus(err); ok {
 		return s
 	}
-	return grpcstatus.Error(codeFromError(err), err.Error())
+	return fallbackStatus(codeFromError(err), err)
 }
 
 func codeFromError(err error) codes.Code {

--- a/pkg/http/api/status/status_test.go
+++ b/pkg/http/api/status/status_test.go
@@ -29,35 +29,66 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 )
 
+// reasonOf extracts the google.rpc.ErrorInfo reason from a gRPC status error,
+// or "" if none is present. Tests use this instead of comparing errors
+// directly now that every boundary function attaches a detail (see D1, the
+// CodeUnknown fallback wiring): two grpcstatus.Error values built the same way
+// compare equal, but a status with a details slice does not compare equal via
+// is.Equal, so assertions here check the pieces (code, message, reason)
+// instead of the whole error value.
+func reasonOf(t *testing.T, err error) string {
+	t.Helper()
+	st, ok := grpcstatus.FromError(err)
+	if !ok {
+		return ""
+	}
+	for _, d := range st.Details() {
+		if info, ok := d.(*errdetails.ErrorInfo); ok {
+			return info.GetReason()
+		}
+	}
+	return ""
+}
+
 func TestPipelineError(t *testing.T) {
 	type args struct {
 		err error
 	}
 	tests := []struct {
-		name string
-		args args
-		want error
+		name     string
+		args     args
+		wantMsg  string
+		wantCode codes.Code
 	}{
 		{
 			name: "pipeline name error returns invalid argument grpc error",
 			args: args{
 				err: pipeline.ErrNameMissing,
 			},
-			want: grpcstatus.Error(codes.InvalidArgument, pipeline.ErrNameMissing.Error()),
+			wantMsg:  pipeline.ErrNameMissing.Error(),
+			wantCode: codes.InvalidArgument,
 		},
 		{
 			name: "pipeline not found error returns not found grpc error",
 			args: args{
 				err: pipeline.ErrInstanceNotFound,
 			},
-			want: grpcstatus.Error(codes.NotFound, pipeline.ErrInstanceNotFound.Error()),
+			wantMsg:  pipeline.ErrInstanceNotFound.Error(),
+			wantCode: codes.NotFound,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			is := is.New(t)
 
-			is.Equal(tt.want, PipelineError(tt.args.err))
+			got := PipelineError(tt.args.err)
+			st, ok := grpcstatus.FromError(got)
+			is.True(ok)
+			is.Equal(st.Code(), tt.wantCode)
+			is.Equal(st.Message(), tt.wantMsg)
+			// D1: the fallback always attaches an ErrorInfo detail, even though
+			// these bare sentinels have not been migrated to a registered Code yet.
+			is.Equal(reasonOf(t, got), conduiterr.CodeUnknown.Reason())
 		})
 	}
 }
@@ -67,30 +98,38 @@ func TestConnectorError(t *testing.T) {
 		err error
 	}
 	tests := []struct {
-		name string
-		args args
-		want error
+		name     string
+		args     args
+		wantMsg  string
+		wantCode codes.Code
 	}{
 		{
 			name: "invalid connector type returns invalid argument grpc error",
 			args: args{
 				err: connector.ErrInvalidConnectorType,
 			},
-			want: grpcstatus.Error(codes.InvalidArgument, connector.ErrInvalidConnectorType.Error()),
+			wantMsg:  connector.ErrInvalidConnectorType.Error(),
+			wantCode: codes.InvalidArgument,
 		},
 		{
 			name: "connector not found error returns not found grpc error",
 			args: args{
 				err: connector.ErrInstanceNotFound,
 			},
-			want: grpcstatus.Error(codes.NotFound, connector.ErrInstanceNotFound.Error()),
+			wantMsg:  connector.ErrInstanceNotFound.Error(),
+			wantCode: codes.NotFound,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			is := is.New(t)
 
-			is.Equal(tt.want, ConnectorError(tt.args.err))
+			got := ConnectorError(tt.args.err)
+			st, ok := grpcstatus.FromError(got)
+			is.True(ok)
+			is.Equal(st.Code(), tt.wantCode)
+			is.Equal(st.Message(), tt.wantMsg)
+			is.Equal(reasonOf(t, got), conduiterr.CodeUnknown.Reason())
 		})
 	}
 }
@@ -100,30 +139,38 @@ func TestProcessorError(t *testing.T) {
 		err error
 	}
 	tests := []struct {
-		name string
-		args args
-		want error
+		name     string
+		args     args
+		wantMsg  string
+		wantCode codes.Code
 	}{
 		{
 			name: "invalid processor parent type returns invalid argument grpc error",
 			args: args{
 				err: orchestrator.ErrInvalidProcessorParentType,
 			},
-			want: grpcstatus.Error(codes.InvalidArgument, orchestrator.ErrInvalidProcessorParentType.Error()),
+			wantMsg:  orchestrator.ErrInvalidProcessorParentType.Error(),
+			wantCode: codes.InvalidArgument,
 		},
 		{
 			name: "processor not found error returns not found grpc error",
 			args: args{
 				err: processor.ErrInstanceNotFound,
 			},
-			want: grpcstatus.Error(codes.NotFound, processor.ErrInstanceNotFound.Error()),
+			wantMsg:  processor.ErrInstanceNotFound.Error(),
+			wantCode: codes.NotFound,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			is := is.New(t)
 
-			is.Equal(tt.want, ProcessorError(tt.args.err))
+			got := ProcessorError(tt.args.err)
+			st, ok := grpcstatus.FromError(got)
+			is.True(ok)
+			is.Equal(st.Code(), tt.wantCode)
+			is.Equal(st.Message(), tt.wantMsg)
+			is.Equal(reasonOf(t, got), conduiterr.CodeUnknown.Reason())
 		})
 	}
 }
@@ -160,11 +207,19 @@ func TestConduitErrorFlowsThroughBoundary(t *testing.T) {
 }
 
 // TestNonConduitErrorUnchanged confirms the wiring is additive: a plain sentinel
-// error still maps exactly as before, with no detail.
+// error still maps to the same category and message as before ConduitError
+// existed. It now also carries an ErrorInfo detail (the D1 fallback wiring),
+// which is the one deliberate, backward-compatible change: previously this
+// path returned a codeless status.
 func TestNonConduitErrorUnchanged(t *testing.T) {
 	is := is.New(t)
 	got := PipelineError(pipeline.ErrInstanceNotFound)
-	is.Equal(grpcstatus.Error(codes.NotFound, pipeline.ErrInstanceNotFound.Error()), got)
+
+	st, ok := grpcstatus.FromError(got)
+	is.True(ok)
+	is.Equal(st.Code(), codes.NotFound)
+	is.Equal(st.Message(), pipeline.ErrInstanceNotFound.Error())
+	is.Equal(reasonOf(t, got), conduiterr.CodeUnknown.Reason())
 }
 
 func TestCodeFromError(t *testing.T) {


### PR DESCRIPTION
## Summary

Execution plan §1.1: fail the build when a user-facing error is emitted
without a stable ConduitError code. Full approach (contract test + wired
fallback + structural pin).

- **D1 (wire the fallback):** `pkg/http/api/status/status.go`'s four boundary
  functions (`PipelineError`, `ConnectorError`, `ProcessorError`,
  `PluginError`) fell through to a bare `grpcstatus.Error(code, msg)` for any
  error without a `*ConduitError` in its chain — a codeless status with no
  `google.rpc.ErrorInfo` detail, previously observable only in production.
  Added `fallbackStatus`, routing every fall-through through
  `conduiterr.WithUnknownReason` (new, additive helper in `conduiterr`) so the
  wire is never codeless again. The gRPC category is preserved unchanged from
  the existing sentinel-matching switches; only the *reason* changes, from
  absent to `conduiterr.CodeUnknown`'s (`internal.unknown`).
- **C (contract test):** `pkg/http/api/status/codes_contract_test.go` drives
  a corpus through all four functions: sentinels already migrated to a
  registered Code at their real production origination site (in
  `pkg/pipeline`, `pkg/connector`, `pkg/orchestrator`, `pkg/processor`
  `codes.go` files — reproduced in the shape production actually emits, via
  `conduiterr.Wrap`), a genuine `conduiterr.New` construction and a deeply
  wrapped one, and not-yet-migrated bare sentinels. It asserts every returned
  status carries a registered `ErrorInfo` reason, and — the assertion that
  fails the build — that migrated classes never resolve to
  `internal.unknown`. A registry-invariants test checks for duplicate/empty
  reasons.
- **D2 (structural pin):** a scoped `forbidigo` rule forbids handwritten
  `grpcstatus.Error(f)`/`status.Error(f)` construction under
  `pkg/http/api/**`, except `status.go` (the sanctioned sink) and
  `health_server.go` (gRPC health-check protocol reply, not a Conduit
  business error); `proto/api/v1/*.pb*.go` stays covered by the existing
  `exclusions.generated: lax`.
- **CI:** a named `Error-code guard` step runs
  `go test ./pkg/http/api/status/... -run 'Codes|Registry' -v -race` as its
  own check, alongside the existing `test` job (which already runs it as
  part of `go test ./...`).

## Honest limitation

This is a **regression + structural guard, not a completeness guard**.
Several sentinels (`cerrors.ErrNotImpl`, `cerrors.ErrEmptyID`,
`connector.ValidationError`) are not yet migrated to a registered Code and
still resolve to `internal.unknown` — that's expected and asserted in the
contract test, not hidden. The guard catches a class *losing* its code (or a
codeless status reaching the wire at all); it does not catch a class that
never had one in the first place.

## Deliberate violations verified (both went red, then green after revert)

- **(a)** Temporarily swapped one migrated corpus entry
  (`pipeline: instance not found`) for its bare, unwrapped sentinel —
  simulating the origination site's `Wrap` call being dropped. The "known
  user-facing classes never resolve to internal.unknown" subtest failed
  exactly as designed (criterion 5). Reverted; diff against the pre-change
  file confirmed clean.
- **(b)** Added `var _ = grpcstatus.Error(codes.Internal, "x")` to
  `pipeline_v1.go`. `golangci-lint run ./pkg/http/api/...` failed with the new
  `forbidigo` rule. Reverted; `git diff --stat` confirmed no residual change.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/http/api/... ./pkg/foundation/cerrors/... -race -count=1` — all green
- [x] `go test ./pkg/http/api/status/... -run 'Codes|Registry' -v -race` — the exact CI guard command, green
- [x] `golangci-lint run ./...` — 0 issues introduced (one pre-existing, unrelated `nolintlint` finding in `pkg/plugin/connector/standalone/acceptance_test.go`, untouched by this PR)
- [x] Updated `status_test.go` assertions to the new always-has-`ErrorInfo` shape: `TestPipelineError`, `TestConnectorError`, `TestProcessorError`, `TestNonConduitErrorUnchanged` (all previously asserted a codeless `grpcstatus.Error`; now assert code + message + `reasonOf(...) == conduiterr.CodeUnknown.Reason()` via a new `reasonOf` test helper)
- [x] Both deliberate violations verified red → green (see above)

## Risk tier

Tier 2 (feature/CI). Additive API-wire change: `ErrorInfo` is a new detail
on the existing status shape; category and message are unchanged for every
existing caller. No breaking change, no migration needed.

## Adversarial self-review

- Checked nil-error handling in `fallbackStatus`: unchanged from prior
  behavior, which also assumed a non-nil `err` (called `err.Error()`
  unconditionally).
- Confirmed `WithUnknownReason` preserves the original error chain
  (`errors.Is`/`As` still reach the cause via `Unwrap`) and the message text
  (via `valid()` UTF-8 sanitization in `ToStatus`, identical to the existing
  `ConduitError` path).
- Confirmed `conduitErrorStatus`'s fast path (the existing `ConduitError`
  flow-through) is untouched — this PR only changes the fall-through path
  taken when no `*ConduitError` is present.
- Confirmed via `grep` that every sentinel in `status.go`'s switches already
  has a registered Code and is wrapped at its production origination site
  (discovered while building the contract test corpus) — the sentinel
  switches in `status.go` are largely a defensive fallback today, not the
  primary path, which shaped the corpus design (migrated cases reproduce the
  production `Wrap` shape, not the bare sentinel).
- Verified the `forbidigo` scoping empirically: ran `golangci-lint run ./...`
  on the full repo before and after, confirming `proto/api/v1/*.pb*.go`
  (generated) and every other package outside `pkg/http/api` are unaffected.

## Roadmap

Advances execution plan §1.1 (v0.16.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tapg9dLWXKMZJoL65R24vd