### PR TITLE
fix(log): redact connector config values in logs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,11 @@ linters:
             - pkg: encoding/json
               desc: github.com/goccy/go-json is preferred for performance reasons.
     forbidigo:
+      # Needed for the pconnector.*Request field-access pattern below: without
+      # analyze-types, forbidigo only has literal source text to match against,
+      # and cannot tell a `config.Config`-typed selector from any other `.Config`
+      # access.
+      analyze-types: true
       forbid:
         # conduiterr#2526 follow-up: construction must go through New/Wrap (or the
         # WithCode escape hatch), which guarantee a stack frame and a validated,
@@ -83,6 +88,43 @@ linters:
           msg: build gRPC statuses via pkg/http/api/status (PipelineError/ConnectorError/ProcessorError/PluginError), not a raw grpcstatus.Error(f) call - see status.go's fallbackStatus.
         - pattern: '^status\.Error(f)?$'
           msg: build gRPC statuses via pkg/http/api/status (PipelineError/ConnectorError/ProcessorError/PluginError), not a raw status.Error(f) call - see status.go's fallbackStatus.
+        # v0.16.1 secrets-redaction follow-up (execution plan §1.1): connector
+        # config.Config routinely carries secrets (DB urls with embedded
+        # passwords, SASL credentials, access keys) and there is no
+        # per-parameter sensitivity metadata yet, so it must never be logged
+        # raw - see pkg/foundation/log/redact.go.
+        #
+        # This pattern only catches a direct `.Config`/`.ConfigBefore`/
+        # `.ConfigAfter` field read on one of the 8 pconnector request types
+        # that carry connector settings (verified empirically: with
+        # analyze-types on, forbidigo expands a field-selector expression like
+        # `in.Config` to "pconnector.SourceConfigureRequest.Config", but a
+        # composite literal key such as `pconnector.SourceConfigureRequest{Config:
+        # cfg}` expands to just "pconnector.Config" - so building the real
+        # request to send to a plugin does not trip this rule, only reading the
+        # field back out, e.g. to log it, does). Wrapping the value in
+        # log.RedactAll(...) still trips it, since forbidigo has no way to see
+        # the wrapping call - those (currently 10, all in
+        # pkg/plugin/connector/builtin/{source,destination}.go) need a
+        # `//nolint:forbidigo` with that justification.
+        #
+        # Known gap, documented rather than silently accepted: this does NOT
+        # cover pkg/connector/{source,destination}.go's
+        # `oldConfig`/`newConfig map[string]string` (bare locals, not a
+        # selector on a named type - forbidigo has no type info for them) or
+        # sandbox.go's generic `res any` echoed on a cancelled context (same
+        # reason, plus `res`/`oldConfig`/`newConfig` are reused throughout
+        # their functions for legitimate, unrelated purposes, so a name-based
+        # rule there would be all noise). sandbox.go's site has a dedicated
+        # regression test (pkg/plugin/connector/builtin/redact_test.go); the
+        # pkg/connector default branch is unreachable today (isEqual(nil, nil)
+        # returns early before the switch, per its own "should never happen"
+        # comment) and is fixed defensively, sharing the same RedactAll
+        # covered by pkg/foundation/log's tests, but has no dedicated
+        # reachability test since there is no live path to drive.
+        - pattern: '^pconnector\.(Source|Destination)(Configure|LifecycleOnCreated|LifecycleOnUpdated|LifecycleOnDeleted)Request\.(Config|ConfigBefore|ConfigAfter)$'
+          pkg: '^github\.com/conduitio/conduit-connector-protocol/pconnector$'
+          msg: never log a raw pconnector request Config/ConfigBefore/ConfigAfter field - wrap it in log.RedactAll(...) (pkg/foundation/log/redact.go) and silence this line with a `//nolint:forbidigo` explaining it is wrapped.
       exclude-godoc-examples: true
     gocyclo:
       min-complexity: 20

--- a/pkg/connector/destination.go
+++ b/pkg/connector/destination.go
@@ -359,9 +359,13 @@ func (d *Destination) triggerLifecycleEvent(ctx context.Context, oldConfig, newC
 
 	// default should never happen
 	default:
+		// oldConfig/newConfig are connector settings and routinely carry
+		// secrets (DB urls with embedded passwords, SASL credentials, access
+		// keys). log.RedactAll redacts every value until per-parameter
+		// sensitivity metadata exists - see pkg/foundation/log/redact.go.
 		d.Instance.logger.Warn(ctx).
-			Any("oldConfig", oldConfig).
-			Any("newConfig", newConfig).
+			Any("oldConfig", log.RedactAll(oldConfig)).
+			Any("newConfig", log.RedactAll(newConfig)).
 			Msg("unexpected combination of old and new config")
 		// don't return an error when no event was triggered, strictly speaking
 		// the action did not fail

--- a/pkg/connector/source.go
+++ b/pkg/connector/source.go
@@ -374,9 +374,13 @@ func (s *Source) triggerLifecycleEvent(ctx context.Context, oldConfig, newConfig
 
 	// default should never happen
 	default:
+		// oldConfig/newConfig are connector settings and routinely carry
+		// secrets (DB urls with embedded passwords, SASL credentials, access
+		// keys). log.RedactAll redacts every value until per-parameter
+		// sensitivity metadata exists - see pkg/foundation/log/redact.go.
 		s.Instance.logger.Warn(ctx).
-			Any("oldConfig", oldConfig).
-			Any("newConfig", newConfig).
+			Any("oldConfig", log.RedactAll(oldConfig)).
+			Any("newConfig", log.RedactAll(newConfig)).
 			Msg("unexpected combination of old and new config")
 		// don't return an error when no event was triggered, strictly speaking
 		// the action did not fail

--- a/pkg/foundation/log/redact.go
+++ b/pkg/foundation/log/redact.go
@@ -1,0 +1,149 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/conduitio/conduit-commons/config"
+	"github.com/rs/zerolog"
+)
+
+// Redacted is written in place of a config value that has been redacted from
+// log output.
+const Redacted = "***"
+
+// RedactedConfig wraps a connector config.Config so it can be passed to
+// zerolog's Any (or Object/EmbedObject) without leaking secret values.
+//
+// connector settings (config.Config, a map[string]string) routinely contain
+// secrets: database URLs with embedded passwords, SASL credentials, access
+// keys. A central zerolog Hook cannot redact these, because a zerolog.Event
+// is write-only once fields have been added to it - redaction has to happen
+// at the log call site, by wrapping the value before it reaches Any/Object.
+//
+// Interim behavior: conduit-commons config.Parameter has no field marking a
+// parameter as secret yet (no ParameterTypeSecret, no Parameter.Sensitive),
+// so there is currently no reliable way to know which keys in a given Config
+// are safe to print. Until that metadata exists upstream, every value is
+// redacted and only keys are left visible - keys are not secret and are
+// useful on their own for debugging ("which parameter is set" vs "to what").
+// See https://github.com/ConduitIO/conduit/issues/2566 for the planned
+// keyed-on-sensitivity version.
+type RedactedConfig struct {
+	// Params holds the parameter specification for Config, if known. It is
+	// reserved for a future version of this type that redacts only the
+	// values Params (or a name heuristic) marks as sensitive.
+	//
+	// RedactAll always sets this to nil, which selects the interim
+	// redact-everything behavior: MarshalZerologObject redacts every value
+	// in Config regardless of Params when Params is nil.
+	Params config.Parameters
+	// Config is the configuration being logged.
+	Config config.Config
+}
+
+var _ zerolog.LogObjectMarshaler = RedactedConfig{}
+
+// RedactAll wraps cfg so that every value is redacted when logged and every
+// key stays visible. This is the only constructor in use today: nothing in
+// this codebase currently has per-parameter sensitivity metadata to pass as
+// Params (see the RedactedConfig doc comment), so every log call site that
+// would otherwise print a raw config.Config should go through RedactAll.
+func RedactAll(cfg config.Config) RedactedConfig {
+	return RedactedConfig{Params: nil, Config: cfg}
+}
+
+// MarshalZerologObject implements zerolog.LogObjectMarshaler. Config keys are
+// written in sorted order for deterministic output. A value is redacted
+// (replaced with Redacted) unless Params is non-nil and explicitly marks the
+// key as non-sensitive; see isSensitive.
+//
+// This method never mutates r.Config and never writes a value verbatim when
+// Params is nil, which is the only mode RedactAll produces today.
+func (r RedactedConfig) MarshalZerologObject(e *zerolog.Event) {
+	keys := make([]string, 0, len(r.Config))
+	for k := range r.Config {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		if r.Params == nil || isSensitive(r.Params, k) {
+			e.Str(k, Redacted)
+			continue
+		}
+		e.Str(k, r.Config[k])
+	}
+}
+
+// isSensitive reports whether key should be treated as a secret.
+//
+// It is not reached by RedactAll (RedactAll always passes Params as nil,
+// which redacts every key unconditionally) - it exists so the durable,
+// keyed-on-sensitivity version of RedactedConfig can be introduced later
+// without changing this file's public surface, and so it can be unit tested
+// on its own ahead of that migration. The planned upstream work (tracked in
+// https://github.com/ConduitIO/conduit/issues/2566) is to add
+// a sensitivity flag to conduit-commons config.Parameter (e.g.
+// ParameterTypeSecret or Parameter.Sensitive), thread it through the
+// connector protocol and SDK (paramgen tag), mark built-in connectors'
+// secret parameters, and then have isSensitive consult params first before
+// falling back to the name heuristic below.
+func isSensitive(params config.Parameters, key string) bool {
+	if p, ok := params[key]; ok && isSensitiveParameter(p) {
+		return true
+	}
+
+	lower := strings.ToLower(key)
+	for _, needle := range sensitiveKeyNeedles {
+		if strings.Contains(lower, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// isSensitiveParameter reports whether p is marked as carrying a secret
+// value. conduit-commons config.Parameter does not have such a field yet
+// (see https://github.com/ConduitIO/conduit/issues/2566), so this always
+// returns false today; it is factored out so that adding the field
+// upstream is a one-line change here.
+func isSensitiveParameter(_ config.Parameter) bool {
+	return false
+}
+
+// sensitiveKeyNeedles is a case-insensitive, best-effort list of substrings
+// that tend to appear in connector config keys carrying secret material
+// (e.g. "sasl.password", "aws.secret_access_key", "url" for a DB connection
+// string with an embedded password). It is a heuristic, not a guarantee -
+// used only by isSensitive, which itself is not on the path RedactAll takes.
+var sensitiveKeyNeedles = []string{
+	"password",
+	"passphrase",
+	"secret",
+	"token",
+	"credential",
+	"private",
+	"sasl",
+	"auth",
+	"apikey",
+	"api_key",
+	"access_key",
+	"dsn",
+	"url",
+	"connection_string",
+}

--- a/pkg/foundation/log/redact_test.go
+++ b/pkg/foundation/log/redact_test.go
@@ -1,0 +1,193 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/conduitio/conduit-commons/config"
+	"github.com/matryer/is"
+	"github.com/rs/zerolog"
+)
+
+// Sentinel secret values. If any of these ever show up in a log buffer in
+// this file's tests, redaction failed to redact.
+const (
+	urlSentinel      = "postgres://u:S3CR3T_SENTINEL_9f3a@h/db"
+	passwordSentinel = "PW_SENTINEL_9f3a"
+
+	// urlKey avoids repeating the "url" string literal (goconst); it's also
+	// one of the entries in sensitiveKeyNeedles, exercised by TestIsSensitive.
+	urlKey = "url"
+)
+
+// secretFixture returns a connector config carrying the kind of values real
+// connectors put in config.Config: a DB URL with an embedded password and a
+// SASL credential, plus one clearly non-secret value so the test can also
+// confirm RedactAll's interim "redact everything" behavior redacts values
+// that a keyed-on-sensitivity version would have left visible.
+func secretFixture() config.Config {
+	return config.Config{
+		urlKey:          urlSentinel,
+		"sasl.password": passwordSentinel,
+		"topic":         "orders", // not a secret, still redacted (interim behavior)
+	}
+}
+
+// TestRedactAll_NeverLeaksSentinels is the secrets-redaction regression test
+// required by the v0.16.1 execution plan (§1.1): it drives RedactAll with a
+// logger writing to an in-memory buffer and asserts the sentinel secret
+// values never appear in the output, Redacted does appear, and every key
+// stays visible.
+func TestRedactAll_NeverLeaksSentinels(t *testing.T) {
+	is := is.New(t)
+	var buf bytes.Buffer
+	logger := New(zerolog.New(&buf))
+
+	cfg := secretFixture()
+	logger.Info(context.Background()).Any("config", RedactAll(cfg)).Msg("calling Configure")
+
+	got := buf.String()
+
+	is.True(!strings.Contains(got, urlSentinel))      // url sentinel must never appear in log output
+	is.True(!strings.Contains(got, passwordSentinel)) // password sentinel must never appear in log output
+
+	is.True(strings.Contains(got, Redacted)) // redacted marker must appear
+
+	// Keys are not secret and stay visible so operators can still tell which
+	// parameters were set.
+	is.True(strings.Contains(got, `"`+urlKey+`":"***"`))
+	is.True(strings.Contains(got, `"sasl.password":"***"`))
+	is.True(strings.Contains(got, `"topic":"***"`)) // interim behavior: redacts non-secret keys too
+}
+
+// TestRedactAll_EmptyAndNilConfig verifies RedactAll doesn't panic or write
+// anything odd for the empty/nil edge cases (a connector with no settings,
+// or a lifecycle event with a nil ConfigBefore/ConfigAfter).
+func TestRedactAll_EmptyAndNilConfig(t *testing.T) {
+	is := is.New(t)
+
+	testCases := []config.Config{nil, {}}
+	for _, cfg := range testCases {
+		var buf bytes.Buffer
+		logger := New(zerolog.New(&buf))
+		logger.Info(context.Background()).Any("config", RedactAll(cfg)).Msg("calling Configure")
+
+		got := buf.String()
+		is.True(strings.Contains(got, `"config":{}`))
+	}
+}
+
+// TestRedactedConfig_KeysSortedDeterministic checks that output is
+// deterministic across repeated calls with the same input, which matters for
+// log-diffing and for the test assertions above to be reliable (map
+// iteration order is randomized in Go, MarshalZerologObject must not depend
+// on it).
+func TestRedactedConfig_KeysSortedDeterministic(t *testing.T) {
+	is := is.New(t)
+	cfg := config.Config{"z": "1", "a": "2", "m": "3"}
+
+	var first string
+	for i := 0; i < 5; i++ {
+		var buf bytes.Buffer
+		logger := New(zerolog.New(&buf))
+		logger.Info(context.Background()).Any("config", RedactAll(cfg)).Msg("")
+		if i == 0 {
+			first = buf.String()
+			continue
+		}
+		is.Equal(first, buf.String())
+	}
+	is.True(strings.Contains(first, `"config":{"a":"***","m":"***","z":"***"}`))
+}
+
+// TestIsSensitive exercises the name heuristic on its own. isSensitive is not
+// reached by RedactAll today (RedactAll always passes Params as nil, which
+// redacts unconditionally) - this test exists so the heuristic is verified
+// ahead of the follow-up that wires a real Params-based check into
+// RedactedConfig.
+func TestIsSensitive(t *testing.T) {
+	testCases := []struct {
+		key  string
+		want bool
+	}{
+		{"password", true},
+		{"db.password", true},
+		{"PASSWORD", true},
+		{"sasl.password", true},
+		{"sasl.mechanism", true}, // heuristic is coarse: matches on "sasl", not just credential sub-keys
+		{"passphrase", true},
+		{"secret", true},
+		{"client_secret", true},
+		{"token", true},
+		{"access_token", true},
+		{"credential", true},
+		{"credentials.path", true},
+		{"private_key", true},
+		{"auth", true},
+		{"authorization", true},
+		{"apikey", true},
+		{"api_key", true},
+		{"aws.access_key_id", true},
+		{"dsn", true},
+		{urlKey, true},
+		{"connection_string", true},
+		{"topic", false},
+		{"batch.size", false},
+		{"format", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.key, func(t *testing.T) {
+			is := is.New(t)
+			is.Equal(tc.want, isSensitive(nil, tc.key))
+		})
+	}
+}
+
+// TestRedactedConfig_ParamsNonNilStillRedactsUnknownSensitiveKeys documents
+// today's behavior for a caller that does pass Params directly (bypassing
+// RedactAll): a key not present in Params still gets redacted if the name
+// heuristic flags it, and a key present in Params is only ever left visible
+// if isSensitiveParameter says so - which is always false until the
+// conduit-commons follow-up lands (see isSensitiveParameter's doc comment),
+// so today passing a non-nil Params is not actually distinguishable from
+// RedactAll for any key the heuristic doesn't recognize as sensitive... IT
+// STILL REDACTS non-sensitive-looking keys as long as Params is nil; this
+// test is only meaningful once isSensitiveParameter is wired up, but is
+// included so a future change to isSensitiveParameter gets a failing test
+// instead of silent behavior drift.
+func TestRedactedConfig_ParamsNonNilStillRedactsUnknownSensitiveKeys(t *testing.T) {
+	is := is.New(t)
+	var buf bytes.Buffer
+	logger := New(zerolog.New(&buf))
+
+	cfg := config.Config{"sasl.password": passwordSentinel, "topic": "orders"}
+	rc := RedactedConfig{Params: config.Parameters{}, Config: cfg}
+	logger.Info(context.Background()).Any("config", rc).Msg("")
+
+	got := buf.String()
+	is.True(!strings.Contains(got, passwordSentinel))
+	is.True(strings.Contains(got, `"sasl.password":"***"`))
+	// "topic" is not recognized as sensitive by the name heuristic and
+	// Params is empty (no override), so today it is printed verbatim - this
+	// is the intended keyed-on-sensitivity behavior for the future, exercised
+	// here only because isSensitive/isSensitiveParameter already exist; the
+	// RedactAll path used at every real call site does not take this branch.
+	is.True(strings.Contains(got, `"topic":"orders"`))
+}

--- a/pkg/plugin/connector/builtin/destination.go
+++ b/pkg/plugin/connector/builtin/destination.go
@@ -57,7 +57,11 @@ func (d *destinationPluginAdapter) withLogger(ctx context.Context) context.Conte
 }
 
 func (d *destinationPluginAdapter) Configure(ctx context.Context, in pconnector.DestinationConfigureRequest) (pconnector.DestinationConfigureResponse, error) {
-	d.logger.Debug(ctx).Any("request", in).Msg("calling Configure")
+	// in.Config routinely carries secrets (DB urls with embedded passwords,
+	// SASL credentials, access keys). There is no per-parameter sensitivity
+	// metadata yet, so log.RedactAll redacts every value - see
+	// pkg/foundation/log/redact.go.
+	d.logger.Debug(ctx).Any("config", log.RedactAll(in.Config)).Msg("calling Configure") //nolint:forbidigo // in.Config is wrapped in log.RedactAll before logging
 	out, err := runSandbox(d.impl.Configure, d.withLogger(ctx), in.Clone(), d.logger, "Configure")
 	return out.Clone(), err
 }
@@ -108,19 +112,25 @@ func (d *destinationPluginAdapter) Teardown(ctx context.Context, in pconnector.D
 }
 
 func (d *destinationPluginAdapter) LifecycleOnCreated(ctx context.Context, in pconnector.DestinationLifecycleOnCreatedRequest) (pconnector.DestinationLifecycleOnCreatedResponse, error) {
-	d.logger.Debug(ctx).Any("request", in).Msg("calling LifecycleOnCreated")
+	// See the redaction note in Configure above.
+	d.logger.Debug(ctx).Any("config", log.RedactAll(in.Config)).Msg("calling LifecycleOnCreated") //nolint:forbidigo // in.Config is wrapped in log.RedactAll before logging
 	out, err := runSandbox(d.impl.LifecycleOnCreated, d.withLogger(ctx), in.Clone(), d.logger, "LifecycleOnCreated")
 	return out.Clone(), err
 }
 
 func (d *destinationPluginAdapter) LifecycleOnUpdated(ctx context.Context, in pconnector.DestinationLifecycleOnUpdatedRequest) (pconnector.DestinationLifecycleOnUpdatedResponse, error) {
-	d.logger.Debug(ctx).Any("request", in).Msg("calling LifecycleOnUpdated")
+	// See the redaction note in Configure above.
+	d.logger.Debug(ctx).
+		Any("configBefore", log.RedactAll(in.ConfigBefore)). //nolint:forbidigo // in.ConfigBefore is wrapped in log.RedactAll before logging
+		Any("configAfter", log.RedactAll(in.ConfigAfter)).   //nolint:forbidigo // in.ConfigAfter is wrapped in log.RedactAll before logging
+		Msg("calling LifecycleOnUpdated")
 	out, err := runSandbox(d.impl.LifecycleOnUpdated, d.withLogger(ctx), in.Clone(), d.logger, "LifecycleOnUpdated")
 	return out.Clone(), err
 }
 
 func (d *destinationPluginAdapter) LifecycleOnDeleted(ctx context.Context, in pconnector.DestinationLifecycleOnDeletedRequest) (pconnector.DestinationLifecycleOnDeletedResponse, error) {
-	d.logger.Debug(ctx).Any("request", in).Msg("calling LifecycleOnDeleted")
+	// See the redaction note in Configure above.
+	d.logger.Debug(ctx).Any("config", log.RedactAll(in.Config)).Msg("calling LifecycleOnDeleted") //nolint:forbidigo // in.Config is wrapped in log.RedactAll before logging
 	out, err := runSandbox(d.impl.LifecycleOnDeleted, d.withLogger(ctx), in.Clone(), d.logger, "LifecycleOnDeleted")
 	return out.Clone(), err
 }

--- a/pkg/plugin/connector/builtin/redact_test.go
+++ b/pkg/plugin/connector/builtin/redact_test.go
@@ -1,0 +1,217 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builtin
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/conduitio/conduit-commons/config"
+	"github.com/conduitio/conduit-connector-protocol/pconnector"
+	"github.com/conduitio/conduit-connector-protocol/pconnector/mock"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/matryer/is"
+	"github.com/rs/zerolog"
+	"go.uber.org/mock/gomock"
+)
+
+// Sentinel secret values used across this file's tests. If either ever shows
+// up in a captured log buffer, a leak site regressed.
+const (
+	redactTestURLSentinel = "postgres://u:S3CR3T_SENTINEL_9f3a@h/db"
+	redactTestPwSentinel  = "PW_SENTINEL_9f3a"
+)
+
+func redactTestConfig() config.Config {
+	return config.Config{
+		"url":           redactTestURLSentinel,
+		"sasl.password": redactTestPwSentinel,
+	}
+}
+
+// assertNoSecretLeak is the shared assertion for every test below: sentinels
+// must never appear in the captured log output, the redacted marker must
+// appear, and config keys must remain visible.
+func assertNoSecretLeak(is *is.I, buf *bytes.Buffer) {
+	got := buf.String()
+	is.True(!strings.Contains(got, redactTestURLSentinel)) // url sentinel leaked into log output
+	is.True(!strings.Contains(got, redactTestPwSentinel))  // password sentinel leaked into log output
+	is.True(strings.Contains(got, log.Redacted))           // redacted marker missing from log output
+	is.True(strings.Contains(got, `"url"`))                // key should stay visible
+	is.True(strings.Contains(got, `"sasl.password"`))      // key should stay visible
+}
+
+// TestSourcePluginAdapter_DoesNotLeakSecrets is the secrets-redaction
+// regression test (v0.16.1 execution plan §1.1) for the source adapter leak
+// sites fixed in source.go: Configure, LifecycleOnCreated, LifecycleOnUpdated
+// and LifecycleOnDeleted used to log the entire incoming pconnector request
+// (including Config/ConfigBefore/ConfigAfter) via Any("request", in). Each
+// case here drives the real adapter method with a secret-fixture config and
+// asserts the sentinel values never reach the log buffer.
+func TestSourcePluginAdapter_DoesNotLeakSecrets(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	mockSource := mock.NewSourcePlugin(ctrl)
+	mockSource.EXPECT().Configure(gomock.Any(), gomock.Any()).Return(pconnector.SourceConfigureResponse{}, nil).AnyTimes()
+	mockSource.EXPECT().LifecycleOnCreated(gomock.Any(), gomock.Any()).Return(pconnector.SourceLifecycleOnCreatedResponse{}, nil).AnyTimes()
+	mockSource.EXPECT().LifecycleOnUpdated(gomock.Any(), gomock.Any()).Return(pconnector.SourceLifecycleOnUpdatedResponse{}, nil).AnyTimes()
+	mockSource.EXPECT().LifecycleOnDeleted(gomock.Any(), gomock.Any()).Return(pconnector.SourceLifecycleOnDeletedResponse{}, nil).AnyTimes()
+
+	cfg := redactTestConfig()
+
+	testCases := []struct {
+		name string
+		call func(*sourcePluginAdapter) error
+	}{
+		{
+			name: "Configure",
+			call: func(a *sourcePluginAdapter) error {
+				_, err := a.Configure(ctx, pconnector.SourceConfigureRequest{Config: cfg})
+				return err
+			},
+		},
+		{
+			name: "LifecycleOnCreated",
+			call: func(a *sourcePluginAdapter) error {
+				_, err := a.LifecycleOnCreated(ctx, pconnector.SourceLifecycleOnCreatedRequest{Config: cfg})
+				return err
+			},
+		},
+		{
+			name: "LifecycleOnUpdated",
+			call: func(a *sourcePluginAdapter) error {
+				_, err := a.LifecycleOnUpdated(ctx, pconnector.SourceLifecycleOnUpdatedRequest{ConfigBefore: cfg, ConfigAfter: cfg})
+				return err
+			},
+		},
+		{
+			name: "LifecycleOnDeleted",
+			call: func(a *sourcePluginAdapter) error {
+				_, err := a.LifecycleOnDeleted(ctx, pconnector.SourceLifecycleOnDeletedRequest{Config: cfg})
+				return err
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			var buf bytes.Buffer
+			logger := log.New(zerolog.New(&buf).Level(zerolog.DebugLevel))
+			adapter := newSourcePluginAdapter(mockSource, logger)
+
+			err := tc.call(adapter)
+			is.NoErr(err)
+
+			assertNoSecretLeak(is, &buf)
+		})
+	}
+}
+
+// TestDestinationPluginAdapter_DoesNotLeakSecrets mirrors
+// TestSourcePluginAdapter_DoesNotLeakSecrets for destination.go's adapter.
+func TestDestinationPluginAdapter_DoesNotLeakSecrets(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	mockDestination := mock.NewDestinationPlugin(ctrl)
+	mockDestination.EXPECT().Configure(gomock.Any(), gomock.Any()).Return(pconnector.DestinationConfigureResponse{}, nil).AnyTimes()
+	mockDestination.EXPECT().LifecycleOnCreated(gomock.Any(), gomock.Any()).Return(pconnector.DestinationLifecycleOnCreatedResponse{}, nil).AnyTimes()
+	mockDestination.EXPECT().LifecycleOnUpdated(gomock.Any(), gomock.Any()).Return(pconnector.DestinationLifecycleOnUpdatedResponse{}, nil).AnyTimes()
+	mockDestination.EXPECT().LifecycleOnDeleted(gomock.Any(), gomock.Any()).Return(pconnector.DestinationLifecycleOnDeletedResponse{}, nil).AnyTimes()
+
+	cfg := redactTestConfig()
+
+	testCases := []struct {
+		name string
+		call func(*destinationPluginAdapter) error
+	}{
+		{
+			name: "Configure",
+			call: func(a *destinationPluginAdapter) error {
+				_, err := a.Configure(ctx, pconnector.DestinationConfigureRequest{Config: cfg})
+				return err
+			},
+		},
+		{
+			name: "LifecycleOnCreated",
+			call: func(a *destinationPluginAdapter) error {
+				_, err := a.LifecycleOnCreated(ctx, pconnector.DestinationLifecycleOnCreatedRequest{Config: cfg})
+				return err
+			},
+		},
+		{
+			name: "LifecycleOnUpdated",
+			call: func(a *destinationPluginAdapter) error {
+				_, err := a.LifecycleOnUpdated(ctx, pconnector.DestinationLifecycleOnUpdatedRequest{ConfigBefore: cfg, ConfigAfter: cfg})
+				return err
+			},
+		},
+		{
+			name: "LifecycleOnDeleted",
+			call: func(a *destinationPluginAdapter) error {
+				_, err := a.LifecycleOnDeleted(ctx, pconnector.DestinationLifecycleOnDeletedRequest{Config: cfg})
+				return err
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			var buf bytes.Buffer
+			logger := log.New(zerolog.New(&buf).Level(zerolog.DebugLevel))
+			adapter := newDestinationPluginAdapter(mockDestination, logger)
+
+			err := tc.call(adapter)
+			is.NoErr(err)
+
+			assertNoSecretLeak(is, &buf)
+		})
+	}
+}
+
+// TestReturnResponse_DetachedContext_DoesNotLeakResponseValue exercises
+// sandbox.go's returnResponse on the ctx-cancelled path (the call comes from
+// a detached goroutine after the caller stopped waiting - see runSandbox).
+// The response value used to be logged in full via Any("response", res); it
+// is now reduced to its type name. This test doesn't use a secret directly
+// (response types in this protocol version don't carry Config - only
+// requests do), but it does confirm the generic res value's content, whatever
+// it is, is never serialized into the log, only its %T type name.
+func TestReturnResponse_DetachedContext_DoesNotLeakResponseValue(t *testing.T) {
+	is := is.New(t)
+	var buf bytes.Buffer
+	logger := log.New(zerolog.New(&buf).Level(zerolog.DebugLevel))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // ctx is already done before returnResponse runs
+
+	type sensitiveResponse struct {
+		Secret string
+	}
+	res := sensitiveResponse{Secret: redactTestPwSentinel}
+
+	// c is unbuffered and nobody reads from it, so the ctx.Done() branch is
+	// the only one that can complete.
+	c := make(chan any)
+	returnResponse(ctx, res, nil, c, logger)
+
+	got := buf.String()
+	is.True(!strings.Contains(got, redactTestPwSentinel))                         // response content leaked into log output
+	is.True(strings.Contains(got, "sensitiveResponse"))                           // type name should still be logged
+	is.True(strings.Contains(got, `"response_type":"builtin.sensitiveResponse"`)) // exact field shape
+}

--- a/pkg/plugin/connector/builtin/sandbox.go
+++ b/pkg/plugin/connector/builtin/sandbox.go
@@ -16,6 +16,7 @@ package builtin
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
@@ -86,8 +87,11 @@ func returnResponse(ctx context.Context, res any, err error, c chan<- any, logge
 	select {
 	case <-ctx.Done():
 		// The context was cancelled, nobody will fetch the result.
+		// res is a pconnector response (e.g. SourceConfigureResponse) and, for
+		// some plugin calls, can echo back config values - log its type only,
+		// never its content. See pkg/foundation/log/redact.go.
 		logger.Error(ctx).
-			Any("response", res).
+			Str("response_type", fmt.Sprintf("%T", res)).
 			Err(err).
 			Msg("context cancelled when trying to return response from builtin connector plugin (this message comes from a detached plugin)")
 	case c <- res:

--- a/pkg/plugin/connector/builtin/source.go
+++ b/pkg/plugin/connector/builtin/source.go
@@ -57,7 +57,11 @@ func (s *sourcePluginAdapter) withLogger(ctx context.Context) context.Context {
 }
 
 func (s *sourcePluginAdapter) Configure(ctx context.Context, in pconnector.SourceConfigureRequest) (pconnector.SourceConfigureResponse, error) {
-	s.logger.Debug(ctx).Any("request", in).Msg("calling Configure")
+	// in.Config routinely carries secrets (DB urls with embedded passwords,
+	// SASL credentials, access keys). There is no per-parameter sensitivity
+	// metadata yet, so log.RedactAll redacts every value - see
+	// pkg/foundation/log/redact.go.
+	s.logger.Debug(ctx).Any("config", log.RedactAll(in.Config)).Msg("calling Configure") //nolint:forbidigo // in.Config is wrapped in log.RedactAll before logging
 	out, err := runSandbox(s.impl.Configure, s.withLogger(ctx), in.Clone(), s.logger, "Configure")
 	return out.Clone(), err
 }
@@ -108,19 +112,25 @@ func (s *sourcePluginAdapter) Teardown(ctx context.Context, in pconnector.Source
 }
 
 func (s *sourcePluginAdapter) LifecycleOnCreated(ctx context.Context, in pconnector.SourceLifecycleOnCreatedRequest) (pconnector.SourceLifecycleOnCreatedResponse, error) {
-	s.logger.Debug(ctx).Any("request", in).Msg("calling LifecycleOnCreated")
+	// See the redaction note in Configure above.
+	s.logger.Debug(ctx).Any("config", log.RedactAll(in.Config)).Msg("calling LifecycleOnCreated") //nolint:forbidigo // in.Config is wrapped in log.RedactAll before logging
 	out, err := runSandbox(s.impl.LifecycleOnCreated, s.withLogger(ctx), in.Clone(), s.logger, "LifecycleOnCreated")
 	return out.Clone(), err
 }
 
 func (s *sourcePluginAdapter) LifecycleOnUpdated(ctx context.Context, in pconnector.SourceLifecycleOnUpdatedRequest) (pconnector.SourceLifecycleOnUpdatedResponse, error) {
-	s.logger.Debug(ctx).Any("request", in).Msg("calling LifecycleOnUpdated")
+	// See the redaction note in Configure above.
+	s.logger.Debug(ctx).
+		Any("configBefore", log.RedactAll(in.ConfigBefore)). //nolint:forbidigo // in.ConfigBefore is wrapped in log.RedactAll before logging
+		Any("configAfter", log.RedactAll(in.ConfigAfter)).   //nolint:forbidigo // in.ConfigAfter is wrapped in log.RedactAll before logging
+		Msg("calling LifecycleOnUpdated")
 	out, err := runSandbox(s.impl.LifecycleOnUpdated, s.withLogger(ctx), in.Clone(), s.logger, "LifecycleOnUpdated")
 	return out.Clone(), err
 }
 
 func (s *sourcePluginAdapter) LifecycleOnDeleted(ctx context.Context, in pconnector.SourceLifecycleOnDeletedRequest) (pconnector.SourceLifecycleOnDeletedResponse, error) {
-	s.logger.Debug(ctx).Any("request", in).Msg("calling LifecycleOnDeleted")
+	// See the redaction note in Configure above.
+	s.logger.Debug(ctx).Any("config", log.RedactAll(in.Config)).Msg("calling LifecycleOnDeleted") //nolint:forbidigo // in.Config is wrapped in log.RedactAll before logging
 	out, err := runSandbox(s.impl.LifecycleOnDeleted, s.withLogger(ctx), in.Clone(), s.logger, "LifecycleOnDeleted")
 	return out.Clone(), err
 }


### PR DESCRIPTION
## Summary

Fixes secrets leaking into logs via raw connector `config.Config` dumps.
Roadmap: v0.16.1, execution plan `docs/design-documents/20260704-phase-1-execution-plan.md`
§1.1 edge case ("Secrets in errors/logs → redaction pass keyed on connector
param sensitivity; test with a secret fixture").

**Risk tier: Tier 2** (logging-only; no data-path, wire-format, or config-schema change).

## What leaked

Connector settings (`config.Config`, a `map[string]string`) routinely carry
secrets - DB URLs with embedded passwords, SASL credentials, access keys.
Several call sites logged the raw value via zerolog's `Any(...)`, which
reflects the whole value into the log record at debug/warn level:

| Site | Before |
| --- | --- |
| `pkg/plugin/connector/builtin/source.go:60` (`Configure`) | `Any("request", in)` — `in.Config` |
| `pkg/plugin/connector/builtin/source.go:111/117/123` (`LifecycleOn{Created,Updated,Deleted}`) | same — `in.Config`/`in.ConfigBefore`/`in.ConfigAfter` |
| `pkg/plugin/connector/builtin/destination.go` (same 4 methods) | same pattern |
| `pkg/plugin/connector/builtin/sandbox.go:90` (`returnResponse`, ctx-cancelled path) | `Any("response", res)` |
| `pkg/connector/source.go:378-379` / `destination.go:363-364` (`triggerLifecycleEvent` default branch) | `Any("oldConfig", oldConfig).Any("newConfig", newConfig)` |

A central zerolog `Hook` can't fix this: a `zerolog.Event` is write-only once
a field has been added to it, so redaction has to happen at the log call
site, before the value reaches `Any()`.

## What changed

- Added `pkg/foundation/log/redact.go`: `RedactedConfig` (implements
  `zerolog.LogObjectMarshaler`) and `RedactAll(cfg)`. Every listed site now
  wraps its config value in `log.RedactAll(...)` before logging. **Redaction
  is logging-only** — every `runSandbox(...)` call still passes the
  unmodified `in.Clone()`, and `triggerLifecycleEvent`'s real
  `oldConfig`/`newConfig` are untouched; only the log statements changed.
- **Interim behavior (locked decision):** `conduit-commons` `config.Parameter`
  has no per-parameter sensitivity flag yet, so `RedactAll` redacts **every**
  value and leaves only keys visible. `isSensitive`/`isSensitiveParameter`
  already exist and are unit-tested ahead of the real metadata landing, but
  aren't reachable from `RedactAll` today (documented in the doc comments).
- Filed **#2566** to thread real per-parameter sensitivity metadata through
  conduit-commons → connector protocol → SDK (paramgen) → built-in
  connectors, then flip these call sites to pass real `Params`.
- `sandbox.go`'s `returnResponse` now logs `response_type` (`%T`) instead of
  the response value.
- Left `Open`/`Stop`/`Teardown` alone — their request types
  (`SourceOpenRequest{Position}`, `*StopRequest`, `*TeardownRequest`) don't
  carry a `Config` field, so there's nothing to redact there.

## CI guard

Added a `forbidigo` rule in `.golangci.yml` with `analyze-types: true`,
empirically verified before committing to it (see the in-file comment):
with type analysis on, forbidigo expands a field-selector expression like
`in.Config` (where `in` is `pconnector.SourceConfigureRequest`) to
`"pconnector.SourceConfigureRequest.Config"`, but a composite literal like
`pconnector.SourceConfigureRequest{Config: cfg}` expands to just
`"pconnector.Config"` — so the rule flags a raw field *read* (the logging
shape) without also flagging legitimate request *construction* (verified
with a scratch repro before wiring it into this repo's config, and
confirmed with `golangci-lint run --enable-only forbidigo ./...` — 0 issues,
no new false positives anywhere in the repo).

**This is a partial guard, documented as such in `.golangci.yml`:**
forbidigo only matches identifier/selector *text*, never call arguments or
string literals, so it structurally cannot express "a `Config` field was
passed to `Any(...)` without going through `RedactAll`" as a single rule.
Concretely:
- It **does** catch a future contributor writing `in.Config` (or
  `.ConfigBefore`/`.ConfigAfter`) directly into a log call in the builtin
  adapter files — the 10 already-safe `log.RedactAll(in.Config)` sites need
  a `//nolint:forbidigo` explaining they're wrapped.
- It **cannot** cover `pkg/connector/{source,destination}.go`'s
  `oldConfig`/`newConfig map[string]string` locals (no selector on a named
  type, no type info for bare identifiers) or `sandbox.go`'s generic
  `res any` (same reason, plus `res` is reused throughout the function for
  unrelated purposes — a name-based rule there would be all noise). Those
  are guarded by the secret-fixture tests below, not static analysis.

## Testing

- `pkg/foundation/log/redact_test.go`: unit tests for `RedactAll`,
  `MarshalZerologObject` (deterministic sorted-key output), and the
  `isSensitive` name heuristic, using sentinel secret values
  (`S3CR3T_SENTINEL_9f3a`, `PW_SENTINEL_9f3a`).
- `pkg/plugin/connector/builtin/redact_test.go`: drives the real
  `sourcePluginAdapter`/`destinationPluginAdapter` methods (`Configure`,
  `LifecycleOnCreated`, `LifecycleOnUpdated`, `LifecycleOnDeleted`) with a
  secret-fixture config and a logger writing to an in-memory buffer;
  asserts sentinels never appear, `***` does, and keys stay visible. Also
  covers `sandbox.go`'s `returnResponse` on the ctx-cancelled path.
- **Verified these tests actually catch the regression:** temporarily
  reverted the three `pkg/plugin/connector/builtin/*.go` fixes (`git stash`)
  and confirmed all 3 new test functions fail with the sentinel appearing in
  the buffer; restored the fix and confirmed they pass.
- The `pkg/connector` default-branch fix has no dedicated end-to-end test:
  it's unreachable today (`isEqual(nil, nil)` returns `true` before the
  switch is reached, per the existing "should never happen" comment) - fixed
  defensively for whoever changes `isEqual` later, reusing the same
  `RedactAll` already covered by the `pkg/foundation/log` tests.

```
go build ./...
go test ./pkg/foundation/log/... ./pkg/plugin/connector/... ./pkg/connector/... -race
golangci-lint run ./...          # 0 issues
golangci-lint run --enable-only forbidigo ./...   # 0 issues (repo-wide, confirms no new false positives)
```

## Adversarial self-review

- Re-grepped for residual `Any("request"/"oldConfig"/"newConfig"/"response",
  ...)` with an unredacted argument after the fix - only the
  intentionally-untouched `Open`/`Stop`/`Teardown` calls remain (no `Config`
  field on those request types).
- Re-read every `runSandbox(...)` call site to confirm redaction is
  logging-only: the actual request passed to the plugin is still
  `in.Clone()`, untouched by the new log statements above it.
- Checked `MarshalZerologObject` is only invoked when the log level is
  actually enabled (traced into zerolog's `Event.Any` → `Interface` →
  `Object`, which early-returns on a nil/disabled `*Event` before ever
  calling the marshaler) - no perf or correctness surprise from wrapping
  values that never get logged.
- Grepped the whole repo (including tests) for any other `.Config` field
  access on the 8 `pconnector.*Request` types before adding the forbidigo
  pattern, to be sure it wouldn't flag existing legitimate code - it
  doesn't (all other uses are composite-literal construction, which the
  pattern is verified not to match).

## Definition of done

- [x] Risk tier declared (Tier 2); no data-path change, so no failure-mode
      analysis / human sign-off gate applies
- [x] Compiles, lints clean (`golangci-lint run ./...`), race detector clean
- [x] Every fixed leak site has the secret-fixture test that would have
      caught it, verified to fail without the fix and pass with it
- [x] Godoc on new exported symbols (`Redacted`, `RedactedConfig`,
      `RedactAll`); interim-behavior and follow-up documented in the doc
      comments
- [x] Adversarial self-review findings documented above
- [x] Roadmap item referenced (v0.16.1, execution plan §1.1)
- [x] No new dependencies
- [x] Not a breaking change (logging output format only)

Follow-up issue: #2566
