### PR TITLE
feat: deterministic CLI exit codes (execution plan §1.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,27 @@ or run Conduit and navigate to `http://localhost:8080/openapi` to open
 a [Swagger UI](https://github.com/swagger-api/swagger-ui) which makes it easy to
 try it out.
 
+## Exit codes
+
+Every `conduit` CLI invocation — one-shot commands (`conduit pipelines list`, ...) and the
+long-running `conduit run` — exits with one of a small set of deterministic codes, so scripts and
+agents can branch on failure kind without parsing error text:
+
+| Code  | Meaning       | Examples                                                                     |
+| ----- | ------------- | ----------------------------------------------------------------------------- |
+| `0`   | Success       | The command succeeded, or `conduit run` shut down gracefully on a single SIGINT/SIGTERM. |
+| `1`   | Runtime error | An internal or unclassified error (a bug, an unexpected failure).           |
+| `2`   | Validation    | The request or config was rejected: invalid argument, not found, already exists, failed precondition. |
+| `3`   | Environment   | A required external dependency is unreachable: the server, the database, a rate limit, or an already-bound listen address. |
+
+`conduit run` treats a **second** SIGINT/SIGTERM (received after the first one has already started
+a graceful shutdown) as a forced kill and exits with the POSIX `128+signum` convention instead
+(`SIGINT` → `130`, `SIGTERM` → `143`) — the same value a shell reports for a process killed by that
+signal, so a forced kill is distinguishable from an ordinary classified exit code.
+
+See [ADR: deterministic CLI exit codes](docs/architecture-decision-records/20260706-deterministic-cli-exit-codes.md)
+for the full mapping and rationale, and `pkg/conduit/exitcode` for the implementation.
+
 ## Documentation
 
 To learn more about how to use Conduit

--- a/cmd/conduit/api/client.go
+++ b/cmd/conduit/api/client.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	apiv1 "github.com/conduitio/conduit/proto/api/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -60,9 +61,22 @@ func NewClient(ctx context.Context, address string) (*Client, error) {
 func (c *Client) CheckHealth(ctx context.Context, address string) error {
 	healthResp, err := c.HealthClient.Check(ctx, &healthgrpc.HealthCheckRequest{})
 	if err != nil || healthResp.Status != healthgrpc.HealthCheckResponse_SERVING {
-		return cerrors.Errorf("we couldn't connect to Conduit at the configured address %q\n"+
+		// cerrors.Errorf always captures a stack frame (unlike fmt.Errorf),
+		// regardless of whether %w or %v is used; %v is deliberate here (err
+		// may be nil, when the response came back with a non-SERVING status
+		// and no transport error) so this must not use %w with a possibly-nil
+		// operand. Passing the wrapped error itself (not the raw err) as
+		// Wrap's cause keeps that frame: conduiterr.Wrap only synthesizes a
+		// frame of its own when cause is nil, so handing it a frame-less raw
+		// err here would silently produce a traceless ConduitError.
+		wrapped := cerrors.Errorf("we couldn't connect to Conduit at the configured address %q\n"+
 			"Please execute `conduit run` to start it.\nTo check the current configured `api.grpc.address`, run `conduit config`\n\n"+
 			"Error details: %v", address, err)
+		// Tagged Unavailable (an environment failure, not a validation or
+		// internal one): pkg/conduit/exitcode maps it to exit code 3 so a
+		// script or agent can tell "the server isn't reachable" apart from a
+		// rejected request or a bug.
+		return conduiterr.Wrap(conduiterr.CodeUnavailable, wrapped.Error(), wrapped)
 	}
 	return nil
 }

--- a/cmd/conduit/api/client_test.go
+++ b/cmd/conduit/api/client_test.go
@@ -1,0 +1,115 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/matryer/is"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
+	grpcstatus "google.golang.org/grpc/status"
+)
+
+// fakeHealthClient lets CheckHealth be exercised without a real gRPC server.
+// Only Check is used by CheckHealth; List/Watch are unused stubs that
+// satisfy healthgrpc.HealthClient structurally.
+type fakeHealthClient struct {
+	resp *healthgrpc.HealthCheckResponse
+	err  error
+}
+
+func (f fakeHealthClient) Check(context.Context, *healthgrpc.HealthCheckRequest, ...grpc.CallOption) (*healthgrpc.HealthCheckResponse, error) {
+	return f.resp, f.err
+}
+
+func (f fakeHealthClient) List(context.Context, *healthgrpc.HealthListRequest, ...grpc.CallOption) (*healthgrpc.HealthListResponse, error) {
+	return nil, cerrors.New("not implemented in fakeHealthClient")
+}
+
+func (f fakeHealthClient) Watch(context.Context, *healthgrpc.HealthCheckRequest, ...grpc.CallOption) (grpc.ServerStreamingClient[healthgrpc.HealthCheckResponse], error) {
+	return nil, cerrors.New("not implemented in fakeHealthClient")
+}
+
+// TestClient_CheckHealth_Serving is the trivial success path: no error, no
+// tagging.
+func TestClient_CheckHealth_Serving(t *testing.T) {
+	is := is.New(t)
+	c := &Client{HealthClient: fakeHealthClient{resp: &healthgrpc.HealthCheckResponse{Status: healthgrpc.HealthCheckResponse_SERVING}}}
+
+	err := c.CheckHealth(context.Background(), ":8084")
+	is.NoErr(err)
+}
+
+// TestClient_CheckHealth_Unreachable covers both response shapes
+// CheckHealth tags conduiterr.CodeUnavailable for (so pkg/conduit/exitcode
+// classifies either as an environment failure, exit code 3, instead of the
+// generic runtime bucket), and both must carry a stack trace.
+//
+// The "transport error" case is also the regression test for an
+// adversarial-self-review finding caught before this landed: an earlier
+// version of this fix built the error message via
+// cerrors.Errorf(...).Error() (which captures a stack frame) but then
+// discarded that frame-carrying error and passed the raw err to
+// conduiterr.Wrap as the cause instead. conduiterr.Wrap only synthesizes a
+// frame of its own when its cause argument is nil, so a non-nil, frame-less
+// cause (a real gRPC transport error, unlike a cerrors-constructed one,
+// carries no frame) silently produced a traceless ConduitError. The
+// "non-SERVING response" case doesn't exercise that specific bug (its cause
+// is nil either way, which Wrap always covers), but is kept for basic
+// coverage of that response shape.
+func TestClient_CheckHealth_Unreachable(t *testing.T) {
+	tests := []struct {
+		name string
+		hc   fakeHealthClient
+	}{
+		{
+			// A real gRPC transport error (what HealthClient.Check actually
+			// returns on a connection failure) carries no xerrors frame of
+			// its own — unlike cerrors.New/Errorf, which always do. Using a
+			// frame-less error here is what makes this case able to catch
+			// the discarded-frame bug at all: a cerrors-constructed fake
+			// would carry a frame regardless of whether Wrap's cause
+			// handling is correct.
+			name: "transport error",
+			hc:   fakeHealthClient{err: grpcstatus.New(codes.Unavailable, "connection refused").Err()},
+		},
+		{
+			name: "non-SERVING response, no transport error",
+			hc:   fakeHealthClient{resp: &healthgrpc.HealthCheckResponse{Status: healthgrpc.HealthCheckResponse_NOT_SERVING}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			is := is.New(t)
+			c := &Client{HealthClient: tt.hc}
+
+			err := c.CheckHealth(context.Background(), ":8084")
+			is.True(err != nil)
+
+			ce, ok := conduiterr.Get(err)
+			is.True(ok) // CheckHealth must return a *conduiterr.ConduitError
+			is.Equal(ce.Code, conduiterr.CodeUnavailable)
+
+			frames, _ := cerrors.GetStackTrace(err).([]cerrors.Frame)
+			is.True(len(frames) > 0) // must carry a stack frame, not silently trace-less
+		})
+	}
+}

--- a/cmd/conduit/cli/cli.go
+++ b/cmd/conduit/cli/cli.go
@@ -20,6 +20,7 @@ import (
 	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
 	"github.com/conduitio/conduit/cmd/conduit/root"
 	"github.com/conduitio/conduit/pkg/conduit"
+	"github.com/conduitio/conduit/pkg/conduit/exitcode"
 	"github.com/conduitio/ecdysis"
 )
 
@@ -37,8 +38,12 @@ func Run(cfg conduit.Config) {
 	cmd.SilenceUsage = true
 
 	if err := cmd.Execute(); err != nil {
-		// error is already printed out
-		os.Exit(1)
+		// error is already printed out by cobra; the exit code is the single
+		// deterministic classifier shared with the `run` entrypoint (see
+		// pkg/conduit/exitcode) so one-shot commands and the long-running
+		// server never drift onto different exit conventions for the same
+		// kind of error.
+		os.Exit(exitcode.ExitCode(err))
 	}
-	os.Exit(0)
+	os.Exit(exitcode.OK)
 }

--- a/docs/architecture-decision-records/20260706-deterministic-cli-exit-codes.md
+++ b/docs/architecture-decision-records/20260706-deterministic-cli-exit-codes.md
@@ -1,0 +1,176 @@
+# Deterministic CLI exit codes
+
+## Summary
+
+Every `conduit` process exit — one-shot CLI commands and the long-running `conduit run` — goes
+through a single classifier (`pkg/conduit/exitcode`) that maps an error to one of four
+process exit codes: `0` success, `1` runtime/unclassified, `2` validation, `3` environment. A
+forced double-signal kill of `conduit run` now reports the POSIX `128+signum` convention
+(`SIGINT` → `130`, `SIGTERM` → `143`) instead of a fixed value, which **changes that exit code
+from `2` to `130`/`143`** — a breaking change, documented below.
+
+## Context
+
+Before this change, `conduit`'s exit codes were accidental, not designed:
+
+- `cmd/conduit/cli/cli.go` exited `1` for any `cmd.Execute()` error and `0` otherwise — every
+  failure, from "pipeline not found" to "the server is unreachable," looked identical to a
+  script.
+- `pkg/conduit/entrypoint.go` exited `1` (`exitCodeErr`) for any `conduit run` setup or runtime
+  failure, and `2` (`exitCodeInterrupt`) for a **second** termination signal (a forced kill after
+  a graceful shutdown was already in progress) — an exit code chosen arbitrarily, not from any
+  convention.
+- Errors carried no stable classification a CLI-boundary function could switch on for most of
+  the codebase. That gap is being closed independently by the `conduiterr` package (see
+  `docs/design-documents/20260705-conduit-error-and-structured-output.md`), which gives some
+  errors a stable `Code` with an explicit gRPC category, but most call sites are not migrated yet.
+
+Phase 1 execution plan §1.1 (`docs/design-documents/20260704-phase-1-execution-plan.md`) commits
+to "documented deterministic exit codes (0 ok · 1 runtime · 2 config/validation · 3
+environment)" as one of the structured-output acceptance criteria. Landing that classifier
+requires deciding, concretely:
+
+- What does "2 config/validation" mean in terms of gRPC status categories, given most errors
+  aren't `conduiterr`-tagged yet?
+- Where does `3 environment` get its signal, given almost nothing is tagged as an environment
+  failure today?
+- The existing "second signal" hard-exit already uses `2`. Freeing `2` for the
+  config/validation bucket means the hard-exit code must move — to what, and is that safe to
+  change?
+- One-shot commands (talk to a running server over gRPC) and `conduit run` (the process that
+  starts the server) fail in different shapes. Can they share one classifier without one of them
+  becoming a lie?
+
+## Decision
+
+### One classifier, `pkg/conduit/exitcode.ExitCode(err error) int`
+
+A new leaf package, `pkg/conduit/exitcode`, is the single source of truth. It is imported by
+both `cmd/conduit/cli` (one-shot commands) and `pkg/conduit` (the `run` entrypoint), so the two
+surfaces cannot drift onto different conventions for the same kind of error. It has no
+dependency on either caller, only on `pkg/foundation/cerrors` and
+`pkg/foundation/cerrors/conduiterr`, so importing it introduces no cycle.
+
+Classification order:
+
+1. `err == nil` or `errors.Is(err, context.Canceled)` → `0` (OK). Canceled covers the graceful
+   `conduit run` shutdown path: the tomb's context is canceled on the first SIGINT/SIGTERM, and
+   `Runtime.Run` returning `context.Canceled` is success, not failure.
+2. A `*conduiterr.ConduitError` anywhere in `err`'s chain (found via `conduiterr.Get`, which uses
+   `errors.As` and so sees through any number of `cerrors.Errorf("...: %w", err)` wraps) →
+   classified by its registered gRPC category.
+3. Otherwise, a raw gRPC client error (`google.golang.org/grpc/status.FromError`) → classified
+   the same way. This step exists because a `ConduitError` a server raises crosses the gRPC
+   boundary with its category set on the **top-level** status code
+   (`conduiterr.ToStatus`/`status.New(e.Code.GRPCCode(), ...)`), but no CLI call site decodes the
+   `ErrorInfo` detail back into a `*ConduitError` today (`conduiterr.FromStatus` is unused outside
+   its own tests) — so most server-raised errors reach the CLI as a plain `*status.Error`, not a
+   `ConduitError`. Skipping this step would silently misclassify nearly every `NotFound`/
+   `FailedPrecondition` a real command returns.
+4. Otherwise, a narrow OS-level sentinel check (`syscall.ECONNREFUSED`, `syscall.EADDRINUSE`) →
+   `3` (environment). A deliberately small safety net, not a general network-error classifier —
+   see "Coverage is intentionally partial" below.
+5. Otherwise → `1` (runtime), the catch-all.
+
+gRPC category → bucket mapping (`fromGRPCCode`):
+
+| Bucket             | Code | gRPC categories                                                                 |
+| ------------------ | ---- | -------------------------------------------------------------------------------- |
+| OK                 | `0`  | `OK`, `Canceled`                                                                  |
+| Runtime            | `1`  | `Internal`, `Unknown`, `DataLoss`, `Aborted`, `Unimplemented`                     |
+| Validation         | `2`  | `InvalidArgument`, `NotFound`, `AlreadyExists`, `FailedPrecondition`, `OutOfRange` |
+| Environment        | `3`  | `Unavailable`, `DeadlineExceeded`, `ResourceExhausted`, `Unauthenticated`, `PermissionDenied` |
+
+`FailedPrecondition` and `NotFound` land in Validation (`2`), not Runtime: both mean the request
+was rejected because of the state of the world the caller controls (a pipeline is already
+running, a referenced instance doesn't exist), which is a validation-shaped failure from the
+caller's point of view, not an internal bug or an unreachable dependency.
+
+### Coverage is intentionally partial — tag only the high-value environment cases now
+
+Almost nothing in the codebase is tagged as an environment error today. Rather than block this
+change on migrating every relevant call site (explicitly out of scope per the incremental,
+boundary-first rollout in the structured-output design doc), this change tags only the highest-
+value cases, each via a new `conduiterr.CodeUnavailable` (`common.unavailable`, gRPC
+`Unavailable`):
+
+- **Server unreachable**: `cmd/conduit/api/client.go` `CheckHealth` — the error every client
+  command returns when `conduit run` isn't up.
+- **Bind-in-use**: `pkg/conduit/runtime.go` `serveGRPC`/`serveHTTP` — `net.ListenConfig.Listen`
+  failing because the configured address is already bound.
+- **Database unreachable**: `pkg/conduit/runtime.go` `NewRuntime` — `badger.New`/`postgres.New`/
+  `sqlite.New` failing to open/dial the configured database. (An *invalid* DB type, a
+  config/validation problem, is deliberately **not** tagged Unavailable — it returns directly as
+  a plain error, unchanged from before this PR, so it still exits `1`, matching prior behavior.)
+
+Everywhere else, an untagged error still classifies as Runtime (`1`) — the same as every
+`conduit run` failure exited before this change. That is not a regression; it is the explicit,
+documented starting point. Coverage grows as more boundaries adopt `conduiterr` tagging, without
+this package's contract changing.
+
+The new `conduiterr.CodeUnavailable` lives in a **new file**
+(`pkg/foundation/cerrors/conduiterr/environment.go`), not an edit to the package's existing
+files: a parallel change is migrating `conduiterr`'s codes and `status.go`, so keeping this
+addition purely additive avoids a merge conflict with that work.
+
+### The second-signal hard exit moves off `2`, onto POSIX `128+signum`
+
+`pkg/conduit/entrypoint.go`'s `cancelOnSignal` used exit code `2` for a forced kill (a second
+SIGINT/SIGTERM received after the first one already started a graceful shutdown). That value now
+belongs to the Validation bucket, so a forced kill needed to move. It moves to the POSIX
+convention shells already use for "killed by signal N" — `128+N` — rather than to another
+arbitrary constant:
+
+- `SIGINT` (2) → `130`
+- `SIGTERM` (15) → `143`
+
+This is picked over reusing `1` (indistinguishable from an ordinary runtime error) or inventing
+a fifth bucket (loses the standard meaning scripts already know for `128+signum`). It also
+deliberately does **not** route through `exitcode.ExitCode`: a forced double-signal kill isn't a
+classified error at all, it's "the operator asked twice, so we stopped waiting" — a different
+kind of thing than "the command failed for reason X."
+
+`cancelOnSignal` is changed to capture the second signal's actual value (previously discarded;
+only its arrival mattered) and derive the code from it via `syscall.Signal`, instead of an
+`exitCodeInterrupt` constant.
+
+### One-shot commands and `run` share the classifier, not the call sites
+
+`cmd/conduit/cli/cli.go`'s `Run` and `pkg/conduit/entrypoint.go`'s `exitWithError` both call
+`exitcode.ExitCode(err)` directly; neither reimplements or duplicates the classification logic.
+This is what makes "validation/not-found/precondition errors exit `2` from both a one-shot
+command and the `run`/provisioning path" true by construction rather than by two independently
+maintained switch statements staying in sync.
+
+## Consequences
+
+- **Breaking change: the second-signal `conduit run` exit code changes from `2` to `130`
+  (SIGINT) or `143` (SIGTERM).** Any script or supervisor (systemd, Docker healthchecks, a CI
+  job) that specifically checked for exit code `2` on a forced Conduit kill must be updated. This
+  is the only behavior change to an existing, documented exit code; `1` (default failure) and `0`
+  (success) are unchanged for every case that produced them before.
+- One-shot commands gain non-`1` exit codes for the first time (previously always `0` or `1`).
+  This is additive for scripts that only checked "zero vs. nonzero," and new information for
+  anything more specific.
+- `pkg/conduit/exitcode` becomes the place every future CLI/`run` boundary must route errors
+  through to get a correct exit code; a boundary that calls `os.Exit` directly instead would
+  silently bypass the classifier. There is no static enforcement of this yet (matching the
+  `conduiterr` CI-guard's own current scope — boundary-only, not repo-wide).
+- The environment bucket (`3`) is under-covered by design today. A real environment failure that
+  isn't one of the three tagged call sites, and doesn't hit the `ECONNREFUSED`/`EADDRINUSE`
+  sentinel check, still exits `1`. This is visible and intentional, not silently wrong: `1` was
+  the exit code for every `conduit run` failure before this change, so nothing regresses; it
+  simply doesn't yet get the more specific `3`.
+
+## Related
+
+- Phase 1 execution plan §1.1 (`docs/design-documents/20260704-phase-1-execution-plan.md`) —
+  "documented deterministic exit codes (0 ok · 1 runtime · 2 config/validation · 3 environment)"
+  acceptance criterion this ADR satisfies.
+- `docs/design-documents/20260705-conduit-error-and-structured-output.md` — the `ConduitError`/
+  `conduiterr` model this classifier's first two tiers depend on, and the incremental,
+  boundary-first migration this ADR's "coverage is intentionally partial" section follows.
+- `pkg/conduit/exitcode` — the implementation.
+- `pkg/foundation/cerrors/conduiterr/environment.go` — the new, additive `CodeUnavailable`
+  registration.
+- README "Exit codes" section — the user-facing mapping table.

--- a/docs/architecture-decision-records/20260706-deterministic-cli-exit-codes.md
+++ b/docs/architecture-decision-records/20260706-deterministic-cli-exit-codes.md
@@ -99,7 +99,7 @@ value cases, each via a new `conduiterr.CodeUnavailable` (`common.unavailable`, 
 - **Bind-in-use**: `pkg/conduit/runtime.go` `serveGRPC`/`serveHTTP` — `net.ListenConfig.Listen`
   failing because the configured address is already bound.
 - **Database unreachable**: `pkg/conduit/runtime.go` `NewRuntime` — `badger.New`/`postgres.New`/
-  `sqlite.New` failing to open/dial the configured database. (An *invalid* DB type, a
+  `sqlite.New` failing to open/dial the configured database. (An _invalid_ DB type, a
   config/validation problem, is deliberately **not** tagged Unavailable — it returns directly as
   a plain error, unchanged from before this PR, so it still exits `1`, matching prior behavior.)
 

--- a/pkg/conduit/entrypoint.go
+++ b/pkg/conduit/entrypoint.go
@@ -21,12 +21,8 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/conduitio/conduit/pkg/conduit/exitcode"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
-)
-
-const (
-	exitCodeErr       = 1
-	exitCodeInterrupt = 2
 )
 
 // Entrypoint provides methods related to the Conduit entrypoint (parsing
@@ -67,7 +63,8 @@ func (e *Entrypoint) Serve(cfg Config) {
 // Invariant 7: SIGTERM drains in-flight records and checkpoints before exit.
 // * After the first signal the function will continue to listen
 // * On the second signal executes a hard exit, without waiting for a graceful
-// shutdown.
+// shutdown, reporting the POSIX 128+signum exit code for the signal that
+// triggered it (SIGINT -> 130, SIGTERM -> 143) — see hardExitCode.
 func (*Entrypoint) CancelOnInterrupt(ctx context.Context) context.Context {
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
@@ -94,8 +91,13 @@ func (*Entrypoint) CancelOnInterrupt(ctx context.Context) context.Context {
 //
 // The returned context is canceled when the first value is received on
 // sigChan. If a second value is received afterwards, exit is called with
-// exitCodeInterrupt, mirroring the hard-exit-on-second-signal behavior
-// documented on CancelOnInterrupt.
+// the POSIX 128+signum code for that second signal (see hardExitCode),
+// mirroring the hard-exit-on-second-signal behavior documented on
+// CancelOnInterrupt. This intentionally does not go through
+// pkg/conduit/exitcode.ExitCode: a forced double-signal kill is not a
+// classified error, and 128+signum is a distinct, well-known convention
+// (matching what a shell reports for a process killed by a signal) that a
+// script can tell apart from an ordinary exit-code bucket.
 //
 // The caller remains responsible for registering sigChan with signal.Notify
 // (and calling signal.Stop when done); this function only consumes the
@@ -110,16 +112,30 @@ func cancelOnSignal(ctx context.Context, sigChan <-chan os.Signal, exit func(int
 			return
 		}
 
-		<-sigChan // second interrupt signal
-		exit(exitCodeInterrupt)
+		sig := <-sigChan // second interrupt signal
+		exit(hardExitCode(sig))
 	}()
 
 	return ctx
 }
 
+// hardExitCode maps a second termination signal to the POSIX 128+signum exit
+// code convention (SIGINT -> 130, SIGTERM -> 143). CancelOnInterrupt only
+// ever registers os.Interrupt and syscall.SIGTERM, and os/signal always
+// delivers a syscall.Signal for those on every platform Conduit builds for,
+// so the fallback below is not expected to trigger in practice; it exists so
+// this function has no unhandled case.
+func hardExitCode(sig os.Signal) int {
+	s, ok := sig.(syscall.Signal)
+	if !ok {
+		return exitcode.Runtime
+	}
+	return 128 + int(s)
+}
+
 func (*Entrypoint) exitWithError(err error) {
 	_, _ = fmt.Fprintf(os.Stderr, "error: %+v\n", err)
-	os.Exit(exitCodeErr)
+	os.Exit(exitcode.ExitCode(err))
 }
 
 func (*Entrypoint) Splash() string {

--- a/pkg/conduit/entrypoint_test.go
+++ b/pkg/conduit/entrypoint_test.go
@@ -68,32 +68,50 @@ func TestEntrypoint_CancelOnSignal_FirstSignalCancelsContext(t *testing.T) {
 // covering the hard-exit-on-second-signal half of CancelOnInterrupt's
 // contract, which the previous, os.Exit-based test could never assert
 // (asserting it would have killed the test binary). By injecting a fake exit
-// func, we can verify the second signal actually triggers exitCodeInterrupt
-// without terminating anything.
+// func, we can verify the second signal triggers the hard-exit path with the
+// POSIX 128+signum exit code for that signal (SIGINT -> 130, SIGTERM -> 143)
+// without terminating anything. This code moved off exitCodeInterrupt (2) in
+// the deterministic-exit-codes change: 2 is now the config/validation bucket
+// (pkg/conduit/exitcode), so a double-signal hard exit needed a value that
+// can't collide with it — 128+signum both avoids the collision and matches
+// what a shell reports for a process killed by that signal.
 func TestEntrypoint_CancelOnSignal_SecondSignalExits(t *testing.T) {
-	is := is.New(t)
-
-	sigChan := make(chan os.Signal, 1)
-	exitCalled := make(chan int, 1)
-	exit := func(code int) { exitCalled <- code }
-
-	ctx := cancelOnSignal(context.Background(), sigChan, exit)
-
-	sigChan <- syscall.SIGTERM
-
-	select {
-	case <-ctx.Done():
-	case <-time.After(5 * time.Second):
-		t.Fatal("first signal did not cancel the context")
+	tests := []struct {
+		name string
+		sig  syscall.Signal
+		want int
+	}{
+		{name: "SIGTERM", sig: syscall.SIGTERM, want: 143},
+		{name: "SIGINT", sig: syscall.SIGINT, want: 130},
 	}
 
-	sigChan <- syscall.SIGTERM
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			is := is.New(t)
 
-	select {
-	case code := <-exitCalled:
-		is.Equal(code, exitCodeInterrupt)
-	case <-time.After(5 * time.Second):
-		t.Fatal("second signal did not trigger the hard-exit path")
+			sigChan := make(chan os.Signal, 1)
+			exitCalled := make(chan int, 1)
+			exit := func(code int) { exitCalled <- code }
+
+			ctx := cancelOnSignal(context.Background(), sigChan, exit)
+
+			sigChan <- syscall.SIGTERM // first signal: value doesn't affect the exit code
+
+			select {
+			case <-ctx.Done():
+			case <-time.After(5 * time.Second):
+				t.Fatal("first signal did not cancel the context")
+			}
+
+			sigChan <- tt.sig
+
+			select {
+			case code := <-exitCalled:
+				is.Equal(code, tt.want)
+			case <-time.After(5 * time.Second):
+				t.Fatal("second signal did not trigger the hard-exit path")
+			}
+		})
 	}
 }
 

--- a/pkg/conduit/exitcode/exitcode.go
+++ b/pkg/conduit/exitcode/exitcode.go
@@ -1,0 +1,162 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package exitcode computes Conduit's deterministic CLI process exit code
+// from an error. It is the single source of truth for the mapping documented
+// in the README and in docs/architecture-decision-records — every place that
+// calls os.Exit for a command or the `run` entrypoint goes through ExitCode,
+// so a one-shot command (`cmd/conduit/cli`) and the long-running server
+// (`pkg/conduit/entrypoint.go`) can never silently drift onto different exit
+// conventions.
+//
+// # Exit code buckets
+//
+//   - 0 (OK) — success, or the run was canceled deliberately (context.Canceled,
+//     the graceful-shutdown path on a single SIGINT/SIGTERM).
+//   - 1 (Runtime) — an internal or unclassified error: a bug, an unexpected
+//     panic-adjacent failure, or any error this package has no more specific
+//     classification for. This is also the fallback for a signal that
+//     doesn't fit the syscall.Signal-based hard-exit convention (should not
+//     happen in practice).
+//   - 2 (Validation) — the request or config was rejected: invalid argument,
+//     not found, already exists, failed precondition, out of range. The fix
+//     is on the caller's side (bad input), not the environment.
+//   - 3 (Environment) — Conduit could not reach something it depends on:
+//     the server is unreachable, a listen address is already bound, the
+//     database can't be dialed, or the call was rate-limited/unauthenticated/
+//     timed out. The fix is "check the environment", not "fix your request".
+//
+// A hard exit on a second termination signal (see entrypoint.go) is a
+// special case outside this bucketing: it reports the POSIX 128+signum
+// convention (SIGINT -> 130, SIGTERM -> 143) instead, so scripts can tell a
+// forced kill from an ordinary classified error.
+//
+// # Classification order
+//
+// ExitCode tries, in order: nil or context.Canceled (0); a *conduiterr.ConduitError
+// anywhere in err's chain, classified by its registered gRPC category; a raw
+// gRPC client error (google.golang.org/grpc/status), classified the same way —
+// this covers server-side ConduitErrors that reach a CLI-via-client command as
+// a plain status error, since the client never decodes the ErrorInfo detail
+// back into a ConduitError today; a narrow set of OS/network-level sentinel
+// errors that indicate an environment problem even when nothing wrapped them;
+// and finally Runtime (1) as the catch-all.
+//
+// # Coverage is intentionally partial today
+//
+// Only the highest-value environment call sites are tagged with
+// conduiterr.CodeUnavailable so far (CLI-to-server health check, listen
+// address already in use, database unreachable at startup) — see the ADR for
+// the rationale. Everywhere else, an untagged error still classifies as
+// Runtime (1), which matches today's actual behavior (every entrypoint
+// failure exits 1) and is not a regression; coverage grows as more
+// boundaries adopt conduiterr, without changing this package's contract.
+package exitcode
+
+import (
+	"context"
+	"syscall"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+)
+
+// Process exit codes. See the package doc for the meaning of each bucket.
+const (
+	// OK is returned for success and for a deliberately canceled run.
+	OK = 0
+	// Runtime is returned for internal/unclassified errors, and is the
+	// catch-all when no more specific classification applies.
+	Runtime = 1
+	// Validation is returned when the request or config was rejected.
+	Validation = 2
+	// Environment is returned when a required external dependency could not
+	// be reached.
+	Environment = 3
+)
+
+// ExitCode classifies err into one of the process exit code buckets
+// documented on the package. It is the single classifier shared by one-shot
+// CLI commands (cmd/conduit/cli) and the `run` entrypoint
+// (pkg/conduit/entrypoint.go), so the two surfaces cannot drift onto
+// different conventions for the same underlying error.
+//
+// ExitCode never panics: every branch has a total fallback, ending in
+// Runtime for anything it cannot classify more specifically.
+func ExitCode(err error) int {
+	if err == nil || cerrors.Is(err, context.Canceled) {
+		return OK
+	}
+
+	if ce, ok := conduiterr.Get(err); ok {
+		return fromGRPCCode(ce.Code.GRPCCode())
+	}
+
+	// A ConduitError raised by the server crosses the gRPC boundary as a
+	// plain status error on the client: the top-level gRPC code is set
+	// explicitly from the registry (conduiterr.ToStatus), but the client
+	// stubs don't decode the ErrorInfo detail back into a *ConduitError
+	// today (no call site does `conduiterr.FromStatus` yet). status.FromError
+	// only reports ok=true for an error that actually carries a gRPC status
+	// (nil, or implements the GRPCStatus() interface); a plain Go error
+	// correctly falls through to the sentinel check below instead of being
+	// misclassified as codes.Unknown.
+	if st, ok := grpcstatus.FromError(err); ok {
+		return fromGRPCCode(st.Code())
+	}
+
+	if isEnvironmentSentinel(err) {
+		return Environment
+	}
+
+	return Runtime
+}
+
+// fromGRPCCode maps a gRPC status category to an exit code bucket. The
+// mapping is total: every codes.Code value (including any the switch doesn't
+// name explicitly, and codes.OK) falls through to a defined bucket, matching
+// TestExitCode_CoversEveryRegisteredCode's assumption that every registered
+// conduiterr.Code lands in exactly one of {1, 2, 3}.
+func fromGRPCCode(c codes.Code) int {
+	switch c {
+	case codes.OK, codes.Canceled:
+		return OK
+	case codes.InvalidArgument, codes.NotFound, codes.AlreadyExists,
+		codes.FailedPrecondition, codes.OutOfRange:
+		return Validation
+	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted,
+		codes.Unauthenticated, codes.PermissionDenied:
+		return Environment
+	case codes.Internal, codes.Unknown, codes.DataLoss, codes.Aborted, codes.Unimplemented:
+		return Runtime
+	default:
+		return Runtime
+	}
+}
+
+// isEnvironmentSentinel reports whether err carries one of a narrow set of
+// OS-level connection sentinels that indicate an environment problem even
+// when it reaches ExitCode unwrapped by a ConduitError or a gRPC status —
+// e.g. a lower-level dependency (not yet migrated to conduiterr tagging)
+// that returns a raw *net.OpError. This is deliberately narrow: it is a
+// safety net for the same high-value cases the tagged call sites cover
+// (server/database unreachable, listen address already bound), not a
+// general network-error classifier — a broader net (e.g. matching on
+// *net.OpError alone) risks misclassifying an unrelated connector-plugin
+// network error as an environment failure for the whole process.
+func isEnvironmentSentinel(err error) bool {
+	return cerrors.Is(err, syscall.ECONNREFUSED) || cerrors.Is(err, syscall.EADDRINUSE)
+}

--- a/pkg/conduit/exitcode/exitcode.go
+++ b/pkg/conduit/exitcode/exitcode.go
@@ -128,7 +128,7 @@ func ExitCode(err error) int {
 // fromGRPCCode maps a gRPC status category to an exit code bucket. The
 // mapping is total: every codes.Code value (including any the switch doesn't
 // name explicitly, and codes.OK) falls through to a defined bucket, matching
-// TestExitCode_CoversEveryRegisteredCode's assumption that every registered
+// TestExitCode_RegistryCompleteness's assumption that every registered
 // conduiterr.Code lands in exactly one of {1, 2, 3}.
 func fromGRPCCode(c codes.Code) int {
 	switch c {

--- a/pkg/conduit/exitcode/exitcode_test.go
+++ b/pkg/conduit/exitcode/exitcode_test.go
@@ -1,0 +1,176 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exitcode_test
+
+import (
+	"context"
+	"syscall"
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/conduit/exitcode"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+
+	// Blank-imported so their init-time conduiterr.Register calls populate
+	// the registry that TestExitCode_RegistryCompleteness iterates. Without
+	// these, conduiterr.Codes() would only see the codes conduiterr itself
+	// registers (the foundational ones plus CodeUnavailable), since Go only
+	// runs a package's init on packages actually reachable from this test
+	// binary's import graph.
+	_ "github.com/conduitio/conduit/pkg/connector"
+	_ "github.com/conduitio/conduit/pkg/orchestrator"
+	_ "github.com/conduitio/conduit/pkg/pipeline"
+	_ "github.com/conduitio/conduit/pkg/processor"
+	_ "github.com/conduitio/conduit/pkg/provisioning/config"
+
+	"github.com/matryer/is"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+)
+
+// testCodes registers one conduiterr.Code per gRPC category this package
+// classifies, independent of whatever happens to be registered by
+// production packages at the time this test runs. This keeps
+// TestExitCode_ByGRPCCategory a pure test of the classifier's category ->
+// bucket mapping, not coupled to which production reason happens to use
+// which category today.
+//
+// codes.Canceled is deliberately not registered here: no real boundary would
+// ever register a domain error code in the Canceled category (a "canceled"
+// ConduitError is a contradiction — Canceled means the operation was
+// deliberately aborted, not that something went wrong), and registering one
+// here would pollute TestExitCode_RegistryCompleteness, whose whole point is
+// that every *registered* code is definitionally an error and must never
+// classify as OK. Canceled is still fully covered below via the raw-status
+// path, which is how it actually reaches ExitCode in practice.
+var testCodes = map[codes.Code]conduiterr.Code{
+	codes.Unknown:            conduiterr.Register("test.exitcode.unknown", codes.Unknown),
+	codes.InvalidArgument:    conduiterr.Register("test.exitcode.invalid_argument", codes.InvalidArgument),
+	codes.DeadlineExceeded:   conduiterr.Register("test.exitcode.deadline_exceeded", codes.DeadlineExceeded),
+	codes.NotFound:           conduiterr.Register("test.exitcode.not_found", codes.NotFound),
+	codes.AlreadyExists:      conduiterr.Register("test.exitcode.already_exists", codes.AlreadyExists),
+	codes.PermissionDenied:   conduiterr.Register("test.exitcode.permission_denied", codes.PermissionDenied),
+	codes.ResourceExhausted:  conduiterr.Register("test.exitcode.resource_exhausted", codes.ResourceExhausted),
+	codes.FailedPrecondition: conduiterr.Register("test.exitcode.failed_precondition", codes.FailedPrecondition),
+	codes.Aborted:            conduiterr.Register("test.exitcode.aborted", codes.Aborted),
+	codes.OutOfRange:         conduiterr.Register("test.exitcode.out_of_range", codes.OutOfRange),
+	codes.Unimplemented:      conduiterr.Register("test.exitcode.unimplemented", codes.Unimplemented),
+	codes.Internal:           conduiterr.Register("test.exitcode.internal", codes.Internal),
+	codes.Unavailable:        conduiterr.Register("test.exitcode.unavailable", codes.Unavailable),
+	codes.DataLoss:           conduiterr.Register("test.exitcode.data_loss", codes.DataLoss),
+	codes.Unauthenticated:    conduiterr.Register("test.exitcode.unauthenticated", codes.Unauthenticated),
+}
+
+func TestExitCode_NilAndCanceled(t *testing.T) {
+	is := is.New(t)
+
+	is.Equal(exitcode.ExitCode(nil), exitcode.OK)
+	is.Equal(exitcode.ExitCode(context.Canceled), exitcode.OK)
+	// Canceled must still resolve to OK when wrapped, since that's how it
+	// reaches ExitCode in practice (entrypoint.go wraps the tomb's error).
+	is.Equal(exitcode.ExitCode(cerrors.Errorf("run: %w", context.Canceled)), exitcode.OK)
+}
+
+func TestExitCode_PlainError(t *testing.T) {
+	is := is.New(t)
+	is.Equal(exitcode.ExitCode(cerrors.New("boom")), exitcode.Runtime)
+}
+
+// TestExitCode_ByGRPCCategory is the per-bucket table test required by the
+// exit-code design: every gRPC category the classifier knows about, both as
+// a *conduiterr.ConduitError and as a raw gRPC client error (the shape a
+// server-raised ConduitError actually takes once it crosses the wire, since
+// no client call site decodes the ErrorInfo detail back into a ConduitError
+// today).
+func TestExitCode_ByGRPCCategory(t *testing.T) {
+	tests := []struct {
+		code codes.Code
+		want int
+	}{
+		{codes.Canceled, exitcode.OK},
+		{codes.InvalidArgument, exitcode.Validation},
+		{codes.NotFound, exitcode.Validation},
+		{codes.AlreadyExists, exitcode.Validation},
+		{codes.FailedPrecondition, exitcode.Validation},
+		{codes.OutOfRange, exitcode.Validation},
+		{codes.Internal, exitcode.Runtime},
+		{codes.Unknown, exitcode.Runtime},
+		{codes.DataLoss, exitcode.Runtime},
+		{codes.Aborted, exitcode.Runtime},
+		{codes.Unimplemented, exitcode.Runtime},
+		{codes.Unavailable, exitcode.Environment},
+		{codes.DeadlineExceeded, exitcode.Environment},
+		{codes.ResourceExhausted, exitcode.Environment},
+		{codes.Unauthenticated, exitcode.Environment},
+		{codes.PermissionDenied, exitcode.Environment},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.code.String(), func(t *testing.T) {
+			is := is.New(t)
+
+			// codes.Canceled has no registered conduiterr.Code (see testCodes'
+			// doc); exercise it only via the raw-status path below.
+			if tt.code != codes.Canceled {
+				ce := conduiterr.New(testCodes[tt.code], "test error")
+				is.Equal(exitcode.ExitCode(ce), tt.want)
+
+				// A ConduitError surviving several layers of ordinary wrapping
+				// (cerrors.Errorf %w, as every real boundary in this codebase
+				// does) must still classify the same way.
+				wrapped := cerrors.Errorf("outer: %w", cerrors.Errorf("inner: %w", ce))
+				is.Equal(exitcode.ExitCode(wrapped), tt.want)
+			}
+
+			// The raw gRPC client-error shape: no ConduitError anywhere in
+			// the chain, only the top-level status code (what a CLI command
+			// actually receives back from a grpc.ClientConn call today).
+			rawStatus := grpcstatus.New(tt.code, "test error").Err()
+			is.Equal(exitcode.ExitCode(rawStatus), tt.want)
+		})
+	}
+}
+
+// TestExitCode_RegistryCompleteness guards every registered conduiterr.Code
+// against ever being un-classifiable: whatever gRPC category a boundary
+// registers a new code with, ExitCode must resolve it to exactly one of
+// {Runtime, Validation, Environment} (never OK — a registered code is
+// definitionally an error, so it must never silently exit 0).
+func TestExitCode_RegistryCompleteness(t *testing.T) {
+	is := is.New(t)
+
+	valid := map[int]bool{exitcode.Runtime: true, exitcode.Validation: true, exitcode.Environment: true}
+
+	codesList := conduiterr.Codes()
+	is.True(len(codesList) > 0) // sanity: the registry isn't empty in this test binary
+
+	for _, c := range codesList {
+		got := exitcode.ExitCode(conduiterr.New(c, "test error"))
+		if !valid[got] {
+			t.Errorf("registered code %q (gRPC %s) maps to exit code %d, want one of {%d,%d,%d}",
+				c.Reason(), c.GRPCCode(), got, exitcode.Runtime, exitcode.Validation, exitcode.Environment)
+		}
+	}
+}
+
+func TestExitCode_EnvironmentSentinel(t *testing.T) {
+	is := is.New(t)
+
+	is.Equal(exitcode.ExitCode(syscall.ECONNREFUSED), exitcode.Environment)
+	is.Equal(exitcode.ExitCode(syscall.EADDRINUSE), exitcode.Environment)
+	// Still classifies correctly wrapped, the same way a real dial/listen
+	// failure reaches ExitCode after cerrors.Errorf %w context.
+	is.Equal(exitcode.ExitCode(cerrors.Errorf("dial: %w", syscall.ECONNREFUSED)), exitcode.Environment)
+}

--- a/pkg/conduit/exitcode/exitcode_test.go
+++ b/pkg/conduit/exitcode/exitcode_test.go
@@ -139,6 +139,12 @@ func TestExitCode_ByGRPCCategory(t *testing.T) {
 			// actually receives back from a grpc.ClientConn call today).
 			rawStatus := grpcstatus.New(tt.code, "test error").Err()
 			is.Equal(exitcode.ExitCode(rawStatus), tt.want)
+
+			// The same status %w-wrapped — the shape a CLI command's error
+			// actually takes after passing back up through cerrors.Errorf
+			// layers. ExitCode must still unwrap to the gRPC category.
+			wrapped := cerrors.Errorf("call failed: %w", rawStatus)
+			is.Equal(exitcode.ExitCode(wrapped), tt.want)
 		})
 	}
 }

--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -146,7 +146,8 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 			db, err = sqlite.New(context.Background(), logger.Logger, cfg.DB.SQLite.Path, cfg.DB.SQLite.Table)
 		default:
 			// An unsupported DB type is a config/validation problem, not an
-			// environment one — return it directly instead of falling into
+			// environment one. It stays exit 1 (the runtime default for an
+			// untagged error) by design — return it directly instead of falling into
 			// the Unavailable tagging below, which is reserved for a
 			// genuinely unreachable database (connection refused, file
 			// locked/inaccessible, etc.) for the configured, valid type.

--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -39,6 +39,7 @@ import (
 	conduitschemaregistry "github.com/conduitio/conduit-schema-registry"
 	"github.com/conduitio/conduit/pkg/connector"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/ctxutil"
 	"github.com/conduitio/conduit/pkg/foundation/grpcutil"
 	"github.com/conduitio/conduit/pkg/foundation/log"
@@ -144,10 +145,23 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 		case DBTypeSQLite:
 			db, err = sqlite.New(context.Background(), logger.Logger, cfg.DB.SQLite.Path, cfg.DB.SQLite.Table)
 		default:
-			err = cerrors.Errorf("invalid DB type %q", cfg.DB.Type)
+			// An unsupported DB type is a config/validation problem, not an
+			// environment one — return it directly instead of falling into
+			// the Unavailable tagging below, which is reserved for a
+			// genuinely unreachable database (connection refused, file
+			// locked/inaccessible, etc.) for the configured, valid type.
+			return nil, cerrors.Errorf("invalid DB type %q", cfg.DB.Type)
 		}
 		if err != nil {
-			return nil, cerrors.Errorf("failed to create a DB instance: %w", err)
+			// Pass the wrapped error (not the raw err) as Wrap's cause so the
+			// stack frame cerrors.Errorf captures here isn't discarded:
+			// conduiterr.Wrap only synthesizes a frame of its own when cause
+			// is nil, and the raw driver error typically carries none.
+			wrapped := cerrors.Errorf("failed to create a DB instance: %w", err)
+			// Tagged Unavailable: the database Conduit depends on could not
+			// be opened/dialed. pkg/conduit/exitcode maps this to exit code
+			// 3 (environment), distinct from a config/validation failure.
+			return nil, conduiterr.Wrap(conduiterr.CodeUnavailable, wrapped.Error(), wrapped)
 		}
 	}
 
@@ -780,7 +794,13 @@ func (r *Runtime) serveGRPC(
 	var lc net.ListenConfig
 	ln, err := lc.Listen(ctx, "tcp", address)
 	if err != nil {
-		return nil, cerrors.Errorf("failed to listen on address %q: %w", address, err)
+		// See the comment on the equivalent DB-creation-failure branch above:
+		// wrap first, then pass the wrapped error as the cause, so the
+		// captured stack frame isn't discarded.
+		wrapped := cerrors.Errorf("failed to listen on address %q: %w", address, err)
+		// Tagged Unavailable (e.g. the address is already bound by another
+		// process): pkg/conduit/exitcode maps this to exit code 3.
+		return nil, conduiterr.Wrap(conduiterr.CodeUnavailable, wrapped.Error(), wrapped)
 	}
 
 	t.Go(func() error {
@@ -815,7 +835,11 @@ func (r *Runtime) serveHTTP(
 	var lc net.ListenConfig
 	ln, err := lc.Listen(ctx, "tcp", srv.Addr)
 	if err != nil {
-		return nil, cerrors.Errorf("failed to listen on address %q: %w", r.Config.API.HTTP.Address, err)
+		// Wrap-then-pass-the-wrapped-error, same reasoning as serveGRPC above
+		// (keeps the captured stack frame instead of discarding it).
+		wrapped := cerrors.Errorf("failed to listen on address %q: %w", r.Config.API.HTTP.Address, err)
+		// Tagged Unavailable, same reasoning as serveGRPC above.
+		return nil, conduiterr.Wrap(conduiterr.CodeUnavailable, wrapped.Error(), wrapped)
 	}
 
 	t.Go(func() error {

--- a/pkg/foundation/cerrors/conduiterr/environment.go
+++ b/pkg/foundation/cerrors/conduiterr/environment.go
@@ -1,0 +1,38 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conduiterr
+
+import "google.golang.org/grpc/codes"
+
+// This file is additive only (a new file — no edits to conduiterr's existing
+// code) by design: a parallel change is touching this package's codes and
+// status.go, so a shared registration point needs to avoid colliding with it
+// and expect to rebase. See pkg/conduit/exitcode's package doc and the
+// deterministic exit-code ADR (docs/architecture-decision-records) for the
+// full rationale.
+
+// CodeUnavailable is raised when Conduit itself cannot reach a required
+// external dependency it needs to start or operate: the CLI can't reach a
+// running server, the configured database can't be opened/dialed, or a
+// listen address is already bound. It is deliberately generic (unlike the
+// per-domain codes elsewhere in the registry) because these are
+// environment-of-execution failures, not domain business errors — the
+// caller's remediation is "check the environment", not "fix a config field".
+//
+// It maps to the gRPC Unavailable category, which pkg/conduit/exitcode's
+// classifier treats as an environment failure (process exit code 3),
+// distinct from validation errors (exit 2) and internal/runtime errors
+// (exit 1).
+var CodeUnavailable = Register("common.unavailable", codes.Unavailable)


### PR DESCRIPTION
## Summary

Implements Phase 1 execution plan §1.1's "documented deterministic exit codes (0 ok · 1 runtime ·
2 config/validation · 3 environment)" acceptance criterion.

- New package `pkg/conduit/exitcode` — a single `ExitCode(err error) int` classifier imported by
  both `cmd/conduit/cli` (one-shot commands) and `pkg/conduit/entrypoint.go` (`run`), so the two
  surfaces cannot drift onto different exit conventions for the same kind of error.
- Classification order: nil/`context.Canceled` → 0; a `*conduiterr.ConduitError` anywhere in the
  chain → its registered gRPC category; a raw gRPC client-error status (covers server-raised
  `ConduitError`s that reach a CLI command undecoded — no call site decodes the `ErrorInfo` detail
  back into a `ConduitError` today) → the same category mapping; a narrow
  `ECONNREFUSED`/`EADDRINUSE` sentinel → environment; else runtime.
- gRPC category → bucket: `InvalidArgument/NotFound/AlreadyExists/FailedPrecondition/OutOfRange` →
  **2**; `Internal/Unknown/DataLoss/Aborted/Unimplemented` → **1**;
  `Unavailable/DeadlineExceeded/ResourceExhausted/Unauthenticated/PermissionDenied` → **3**;
  `Canceled` → **0**.
- Tags the three highest-value environment call sites with a new `conduiterr.CodeUnavailable`
  (added additively in a new file, `conduiterr/environment.go` — a parallel PR is migrating
  `conduiterr`'s existing codes/`status.go`, so this stays out of its way and expects to rebase):
  - `cmd/conduit/api/client.go` `CheckHealth` (server unreachable from a one-shot command)
  - `pkg/conduit/runtime.go` `serveGRPC`/`serveHTTP` (listen address already bound)
  - `pkg/conduit/runtime.go` `NewRuntime` (database unreachable at startup — the *invalid DB
    type* validation error is deliberately **not** tagged Unavailable, and still exits 1 unchanged)
  - Everywhere else, an untagged error still classifies as runtime (1) — the same as every
    `conduit run` failure exited before this change. Coverage grows later; this is not a
    regression.

**Breaking change:** `conduit run`'s hard exit on a **second** termination signal moves off exit
code `2` (now the validation bucket) onto the POSIX `128+signum` convention (`SIGINT` → `130`,
`SIGTERM` → `143`), matching what a shell reports for a process killed by that signal. Documented
in the ADR and README; a script checking for exit code `2` on a forced Conduit kill needs to
update to `130`/`143`.

## Docs

- README "Exit codes" section (mapping table + the signal breaking change).
- ADR: `docs/architecture-decision-records/20260706-deterministic-cli-exit-codes.md`.

## Failure-mode / breaking-change analysis

- **What could this break:** any script/supervisor keying off `conduit run`'s old exit code `2`
  for a forced double-signal kill will see `130`/`143` instead. Nothing else in the existing exit
  surface changes — every path that exited `0` or `1` before still does, since coverage of the
  new `2`/`3` buckets is purely additive (only newly-tagged/newly-classified errors move off the
  old default).
- **Which signal would show it:** a supervisor/CI job asserting on Conduit's forced-kill exit code
  would start failing its own assertion, not silently misbehave — visible immediately, not a
  silent data-integrity issue (this PR touches no data path).
- **Rollback:** revert the PR; `pkg/conduit/exitcode` and the new `conduiterr.CodeUnavailable` are
  additive and isolated, so reverting is a clean, single-commit revert.

## Adversarial self-review

Found and fixed one real bug before opening this PR: the first draft of all four
`conduiterr.Wrap` call sites (`client.go` + 3× `runtime.go`) built the error message via
`cerrors.Errorf(...).Error()` — which captures a stack frame — but then discarded that
frame-carrying error and passed the **raw**, frame-less `err` as `Wrap`'s `cause` argument.
`conduiterr.Wrap` only synthesizes a frame of its own when `cause == nil`, so a non-nil,
frame-less cause (e.g. a real gRPC transport error, which unlike a `cerrors`-constructed error
carries no frame) silently produced a traceless `ConduitError`. Fixed at all four sites by passing
the wrapped (frame-carrying) error as the cause instead of the raw one. Covered by
`TestClient_CheckHealth_Unreachable`, which I verified fails on the buggy pattern (reverted
locally, confirmed the `len(frames) > 0` assertion fails, then restored the fix) and passes with
it.

Also checked: import graph (no cycle — `exitcode` only imports `cerrors`/`conduiterr`, both
leaves); concurrency in `cancelOnSignal` (no new goroutines, same channel/select shape as before,
race-detector clean); the `default:` case in `NewRuntime`'s DB-type switch is deliberately
**not** tagged Unavailable (it's a config error, not an environment one) so it doesn't get
misclassified as exit 3.

## Test plan

- [x] `TestExitCode_ByGRPCCategory` — every gRPC category, both as a constructed `*ConduitError`
      and as a raw `status.New(code, …).Err()`, including through several layers of ordinary
      `cerrors.Errorf %w` wrapping.
- [x] `TestExitCode_RegistryCompleteness` — iterates `conduiterr.Codes()` (widened via blank
      imports of `pipeline`/`connector`/`processor`/`orchestrator`/`provisioning/config` so their
      registered codes are actually in scope), asserts every one maps to exactly one of `{1,2,3}`.
- [x] `TestExitCode_EnvironmentSentinel`, `TestExitCode_NilAndCanceled`, `TestExitCode_PlainError`.
- [x] `TestEntrypoint_CancelOnSignal_SecondSignalExits` updated to a table test over
      SIGINT→130/SIGTERM→143 (previously asserted the old `exitCodeInterrupt`=2).
- [x] `TestClient_CheckHealth_Unreachable`/`_Serving` — new, covers the `CodeUnavailable` tagging
      and the stack-trace regression above.
- [x] Live end-to-end check against a built binary (not part of the automated suite, done during
      review): a second `conduit run` on an already-bound port exits 3; a one-shot command against
      no running server exits 3; `pipelines describe <missing-id>` against a live server exits 2.
- [x] `go build ./...`, `go vet ./...`, `go test ./... -race -count=1` (repo-wide), and
      `golangci-lint run ./...` all clean.

Roadmap: Phase 1 execution plan §1.1 (`docs/design-documents/20260704-phase-1-execution-plan.md`).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01Tapg9dLWXKMZJoL65R24vd