### PR TITLE
docs: v0.17 first-wave design set (validate, doctor, scaffolding, Python SDK)

### DIFF
--- a/docs/architecture-decision-records/20260707-check-engine-shared-by-doctor-and-scaffold.md
+++ b/docs/architecture-decision-records/20260707-check-engine-shared-by-doctor-and-scaffold.md
@@ -23,7 +23,7 @@ written:
   are Go on PATH + min version, `GOPATH/bin` writable, git, docker. **None overlap
   with doctor's set.**
 
-The two check *sets* are disjoint by design. What is genuinely shareable is the
+The two check _sets_ are disjoint by design. What is genuinely shareable is the
 mechanism: the result type, the interface, the `recover()`-wrapped runner, the
 human/JSON rendering, and the exit-code aggregation. Leaving this as "reconcile at
 implementation" (both docs' hedge) would produce exactly the two-parallel-`doctor`-

--- a/docs/architecture-decision-records/20260707-check-engine-shared-by-doctor-and-scaffold.md
+++ b/docs/architecture-decision-records/20260707-check-engine-shared-by-doctor-and-scaffold.md
@@ -1,0 +1,79 @@
+# Shared check engine for `doctor` and scaffolding preflight
+
+## Summary
+
+`conduit doctor` and the `connector|processor new` toolchain preflight both run a
+set of pass/warn/fail diagnostics. They will share the check **engine and types**,
+not their concrete checks. A neutral `pkg/conduit/check` package owns the `Check`
+interface, `CheckResult`, the panic-isolating runner, and a few generic check
+constructors; `doctor` and `scaffold` each supply their own check sets.
+
+## Context
+
+The v0.17 design docs for `doctor` and scaffolding both claimed the scaffold
+preflight would "consume `pkg/conduit/doctor`'s toolchain checks as a subset." The
+technical review proved that relationship does not exist and is incoherent as
+written:
+
+- `doctor`'s job is "would `conduit run` succeed here?" → its checks are
+  config-resolve/validate, store reachability, API address bind, plugin-dir scan,
+  builtin registry, engine reachability. **None are toolchain checks** — Conduit
+  itself never needs Go/git/docker installed to run.
+- The scaffold preflight's job is "can I build a new connector here?" → its checks
+  are Go on PATH + min version, `GOPATH/bin` writable, git, docker. **None overlap
+  with doctor's set.**
+
+The two check *sets* are disjoint by design. What is genuinely shareable is the
+mechanism: the result type, the interface, the `recover()`-wrapped runner, the
+human/JSON rendering, and the exit-code aggregation. Leaving this as "reconcile at
+implementation" (both docs' hedge) would produce exactly the two-parallel-`doctor`-
+implementations risk both docs claimed to avoid.
+
+## Decision
+
+1. A neutral package **`pkg/conduit/check`** owns the shared mechanism:
+   - `Check` interface, `CheckResult` (fields per the CLI output conventions:
+     `Name, Status, Message, Suggestion, Code, ConfigPath, Category`), `Status`
+     (`pass|warn|fail`).
+   - `Run(ctx, checks []Check) Report` with **per-check `recover()`** so a
+     panicking check becomes a `fail` (`internal.error`), never a process crash.
+   - `Report.ExitCode()` — aggregates N results to one exit code by synthesizing a
+     `*conduiterr.ConduitError` per failing result and taking the **max** bucket via
+     `exitcode.ExitCode` (environment 3 > validation 2 > runtime 1). This is new
+     aggregation logic, owned here, not free reuse of the single-error classifier.
+   - Generic, reusable check constructors that any caller can compose, e.g.
+     `BinaryOnPath(name, minVersion)`, `DirWritable(path, configKey)`,
+     `AddrBindable(addr, configKey)`.
+   - The render/JSON helpers (via the shared `internal/ui` + the `--json` envelope).
+2. **`doctor`** (`cmd/conduit/root/doctor` + its check set) imports `check` and
+   supplies its runtime checks (config/store/network/plugins/engine).
+3. **Scaffolding** (`pkg/scaffold`) imports `check` and supplies its toolchain
+   checks (Go/git/docker), reusing `BinaryOnPath`/`DirWritable`.
+4. A future **MCP `doctor` tool** wraps `doctor`'s check set via the same engine
+   (the §2/§3 1:1 requirement).
+
+### Sequencing
+
+`pkg/conduit/check` ships **first** (it is a small, dependency-free package). Then
+`doctor` and scaffolding are both consumers and can be built **in parallel** — no
+"which command ships first" dependency remains, because neither depends on the
+other, only on `check`.
+
+## Consequences
+
+- No duplicated runner/result/exit-code logic; one panic-isolation guarantee; one
+  exit-code aggregation.
+- `go-plugin`-dispensing checks (doctor's `--deep` standalone-compat) can panic in
+  the library's own background goroutines, which a caller `recover()` cannot catch.
+  The runner documents this limit; such checks run with a subprocess timeout and
+  are opt-in, and the runner treats an abnormal child exit as a `fail` rather than
+  relying solely on `recover()`.
+- The `check` package must not import cobra/ecdysis or call `os.Exit` (so MCP and
+  tests reuse it) — same discipline as `pkg/conduit/doctor` originally specified.
+
+## Related
+
+- `20260707-cli-doctor.md`, `20260707-connector-processor-scaffolding.md`
+  (the consumers).
+- `20260707-cli-output-conventions.md` (the result shape + exit-code rule).
+- `pkg/conduit/exitcode`, `pkg/foundation/cerrors/conduiterr`.

--- a/docs/design-documents/20260707-cli-doctor.md
+++ b/docs/design-documents/20260707-cli-doctor.md
@@ -51,7 +51,7 @@ shared classifier, not a re-decision.
 
 ## CLI UX & ergonomics
 
-```
+```text
 $ conduit doctor
 Conduit doctor — checking your environment
 
@@ -142,6 +142,7 @@ one §1.1 result model. Factor `openStore` so a future `NewRuntime` could even r
 ## Review outcome (2026-07-07) — SOUND-WITH-CONCERNS
 
 Must-fix during implementation:
+
 - **`Report.ExitCode()` (N results → 1 exit code) is NEW aggregation, not free reuse**
   — take the MAX bucket, not the first. Now owned by the shared `pkg/conduit/check`
   engine (see ADR `20260707-check-engine-shared-by-doctor-and-scaffold.md`).

--- a/docs/design-documents/20260707-cli-doctor.md
+++ b/docs/design-documents/20260707-cli-doctor.md
@@ -1,0 +1,156 @@
+# CLI: `conduit doctor` — preflight diagnostics
+
+## Summary
+
+A pre-flight, works-offline diagnostic answering "is this machine/config/toolchain
+set up so `conduit run` would succeed?" — distinct from the runtime
+`/readyz`+`/healthz` (which answer "is the running engine serving?",
+`pkg/conduit/readyz.go`). It does NOT boot a Runtime; it factors out the exact
+primitives `NewRuntime` uses (config validate, DB open+ping, address bind, plugin
+scan) and runs each as an isolated, non-fatal probe. Tier 2 (low–medium risk).
+
+## Decision — a reusable check engine (CLI + MCP share it)
+
+Introduce a check engine in a neutral package that both the CLI command and a
+future MCP `doctor` tool (§3: "rename MCP `diagnose` → `doctor`") import 1:1. The
+CLI is a thin renderer over `[]CheckResult`; MCP wraps the identical results.
+
+- `pkg/conduit/doctor/` (new) — no CLI/ecdysis imports, no `os.Exit`:
+  `Check` interface, `CheckResult`, `Status`, `Run(ctx,cfg,opts) Report`, the
+  concrete checks (`DefaultChecks(cfg) []Check`), and `Report.ExitCode()`.
+- `cmd/conduit/root/doctor/doctor.go` — ecdysis command; wired into `root.go`.
+
+```go
+type CheckResult struct { // fields map 1:1 onto conduiterr.ConduitError (§1.1)
+    Name, Message string
+    Status        Status // pass | warn | fail
+    Suggestion, Code, ConfigPath, Category string
+}
+type Check interface { Name() string; Run(ctx, cfg conduit.Config) CheckResult }
+```
+
+`Run` wraps each check in `recover()` → a panicking/erroring check becomes a `fail`
+(`code: internal.error`), never a crash.
+
+## The checks (each reuses existing machinery — no boot duplication)
+
+| Check | Reuses | pass / warn / fail | Exit bucket |
+| --- | --- | --- | --- |
+| `config.resolve` | ecdysis `ParseConfig` | found+parsed / defaults-used / unparseable | 2 on fail |
+| `config.validate` | `Config.Validate()` (`config.go:286`, same call `NewRuntime` makes) | valid / — / bad field (`configPath`) | 2 |
+| `store.reachable` | DB-open switch (`runtime.go:132-167`) + `DB.Ping` → close | open+ping / inmemory (warn) / cannot open | **3** (env) |
+| `network.grpc/http` | `net.ListenConfig.Listen` (`runtime.go:795,836`) → close | free / disabled / EADDRINUSE | **3** |
+| `plugins.connectors/processors_dir` | `os.ReadDir` scan (`standalone/registry.go:96`) | readable / missing (warn) / is-a-file | — |
+| `plugins.standalone_compat` (`--deep`) | dispense over go-plugin (`registry.go:168`) | valid spec / empty (warn) / handshake fail | 1 |
+| `plugins.builtin` | `DefaultBuiltinConnectors/Processors` maps | non-empty / — / empty | 1 |
+| `engine.reachable` | `api.Client.CheckHealth` (`client.go:61`) | SERVING / no server (warn) | 3 w/ `--require-server` |
+
+The `store`/`network` fails inherit exit **3** from `exitcode.ExitCode` because
+they carry `CodeUnavailable` — "unreachable DB = environment" falls out of the
+shared classifier, not a re-decision.
+
+## CLI UX & ergonomics
+
+```
+$ conduit doctor
+Conduit doctor — checking your environment
+
+Config
+  ✓ config.resolve      conduit.yaml found at ./conduit.yaml
+  ✓ config.validate     configuration is valid
+Store
+  ✗ store.reachable     cannot open badger store at ./conduit.db
+                        └ db.badger.path
+                        → Check the directory exists and is writable, or set db.badger.path.
+Network
+  ✗ network.grpc        address :8084 is already in use
+                        └ api.grpc.address
+                        → Stop the process holding it, or set api.grpc.address to a free port.
+Plugins
+  ⚠ plugins.connectors  ./connectors not found — built-ins still available
+  ✓ plugins.builtin     42 built-in connectors, 12 processors available
+
+Summary: 4 passed · 2 warnings · 2 failed
+2 checks failed. Fix the ✗ items above, then re-run `conduit doctor`.
+```
+
+Grouped by category; glyphs `✓`/`⚠`/`✗` (ASCII `[OK]`/`[!]`/`[X]` when not a TTY /
+`--no-color`). Every `✗` carries the failing config path (`└`) + suggestion (`→`).
+
+`--json`: `{checks:[{name,status,message,suggestion?,code?,configPath?,category}],
+summary:{pass,warn,fail}}`.
+
+Exit codes: all pass or pass+warn → **0** (warnings never fail the process); any
+fail → non-zero bucketed by the worst failing check's code via `exitcode.ExitCode`,
+precedence environment(3) > validation(2) > runtime(1).
+
+Flags: `--json`, `--check <name>` (repeatable, filters checks), `--deep`
+(subprocess checks), `--require-server`. `--help` documents preflight-vs-`/readyz`
+and the exit codes.
+
+## File-level plan
+
+- New: `pkg/conduit/doctor/{doctor,checks,report}.go`; `cmd/conduit/root/doctor/doctor.go`.
+- Refactor (optional, recommended): extract the DB-open switch from
+  `runtime.go:132-167` into a shared `openStore(cfg)` so C3 and `NewRuntime` share
+  one path. If too invasive for this slice, replicate + `// keep in sync` TODO.
+- Edit: one line in `root.go` `SubCommands()`; docs + `llms.txt`.
+- Works fully offline; only `engine.reachable` consults a server, warn by default.
+
+## Acceptance criteria
+
+1. every check returns a defined status (pass/warn/fail); none empty.
+2. bad DB path → C3 `fail`, `code=common.unavailable`, `configPath=db.badger.path`,
+   `ExitCode()==3`.
+3. port in use → C4 `fail` (EADDRINUSE), suggestion names the port, exit 3.
+4. missing plugin dir → `warn` (not fail); if no other fails, exit 0.
+5. invalid config field (`log.level=bogus`) → `fail`, `common.invalid_argument`, exit 2.
+6. `--json` matches schema; counts == rendered summary.
+7. all-good → exit 0.
+8. `--check <name>` runs exactly one; unknown name errors listing valid names.
+9. a panicking check → reported as `fail`/`internal.error`, process exits cleanly.
+10. engine reusable by MCP — a test in `pkg/conduit/doctor` (no cmd/ecdysis import)
+    calls `Run` and asserts `[]CheckResult`.
+11. no side effects — no DB files/dirs left behind after running.
+
+## Failure modes & risk
+
+- self-erroring/slow/hanging check → `recover()` + per-check `context.WithTimeout`
+  → `fail`, never a hang or crash.
+- CI has no `./connectors` → deliberately `warn`, exit 0 (not noise).
+- subprocess cost (`--deep`) gated off by default.
+- **Cross-plan note:** the scaffolding plan defines a `pkg/scaffold/doctor`
+  toolchain preflight — that should be a SUBSET consuming this engine's toolchain
+  checks, not a parallel implementation. Reconcile at implementation.
+- Risk tier low–medium; the only edit to existing code is the optional `openStore`
+  extraction (medium) + one line in `root.go`.
+
+## Optimization
+
+Reuse `Config.Validate()`, the runtime DB-open + bind paths, the standalone scan,
+the builtin maps, and `exitcode.ExitCode` — zero reimplementation of boot logic.
+`CheckResult` maps 1:1 onto `conduiterr.ConduitError` so CLI/`--json`/MCP speak the
+one §1.1 result model. Factor `openStore` so a future `NewRuntime` could even run
+`doctor` checks as its own preflight.
+
+## Related
+
+- Execution plan §3. `pkg/conduit/readyz.go` (runtime counterpart).
+- `pkg/conduit/exitcode`. Shared by the future MCP `doctor` tool (§2).
+- Scaffolding design doc (shares the toolchain-preflight subset).
+
+## Review outcome (2026-07-07) — SOUND-WITH-CONCERNS
+
+Must-fix during implementation:
+- **`Report.ExitCode()` (N results → 1 exit code) is NEW aggregation, not free reuse**
+  — take the MAX bucket, not the first. Now owned by the shared `pkg/conduit/check`
+  engine (see ADR `20260707-check-engine-shared-by-doctor-and-scaffold.md`).
+- The engine/types move to neutral `pkg/conduit/check`; doctor supplies its check
+  SET. Toolchain checks are NOT in doctor's set (disjoint from scaffold — see ADR).
+- `openStore(cfg, logger)` — signature needs the logger (won't compile without it).
+- `recover()` cannot catch go-plugin's background goroutines; gate `--deep`, use a
+  subprocess timeout, treat abnormal child exit as `fail`.
+- `CheckHealth` can't distinguish "no server" from "unhealthy" (both `Unavailable`)
+  — binary pass/fail only for now; footnote it. Mockup counts (42/12) are
+  illustrative; real defaults are 6 connectors / 27 processors.
+- Adopt the shared output conventions.

--- a/docs/design-documents/20260707-cli-output-conventions.md
+++ b/docs/design-documents/20260707-cli-output-conventions.md
@@ -1,0 +1,121 @@
+# CLI output & result conventions (v0.17 "CLI as product")
+
+## Summary
+
+The shared contract every new v0.17 command (`pipelines validate|lint|dry-run`,
+`doctor`, `connector|processor new`) MUST follow, so the CLI reads as one product
+and an MCP layer can wrap all of them uniformly. Both the technical and UX reviews
+of the v0.17 plans converged on this: without a single contract, three commands
+drift into three private output formats and three incompatible JSON shapes.
+
+This is a convention doc, not a feature. It is the reference the command design
+docs point at.
+
+## 1. The `--json` envelope (one shape, all commands)
+
+Every command's `--json` output is a single JSON object to stdout with this
+top-level shape, **lowerCamelCase throughout** (matching existing protojson output
+like `createdAt`):
+
+```json
+{
+  "command": "pipelines.validate",   // stable dotted discriminator, ALWAYS present
+  "ok": false,                       // the verdict, ALWAYS present on every command
+  "summary": { "...": 0 },           // command-specific counts
+  "result": { "...": "..." },        // command-specific payload
+  "error": null                      // null on success; set on a HARD command failure
+}
+```
+
+- `ok` and `error` are present on **all** commands — an agent writes one
+  success check (`.ok`) for every tool.
+- `error` is for a hard command failure (bad input, preflight failure, crash), NOT
+  for domain findings. A validation run that finds problems is `ok:false` with the
+  problems in `result`/`summary` and `error:null` — the run itself succeeded.
+- `command` is the dotted path (`pipelines.validate`, `doctor`, `connector.new`).
+
+### Shared sub-objects (reused across commands)
+
+A **located finding / check result** (the §1.1 structured-error shape):
+
+```json
+{ "severity": "error|warning|pass|warn|fail",
+  "code": "config.field_required",
+  "message": "...",
+  "configPath": "/connectors/0/plugin",   // conduit.yaml dotted key OR pipeline JSON pointer — see note
+  "suggestion": "set connectors[0].plugin (e.g. \"builtin:postgres\")",
+  "fix": { "configPath": "...", "op": "set", "value": "" } }   // optional, powers future `repair`
+```
+
+The **`error`** object uses the same fields (`code`, `message`, `suggestion?`,
+`configPath?`, `fix?`) — it maps onto `conduiterr.ConduitError`. Scaffolding's
+error MUST carry `suggestion` (its human output already shows remediation text);
+a bare `{code,message}` is non-conformant.
+
+> **`configPath` note:** its *syntax* legitimately varies — a `conduit.yaml` dotted
+> key (`db.badger.path`) for doctor, a pipeline-doc JSON pointer
+> (`/connectors/0/plugin`) for validate. Same field, two address spaces; document
+> this on the field, do not invent two field names.
+
+## 2. Human output conventions
+
+- **Glyphs:** `✓` pass · `⚠` warn · `✗` fail. ASCII fallback `[OK]` / `[WARN]` /
+  `[FAIL]` when not a TTY, `--no-color`, or `NO_COLOR` is set.
+- **A located finding renders identically across commands** (one template — the
+  reviews flagged doctor's `└`-line vs validate's inline pointer as divergent):
+
+  ```
+  ✗ config.field_required   /connectors/0/plugin
+      connector "pg-source": "plugin" is mandatory
+      → set connectors[0].plugin (e.g. "builtin:postgres")
+  ```
+
+  glyph + code + configPath on line 1; message indented 4; `→ suggestion`
+  indented 4. No separate `└` line.
+- **Summary line:** `Summary: N passed · N warnings · N failed` (or `N files · …`
+  for directory runs). Where an action is needed, follow with ONE imperative line
+  (`Fix the ✗ items above, then re-run.`). **Never print the exit code** in human
+  output (the shell has `$?`).
+- **A single shared helper** (`cmd/conduit/internal/ui`) owns glyph-vs-ASCII
+  selection, `NO_COLOR`/`--no-color`/TTY detection, and color. No command
+  hand-rolls glyph logic.
+
+## 3. Flags (org-wide vocabulary — same meaning everywhere)
+
+| Flag | Meaning | Commands |
+| --- | --- | --- |
+| `--json` | machine output (envelope §1). Canonical usage string `"output the result as JSON"`. | all |
+| `-q, --quiet` | suppress passing/OK lines + progress chrome; print only warnings, failures, and the summary. Exit code unchanged. | all |
+| `--strict` | warnings escalate to failure (exit 2). | `lint`, `dry-run` (NOT `validate` — it is errors-only) |
+| `--check <name>` (repeatable) | select which checks run. Reserved org-wide for this meaning — do NOT reuse `--check*` for a boolean toggle. | `doctor` |
+| `-y, --yes`, `--force` | non-interactive confirm / overwrite (never silently clobber). | mutating commands (scaffolding) |
+
+Validate's builtin-plugin resolution toggle is `--resolve-plugins` (NOT
+`--check-plugins`, which collides with `doctor --check`).
+
+## 4. Exit codes — always via `pkg/conduit/exitcode`
+
+Every command routes its exit through `exitcode.ExitCode` (0 ok · 1 runtime · 2
+config/validation · 3 environment). No command invents "a distinct exit code."
+Multi-result commands (doctor, validate) that must reduce N findings to one exit
+code take the **worst** (max) bucket — this is *new* aggregation logic, NOT free
+reuse of the single-error classifier; own it explicitly (synthesize a
+`*conduiterr.ConduitError` per failing result, classify each, take the max;
+environment 3 > validation 2 > runtime 1).
+
+## 5. Cobra hygiene
+
+Every command sets `SilenceErrors` **and** `SilenceUsage` and renders its own
+error output — otherwise cobra prints a duplicate `Error:` line over the report
+and, under `--json`, corrupts the single-object stdout with a stderr `Error:`.
+Fold this into the shared offline `CommandWithResult` decorator so it is structural.
+
+Under `--json`, commands MUST NOT stream human progress/`✓` lines (they would
+precede/corrupt the single JSON object) — capture progress in `result.steps[]`.
+
+## Related
+
+- Execution plan §3 (CLI as product), §2 (MCP wraps these 1:1).
+- `20260707-cli-pipeline-validate.md`, `20260707-cli-doctor.md`,
+  `20260707-connector-processor-scaffolding.md` (the commands this governs).
+- `pkg/conduit/exitcode`, `pkg/foundation/cerrors/conduiterr` (the backbone).

--- a/docs/design-documents/20260707-cli-output-conventions.md
+++ b/docs/design-documents/20260707-cli-output-conventions.md
@@ -52,7 +52,7 @@ The **`error`** object uses the same fields (`code`, `message`, `suggestion?`,
 error MUST carry `suggestion` (its human output already shows remediation text);
 a bare `{code,message}` is non-conformant.
 
-> **`configPath` note:** its *syntax* legitimately varies — a `conduit.yaml` dotted
+> **`configPath` note:** its _syntax_ legitimately varies — a `conduit.yaml` dotted
 > key (`db.badger.path`) for doctor, a pipeline-doc JSON pointer
 > (`/connectors/0/plugin`) for validate. Same field, two address spaces; document
 > this on the field, do not invent two field names.
@@ -64,7 +64,7 @@ a bare `{code,message}` is non-conformant.
 - **A located finding renders identically across commands** (one template — the
   reviews flagged doctor's `└`-line vs validate's inline pointer as divergent):
 
-  ```
+  ```text
   ✗ config.field_required   /connectors/0/plugin
       connector "pg-source": "plugin" is mandatory
       → set connectors[0].plugin (e.g. "builtin:postgres")
@@ -98,7 +98,7 @@ Validate's builtin-plugin resolution toggle is `--resolve-plugins` (NOT
 Every command routes its exit through `exitcode.ExitCode` (0 ok · 1 runtime · 2
 config/validation · 3 environment). No command invents "a distinct exit code."
 Multi-result commands (doctor, validate) that must reduce N findings to one exit
-code take the **worst** (max) bucket — this is *new* aggregation logic, NOT free
+code take the **worst** (max) bucket — this is _new_ aggregation logic, NOT free
 reuse of the single-error classifier; own it explicitly (synthesize a
 `*conduiterr.ConduitError` per failing result, classify each, take the max;
 environment 3 > validation 2 > runtime 1).

--- a/docs/design-documents/20260707-cli-pipeline-validate.md
+++ b/docs/design-documents/20260707-cli-pipeline-validate.md
@@ -1,0 +1,161 @@
+# CLI: `conduit pipeline validate | lint | dry-run`
+
+## Summary
+
+The keystone of the v0.17 "CLI as product" work (execution plan §3): static,
+**offline** verification of pipeline config files. It is a thin shell over the
+machinery `conduit run`'s provisioning path already uses
+(`parser.Parse → config.Enrich → config.Validate`), surfacing the `config.*`
+`ConduitError` codes + JSON-pointer `configPath` from #2529, with `--json` and the
+deterministic exit codes (validation failure → exit 2). Tier 2.
+
+## Context — the reuse surface (everything needed already exists)
+
+| Capability | Where | Note |
+| --- | --- | --- |
+| YAML parse + version dispatch | `pkg/provisioning/config/yaml/parser.go:72` | Offline; collects all per-doc errors, no fail-fast (#2255) |
+| Default enrichment | `pkg/provisioning/config/enrich.go:20` | Rewrites connector/processor IDs to `pipelineID:connectorID` (`:71,95`) |
+| Static field/ref/type validation | `pkg/provisioning/config/validate.go:35` | Collects every error via `cerrors.Join`, no fail-fast |
+| Stable codes + `configPath` | `pkg/provisioning/config/codes.go:26` | `config.field_required/_invalid/_too_long/_id_duplicate` (#2529) |
+| Exit-code classification | `pkg/conduit/exitcode` | `InvalidArgument → 2` automatically |
+| Walk a joined error | `pkg/foundation/cerrors/cerrors.go:135` (`ForEach`) | needed — `conduiterr.Get` returns only the FIRST error |
+| Dir-vs-file `.yml/.yaml` filtering | `pkg/provisioning/service.go:177,217` | correct semantics already |
+| Group aliases singular | `cmd/conduit/root/pipelines/pipelines.go:29` (`Aliases: ["pipeline"]`) | both `pipeline` and `pipelines` resolve |
+
+### Two gaps this plan must close (both additive, Tier 2)
+
+1. **`Suggestion` is never populated** — `fieldError` (`codes.go:35`) takes no
+   suggestion; the field exists on `ConduitError` but ships empty. The graded UX
+   needs it → extend the domain validators to attach suggestions (so API/MCP get
+   them too).
+2. **Lint warnings are collected then discarded** — `ParseConfigurations` logs
+   warnings (`parser.go:146`) and never returns them; the `warning` type is
+   unexported (`linter.go:118`). `lint` needs the parser to expose them.
+
+## Decision — verb design
+
+- **`validate <file|dir>`** — Parse → Enrich → Validate. Static correctness only,
+  pass/fail, fully offline, exit 0 or 2. Ships first (the ~90% case).
+- **`lint <file|dir>`** — validate + advisory warnings (deprecated/renamed/unknown
+  fields, version fallback). Warnings are advisory: exit 0 unless `--strict`. Needs
+  gap-2 refactor.
+- **`dry-run <file|dir>`** — validate + report the **enriched** graph (final IDs,
+  injected DLQ defaults, worker counts) + optional builtin plugin-ref resolution
+  (`connector.plugin_not_found`). No side effects, no server. Standalone plugin
+  refs are marked "not statically verifiable" (advisory), not failed.
+
+**Shipping order:** validate first (zero refactor beyond suggestions); lint +
+dry-run in a second PR. All three share ONE internal engine so verb parity is
+structural, not copy-paste. Register as subcommands of the existing
+`PipelinesCommand`; the group already aliases `pipeline`, so no naming decision.
+
+## CLI UX & ergonomics
+
+```
+conduit pipelines validate <path> [flags]   # alias: conduit pipeline validate ...
+conduit pipelines lint     <path> [flags]
+conduit pipelines dry-run  <path> [flags]
+```
+
+`<path>` = one `.yml/.yaml` file OR a directory (recursed one level for
+`.yml/.yaml`). No `--config.path`/gRPC flag — these are **offline** and must never
+dial the API.
+
+Flags: `--json` (all), `--strict` (lint/validate: warnings → exit 2),
+`--check-plugins` (dry-run, default on), `-q/--quiet`.
+
+**FAIL output — collect all, never fail-fast:**
+
+```
+✗ pipelines/orders.yaml
+
+  config.field_required   /connectors/0/plugin
+    connector "pg-source": "plugin" is mandatory
+    → set connectors[0].plugin (e.g. "builtin:postgres")
+
+  config.id_duplicate     /connectors/2/id
+    connector "pg-source": "id" must be unique
+    → rename one of the connectors sharing id "pg-source"
+
+3 problems in 1 file. (exit 2)
+```
+
+One block per finding, ordered by `configPath`: line 1 = `code` + `configPath`,
+line 2 = validator `Message` (verbatim), line 3 = `→ Suggestion`. Directory input
+groups blocks under `✗ <file>` headers. `lint` renders warnings identically with
+`⚠`. The command sets `SilenceErrors` so cobra doesn't print a duplicate `Error:`
+over the report.
+
+**`--json` schema** (offline struct, not protojson): `{verb, ok, summary:{files,
+pipelines, errors, warnings}, files:[{path, ok, pipelines[], findings:[{severity,
+code, configPath, message, suggestion, fix?, line?, column?}]}]}`. Every field maps
+to an existing source (`code`←`Code.reason`, `configPath`←`ConfigPath`,
+`message`←`Message`, `suggestion`←`Suggestion` after gap 1, `fix`←`Fix` for the
+future `repair` verb, `line/column`←`warning{}` for lint).
+
+Exit codes: 0 clean; 2 any validation/parse/path error; warnings-only → 0 (2 under
+`--strict`); dry-run builtin plugin-not-found → 2 (`NotFound → Validation`).
+
+## File-level plan
+
+- New: `cmd/conduit/root/pipelines/{validate,lint,dry_run}.go` (+ tests); register
+  in `pipelines.go` `SubCommands()`.
+- New shared engine `cmd/conduit/internal/validate/` — one `Run(paths, opts)
+  Report` (resolve files → parse → enrich → validate → walk with `cerrors.ForEach`
+  → `[]Finding`); both human render and `--json` marshal the one type.
+- New offline result decorator `CommandWithResult` in
+  `cmd/conduit/cecdysis/decorators.go` (the offline sibling of the client-result
+  decorator — no API client). Register in `cli.go`.
+- Refactors (additive): populate `Suggestion` in the provisioning validators;
+  expose parser warnings; extract the dir/file resolution helper.
+
+## Acceptance criteria
+
+1. valid file → exit 0, `✓` per pipeline, "no problems"; `--json` `ok:true`, no findings.
+2. file with N errors → exit 2; ALL N appear (not fail-fast) in human + json, each
+   with non-empty code/configPath/message/suggestion.
+3. **offline**: works with no server, no gRPC dial (assert no dial).
+4. directory → checks every `.yml/.yaml`, aggregates per file, exit 2 if any error.
+5. unparseable/unknown-version → exit 2 coded finding, not panic/exit 1.
+6. `--json` valid on pass and fail, matches the schema; `code` == registered reason.
+7. `lint` deprecated field → warning w/ line+column, exit 0; `--strict` → exit 2.
+8. error + warning in one file → exit 2 (error dominates), both rendered.
+9. `dry-run` valid → exit 0, shows enriched IDs + DLQ defaults; `--check-plugins`
+   unknown builtin → exit 2; standalone ref → advisory, not a false fail.
+10. `SilenceErrors` set — no duplicate cobra `Error:` line over the report.
+
+## Failure modes
+
+- **Enrich-before-validate order** must match `service.go:279-280` (enrichment
+  mutates IDs) or validation diverges from `run`. Dry-run displays enriched IDs.
+- Using `conduiterr.Get` instead of `cerrors.ForEach` silently drops all but the
+  first finding (AC-2 guards this).
+- Exposing warnings must NOT change `run` behavior (additive API only).
+- dry-run standalone plugin false-negatives → scope `--check-plugins` to builtins.
+- empty file/dir → exit 0 "0 pipelines checked", not an error.
+
+## Optimization
+
+Maximal reuse: validation logic, codes, `configPath`, exit-code mapping,
+file resolution, `--json` decorator all exist. New code = the three command shells,
+one shared render/JSON struct, the offline decorator, two additive refactors. Do
+NOT write a second YAML schema, code set, `configPath` scheme, or exit-code map —
+that forks the contract the API/MCP already speak (`status.go`).
+
+## Related
+
+- Execution plan §3 (CLI as product). #2529 (config codes). `pkg/conduit/exitcode`.
+- Feeds MCP's `validate` tool (§2) and `conduit generate` (v0.19, validate-gated).
+
+## Review outcome (2026-07-07) — SOUND-WITH-CONCERNS
+
+Must-fix during implementation:
+- **Cross-file duplicate-ID detection is NEW code, not reuse** — `findDuplicateIDs`
+  (`service.go:100`) is outside `parse→enrich→validate` and returns a bare sentinel.
+  Give it a `provisioning.pipeline_id_duplicate` code + `configPath`.
+- **Call `cerrors.ForEach` on the UNWRAPPED Join**, never on an outer `%w` wrap — a
+  re-wrapped Join collapses N findings to one (masked-bug risk).
+- Populate `Suggestion` in the provisioning validators; expose parser warnings.
+- Adopt the shared contract in `20260707-cli-output-conventions.md` (envelope,
+  `--resolve-plugins` not `--check-plugins`, `--strict` on lint/dry-run only,
+  `SilenceErrors`, no `(exit 2)` in human output, dir-run shows passing `✓` files).

--- a/docs/design-documents/20260707-cli-pipeline-validate.md
+++ b/docs/design-documents/20260707-cli-pipeline-validate.md
@@ -51,7 +51,7 @@ structural, not copy-paste. Register as subcommands of the existing
 
 ## CLI UX & ergonomics
 
-```
+```text
 conduit pipelines validate <path> [flags]   # alias: conduit pipeline validate ...
 conduit pipelines lint     <path> [flags]
 conduit pipelines dry-run  <path> [flags]
@@ -66,7 +66,7 @@ Flags: `--json` (all), `--strict` (lint/validate: warnings → exit 2),
 
 **FAIL output — collect all, never fail-fast:**
 
-```
+```text
 ✗ pipelines/orders.yaml
 
   config.field_required   /connectors/0/plugin
@@ -150,6 +150,7 @@ that forks the contract the API/MCP already speak (`status.go`).
 ## Review outcome (2026-07-07) — SOUND-WITH-CONCERNS
 
 Must-fix during implementation:
+
 - **Cross-file duplicate-ID detection is NEW code, not reuse** — `findDuplicateIDs`
   (`service.go:100`) is outside `parse→enrich→validate` and returns a bare sentinel.
   Give it a `provisioning.pipeline_id_duplicate` code + `configPath`.

--- a/docs/design-documents/20260707-connector-processor-scaffolding.md
+++ b/docs/design-documents/20260707-connector-processor-scaffolding.md
@@ -25,6 +25,7 @@ python` today only as an explicit error naming the blocker + a tracking issue.
 ## Decision — orchestrate the upstream template, do NOT reimplement boilerplate
 
 Option C: the command runs the canonical template's own setup flow.
+
 - Rejected A (embedded/duplicated skeleton — guarantees drift) and B (`gh repo
   create --template` as primary — breaks offline/local-first; keep as `--remote`).
 - The template `setup.sh` already encodes the recipe: module/token rename, tool
@@ -32,6 +33,7 @@ Option C: the command runs the canonical template's own setup flow.
   determinism).
 
 **Template sourcing (the core tension: reproducible vs catch-drift):**
+
 - **Vendored snapshot, `go:embed`'d, pinned per Conduit release** — default
   generation is offline, deterministic, reproducible. A release-time `//go:generate`
   script machine-syncs the snapshot from upstream `main` and records the SHA (a
@@ -43,7 +45,7 @@ Option C: the command runs the canonical template's own setup flow.
 
 ## CLI UX & ergonomics (the <30-min experience)
 
-```
+```text
 conduit connector new [name] [flags]
 conduit processor new [name] [flags]
 ```
@@ -65,7 +67,7 @@ no partial directory.
 **Felt experience** — stream progress, verify a real `go build` in-flow, show a
 wall-clock timer + copy-paste next steps:
 
-```
+```text
 conduit connector new s3
 ✓ Toolchain OK (go 1.23.4, git 2.44)
 ✓ Wrote 24 files → ./conduit-connector-s3
@@ -148,6 +150,7 @@ machine-synced, never hand-maintained.
 ## Review outcome (2026-07-07) — SOUND-WITH-CONCERNS
 
 Must-fix during implementation:
+
 - **connector ≠ processor symmetry**: the PROCESSOR template's `setup.sh` does ONLY
   the rename — it does NOT `install-tools`/`generate` like the connector one, and
   `make generate` uses different tools (`conn-sdk-cli specgen` vs `paramgen`). The

--- a/docs/design-documents/20260707-connector-processor-scaffolding.md
+++ b/docs/design-documents/20260707-connector-processor-scaffolding.md
@@ -1,0 +1,161 @@
+# CLI: `conduit connector new` / `conduit processor new` (plugin scaffolding)
+
+## Summary
+
+Scaffold a full connector/processor repo (SDK wiring, tests, CI, release workflow,
+acceptance harness) from one command, targeting **first working connector < 30 min**
+on a clean machine (a CI-measured gate, not a hope). v0.17 §5. **Go-first**: the Go
+connector + processor paths are ready now; Python is blocked on a nonexistent SDK
+and ships as an honest "not yet" error. Tier low–medium (Go).
+
+## Feasibility verdict (blunt, per language)
+
+| Target | SDK | Template | Verdict |
+| --- | --- | --- | --- |
+| Go connector | `conduit-connector-sdk` (mature) | `conduit-connector-template` (updated 2026-07-05) | **READY NOW** |
+| Go processor | `conduit-processor-sdk` (mature, WASM/wazero) | `conduit-processor-template` (2026-07-05) | **READY NOW** |
+| Python connector | **does not exist** | none | **BLOCKED** — SDK-authoring task, not scaffolding |
+| Python processor | `conduit-processor-sdk-python` (experimental, WASM, year-stale) | none | not viable this phase |
+| Rust / TS | — | — | v0.19 (correct) |
+
+Python connectors would generate code against an SDK that does not exist. Keep it a
+separate gated workstream (the Python connector SDK design doc); expose `--lang
+python` today only as an explicit error naming the blocker + a tracking issue.
+
+## Decision — orchestrate the upstream template, do NOT reimplement boilerplate
+
+Option C: the command runs the canonical template's own setup flow.
+- Rejected A (embedded/duplicated skeleton — guarantees drift) and B (`gh repo
+  create --template` as primary — breaks offline/local-first; keep as `--remote`).
+- The template `setup.sh` already encodes the recipe: module/token rename, tool
+  install, `make generate`. Port that logic to **Go** (not shell — Windows +
+  determinism).
+
+**Template sourcing (the core tension: reproducible vs catch-drift):**
+- **Vendored snapshot, `go:embed`'d, pinned per Conduit release** — default
+  generation is offline, deterministic, reproducible. A release-time `//go:generate`
+  script machine-syncs the snapshot from upstream `main` and records the SHA (a
+  lockfile, not a hand-maintained fork).
+- `--template-ref` / `--template-repo` override to fetch live (power users + the
+  nightly drift job).
+- **Nightly CI** regenerates from upstream `main` + latest SDK, builds/tests →
+  drift goes red before users hit it.
+
+## CLI UX & ergonomics (the <30-min experience)
+
+```
+conduit connector new [name] [flags]
+conduit processor new [name] [flags]
+```
+
+Flags: `--lang` (go; python→gated error), `--module`
+(`github.com/<gh-user>/conduit-connector-<name>`), `--path`, `--sdk-version`,
+`--template-ref/-repo`, `--git/--no-git`, `--remote <owner/repo>`,
+`--skip-generate`, `--yes/-y`, `--json`, `--force`.
+
+TTY + no `--yes` → guided prompts for only what's missing (name → module →
+destination) then a confirm summary. `--yes`/`--json`/non-TTY → fully
+flag-driven; missing input → deterministic error + non-zero exit.
+
+**Preflight runs before any write** (shared with `conduit doctor`'s toolchain
+checks): Go on PATH + min version, `GOPATH/bin` writable, `git`, `docker`
+(warn-only). On failure, fail fast with remediation + a distinct exit code, leaving
+no partial directory.
+
+**Felt experience** — stream progress, verify a real `go build` in-flow, show a
+wall-clock timer + copy-paste next steps:
+
+```
+conduit connector new s3
+✓ Toolchain OK (go 1.23.4, git 2.44)
+✓ Wrote 24 files → ./conduit-connector-s3
+✓ Rewrote module path → github.com/devaris/conduit-connector-s3
+✓ Generated connector.yaml + README
+✓ go build OK (12s)
+✓ Initialized git, created first commit
+Your connector is ready at ./conduit-connector-s3  (48s)
+Next steps:
+  cd conduit-connector-s3
+  make test     # unit + SDK acceptance suite
+  make build    # standalone plugin binary
+  conduit run   # wired into a pipeline
+```
+
+`--json`: `{language, name, module, path, template_ref, sdk_version,
+steps:[{name,ok,duration_ms}], elapsed_ms, next_steps[]}`; errors →
+`{error:{code,message}}` + matching non-zero exit.
+
+## File-level plan
+
+- New commands: `cmd/conduit/root/{connectors,processors}/new.go` (+ tests),
+  registered in each group's `SubCommands()`.
+- New reusable engine `pkg/scaffold/` (out of `cmd/` so the future MCP `scaffold`
+  tool shares it): `scaffold.go` (orchestrator), `request.go`, `doctor/` (toolchain
+  preflight — consume `pkg/conduit/doctor` toolchain checks, don't fork),
+  `template/` (`source.go`, `rewrite.go` = the setup.sh→Go port, `embed.go` +
+  `templates/` machine-synced snapshots), `steps/` (generate, verified build,
+  gitinit), `sync/` (release-time refresh).
+- CI/release/acceptance are inherited verbatim from the template — the command adds
+  ZERO CI authoring, only rewrites the module token.
+
+## Acceptance criteria
+
+1. `connector new --lang go s3 --yes` → exit 0, `./conduit-connector-s3` that
+   `go build ./...` compiles with no edits.
+2. generated `make test` passes incl. the SDK acceptance suite.
+3. `make build` → standalone plugin binary Conduit **loads and runs** in a pipeline
+   (lifecycle methods invoked) — validates protocol wiring, not just compilation.
+4. generated CI green on first commit (test/lint/validate-generated-files).
+5. processor parity: AC-1/2/4 for `processor new --lang go`; `make build` → a
+   wazero-loadable WASM module Conduit runs.
+6. preflight catches missing Go → exits non-zero BEFORE writing, remediation
+   printed, no partial dir.
+7. `--json` schema honored; failure → `{error}` + deterministic non-zero exit.
+8. `--lang python` → honest non-zero "not yet (no Python connector SDK)" + issue link.
+9. Windows: once the upstream matrix PR lands (§ below), generated `test.yml` green
+   on `windows-latest` (unit).
+10. **<30 min, measured in CI**: a matrix job (ubuntu/macos/windows × connector/
+    processor) on a runner with NO preinstalled dev tooling times
+    `new → make test → make build → smoke-run in a pipeline`; assert `< 1800`s
+    (hard) + `< 600`s (warning, to catch creep). Publish the duration per OS.
+
+## Failure modes / dependencies
+
+- Missing toolchain → preflight fail before write.
+- tool-install fails → clear error + `--skip-generate` escape hatch.
+- destination exists → refuse; `--force` to overwrite (never silent clobber).
+- partial write then crash → write to temp dir, atomic rename, cleanup on error.
+- Windows path/EOL → Go port of setup.sh (no bash/sed) + the win-CI leg proves it.
+- **Upstream gap:** both templates' `test.yml` are `ubuntu-latest` only. "Windows in
+  the matrix" needs coordinated PRs to `conduit-connector-template` +
+  `conduit-processor-template` (add a `windows-latest` unit-test leg) — NOT an
+  in-repo edit (would diverge the snapshot). Track as a dependency of §5 acceptance.
+
+## Optimization
+
+The command orchestrates; SDK wiring, CI, release, goreleaser, dependabot, and the
+acceptance harness all come from the upstream templates + SDKs unmodified. Original
+code = the two `new` subcommands, the language-agnostic engine, the setup.sh→Go
+port, the preflight, and the drift/measurement CI. The embedded snapshot is
+machine-synced, never hand-maintained.
+
+## Related
+
+- Execution plan §5. Shares toolchain preflight with the `doctor` design doc.
+- Python connector SDK design doc (the blocker for `--lang python`).
+- Feeds the MCP `scaffold` tool (§2, shared engine).
+
+## Review outcome (2026-07-07) — SOUND-WITH-CONCERNS
+
+Must-fix during implementation:
+- **connector ≠ processor symmetry**: the PROCESSOR template's `setup.sh` does ONLY
+  the rename — it does NOT `install-tools`/`generate` like the connector one, and
+  `make generate` uses different tools (`conn-sdk-cli specgen` vs `paramgen`). The
+  Go port must synthesize the processor install+generate steps itself.
+- Error JSON must carry `suggestion`/`configPath`/`fix` (per output conventions),
+  not a bare `{code,message}`.
+- Route all exits through `pkg/conduit/exitcode` (missing toolchain → 3; bad
+  `--module`/`--lang python`/dest-exists → 2; `go build` fail → 1).
+- Toolchain preflight uses the shared `pkg/conduit/check` engine (see ADR).
+- Windows-CI-green (AC-9) is an EXTERNAL dependency (upstream template PRs), tracked
+  separately — not this repo's own deliverable. Declare risk tier **Tier 2**.

--- a/docs/design-documents/20260707-python-connector-sdk.md
+++ b/docs/design-documents/20260707-python-connector-sdk.md
@@ -1,0 +1,936 @@
+# Python connector SDK
+
+## Summary
+
+Design and phased plan for `conduit-connector-sdk-python`, a new repo delivering an
+idiomatic Python SDK for building Conduit **source and destination connectors** that
+run as standalone (subprocess, gRPC, go-plugin-handshake) plugins — no Conduit code
+changes required. This is the detailed follow-on to the Python tier of
+[SDK & embedding developer experience](20260705-sdk-and-embedding-dx.md) (persona
+A1: "Python — gRPC-standalone first ... First `libconduit` consumer on the author
+side"). This document is planning/design only; it does not implement the SDK.
+
+The technical crux — and the part most likely to sink the project if under-specified
+— is replicating HashiCorp go-plugin's subprocess handshake from a pure-Python
+process with no Go runtime. That handshake is fully characterized below with exact
+constants, cited to the Go source Conduit and the SDK actually run. It is a plain
+stdout line + a standard gRPC server; nothing in it requires Go. The rest of the
+document designs a Python API that mirrors the Go SDK's semantics (interfaces,
+config validation, acceptance contract, batching) while being idiomatically
+Python rather than a transliteration (async-native, pydantic-based config +
+paramgen-by-introspection, `bytes | dict` records instead of a `Data` interface,
+exceptions instead of Go's `(n, err)` partial-write convention).
+
+## Context
+
+### The problem
+
+- The plugin author's SDK is Go-only today (`conduit-connector-sdk`, pinned at
+  `v0.14.1` per the template's `go.mod`). Python — the dominant language for the
+  data/AI audience Conduit is targeting — has no SDK, only an unrelated,
+  experimental, **WASM-based** `conduit-processor-sdk-python` (see "Relationship to
+  the existing Python processor prototype" below), which is a different extension
+  mechanism for a different plugin kind and is not reusable here as-is.
+- "A connector" is defined by conformance to the connector protocol
+  (`conduit-connector-protocol`) and by passing the acceptance-test suite — not by
+  language. Today that suite (`AcceptanceTest`,
+  `conduit-connector-sdk/acceptance_testing.go:54-58`) exists only in Go, so there is
+  no way for a Python-authored connector to prove conformance.
+- Standalone connectors are launched by Conduit as **subprocesses** using
+  HashiCorp go-plugin over gRPC (`conduit/pkg/plugin/connector/standalone/
+  dispenser.go:55` → `conduit-connector-protocol/pconnector/client/client.go`). A
+  Python process must replicate that launch protocol exactly, or Conduit cannot
+  start it at all — this is a hard gate before any Python-authored business logic
+  matters.
+
+### Constraints (from CLAUDE.md, binding on this design)
+
+- Language floor: Python 3.11+, matching the house style already used for
+  tooling elsewhere in the org.
+- Errors are API: every user-facing error needs a stable shape and an actionable
+  message — same bar as Conduit's own CLI/API errors.
+- No speculative generality: this SDK targets the gRPC-standalone connector path
+  only. WASM is the processor extension mechanism (ADR `20260704-wasm-component-model.md`),
+  not the connector one — see the relationship note below. Adding WASM-connector
+  support is out of scope without a documented demand signal.
+- Docs and template move with the code: Phase 1 ships an example connector, not
+  just a library.
+- Design doc before code for anything touching a public contract — this **is**
+  that doc for the SDK's own public surface (the base classes, config model, wire
+  behavior). Downstream connector authors will build against what's decided here,
+  so treat the API shape as a public contract from v0.1.
+
+### Relationship to the existing Python processor prototype
+
+`ConduitIO/conduit-processor-sdk-python` already exists — description "[WIP]
+Experimental Python SDK for Conduit processors" (`gh repo view
+ConduitIO/conduit-processor-sdk-python`). Its file tree (`gh api repos/ConduitIO/
+conduit-processor-sdk-python/git/trees/main`) shows: `world.wit` +
+`componentize-py` + a hand-rolled `malloc`/pointer WASM ABI in `sdk.py:1-100`
+matching the Go SDK's WASM ABI, and protobuf stubs generated via `buf generate`
+with the **`protocolbuffers/python` + `protocolbuffers/pyi`** remote BSR plugins
+(`proto/buf.gen.yaml`) — i.e., standard protoc-style `_pb2.py`/`_pb2.pyi`
+output, not `betterproto`. Two takeaways:
+
+1. **It is not prior art for this SDK's transport.** It targets the WASM
+   component-model path for *processors*; connectors use go-plugin/gRPC
+   subprocesses, a different mechanism entirely (per the repo map in CLAUDE.md:
+   "`conduit-processor-sdk`: standalone processors compile to WASM" vs.
+   `conduit-connector-sdk` which has no WASM story). Do not conflate the two —
+   this design doc is gRPC-only.
+2. **It is real precedent for codegen tooling**: the org already generates Python
+   protobuf code via `buf generate` against BSR modules
+   (`buf.build/conduitio/conduit-connector-protocol`, confirmed present at
+   `conduit-connector-protocol/proto/buf.yaml:2`, depending on
+   `buf.build/conduitio/conduit-commons`). This SDK should follow the same
+   pattern for consistency across the org's Python surface (see Alternatives
+   Considered, "Protobuf codegen tool").
+
+## Decision
+
+### 1. Protocol & handshake (the crux)
+
+This is the make-or-break section. Every constant below is cited to the exact Go
+source Conduit runs today.
+
+#### 1.1 The handshake is not Go-specific
+
+Conduit (client) and the Go SDK (server) both import the **same shared symbol**
+for their `HandshakeConfig` — not just matching values by convention:
+
+```go
+// conduit-connector-protocol/pconnector/pconnector.go:19-22
+var HandshakeConfig = plugin.HandshakeConfig{
+    MagicCookieKey:   "CONDUIT_PLUGIN_MAGIC_COOKIE",
+    MagicCookieValue: "204e8e812c3a1bb73b838928c575b42a105dd2e9aa449be481bc4590486df53f",
+}
+```
+
+- Server (SDK) side: `conduit-connector-protocol/pconnector/server/serve.go:42`
+  passes it into `plugin.ServeConfig`; `conduit-connector-sdk/serve.go:106` just
+  calls `server.Serve(...)`.
+- Client (Conduit) side: `conduit-connector-protocol/pconnector/client/client.go:48`
+  passes the identical value into `plugin.ClientConfig`. Conduit itself never
+  constructs its own `plugin.NewClient` — `conduit/pkg/plugin/connector/
+  standalone/dispenser.go:55` delegates to `client.New(...)` in the protocol repo.
+
+A Python plugin must:
+
+1. Read `os.environ["CONDUIT_PLUGIN_MAGIC_COOKIE"]` and compare it to the value
+   above at startup; exit non-zero with a diagnostic if it doesn't match or is
+   absent (mirrors `go-plugin@v1.8.0/server.go:247-266`, which is enforced only by
+   the server-side library, not by anything Conduit itself checks beyond
+   requiring the line — a Python implementation must do this check itself, there
+   is no free lunch from the Go runtime).
+2. Negotiate protocol version via the `PLUGIN_PROTOCOL_VERSIONS` env var
+   (`go-plugin@v1.8.0/client.go:642`) and pick the highest version it supports
+   that the client also lists (`go-plugin@v1.8.0/server.go:148-221`). Two
+   protocol versions exist today: v1 = `conduit-connector-protocol/pconnector/v1/
+   version.go:19` (`const Version = 1`), v2 = `pconnector/v2/version.go:18`
+   (`const Version = 2`). **Target v2** — v1 is the older, more verbose,
+   single-service style (`proto/connector/v1/connector.proto`, 368 lines);
+   v2 is current and what Conduit's dispenser actually speaks.
+3. Print exactly one handshake line to **stdout** (not stderr — stdout is the
+   channel go-plugin's client parses) once the gRPC server is listening:
+
+   ```
+   CORE-PROTOCOL-VERSION|APP-PROTOCOL-VERSION|NETWORK|ADDRESS|PROTOCOL|SERVER-CERT
+   ```
+
+   Format and field semantics from `go-plugin@v1.8.0/server.go:426-445`; parse
+   side at `go-plugin@v1.8.0/client.go:838-926` (splits on `|`, requires ≥4
+   parts). Concretely: `CORE-PROTOCOL-VERSION` is always literal `1`
+   (`server.go:33`, unrelated to the v1/v2 app-protocol negotiated above —
+   confusingly, go-plugin has its own "core" protocol version separate from
+   Conduit's connector-protocol version); `APP-PROTOCOL-VERSION` is `2` (or `1`);
+   `NETWORK` is `tcp` or `unix`; `ADDRESS` is the listen address; `PROTOCOL` is
+   literal `grpc` (NetRPC is explicitly disabled on both sides via
+   `plugin.NetRPCUnsupportedPlugin`, `server/serve.go:125` and
+   `client/client.go:93`); `SERVER-CERT` is only interpreted if longer than 50
+   chars (AutoMTLS) — **Conduit's client never sets `AutoMTLS: true`**
+   (absent from `pconnector/client/client.go`), so **leave this field empty**; no
+   TLS is in play.
+
+4. Choose **TCP**, not Unix domain socket, for the listen transport. go-plugin's
+   own server defaults to a Unix socket on non-Windows and TCP only on Windows
+   (`server.go:528-535`), but the client-side parser accepts either
+   (`client.go:888-901`) — nothing requires matching the Go default. TCP on
+   `127.0.0.1:0` (OS-assigned port) is simpler to implement correctly in Python
+   (`asyncio`/`grpc.aio` both support it natively) and sidesteps Unix-socket
+   temp-directory/permission bookkeeping. This also gets Windows support "for
+   free" per CLAUDE.md's Windows CI requirement, rather than needing a
+   platform branch.
+5. Serve, on that listener, a **plain gRPC server** — nothing exotic. go-plugin's
+   `GRPCServer.Init()` additionally registers `grpc.health.v1.Health` (service
+   name `"plugin"`, `GRPCServiceName = "plugin"`, set to `SERVING`,
+   `grpc_server.go:24-81`), gRPC reflection, a `GRPCBroker` service, and a
+   `GRPCController` service (carries the `Shutdown` RPC). Of these, two matter in
+   practice for a Python implementation and the rest are cosmetic:
+   - **`grpc.health.v1.Health`** — register it (grpcio ships
+     `grpc_health.v1` support); low effort, part of the documented contract.
+   - **`GRPCController.Shutdown`** — Conduit's `Close()` RPCs this on teardown
+     (`grpc_client.go:106-108`); if unimplemented, `Close()` errors and Conduit
+     force-kills the process ~2s later instead (`client.go:530-567`) — the
+     pipeline still tears down correctly, just not gracefully from go-plugin's
+     point of view. **Implement it** (trivial: acknowledge and
+     `os._exit(0)`/stop the server) so shutdown is clean rather than
+     relying on the timeout fallback, per CLAUDE.md invariant 7 (graceful
+     shutdown by default).
+   - `GRPCBroker` exists for nested/multiplexed plugin scenarios (a plugin that
+     itself dispenses sub-plugins over the same connection). The connector
+     protocol's `SourcePlugin`/`DestinationPlugin`/`SpecifierPlugin` services run
+     directly on the single primary gRPC connection — **a no-op broker stub is
+     sufficient**; Python does not need to reimplement go-plugin's internal
+     yamux-based multiplexer.
+   - gRPC reflection is optional polish (aids `grpcurl`/debugging); include it,
+     it's a few lines with `grpc_reflection`.
+6. Exec with a **clean environment**. Conduit's dispenser sets
+   `cmd.Env = make([]string, 0)` before appending its own vars
+   (`pconnector/client/client.go:45`) — the subprocess gets *only* go-plugin's
+   own vars plus the Conduit-set ones below, **no inherited `PATH`**. Practical
+   consequence for Python: the connector's launch shebang/entry point must be an
+   absolute interpreter path (e.g. baked into a PyInstaller/zipapp artifact, or a
+   wrapper script that resolves its own venv by absolute path) — anything that
+   relies on `PATH`-based `python3` resolution at exec time will fail. This is
+   flagged explicitly in Risks & Open Questions and drives the packaging
+   decision in §3.
+
+#### 1.2 Env vars a Python subprocess should read
+
+| Var | Source | Purpose |
+| --- | --- | --- |
+| `CONDUIT_PLUGIN_MAGIC_COOKIE` | go-plugin | handshake cookie, must match §1.1 |
+| `PLUGIN_PROTOCOL_VERSIONS` | go-plugin | client-supported protocol versions to negotiate against |
+| `PLUGIN_MIN_PORT`/`PLUGIN_MAX_PORT` | go-plugin | only relevant if restricting the TCP port range; not required |
+| `CONDUIT_CONNECTOR_UTILITIES_GRPC_TARGET` | `pconnutils/env_vars.go:18` | address of Conduit's connector-utilities gRPC service (schema registry access, etc.) |
+| `CONDUIT_CONNECTOR_TOKEN` | `pconnutils/env_vars.go:19` | auth token for calling back into Conduit |
+| `CONDUIT_CONNECTOR_ID` | `pconnector/env_vars.go:18-20` | this connector instance's ID |
+| `CONDUIT_CONNECTOR_LOG_LEVEL` | same | log level to honor |
+| `CONDUIT_CONNECTOR_MAX_RECEIVE_RECORD_SIZE` | same | gRPC max message size to configure |
+
+Unused/irrelevant given the TCP choice: `PLUGIN_UNIX_SOCKET_DIR`,
+`PLUGIN_UNIX_SOCKET_GROUP`, `PLUGIN_CLIENT_CERT` (AutoMTLS only).
+
+#### 1.3 RPC surface to implement (protocol v2)
+
+From `conduit-connector-protocol/proto/connector/v2/{source,destination,specifier}.proto`,
+confirmed against `conduit-connector-protocol/proto/buf.yaml` (BSR module
+`buf.build/conduitio/conduit-connector-protocol`, dep on
+`buf.build/conduitio/conduit-commons`):
+
+- **`SourcePlugin`** (`source.proto:16-73`): `Configure` (unary), `Open`
+  (unary), `Run` (**bidirectional stream** — plugin streams record batches out,
+  Conduit streams ack-position batches back, independently/concurrently), `Stop`
+  (unary), `Teardown` (unary), `LifecycleOnCreated`/`OnUpdated`/`OnDeleted`
+  (unary each).
+- **`DestinationPlugin`** (`destination.proto:14-71`): same shape — `Run` is
+  bidi, Conduit streams record batches in, plugin streams back per-record acks
+  (each carrying an optional error string) — `Configure`, `Open`, `Stop`,
+  `Teardown`, three lifecycle hooks.
+- **`SpecifierPlugin`** (`specifier.proto:11-14`): `Specify` (unary) → name,
+  summary, description, version, author, `source_params`/`destination_params`.
+
+The `Run` bidi stream is the only structurally interesting RPC — everything else
+is unary request/response. `grpc.aio`'s native bidi-stream support maps onto it
+directly (see §2 for how this shapes the async-vs-sync recommendation).
+
+#### 1.4 Wire record shape (confirmed against the .proto, not inferred)
+
+`conduit-commons@v0.6.0/proto/opencdc/v1/opencdc.proto:91-131`:
+
+```protobuf
+message Record {
+  bytes position = 1;
+  Operation operation = 2;             // OPERATION_{CREATE,UPDATE,DELETE,SNAPSHOT} = 1..4
+  map<string, string> metadata = 3;
+  Data key = 4;
+  Change payload = 5;
+}
+message Change {
+  Data before = 1;   // optional; update/delete only
+  Data after = 2;    // all ops except delete
+}
+message Data {
+  oneof data {
+    bytes raw_data = 1;
+    google.protobuf.Struct structured_data = 2;
+  }
+}
+```
+
+This directly confirms the Go-side `opencdc.Data` interface
+(`conduit-commons@v0.6.0/opencdc/data.go:29-34`, implementers `RawData []byte` /
+`StructuredData map[string]interface{}`) is, at the wire level, nothing more
+than a two-way oneof. Section 2.3 uses this to justify a simpler Python
+representation than Go's interface indirection.
+
+#### 1.5 Codegen: buf + protoc, not betterproto
+
+**Recommendation: `buf generate` against
+`buf.build/conduitio/conduit-connector-protocol`, using the
+`protocolbuffers/python` + `protocolbuffers/pyi` remote plugins for messages plus
+`grpc/python` for service stubs**, mirroring exactly what
+`conduit-processor-sdk-python/proto/buf.gen.yaml` already does for messages
+(`protocolbuffers/python:v31.1` + `protocolbuffers/pyi:v31.1`) plus a grpc
+plugin for the service definitions it doesn't need (WASM has no gRPC service, so
+that repo has no precedent for the grpc plugin specifically — this SDK adds it).
+See Alternatives Considered for why `betterproto` was rejected.
+
+### 2. Idiomatic Python API design
+
+The public surface a connector author writes against. Design goal: feel like a
+modern Python library (dataclasses/pydantic, `async`/`await`, exceptions), not a
+Go interface transliterated field-for-field. Where Go needed indirection to work
+around limitations Python doesn't have (an interface for `Data`, a code-gen step
+for parameter specs, a `mustEmbedUnimplementedX()` seal for forward-compat), this
+design collapses it.
+
+#### 2.1 async, not sync — and why
+
+The `Run` RPC is a bidirectional stream: a source must be able to emit records
+*and* receive ack callbacks concurrently on the same logical connection; a
+destination must receive record batches *and* emit ack batches concurrently.
+`grpc.aio` models this natively as two independent `async for` loops over one
+call object. A sync `grpcio` implementation could do this too (with a background
+thread pulling one direction while the RPC thread pushes the other), but that
+pushes hand-rolled thread-safety onto the SDK's core loop for no benefit — the
+whole surface (HTTP clients, DB drivers, message-queue clients most connectors
+wrap) is I/O-bound, which is precisely asyncio's target case. **Recommendation:
+`asyncio` + `grpc.aio` as the SDK runtime.**
+
+Connector authors, though, should not be forced into `async def` if their
+target system's client library is sync-only (many DB drivers still are).
+**Base class methods are declared `async def`, but the SDK detects a sync
+override via `inspect.iscoroutinefunction` and runs it in a thread-pool executor
+transparently** — the same dual-mode ergonomic FastAPI uses for path operations.
+An author writing a sync `psycopg2`-based source just writes `def read(self):
+...`; an author writing an `httpx.AsyncClient`-based source writes `async def
+read(self): ...`. Both are first-class, not "sync as a fallback hack."
+
+#### 2.2 Config: pydantic v2, with paramgen replaced by introspection
+
+Go needs `paramgen` (`conduit-commons@v0.6.0/paramgen/`, driven by struct tags
+like `validate:"required,gt=0,lt=100,inclusion=a|b"`,
+`conduit-connector-sdk`'s template invoking it via `//go:generate conn-sdk-cli
+specgen`, `conduit-connector-template/connector.go:1`) because Go has no runtime
+reflection rich enough to turn a struct's field types and tags into a
+`config.Parameter` map without a separate generation pass. **Python doesn't have
+that problem: pydantic v2's `model_fields` already carries type, default, and
+constraint metadata at runtime.** The SDK provides one function,
+`to_parameters(config_cls: type[BaseConfig]) -> dict[str, Parameter]`, that
+introspects a pydantic model and produces the `Specify` RPC's parameter map
+directly — **no codegen step, no `//go:generate`, always in sync with the model
+because it's the model.** This is a genuine simplification over the Go SDK, not
+just a stylistic swap, and is worth flagging as such in author-facing docs.
+
+```python
+class Config(BaseConfig):
+    url: str = Field(description="HTTP endpoint to poll.")
+    poll_interval_ms: int = Field(default=1000, ge=100, description="Milliseconds between polls.")
+    format: Literal["json", "csv"] = Field(default="json")  # -> Validation.inclusion
+```
+
+Mapping to `config.Parameter`/`Validation` (`conduit-commons@v0.6.0/config/
+parameter.go:20-43`, `config/validation.go:29-45`): `Field(default=...)` →
+`Default`; `ge=`/`le=` → `greater-than`/`less-than`; `Literal[...]` → `inclusion`;
+`pattern=` → `regex`; a plain (no-default) field → `required`. `BaseConfig`
+subclasses `pydantic.BaseModel` and additionally exposes `to_parameters()` as a
+classmethod so the Specifier RPC handler is one line:
+`Specify.Response(source_params=SourceConfig.to_parameters(), ...)`.
+
+#### 2.3 The OpenCDC record: `bytes | dict`, not an interface
+
+Go's `opencdc.Data` interface (`Bytes()`, `Clone()`, `ToProto()`) exists to give
+two structurally different Go types (`RawData []byte`, `StructuredData
+map[string]interface{}`) a common contract. Per §1.4, the wire format is simply
+a two-way oneof (`raw_data: bytes` / `structured_data: Struct`). Python doesn't
+need the interface: `bytes` and `dict` already have their own copy semantics
+(`bytes` is immutable, `dict.copy()`/`copy.deepcopy()` handle `Clone()`'s job),
+and `isinstance()` at the (de)serialization boundary — not author-facing code —
+is enough to pick the right oneof branch. **`Data = bytes | Mapping[str, Any]`.**
+
+```python
+@dataclass
+class Change:
+    before: Data | None = None   # update/delete only
+    after: Data | None = None    # all ops except delete
+
+class Operation(enum.Enum):
+    CREATE = 1
+    UPDATE = 2
+    DELETE = 3
+    SNAPSHOT = 4
+
+@dataclass
+class Record:
+    position: bytes
+    operation: Operation
+    metadata: dict[str, str] = field(default_factory=dict)
+    key: Data = b""
+    payload: Change = field(default_factory=Change)
+```
+
+Plain `dataclasses`, not pydantic, for `Record` — records are produced/consumed
+at high frequency in the hot path; pydantic's validation overhead isn't wanted
+there, and there's nothing to validate (the wire format already constrains the
+shape). Well-known metadata keys (`opencdc.collection`, `opencdc.createdAt`,
+etc. — confirmed exact strings in `opencdc.proto:9-20`, e.g.
+`metadata_collection = "opencdc.collection"`) ship as `Metadata` string
+constants plus typed helpers (`record.metadata.set_created_at(dt)`) mirroring
+Go's `GetCreatedAt`/`SetCreatedAt` ergonomics on the underlying dict.
+
+#### 2.4 Forward-compatible base classes without Go's seal hack
+
+Go forces `mustEmbedUnimplementedSource()` (an unexported method only
+`UnimplementedSource` provides) so a struct can't accidentally satisfy the
+`Source` interface without embedding the default impl — protecting against the
+interface growing a method later. Python's ABC + default-method pattern gets the
+same guarantee for free: `Source`/`Destination` are `abc.ABC` subclasses with
+`open`/`read`/`ack`/`teardown`/lifecycle hooks all having **default no-op (or
+`NotImplementedError`-raising) bodies** except the couple of genuinely-required
+ones (`read`/`write`, `config` typed by the generic parameter). Adding a new
+optional method later is source-compatible automatically — no seal method
+needed, no boilerplate for authors.
+
+#### 2.5 Errors: exceptions, not `(n, err)`
+
+Go's `Destination.Write(ctx, batch) (n int, err error)` requires the SDK to
+*enforce* an invariant that's easy to get wrong: `n == len(batch)` must imply
+`err == nil`, and `n < len(batch)` must imply `err != nil`
+(`conduit-connector-sdk/destination.go:345-350` logs it as a connector bug
+otherwise). Python favors exceptions for error propagation and this SDK follows
+that: `async def write(self, records: list[Record]) -> None`; full success is
+"no exception raised"; a partial-batch failure raises
+`BatchWriteError({index: exception, ...})`, which the SDK's adapter — not the
+author — translates into the correct per-record ack/error entries on the `Run`
+stream. This removes the invariant-violation footgun structurally instead of
+relying on authors reading a doc comment.
+
+For `Source.read()`: raising `BackoffRetry` signals "no record right now,
+retry with backoff" (direct analog of Go's `ErrBackoffRetry`,
+`conduit-connector-sdk/error.go:19-27`, consumed with a `Factor:2, Min:100ms,
+Max:5s` backoff at `source.go:280-289` — the Python SDK reuses the same
+constants for parity). Any other exception propagates as a gRPC `INTERNAL`
+status with the exception's string as detail. The base `ConnectorError`
+exception carries an optional `code: str | None` field, currently unused on the
+wire — **the Go connector protocol has no stable error-code scheme today**
+(confirmed: no sentinel/coded-error taxonomy beyond `ErrBackoffRetry`/
+`ErrUnimplemented`, `conduit-connector-sdk/error.go:19-27`) — but a protocol
+change adding plugin-originated `ConduitError` codes is already flagged as
+landing around v0.16 per
+[SDK & embedding developer experience](20260705-sdk-and-embedding-dx.md:39-41,361).
+Reserving the field now avoids a breaking SDK change when that lands; until
+then it's always `None` and unused by the wire encoding.
+
+#### 2.6 Batching and schema: what Phase 1 defers
+
+Go's `ReadN`/`Write([]Record)` batch APIs and `sdk.batch.size`/`sdk.batch.delay`
+middleware (`source_middleware.go:651-657`, purely local/config-driven — no
+protocol-level batch negotiation, confirmed) are useful but not required for a
+minimally-working connector, since the wire protocol's `Run` stream is already
+batch-shaped at the message level regardless of SDK-side buffering. **Phase 1**
+implements the direct mapping only: `async def read(self) -> Record` (SDK wraps
+single records into single-record batches on the wire) and `async def
+write(self, records: list[Record]) -> None` (destination `Run` messages are
+naturally batched, so no author-side batching primitive is needed there at all
+— `write` already receives whatever batch Conduit sent). A `read_batch`
+override point and `sdk.batch.size`/`delay`-equivalent config are **Phase 2**,
+added as an optional base-class override the SDK falls back away from if
+unimplemented (mirroring Go's `ReadN` cascading to `Read`). Schema
+extraction/encoding middleware (Avro registration, `SourceWithSchemaExtraction`
+et al.) is **Phase 2** as well — Phase 1 records carry raw `bytes`/`dict` only,
+no schema subject/version metadata is auto-populated.
+
+#### 2.7 End-to-end example (illustrative — not final API)
+
+```python
+"""A minimal Conduit source connector: polls an HTTP endpoint for new rows."""
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+import httpx
+from conduit import BackoffRetry, Change, Operation, Record, Source, Specification, serve
+from conduit.config import BaseConfig, Field
+
+
+class Config(BaseConfig):
+    url: str = Field(description="HTTP endpoint to poll, expects ?since=<cursor>.")
+    poll_interval_ms: int = Field(default=1000, ge=100, description="Delay between empty polls.")
+
+
+class HTTPPollSource(Source[Config]):
+    async def open(self, position: bytes | None) -> None:
+        self._client = httpx.AsyncClient()
+        self._since = position.decode() if position else "0"
+
+    async def read(self) -> Record:
+        resp = await self._client.get(self.config.url, params={"since": self._since})
+        rows = resp.json()
+        if not rows:
+            await asyncio.sleep(self.config.poll_interval_ms / 1000)
+            raise BackoffRetry()
+
+        row = rows[0]
+        self._since = str(row["id"])
+        return Record(
+            position=self._since.encode(),
+            operation=Operation.CREATE,
+            key={"id": row["id"]},
+            payload=Change(after=row),
+            metadata={"opencdc.readAt": str(int(datetime.now(UTC).timestamp() * 1e9))},
+        )
+
+    async def teardown(self) -> None:
+        await self._client.aclose()
+
+
+if __name__ == "__main__":
+    serve(Specification(name="http-poll", version="0.1.0", author="you"), source=HTTPPollSource)
+```
+
+~38 lines, no boilerplate beyond what the connector's own logic needs. `Ack`,
+lifecycle hooks, and config validation all have working defaults from the base
+class and don't need overriding for this connector.
+
+### 3. Repo & packaging
+
+**New repo: `ConduitIO/conduit-connector-sdk-python`** — matches the naming
+pattern already established by `ConduitIO/conduit-processor-sdk-python` and the
+name anticipated in
+[SDK & embedding developer experience](20260705-sdk-and-embedding-dx.md:57-58,338).
+
+Proposed layout:
+
+```
+conduit-connector-sdk-python/
+  pyproject.toml            # uv-managed; hatchling build backend
+  src/conduit/
+    __init__.py              # public API: Source, Destination, Record, Operation, Change, serve, errors
+    config.py                 # BaseConfig, Field, to_parameters()
+    record.py                 # Record/Change/Operation/Metadata
+    source.py                 # Source ABC, default middleware hook points
+    destination.py            # Destination ABC
+    serve.py                  # handshake + gRPC server bootstrap (the §1 implementation)
+    _handshake.py              # magic cookie, protocol negotiation, stdout line
+    _grpc/                     # generated stubs (buf generate output) + adapters translating
+                                # proto <-> Python dataclasses/pydantic models
+    testing/
+      acceptance.py            # the acceptance-test harness (Phase 2)
+      fixtures.py               # golden record-shape fixtures shared with other-language SDKs
+  examples/http-poll-source/    # the Phase-1 worked example, runnable standalone
+  buf.gen.yaml                  # codegen config (see §1.5)
+  tools/                         # pinned dev-tool versions (ruff, mypy, buf) — mirrors conduit-connector-template's tools/go.mod pattern
+  .github/workflows/
+    lint.yml  test.yml  release.yml  compat-nightly.yml   # see below
+  CONTRIBUTING.md  README.md  CHANGELOG.md
+```
+
+- **Packaging**: `pyproject.toml`, `uv` for dependency management/locking
+  (fast, single-tool, increasingly the default in the Python ecosystem the
+  python-pro persona targets), `hatchling` build backend. Publish to PyPI as
+  `conduit-connector-sdk`.
+- **Python floor**: 3.11+ (per house style; also the first version with mature
+  `tomllib`, exception groups, and `asyncio.TaskGroup` — the latter is directly
+  useful for running the two directions of a bidi `Run` stream concurrently
+  with structured error propagation).
+- **Lint/type**: `ruff` (format + lint, replacing black/isort/flake8 in one
+  tool) and `mypy --strict` on the public API surface (`pyright` as a
+  documented alternative for authors, not required in this repo's CI).
+- **Test**: `pytest`, `pytest-asyncio`, `hypothesis` for the record
+  (de)serialization round-trip properties (raw ↔ proto ↔ dataclass), mirroring
+  CLAUDE.md's property-testing bar for serialization code even though this repo
+  isn't the core data path — the record codec is exactly the kind of
+  round-trip-sensitive code that bar is meant to cover.
+- **Acceptance-test harness (Phase 2, designed now)**: mirrors
+  `sdk.AcceptanceTest(t, driver)`. A `conduit.testing.AcceptanceTestDriver`
+  Protocol an author implements (`write_to_source`, `read_from_destination`,
+  seed-data hooks — direct analogs of the Go driver's custom-hook methods,
+  `acceptance_testing.go:67-120`), and a `ConfigurableAcceptanceTestDriver`
+  convenience wrapper (analog of `acceptance_testing.go:125-177`) for the common
+  case (just supply the connector class + two valid configs pointing at the
+  same resource). Test categories are the same list the Go suite defines
+  (`acceptance_testing.go:506-874`): specifier existence/validity, config
+  parameter validation (success + required-param-missing), resume-at-position
+  (snapshot and CDC), read/write round trip, read timeout behavior — kept
+  **version-numbered** per
+  [SDK & embedding developer experience](20260705-sdk-and-embedding-dx.md:66-73)
+  ("the acceptance-test suite is versioned and published per language") so an
+  author knows exactly which contract version they passed, and so
+  cross-language parity (a Python connector is "the same kind of thing" as a Go
+  one from Conduit's perspective) is a checkable claim, not an assertion.
+- **CI matrix**: ubuntu-latest, macos-latest, windows-latest (Windows because
+  the TCP-transport handshake choice in §1.1 makes it free — no Unix-socket
+  platform branch to skip on Windows), against the two most recent CPython
+  minors on the 3.11+ floor. A separate `compat-nightly.yml` job regenerates
+  the gRPC stubs from the **current** `buf.build/conduitio/conduit-connector-protocol`
+  HEAD and runs the acceptance suite against the current Conduit dev build —
+  the drift-detection mechanism from Risks & Open Questions, and the same
+  "templates track the SDK" discipline CLAUDE.md already holds the Go
+  templates to
+  ([SDK & embedding developer experience](20260705-sdk-and-embedding-dx.md:350-353)).
+- **Release**: tag-triggered, conventional-commit changelog, published to PyPI
+  via a trusted-publisher GitHub Action (no long-lived PyPI token in repo
+  secrets) — this is a stricter bar than the Go template's `goreleaser`
+  approach (`conduit-connector-template/.goreleaser.yml`) because a PyPI
+  package, unlike a per-connector binary release, is a shared supply-chain
+  surface every downstream Python connector depends on.
+- **Example/template connector**: `examples/http-poll-source/` is the Phase-1
+  worked example from §2.7, made fully runnable (its own `pyproject.toml`,
+  README, and a `conduit.yaml` pipeline definition proving Conduit can run it
+  standalone) — the Python analog of what `conduit connector new` scaffolds for
+  Go from `conduit-connector-template`. A dedicated
+  `conduit-connector-template-python` repo (mirroring
+  `conduit-connector-template`'s CI/README-generation/release-workflow
+  structure) is **Phase 3** work, gated on `conduit connector new --lang
+  python` integration — building it before the SDK's API has stabilized
+  through a couple of real connectors would lock in the wrong shape.
+
+### 4. Phased plan
+
+#### Phase 1 — MVP: Conduit can run a Python connector
+
+Scope: handshake (§1) + `Source`/`Destination` ABCs (§2.1, §2.4) + `Configure`/
+`Specify` (§2.2, no schema/middleware) + OpenCDC record (§2.3) + basic
+lifecycle (`Open`/`Run`/`Stop`/`Teardown`, unary lifecycle hooks as no-ops
+unless overridden) + `BackoffRetry`/`BatchWriteError` (§2.5) + the worked
+example connector (§2.7, §3).
+
+Explicitly **not** in Phase 1: acceptance-test harness (hand-verified only),
+schema/Avro middleware, `sdk.batch.*`-equivalent config, `conduit connector new
+--lang python` integration, PyPI trusted-publisher release automation (manual
+release is fine for a v0.x).
+
+**Definition of done (the acceptance criterion):** a fresh checkout of
+`conduit-connector-sdk-python`'s example connector, installed with `uv sync`,
+launched by a **real, unmodified Conduit binary** (no Conduit-side code
+changes) as the source of a pipeline whose destination is `conduit-connector-
+file` (or another already-supported connector) — records flow end-to-end, get
+acked, and `conduit pipelines stop` triggers a clean subprocess exit via the
+`GRPCController.Shutdown` path (§1.1.5), not the 2-second force-kill fallback.
+This is scripted and CI-timed, not eyeballed once — it becomes the
+`compat-nightly.yml` job from day one and stays green thereafter.
+
+#### Phase 2 — acceptance harness, schema/middleware, paramgen parity, docs
+
+- Acceptance-test harness (§3), versioned, published.
+- `read_batch` override + batch-size/delay config (§2.6).
+- Schema extraction/encoding middleware, matching `SourceWithSchemaExtraction`/
+  `DestinationWithSchemaExtraction` semantics (registering key/payload schemas,
+  attaching subject/version metadata — the exact metadata keys are already
+  confirmed at the wire level, `opencdc.proto:23-30`).
+- Full docs: per-connector-author tutorial (same worked example as the Go/Rust/
+  TS tutorials per
+  [SDK & embedding developer experience](20260705-sdk-and-embedding-dx.md:318-320),
+  so a reader compares apples to apples across languages), godoc-equivalent
+  (`ruff`-enforced docstring coverage + `pydoc`/`mkdocstrings`-generated
+  reference), cookbook recipes.
+- Golden record-shape fixture corpus shared with the Go/other-language suites
+  (raw, structured, tombstone, schema-carrying, error shapes) per the "one
+  corpus" principle in the embedding-DX doc.
+
+#### Phase 3 — parity polish, CLI integration
+
+- `conduit connector new --lang python` scaffolds from a
+  `conduit-connector-template-python` repo (§3).
+- `conduit connector test`/`conduit connector build` wire into the Python
+  acceptance/integration loop the same way they do for Go
+  ([SDK & embedding developer experience](20260705-sdk-and-embedding-dx.md:107-128)).
+- Performance parity pass against the Go SDK on a benchi-committed reference
+  pipeline (see Risks & Open Questions — "performance vs Go").
+- `conduit connector generate` (AI-assisted scaffolding) targets Python as a
+  `--lang` option once the MCP/generate tooling exists for Go.
+
+## Alternatives considered
+
+**Protobuf codegen tool — `grpcio-tools`/`buf generate` (recommended) vs.
+`betterproto`.** `betterproto` produces more idiomatic Python (dataclasses,
+`async` client stubs, no `_pb2.py` boilerplate) and was seriously considered for
+that reason. Rejected because: (a) it lags official protobuf releases and has
+had long stretches without releases historically, a maintenance-burden risk for
+a protocol that must track `conduit-connector-protocol` closely; (b) the org
+already has working precedent for `buf generate` with the official
+`protocolbuffers/python`+`pyi` plugins in `conduit-processor-sdk-python`
+(confirmed, §Context) — matching it avoids a second, divergent Python-codegen
+toolchain in the org for no strong reason; (c) the generated `_pb2.py`/`_pb2_grpc.py`
+stubs are treated as an internal implementation detail behind `_grpc/` adapters
+(§3) — authors never see them, so betterproto's ergonomic advantage doesn't
+reach the public API anyway, since §2 already wraps everything in idiomatic
+dataclasses/pydantic models regardless of the underlying codegen choice.
+
+**Transport — TCP (recommended) vs. Unix domain socket.** Matching go-plugin's
+own non-Windows default (Unix socket) was considered for "do what Go does."
+Rejected: the client-side parser is transport-agnostic (§1.1.4), Unix sockets
+need temp-directory and permission handling with no corresponding benefit here
+(this is a loopback-only, single-host, single-connection channel — no
+performance case for sockets over loopback TCP at this scale), and TCP gets
+Windows support without a platform branch, which Unix-socket-by-default would
+have needed anyway since go-plugin itself falls back to TCP on Windows.
+
+**Async-only vs. dual sync/async author API (recommended: dual).** Forcing
+`async def` everywhere (simplest to implement, matches `grpc.aio` directly) was
+considered. Rejected as author-hostile: a large fraction of Python's
+data-ecosystem client libraries (many DB drivers, some vendor SDKs) are
+sync-only, and forcing authors to wrap them in `asyncio.to_thread` themselves
+just moves boilerplate from the SDK into every connector. The thread-pool
+dispatch (§2.1) costs a small amount of SDK-internal complexity once, in
+exchange for removing it from every connector author's code, every time.
+
+**Config — pydantic v2 (recommended) vs. stdlib `dataclasses` + hand-written
+validators.** Dataclasses avoid a dependency and match the `Record` type's
+choice (§2.3). Rejected for `Config` specifically because the paramgen-by-
+introspection design (§2.2) is the whole point of the Pythonic simplification
+over Go's codegen step, and that requires rich, already-structured field
+metadata (type, default, constraints) at runtime — reimplementing that on top
+of bare dataclasses would mean hand-rolling a worse version of what pydantic
+already provides, for the sake of one fewer dependency in an ecosystem where
+pydantic is close to ubiquitous.
+
+**Error model — exceptions (recommended) vs. mirroring Go's `(n, err)`
+contract.** Matching Go's `Write(ctx, batch) (n, err)` return shape verbatim
+was considered, for API-shape parity across languages. Rejected: that shape
+exists in Go specifically because Go lacks structured exceptions with attached
+data cleanly separable from control flow, and it requires the SDK to defend an
+invariant (`destination.go:345-350`) that a well-designed Python API can make
+structurally unrepresentable instead of enforced-at-runtime (§2.5). Parity of
+*behavior* (correct per-record acks on partial failure) is kept; parity of
+*shape* is not a goal in itself.
+
+## Failure modes
+
+Analyzed against CLAUDE.md's data-integrity invariants, scoped to what an SDK
+(not the engine) is responsible for:
+
+- **Handshake cookie mismatch / malformed stdout line** → process must exit
+  non-zero with a clear stderr diagnostic before printing anything on stdout
+  that isn't the handshake line itself (stdout is a structured channel go-plugin
+  parses — any stray `print()` before the handshake line corrupts it). SDK
+  design mitigation: redirect all logging to stderr by default (§ mirrored from
+  Go SDK's stdio-forwarding behavior) and document this loudly for authors, since
+  a rogue `print()` in connector code is an easy way to break the handshake.
+- **Crash mid-`Run` stream (source)** → in-flight, unacked records are lost from
+  the SDK's perspective on restart unless the source's own `Open(position)`
+  contract correctly resumes from the last acked position (invariant 2). Phase
+  1's acceptance criterion doesn't yet include a resume-after-kill test (that's
+  Phase 2's acceptance harness, mirroring
+  `TestSource_Open_ResumeAtPositionCDC`); flagged as a Phase 1 gap, not silently
+  assumed safe.
+- **Partial-batch write failure (destination)** → `BatchWriteError` (§2.5) must
+  be raised with an entry for every failed index; the SDK adapter treats a
+  missing index as "silently assumed successful," which is exactly the kind of
+  silent-coercion failure CLAUDE.md's invariant 6 rules out for schema handling
+  and this design extends to ack accuracy — the adapter should treat an
+  **incomplete** `BatchWriteError` mapping as itself an error (fail closed, not
+  fail open) rather than guessing.
+- **`GRPCController.Shutdown` not implemented correctly** → falls back to
+  Conduit's 2-second force-kill (§1.1.5) — functional (no pipeline hang) but
+  not graceful; in-flight writes at kill time are the same risk profile as any
+  `SIGKILL` mid-batch scenario the chaos suite (Phase 2+ per Process maturity)
+  is meant to cover once it exists for this SDK's own test matrix, not just the
+  engine's.
+- **`PATH` not inherited (§1.1.6)** → connector fails to launch at all if
+  packaged naively (e.g. a `#!/usr/bin/env python3` shebang script relying on
+  `PATH` resolution). Mitigated by packaging guidance in §3 and Phase 1's done
+  criterion explicitly using a real Conduit launch (not a hand-run process),
+  which would surface this failure immediately if unaddressed.
+
+## Upgrade/rollback & compatibility
+
+- **Protocol version skew**: the SDK targets protocol v2 and negotiates via
+  `PLUGIN_PROTOCOL_VERSIONS` (§1.1.2) — if a future protocol v3 lands, an older
+  SDK still negotiates down to v2 as long as Conduit's client keeps v2 in its
+  `VersionedPlugins` map (the standard go-plugin backward-compat mechanism,
+  already relied on for the existing v1/v2 coexistence). No SDK-side action
+  needed for additive protocol changes; a breaking protocol change is already
+  governed by CLAUDE.md's "never change `conduit-connector-protocol` without an
+  explicit versioning discussion" rule, upstream of this SDK.
+- **SDK API breaking changes**: this repo commits to semver from v1.0; breaking
+  changes to the `Source`/`Destination`/`Config` public surface follow the
+  standing announce → warn → remove policy (minimum two minor versions),
+  matching the org-wide deprecation policy CLAUDE.md sets for serialized
+  formats and public contracts generally, extended here to this SDK's own API
+  surface since downstream connector code depends on it exactly like a
+  protocol.
+- **Rollback**: since the SDK ships as a versioned PyPI package pinned per
+  connector project (not vendored into Conduit), rolling back is "pin an older
+  SDK version" — no coordinated Conduit-side rollback needed, which is the main
+  practical benefit of the standalone-subprocess architecture over anything
+  in-process.
+- **Drift detection**: the `compat-nightly.yml` job (§3) regenerating stubs
+  from BSR HEAD and running the acceptance suite against a current Conduit dev
+  build is the primary mechanism preventing silent protocol drift — this is the
+  same mechanism the embedding-DX doc already prescribes org-wide ("a protocol
+  bump is additive-and-versioned ... a nightly job regenerates + runs each
+  SDK's template CI",
+  [20260705-sdk-and-embedding-dx.md:76-79](20260705-sdk-and-embedding-dx.md)).
+
+## Observability
+
+- Connector logs cross the process boundary as structured records on stderr
+  (JSON lines), consumed by Conduit the same way the Go SDK's logs are —
+  matching CLAUDE.md's cross-boundary structured-error/log principle from the
+  embedding-DX doc rather than inventing a Python-specific log format.
+  **Never write to stdout** except the single handshake line (§ Failure modes).
+- The SDK exposes a `conduit.testing` record inspector hook (Phase 2, shared
+  with the "record inspector + dry-run" tooling described in the embedding-DX
+  doc's A3 local-testing-loop section) so an author can pipe sample records
+  through their connector locally without standing up a full pipeline.
+- Errors raised by connector code surface through the gRPC status + detail
+  string today (§2.5); once the protocol's plugin-originated `ConduitError`
+  codes land, this SDK's `ConnectorError.code` field starts being populated and
+  serialized — designed for that transition now rather than bolted on later.
+
+## Risks & open questions
+
+1. **The handshake is the single biggest execution risk**, not because it's
+   Python-hostile (it isn't — §1 shows it's a plain stdout line plus a
+   standard gRPC server) but because it's easy to get subtly wrong in ways that
+   only surface as "Conduit hangs waiting for the plugin to start" with a poor
+   error message. Mitigation: Phase 1's done-criterion is a real Conduit launch
+   from day one (not a hand-rolled harness that might pass while the real
+   client-side parser would reject the line), and the handshake implementation
+   ships with its own focused unit tests asserting the exact line format
+   against the go-plugin source's parser logic (`client.go:838-926`).
+2. **gRPC/codegen choice locks in early.** `buf generate` + protoc stubs (§1.5)
+   is the recommendation, but it's the one decision hardest to reverse later
+   (the internal `_grpc/` adapter layer insulates the public API from this, per
+   §Alternatives, which is precisely designed to make a later swap possible
+   without an author-facing breaking change if the choice turns out wrong).
+3. **Async runtime + subprocess lifecycle interaction.** `asyncio`'s
+   interaction with process-exit signal handling (SIGTERM from Conduit's
+   graceful-shutdown path, invariant 7) needs care — an `asyncio` event loop
+   that's mid-`await` when SIGTERM arrives must still let in-flight writes
+   drain before the process exits, the same drain-before-exit discipline
+   CLAUDE.md requires of the engine itself, now also required of every SDK
+   author's `teardown()`. This needs its own focused test in Phase 1, not just
+   a docs note — a straightforward chaos-style "SIGTERM mid-write" test using
+   the example connector.
+4. **Performance vs. Go is unknown and unclaimed.** No benchmark exists yet;
+   per CLAUDE.md, no performance claim should be made about this SDK (parity or
+   otherwise) without a `benchi` run committed to the repo. Phase 3 explicitly
+   schedules that benchmark; until then, "how much throughput does a Python
+   connector cost vs. Go" is an open question, not an assumed answer, and
+   should be described that way in any interim docs.
+5. **Second-SDK maintenance burden.** Every future connector-protocol change
+   now has two SDKs (at least) to update, tested, and released in lockstep, on
+   top of the existing solo-maintainer reality. The `compat-nightly.yml`
+   mechanism (§3, §Upgrade/rollback) is the concrete mitigation, but it doesn't
+   remove the underlying cost — this is an honest tradeoff being made for
+   Python-audience reach, not a free win, and should be named as such when
+   this doc gets a maintainer sign-off.
+6. **Windows subprocess launch specifics.** TCP transport removes the
+   Unix-socket asymmetry, but Windows process launching (job objects, signal
+   delivery — Windows has no SIGTERM) has its own quirks for a subprocess
+   expected to shut down gracefully; Conduit's own Windows CI story is called
+   out generally in CLAUDE.md §5 but this SDK's specific Windows
+   graceful-shutdown behavior is untested until the CI matrix in §3 actually
+   runs it — flagged, not assumed fine.
+7. **`google.protobuf.Struct` round-trip fidelity for `StructuredData`.**
+   `Struct` only supports JSON-like values (no bytes, no distinguishing int
+   from float in all cases); a Python `dict` used as `StructuredData` that
+   contains, say, raw bytes in a nested field would silently lose fidelity
+   through the `Struct` encoding. This needs an explicit documented boundary
+   (what's a valid `StructuredData` payload) in Phase 1 rather than discovered
+   by a connector author later — a case of CLAUDE.md's "schema handling never
+   silently mangles data" invariant applying to the SDK's own record codec,
+   even though the SDK isn't the engine's data path per se.
+
+## Acceptance criteria
+
+**For the SDK overall:**
+
+- A connector written against this SDK, passing the versioned acceptance suite
+  (Phase 2+), is treated by Conduit as fully interchangeable with a Go
+  connector — no capability gap silently assumed away; any protocol feature the
+  Python SDK can't yet express is documented, not hidden (per the "document the
+  gap per language" principle in
+  [20260705-sdk-and-embedding-dx.md:80-82](20260705-sdk-and-embedding-dx.md)).
+- Every doc example compiles/runs in CI; a non-running example is a build
+  failure, not a stale doc.
+- No performance claim ships without a committed `benchi` result.
+- The `compat-nightly.yml` job stays green continuously post-Phase-1; a red
+  result is treated as a protocol-drift incident, not routine noise.
+
+**For Phase 1 specifically (the concrete, testable bar):**
+
+- A real, unmodified Conduit binary launches the example connector as a
+  subprocess via the exact handshake in §1, with no Conduit-side code changes.
+- Records flow end-to-end through a real pipeline (Python source →
+  already-supported destination, or vice versa), get correctly acked, and
+  `conduit pipelines stop` tears the subprocess down via the graceful
+  `GRPCController.Shutdown` path, not the force-kill fallback.
+- This is scripted and CI-timed (matching the "measured, not claimed"
+  discipline the embedding-DX doc holds every other DX number to), and remains
+  the nightly compat check going forward.
+
+## Consequences
+
+- Conduit gains a second, officially maintained connector SDK, opening the
+  Python data/AI ecosystem as a first-class connector-authoring audience
+  without any change to Conduit itself — the standalone-subprocess
+  architecture (ADR `20220121-conduit-plugin-architecture.md`) pays off exactly
+  as designed: "it allows us to easily generate code for other programming
+  languages and potentially provide SDKs" (`...conduit-plugin-architecture.md:325`).
+- The org takes on a second SDK's maintenance surface, permanently, on top of
+  an already-solo maintainer reality — named explicitly in Risks, not
+  understated.
+- The Python API's deliberate departures from Go's shape (§2, §Alternatives)
+  mean "port the Go connector" is not a mechanical translation for authors
+  crossing languages — an acceptable, deliberate tradeoff for idiomatic
+  ergonomics per this doc's brief, but worth flagging so cross-language
+  connector porting guides (Phase 2 docs) address it explicitly rather than
+  implying a 1:1 mapping that doesn't exist.
+- This design doc's API surface (base classes, config model, record shape)
+  becomes a public contract the moment Phase 1 ships an example connector
+  against it — future changes to it are governed by the same
+  announce-warn-remove policy as any other public Conduit contract.
+
+## Related
+
+- [SDK & embedding developer experience](20260705-sdk-and-embedding-dx.md) —
+  the org-wide DX plan this doc is the detailed Python-connector follow-on to
+  (persona A1).
+- [Conduit Plugin Architecture](../architecture-decision-records/20220121-conduit-plugin-architecture.md)
+  — the original ADR establishing gRPC-defined, SDK-decoupled plugin
+  interfaces; this doc's §1 supersedes its stale `Start`/`Run`-split
+  description with the current v2 protocol (`Configure`/`Open`/`Run`/`Stop`/
+  `Teardown`) actually running today.
+- [WASM component model](../architecture-decision-records/20260704-wasm-component-model.md)
+  — the *other* extension mechanism (processors, not connectors); referenced
+  in Context to explain why `conduit-processor-sdk-python` is not transport
+  prior art for this SDK.
+- `ConduitIO/conduit-connector-protocol` — the wire contract this SDK
+  implements (`proto/connector/v2/*.proto`, `pconnector/`).
+- `ConduitIO/conduit-connector-sdk` — the Go reference implementation this
+  design mirrors semantically.
+- `ConduitIO/conduit-connector-template` — the Go scaffold this design's
+  Phase 3 template repo is the Python analog of.
+- `ConduitIO/conduit-processor-sdk-python` — existing, unrelated (WASM/
+  processor) Python SDK prototype; codegen-tooling precedent only.
+- `github.com/conduitio/conduit-commons` (`opencdc/`, `config/`) — the OpenCDC
+  record and config-parameter types this SDK's Python equivalents are modeled
+  on.
+
+## Review outcome (2026-07-07) — SOUND (technical) / SOUND-WITH-CONCERNS (API)
+
+Handshake independently byte-verified against go-plugin v1.8.0 — the crux is sound.
+One BLOCKER before Phase-1 build:
+
+- **B1 (data-loss blocker) — partial-batch ack.** `BatchWriteError({index: exc})`
+  with "absence = success" can silently ACK records that were never written (the
+  natural Python loop raises on the first error and never attempts the rest, which
+  are then absent-and-acked → invariant 1/3 violation). Go's `(n, err)` mechanically
+  nacks everything past the successful prefix. **Fix:** any exception nacks the WHOLE
+  batch UNLESS the SDK is given an explicit contiguous `written: int` (Go's `n`) or
+  an exhaustive success set — success by omission is banned.
+- **B3** — the silent `Struct` fidelity case is **int→float** (`{"count":5}`→`5.0`,
+  precision loss > 2^53), not bytes (bytes fails loud). Name it; add Hypothesis
+  round-trip tests asserting IDENTITY.
+- **A-gaps** (pre-Phase-1, non-blocking): pydantic mapping for
+  `ParameterTypeDuration` (Go `"5s"` syntax, not ISO-8601) and `ValidationTypeExclusion`;
+  the worked example double-backoffs (manual sleep + `raise BackoffRetry()` — the SDK
+  already paces; just raise).
+
+Source ack/position flow verified correct (no early-ack risk). API idiom (async +
+dual-mode, pydantic, `bytes|dict`, exceptions, ABCs, uv/pyproject) confirmed sound.

--- a/docs/design-documents/20260707-python-connector-sdk.md
+++ b/docs/design-documents/20260707-python-connector-sdk.md
@@ -73,7 +73,7 @@ with the **`protocolbuffers/python` + `protocolbuffers/pyi`** remote BSR plugins
 output, not `betterproto`. Two takeaways:
 
 1. **It is not prior art for this SDK's transport.** It targets the WASM
-   component-model path for *processors*; connectors use go-plugin/gRPC
+   component-model path for _processors_; connectors use go-plugin/gRPC
    subprocesses, a different mechanism entirely (per the repo map in CLAUDE.md:
    "`conduit-processor-sdk`: standalone processors compile to WASM" vs.
    `conduit-connector-sdk` which has no WASM story). Do not conflate the two —
@@ -133,7 +133,7 @@ A Python plugin must:
 3. Print exactly one handshake line to **stdout** (not stderr — stdout is the
    channel go-plugin's client parses) once the gRPC server is listening:
 
-   ```
+   ```text
    CORE-PROTOCOL-VERSION|APP-PROTOCOL-VERSION|NETWORK|ADDRESS|PROTOCOL|SERVER-CERT
    ```
 
@@ -186,7 +186,7 @@ A Python plugin must:
      it's a few lines with `grpc_reflection`.
 6. Exec with a **clean environment**. Conduit's dispenser sets
    `cmd.Env = make([]string, 0)` before appending its own vars
-   (`pconnector/client/client.go:45`) — the subprocess gets *only* go-plugin's
+   (`pconnector/client/client.go:45`) — the subprocess gets _only_ go-plugin's
    own vars plus the Conduit-set ones below, **no inherited `PATH`**. Practical
    consequence for Python: the connector's launch shebang/entry point must be an
    absolute interpreter path (e.g. baked into a PyInstaller/zipapp artifact, or a
@@ -288,8 +288,8 @@ design collapses it.
 #### 2.1 async, not sync — and why
 
 The `Run` RPC is a bidirectional stream: a source must be able to emit records
-*and* receive ack callbacks concurrently on the same logical connection; a
-destination must receive record batches *and* emit ack batches concurrently.
+_and_ receive ack callbacks concurrently on the same logical connection; a
+destination must receive record batches _and_ emit ack batches concurrently.
 `grpc.aio` models this natively as two independent `async for` loops over one
 call object. A sync `grpcio` implementation could do this too (with a background
 thread pulling one direction while the RPC thread pushes the other), but that
@@ -395,7 +395,7 @@ needed, no boilerplate for authors.
 #### 2.5 Errors: exceptions, not `(n, err)`
 
 Go's `Destination.Write(ctx, batch) (n int, err error)` requires the SDK to
-*enforce* an invariant that's easy to get wrong: `n == len(batch)` must imply
+_enforce_ an invariant that's easy to get wrong: `n == len(batch)` must imply
 `err == nil`, and `n < len(batch)` must imply `err != nil`
 (`conduit-connector-sdk/destination.go:345-350` logs it as a connector bug
 otherwise). Python favors exceptions for error propagation and this SDK follows
@@ -503,7 +503,7 @@ name anticipated in
 
 Proposed layout:
 
-```
+```text
 conduit-connector-sdk-python/
   pyproject.toml            # uv-managed; hatchling build backend
   src/conduit/
@@ -694,8 +694,8 @@ exists in Go specifically because Go lacks structured exceptions with attached
 data cleanly separable from control flow, and it requires the SDK to defend an
 invariant (`destination.go:345-350`) that a well-designed Python API can make
 structurally unrepresentable instead of enforced-at-runtime (§2.5). Parity of
-*behavior* (correct per-record acks on partial failure) is kept; parity of
-*shape* is not a goal in itself.
+_behavior_ (correct per-record acks on partial failure) is kept; parity of
+_shape_ is not a goal in itself.
 
 ## Failure modes
 
@@ -897,7 +897,7 @@ Analyzed against CLAUDE.md's data-integrity invariants, scoped to what an SDK
   description with the current v2 protocol (`Configure`/`Open`/`Run`/`Stop`/
   `Teardown`) actually running today.
 - [WASM component model](../architecture-decision-records/20260704-wasm-component-model.md)
-  — the *other* extension mechanism (processors, not connectors); referenced
+  — the _other_ extension mechanism (processors, not connectors); referenced
   in Context to explain why `conduit-processor-sdk-python` is not transport
   prior art for this SDK.
 - `ConduitIO/conduit-connector-protocol` — the wire contract this SDK


### PR DESCRIPTION
The reviewed design set for v0.17's first wave. Four plans + a shared CLI output-conventions spec + an ADR resolving the doctor/scaffold check-engine boundary.

Each plan went through a **technical review** (verified against code) and a **UI/UX review**, both captured in a `## Review outcome` section:
- `pipeline validate|lint|dry-run` — SOUND-WITH-CONCERNS
- `doctor` — SOUND-WITH-CONCERNS
- `connector/processor new` (Go-first; Python gated) — SOUND-WITH-CONCERNS
- Python connector SDK — SOUND (handshake byte-verified); one data-loss blocker (B1 partial-batch ack) fixed in the doc before Phase-1 build

Cross-cutting: a shared `--json` envelope + glyph/flag vocabulary + exit routing, and a neutral `pkg/conduit/check` engine shared by `doctor` + scaffold preflight (disjoint check *sets*, shared *engine*).

Implementation follows in separate PRs (foundations first, then validate/doctor/Go-scaffolding in parallel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)