### PR TITLE
feat(cli): shared foundations for v0.17 CLI-as-product commands

### DIFF
--- a/cmd/conduit/cecdysis/decorators.go
+++ b/cmd/conduit/cecdysis/decorators.go
@@ -16,6 +16,7 @@ package cecdysis
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 
 	"github.com/conduitio/conduit/cmd/conduit/api"
@@ -136,11 +137,18 @@ func (CommandWithExecuteWithClientResultDecorator) Decorate(_ *ecdysis.Ecdysis, 
 			if err != nil {
 				return cerrors.Errorf("could not marshal result to JSON: %w", err)
 			}
-			cmd.Println(string(b))
+			// cmd.Println/cmd.Print resolve through cobra's OutOrStderr, not
+			// OutOrStdout (see cobra's own doc on Print: "fallback to
+			// Stderr if not set") — and no production call site ever calls
+			// cmd.SetOut, so using them here put --json output on stderr
+			// instead of stdout. Write to OutOrStdout explicitly instead;
+			// see cecdysis.CommandWithResultDecorator for the same fix
+			// applied to this decorator's offline sibling.
+			fmt.Fprintln(cmd.OutOrStdout(), string(b))
 			return nil
 		}
 
-		cmd.Print(v.Render(result))
+		fmt.Fprint(cmd.OutOrStdout(), v.Render(result))
 		return nil
 	}
 

--- a/cmd/conduit/cecdysis/result.go
+++ b/cmd/conduit/cecdysis/result.go
@@ -16,6 +16,7 @@ package cecdysis
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/conduitio/conduit/cmd/conduit/internal/ui"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
@@ -159,11 +160,17 @@ func (CommandWithResultDecorator) Decorate(_ *ecdysis.Ecdysis, cmd *cobra.Comman
 			if merr != nil {
 				return cerrors.Errorf("could not marshal result to JSON: %w", merr)
 			}
-			cmd.Println(string(b))
+			// cmd.Println/cmd.Print resolve through cobra's OutOrStderr, not
+			// OutOrStdout (cobra's own doc: "fallback to Stderr if not
+			// set") — since no production call site ever calls cmd.SetOut,
+			// using them here would silently put the "single JSON object to
+			// stdout" envelope on stderr instead. Write to OutOrStdout
+			// explicitly everywhere in this file instead.
+			fmt.Fprintln(cmd.OutOrStdout(), string(b))
 			return nil
 		}
 
-		cmd.Print(v.Render(outcome))
+		fmt.Fprint(cmd.OutOrStdout(), v.Render(outcome))
 		return nil
 	}
 
@@ -185,11 +192,16 @@ func renderResultError(cmd *cobra.Command, command string, err error, asJSON boo
 		b, merr := marshalJSON(res)
 		if merr != nil {
 			// Should not happen (see doc above); fall back to something
-			// rather than emitting nothing on stdout under --json.
+			// rather than emitting nothing at all under --json. This one
+			// case intentionally goes to stderr (via the correctly-behaved
+			// PrintErrln, which does resolve through ErrOrStderr) since
+			// there is no well-formed JSON object to put on stdout here.
 			cmd.PrintErrln("Error:", err)
 			return
 		}
-		cmd.Println(string(b))
+		// See the OutOrStdout note in Decorate: cmd.Println would put this
+		// on stderr instead of stdout in production.
+		fmt.Fprintln(cmd.OutOrStdout(), string(b))
 		return
 	}
 

--- a/cmd/conduit/cecdysis/result.go
+++ b/cmd/conduit/cecdysis/result.go
@@ -1,0 +1,221 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cecdysis
+
+import (
+	"context"
+
+	"github.com/conduitio/conduit/cmd/conduit/internal/ui"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/ecdysis"
+	"github.com/spf13/cobra"
+)
+
+// Result is the shared --json envelope every v0.17 "CLI as product" command
+// (pipelines validate|lint|dry-run, doctor, connector|processor new) emits,
+// per the CLI output conventions §1. It is marshaled lowerCamelCase, matching
+// existing protojson output.
+//
+// Command, OK and Error are always present (Error is null on success) so an
+// agent can write one success check (.ok) and one error check (.error) for
+// every command that uses this envelope. Summary and Result are
+// command-specific payloads.
+type Result struct {
+	// Command is the stable dotted discriminator, e.g. "pipelines.validate".
+	Command string `json:"command"`
+	// OK is the run's verdict. This is the domain outcome (e.g. "did
+	// validation find zero errors"), not "did the command execute
+	// successfully" — a validation run that finds problems is OK:false with
+	// Error:nil; the run itself succeeded.
+	OK bool `json:"ok"`
+	// Summary is a command-specific count/rollup payload.
+	Summary any `json:"summary"`
+	// Result is the command-specific detail payload.
+	Result any `json:"result"`
+	// Error is set on a HARD command failure (bad input, preflight failure,
+	// crash) — never for domain findings, which belong in Summary/Result
+	// with OK:false instead. Nil (JSON null) on success.
+	Error *ResultError `json:"error"`
+}
+
+// ResultError is the envelope's error shape. It mirrors
+// conduiterr.ConduitError's structured fields (Code, Message, Suggestion,
+// ConfigPath, Fix) so a --json consumer gets the same remediation data a
+// human sees rendered via ui.RenderFinding.
+type ResultError struct {
+	Code       string `json:"code,omitempty"`
+	Message    string `json:"message"`
+	Suggestion string `json:"suggestion,omitempty"`
+	ConfigPath string `json:"configPath,omitempty"`
+	// Fix is a structured, machine-appliable fix (conduiterr.Fix), when the
+	// underlying error carries one.
+	Fix any `json:"fix,omitempty"`
+}
+
+// Outcome is what CommandWithResult.ExecuteWithResult returns on a
+// successful run — the command completed; OK/Summary/Result carry the
+// domain verdict and findings. A non-nil error return from
+// ExecuteWithResult, not a false OK here, is what signals a HARD command
+// failure (see CommandWithResult's doc).
+type Outcome struct {
+	OK      bool
+	Summary any
+	Result  any
+}
+
+// CommandWithResult can be implemented by a command that needs the shared
+// --json envelope but does NOT dial the Conduit API client — the offline
+// sibling of CommandWithExecuteWithClientResult, for commands like `doctor`
+// and `pipelines validate` whose own checks are the thing being run, not a
+// client call. Use CommandWithExecuteWithClientResult instead for a command
+// that does need a client.
+type CommandWithResult interface {
+	ecdysis.Command
+
+	// ResultCommand returns the stable dotted discriminator for the
+	// envelope's "command" field, e.g. "pipelines.validate".
+	ResultCommand() string
+	// ExecuteWithResult performs the command's work. A non-nil error is a
+	// HARD command failure and populates the envelope's Error field, NOT
+	// domain findings — a validation run that found problems returns
+	// Outcome{OK: false, ...}, err: nil.
+	ExecuteWithResult(ctx context.Context) (Outcome, error)
+	// Render returns the human-readable rendering of a successful run's
+	// Outcome. Not called under --json, and not called on a HARD failure
+	// (the decorator renders that itself via ui.RenderFinding, since there
+	// is no Outcome to hand Render in that case).
+	Render(outcome Outcome) string
+}
+
+// CommandWithResultDecorator wires CommandWithResult's --json flag, renders
+// the shared Result envelope (JSON) or Outcome (human), and — structurally,
+// for every command it decorates, per CLI output conventions §5 — sets
+// SilenceErrors and SilenceUsage so cobra never prints its own duplicate
+// "Error: ..." line over the command's own rendering, and never corrupts a
+// --json run's single JSON object with a stderr error line.
+type CommandWithResultDecorator struct{}
+
+func (CommandWithResultDecorator) Decorate(_ *ecdysis.Ecdysis, cmd *cobra.Command, c ecdysis.Command) error {
+	v, ok := c.(CommandWithResult)
+	if !ok {
+		return nil
+	}
+
+	if cmd.Flags().Lookup("json") == nil {
+		cmd.Flags().Bool("json", false, "output the result as JSON")
+	}
+
+	// Structural, not opt-in: every command that uses this decorator gets
+	// this, per CLI output conventions §5 ("Fold this into the shared
+	// offline CommandWithResult decorator so it is structural").
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	old := cmd.RunE
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		asJSON, _ := cmd.Flags().GetBool("json")
+
+		// A prior decorator in the chain (e.g. a future confirm/prompt step
+		// on a scaffold command) can fail before ExecuteWithResult ever
+		// runs. SilenceErrors above means cobra will not print anything for
+		// that error on its own, so it gets the same rendering treatment as
+		// an ExecuteWithResult failure — otherwise a declined confirmation
+		// would exit nonzero with no output at all, under both --json and
+		// human mode.
+		if old != nil {
+			if err := old(cmd, args); err != nil {
+				renderResultError(cmd, v.ResultCommand(), err, asJSON)
+				return err
+			}
+		}
+
+		ctx := ecdysis.ContextWithCobraCommand(cmd.Context(), cmd)
+
+		outcome, err := v.ExecuteWithResult(ctx)
+		if err != nil {
+			renderResultError(cmd, v.ResultCommand(), err, asJSON)
+			// Preserve err so the process exit code (pkg/conduit/exitcode,
+			// wired in cmd/conduit/cli) still classifies it correctly;
+			// SilenceErrors above stops cobra from printing it a second time.
+			return err
+		}
+
+		if asJSON {
+			res := Result{Command: v.ResultCommand(), OK: outcome.OK, Summary: outcome.Summary, Result: outcome.Result}
+			b, merr := marshalJSON(res)
+			if merr != nil {
+				return cerrors.Errorf("could not marshal result to JSON: %w", merr)
+			}
+			cmd.Println(string(b))
+			return nil
+		}
+
+		cmd.Print(v.Render(outcome))
+		return nil
+	}
+
+	return nil
+}
+
+// renderResultError renders a HARD command failure: the single JSON object
+// (with Error set) under --json, or a located finding via ui.RenderFinding
+// on stderr otherwise. It never returns an error itself — marshaling
+// ResultError can't fail (it's a plain struct of strings and an any Fix that
+// is itself always JSON-safe, being either nil or a conduiterr.Fix), so a
+// marshal failure here would indicate a bug, not a runtime condition to
+// propagate.
+func renderResultError(cmd *cobra.Command, command string, err error, asJSON bool) {
+	re := newResultError(err)
+
+	if asJSON {
+		res := Result{Command: command, OK: false, Error: re}
+		b, merr := marshalJSON(res)
+		if merr != nil {
+			// Should not happen (see doc above); fall back to something
+			// rather than emitting nothing on stdout under --json.
+			cmd.PrintErrln("Error:", err)
+			return
+		}
+		cmd.Println(string(b))
+		return
+	}
+
+	noColor, _ := cmd.Flags().GetBool("no-color")
+	out := cmd.ErrOrStderr()
+	r := ui.NewRenderer(out, noColor)
+	ui.RenderFinding(out, r.Glyph(ui.StatusFail), re.Code, re.ConfigPath, re.Message, re.Suggestion)
+}
+
+// newResultError converts a plain error into the envelope's ResultError
+// shape: a *conduiterr.ConduitError's structured fields are carried through
+// as-is; any other error falls back to conduiterr.CodeUnknown's reason with
+// just a message, so every hard failure still carries a stable code.
+func newResultError(err error) *ResultError {
+	if ce, ok := conduiterr.Get(err); ok {
+		var fix any
+		if ce.Fix != nil {
+			fix = ce.Fix
+		}
+		return &ResultError{
+			Code:       ce.Code.Reason(),
+			Message:    ce.Message,
+			Suggestion: ce.Suggestion,
+			ConfigPath: ce.ConfigPath,
+			Fix:        fix,
+		}
+	}
+	return &ResultError{Code: conduiterr.CodeUnknown.Reason(), Message: err.Error()}
+}

--- a/cmd/conduit/cecdysis/result_test.go
+++ b/cmd/conduit/cecdysis/result_test.go
@@ -1,0 +1,249 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cecdysis_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/ecdysis"
+	json "github.com/goccy/go-json"
+	"github.com/matryer/is"
+)
+
+// resultTestCmd is a throwaway CommandWithResult used only to exercise
+// CommandWithResultDecorator: a --json run emits the shared Result envelope,
+// a human run calls Render, and a HARD failure (ExecuteWithResult returning
+// a non-nil error) is rendered by the decorator itself with SilenceErrors
+// set, so cobra never prints a second, duplicate "Error: ..." line over it.
+type resultTestCmd struct {
+	fail bool
+}
+
+func (c *resultTestCmd) Usage() string         { return "resulttestcmd" }
+func (c *resultTestCmd) ResultCommand() string { return "test.command" }
+
+func (c *resultTestCmd) ExecuteWithResult(context.Context) (cecdysis.Outcome, error) {
+	if c.fail {
+		err := conduiterr.New(conduiterr.CodeInvalidArgument, "bad input")
+		err.Suggestion = "fix your input"
+		err.ConfigPath = "/some/path"
+		return cecdysis.Outcome{}, err
+	}
+	return cecdysis.Outcome{
+		OK:      true,
+		Summary: map[string]any{"count": 3},
+		Result:  map[string]any{"detail": "all good"},
+	}, nil
+}
+
+func (c *resultTestCmd) Render(outcome cecdysis.Outcome) string {
+	return fmt.Sprintf("OK=%v\n", outcome.OK)
+}
+
+func newEcdysis() *ecdysis.Ecdysis {
+	return ecdysis.New(ecdysis.WithDecorators(cecdysis.CommandWithResultDecorator{}))
+}
+
+// priorFailureCmd additionally implements ecdysis.CommandWithExecute, whose
+// decorator (part of ecdysis.DefaultDecorators) runs and sets cmd.RunE
+// before our custom CommandWithResultDecorator gets applied — WithDecorators
+// appends a decorator of a new type after the defaults, per ecdysis's own
+// doc, so by the time CommandWithResultDecorator.Decorate runs, cmd.RunE
+// already wraps Execute. This is exactly the "prior decorator in the chain"
+// shape a future Confirm/Prompt-gated scaffold command would have.
+type priorFailureCmd struct{}
+
+func (c *priorFailureCmd) Usage() string { return "priorfailurecmd" }
+
+func (c *priorFailureCmd) Execute(context.Context) error {
+	err := conduiterr.New(conduiterr.CodeInvalidArgument, "declined")
+	err.Suggestion = "answer y"
+	return err
+}
+
+func (c *priorFailureCmd) ResultCommand() string { return "test.prior" }
+
+func (c *priorFailureCmd) ExecuteWithResult(context.Context) (cecdysis.Outcome, error) {
+	return cecdysis.Outcome{OK: true}, nil // must never be reached; Execute fails first
+}
+
+func (c *priorFailureCmd) Render(cecdysis.Outcome) string { return "should not render\n" }
+
+// TestCommandWithResultDecorator_PriorDecoratorFailure_StillRendered asserts
+// an error from an earlier decorator in the chain (not ExecuteWithResult
+// itself) still gets the envelope/finding rendering and doesn't disappear
+// silently — SilenceErrors means cobra itself would otherwise print nothing
+// at all for it.
+func TestCommandWithResultDecorator_PriorDecoratorFailure_StillRendered(t *testing.T) {
+	is := is.New(t)
+
+	cmd := newEcdysis().MustBuildCobraCommand(&priorFailureCmd{})
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	is.True(err != nil)
+
+	is.True(strings.Contains(errOut.String(), "declined"))
+	is.True(strings.Contains(errOut.String(), "answer y"))
+	is.True(!strings.Contains(errOut.String(), "Error:"))
+	is.True(!strings.Contains(out.String(), "should not render"))
+}
+
+// TestCommandWithResultDecorator_PriorDecoratorFailure_JSON is the --json
+// variant of the same case: the envelope is still emitted, not silence.
+func TestCommandWithResultDecorator_PriorDecoratorFailure_JSON(t *testing.T) {
+	is := is.New(t)
+
+	cmd := newEcdysis().MustBuildCobraCommand(&priorFailureCmd{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--json"})
+
+	err := cmd.Execute()
+	is.True(err != nil)
+
+	var got cecdysis.Result
+	is.NoErr(json.Unmarshal(out.Bytes(), &got))
+	is.Equal(got.Command, "test.prior")
+	is.True(!got.OK)
+	is.True(got.Error != nil)
+	is.Equal(got.Error.Message, "declined")
+}
+
+func TestCommandWithResultDecorator_JSON_Success(t *testing.T) {
+	is := is.New(t)
+
+	cmd := newEcdysis().MustBuildCobraCommand(&resultTestCmd{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--json"})
+
+	is.NoErr(cmd.Execute())
+
+	var got cecdysis.Result
+	is.NoErr(json.Unmarshal(out.Bytes(), &got))
+	is.Equal(got.Command, "test.command")
+	is.True(got.OK)
+	is.True(got.Error == nil)
+
+	summary, ok := got.Summary.(map[string]any)
+	is.True(ok)
+	is.Equal(summary["count"], float64(3)) // JSON numbers decode as float64
+}
+
+// TestCommandWithResultDecorator_JSON_SingleObject asserts --json emits
+// exactly one JSON object to stdout (CLI output conventions §5) — no
+// streamed human lines before or after it.
+func TestCommandWithResultDecorator_JSON_SingleObject(t *testing.T) {
+	is := is.New(t)
+
+	cmd := newEcdysis().MustBuildCobraCommand(&resultTestCmd{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--json"})
+
+	is.NoErr(cmd.Execute())
+
+	var decoded any
+	dec := json.NewDecoder(bytes.NewReader(out.Bytes()))
+	is.NoErr(dec.Decode(&decoded))
+	// Nothing must remain after the one object (a second value, or stray
+	// human-readable text, would fail this).
+	_, err := dec.Token()
+	is.True(err != nil) // io.EOF, i.e. exactly one JSON value was written
+}
+
+func TestCommandWithResultDecorator_JSON_HardFailure(t *testing.T) {
+	is := is.New(t)
+
+	cmd := newEcdysis().MustBuildCobraCommand(&resultTestCmd{fail: true})
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{"--json"})
+
+	err := cmd.Execute()
+	is.True(err != nil) // the error still propagates for exit-code classification
+
+	var got cecdysis.Result
+	is.NoErr(json.Unmarshal(out.Bytes(), &got))
+	is.Equal(got.Command, "test.command")
+	is.True(!got.OK)
+	is.True(got.Error != nil)
+	is.Equal(got.Error.Code, conduiterr.CodeInvalidArgument.Reason())
+	is.Equal(got.Error.Message, "bad input")
+	is.Equal(got.Error.Suggestion, "fix your input")
+	is.Equal(got.Error.ConfigPath, "/some/path")
+
+	// Under --json, cobra's own error line must never land on stdout or
+	// stderr and corrupt/duplicate the single JSON object.
+	is.True(!strings.Contains(out.String(), "Error:"))
+	is.True(!strings.Contains(errOut.String(), "Error:"))
+}
+
+func TestCommandWithResultDecorator_Human_Success(t *testing.T) {
+	is := is.New(t)
+
+	cmd := newEcdysis().MustBuildCobraCommand(&resultTestCmd{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{})
+
+	is.NoErr(cmd.Execute())
+	is.Equal(out.String(), "OK=true\n")
+}
+
+// TestCommandWithResultDecorator_Human_HardFailure_NoDuplicateError is the
+// load-bearing test for CLI output conventions §5: the decorator sets
+// SilenceErrors/SilenceUsage structurally, so a HARD failure's error text
+// appears exactly once (rendered by the decorator via ui.RenderFinding), not
+// twice (once from the decorator, once from cobra's default "Error: ..."
+// handling, which fires whenever SilenceErrors is left false).
+func TestCommandWithResultDecorator_Human_HardFailure_NoDuplicateError(t *testing.T) {
+	is := is.New(t)
+
+	cmd := newEcdysis().MustBuildCobraCommand(&resultTestCmd{fail: true})
+	is.True(cmd.SilenceErrors)
+	is.True(cmd.SilenceUsage)
+
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	is.True(err != nil)
+
+	// cobra's own boilerplate ("Error: <msg>") must never appear — only the
+	// decorator's single ui.RenderFinding-rendered line does.
+	is.True(!strings.Contains(errOut.String(), "Error:"))
+	is.Equal(strings.Count(errOut.String(), "bad input"), 1)
+	is.True(strings.Contains(errOut.String(), "fix your input"))
+}
+
+func TestCommandWithResultDecorator_JSONFlagRegistered(t *testing.T) {
+	is := is.New(t)
+	cmd := newEcdysis().MustBuildCobraCommand(&resultTestCmd{})
+	is.True(cmd.Flags().Lookup("json") != nil)
+}

--- a/cmd/conduit/cecdysis/result_test.go
+++ b/cmd/conduit/cecdysis/result_test.go
@@ -18,6 +18,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -150,6 +152,50 @@ func TestCommandWithResultDecorator_JSON_Success(t *testing.T) {
 	summary, ok := got.Summary.(map[string]any)
 	is.True(ok)
 	is.Equal(summary["count"], float64(3)) // JSON numbers decode as float64
+}
+
+// TestCommandWithResultDecorator_JSON_ActuallyGoesToRealStdout is the
+// regression test for a bug caught in review: cobra's Print/Println
+// resolve through OutOrStderr, not OutOrStdout ("fallback to Stderr if not
+// set", per cobra's own doc) — so Decorate must never call cmd.Print(ln)
+// itself, only fmt.Fprint(ln)(cmd.OutOrStdout(), ...). Every other test in
+// this file calls cmd.SetOut(&buf), which masks that distinction (cobra's
+// getOut returns the same writer regardless of which fallback it would have
+// used), exactly the way the pre-fix code passed all of them. This test
+// deliberately does NOT call SetOut/SetErr — it swaps the real
+// process-level os.Stdout/os.Stderr instead, matching production
+// (cmd/conduit/cli never calls SetOut either), so a regression here would
+// actually be caught.
+func TestCommandWithResultDecorator_JSON_ActuallyGoesToRealStdout(t *testing.T) {
+	is := is.New(t)
+
+	stdoutR, stdoutW, err := os.Pipe()
+	is.NoErr(err)
+	stderrR, stderrW, err := os.Pipe()
+	is.NoErr(err)
+
+	origStdout, origStderr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = stdoutW, stderrW
+
+	cmd := newEcdysis().MustBuildCobraCommand(&resultTestCmd{})
+	cmd.SetArgs([]string{"--json"})
+	execErr := cmd.Execute()
+
+	os.Stdout, os.Stderr = origStdout, origStderr
+	is.NoErr(stdoutW.Close())
+	is.NoErr(stderrW.Close())
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	_, _ = io.Copy(&stdoutBuf, stdoutR)
+	_, _ = io.Copy(&stderrBuf, stderrR)
+
+	is.NoErr(execErr)
+	is.Equal(stderrBuf.String(), "") // nothing at all on stderr for a success
+
+	var got cecdysis.Result
+	is.NoErr(json.Unmarshal(stdoutBuf.Bytes(), &got))
+	is.Equal(got.Command, "test.command")
+	is.True(got.OK)
 }
 
 // TestCommandWithResultDecorator_JSON_SingleObject asserts --json emits

--- a/cmd/conduit/cli/cli.go
+++ b/cmd/conduit/cli/cli.go
@@ -28,6 +28,10 @@ func Run(cfg conduit.Config) {
 	e := ecdysis.New(ecdysis.WithDecorators(
 		cecdysis.CommandWithExecuteWithClientDecorator{},
 		cecdysis.CommandWithExecuteWithClientResultDecorator{},
+		// The offline sibling of CommandWithExecuteWithClientResultDecorator,
+		// for commands (doctor, pipelines validate, connector/processor new)
+		// whose own checks are the thing being run rather than a client call.
+		cecdysis.CommandWithResultDecorator{},
 	))
 
 	cmd := e.MustBuildCobraCommand(&root.RootCommand{Cfg: cfg})

--- a/cmd/conduit/internal/ui/doc.go
+++ b/cmd/conduit/internal/ui/doc.go
@@ -1,0 +1,37 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ui is the single place that owns human-output presentation rules
+// for the v0.17 "CLI as product" commands (`pipelines validate|lint|dry-run`,
+// `doctor`, `connector|processor new`), per
+// docs/design-documents/20260707-cli-output-conventions.md §2. Every command
+// that renders glyphs, color, or a located finding goes through this
+// package instead of hand-rolling its own — the conventions doc calls out
+// doctor's `└`-line vs validate's inline pointer as exactly the drift this
+// package exists to prevent.
+//
+// # What lives here
+//
+//   - Renderer: detects whether to use Unicode glyphs + ANSI color, or the
+//     ASCII fallback, from TTY status, --no-color, and NO_COLOR — once, at
+//     construction — so callers never re-implement that detection.
+//   - RenderFinding: the canonical located-finding layout (glyph + code +
+//     configPath on line 1, message indented 4, "→ suggestion" indented 4,
+//     no trailing "└" line) shared by every command that reports findings.
+//
+// This package is a rendering helper, not a policy engine: it does not know
+// about check.Status, ConduitError, or any domain type. Callers translate
+// their own domain status into a glyph via Renderer and pass plain strings
+// to RenderFinding.
+package ui

--- a/cmd/conduit/internal/ui/finding.go
+++ b/cmd/conduit/internal/ui/finding.go
@@ -1,0 +1,60 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ui
+
+import (
+	"fmt"
+	"io"
+)
+
+// findingIndent is the indentation (in spaces) for a finding's message and
+// suggestion lines, per the CLI output conventions' located-finding layout.
+const findingIndent = "    "
+
+// RenderFinding writes one located finding to w in the canonical layout (CLI
+// output conventions §2) — the single template every command that reports a
+// finding renders identically, so `doctor` and `pipelines validate` never
+// diverge on this the way their design docs originally did (one used a
+// trailing "└" line, the other an inline pointer):
+//
+//	✗ config.field_required   /connectors/0/plugin
+//	    connector "pg-source": "plugin" is mandatory
+//	    → set connectors[0].plugin (e.g. "builtin:postgres")
+//
+// glyph is the caller-resolved glyph string (typically Renderer.Glyph's
+// result) — this function does no glyph/color selection itself. code and
+// configPath render on line 1, separated from the glyph and from each other
+// by the layout's fixed spacing; configPath is omitted (along with its
+// separating space) when empty, since not every finding has one (a check
+// result's ConfigPath is optional). message and suggestion are each on
+// their own 4-space-indented line, in order, and omitted entirely when
+// empty — there is no trailing "└" line.
+func RenderFinding(w io.Writer, glyph, code, configPath, message, suggestion string) {
+	line := glyph
+	if code != "" {
+		line += " " + code
+	}
+	if configPath != "" {
+		line += "   " + configPath
+	}
+	fmt.Fprintln(w, line)
+
+	if message != "" {
+		fmt.Fprintln(w, findingIndent+message)
+	}
+	if suggestion != "" {
+		fmt.Fprintln(w, findingIndent+"→ "+suggestion)
+	}
+}

--- a/cmd/conduit/internal/ui/finding_test.go
+++ b/cmd/conduit/internal/ui/finding_test.go
@@ -1,0 +1,91 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ui
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+// TestRenderFinding_CanonicalLayout locks the exact byte layout from the CLI
+// output conventions doc (§2): glyph + code + configPath on line 1, message
+// indented 4 spaces, "→ suggestion" indented 4 spaces, no trailing "└" line.
+// A byte-for-byte match here is what keeps doctor and pipelines validate
+// from re-diverging the way their original design docs did.
+func TestRenderFinding_CanonicalLayout(t *testing.T) {
+	is := is.New(t)
+
+	var buf bytes.Buffer
+	RenderFinding(&buf, "✗", "config.field_required", "/connectors/0/plugin",
+		`connector "pg-source": "plugin" is mandatory`,
+		`set connectors[0].plugin (e.g. "builtin:postgres")`)
+
+	want := "✗ config.field_required   /connectors/0/plugin\n" +
+		"    connector \"pg-source\": \"plugin\" is mandatory\n" +
+		"    → set connectors[0].plugin (e.g. \"builtin:postgres\")\n"
+
+	is.Equal(buf.String(), want)
+}
+
+func TestRenderFinding_NoConfigPath(t *testing.T) {
+	is := is.New(t)
+
+	var buf bytes.Buffer
+	RenderFinding(&buf, "✗", "common.unavailable", "", "server unreachable", "start the server first")
+
+	want := "✗ common.unavailable\n" +
+		"    server unreachable\n" +
+		"    → start the server first\n"
+
+	is.Equal(buf.String(), want)
+}
+
+func TestRenderFinding_NoSuggestion(t *testing.T) {
+	is := is.New(t)
+
+	var buf bytes.Buffer
+	RenderFinding(&buf, "⚠", "some.warning", "/x/y", "something worth noting", "")
+
+	want := "⚠ some.warning   /x/y\n" +
+		"    something worth noting\n"
+
+	is.Equal(buf.String(), want)
+}
+
+func TestRenderFinding_NoMessage(t *testing.T) {
+	is := is.New(t)
+
+	var buf bytes.Buffer
+	RenderFinding(&buf, "✓", "check.name", "", "", "")
+
+	want := "✓ check.name\n"
+
+	is.Equal(buf.String(), want)
+}
+
+func TestRenderFinding_ASCIIGlyph(t *testing.T) {
+	is := is.New(t)
+
+	var buf bytes.Buffer
+	RenderFinding(&buf, "[FAIL]", "config.field_required", "/connectors/0/plugin", "msg", "fix it")
+
+	want := "[FAIL] config.field_required   /connectors/0/plugin\n" +
+		"    msg\n" +
+		"    → fix it\n"
+
+	is.Equal(buf.String(), want)
+}

--- a/cmd/conduit/internal/ui/renderer.go
+++ b/cmd/conduit/internal/ui/renderer.go
@@ -1,0 +1,131 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ui
+
+import (
+	"io"
+	"os"
+
+	"github.com/mattn/go-isatty"
+)
+
+// Status is the three-way verdict Renderer.Glyph selects a glyph for. It
+// mirrors check.Status in shape only — this package has no dependency on
+// pkg/conduit/check (see the package doc), so a caller maps its own domain
+// status onto this type at the render call site.
+type Status int
+
+const (
+	StatusPass Status = iota
+	StatusWarn
+	StatusFail
+)
+
+// Glyph strings. Unicode is used on a color-capable TTY; ASCII is the
+// fallback everywhere else (see NewRenderer).
+const (
+	glyphPassUnicode = "✓"
+	glyphWarnUnicode = "⚠"
+	glyphFailUnicode = "✗"
+	glyphPassASCII   = "[OK]"
+	glyphWarnASCII   = "[WARN]"
+	glyphFailASCII   = "[FAIL]"
+)
+
+// ANSI SGR codes used when a Renderer has color enabled.
+const (
+	ansiGreen  = "\x1b[32m"
+	ansiYellow = "\x1b[33m"
+	ansiRed    = "\x1b[31m"
+	ansiReset  = "\x1b[0m"
+)
+
+// Renderer owns glyph and color selection for one output stream: Unicode
+// glyphs with ANSI color when the stream is a color-capable TTY, the ASCII
+// fallback ([OK]/[WARN]/[FAIL], no color) otherwise. This is the single
+// place that makes that decision — no command should re-implement TTY or
+// NO_COLOR detection itself (CLI output conventions §2).
+type Renderer struct {
+	// plain is true when Unicode glyphs and color are both disabled.
+	plain bool
+}
+
+// NewRenderer detects whether w supports Unicode glyphs and color, and
+// returns a Renderer that renders accordingly. It falls back to the plain
+// ASCII, no-color mode when any of the following hold:
+//
+//   - noColor is true (the command's own --no-color flag);
+//   - the NO_COLOR environment variable is set, to any value, including
+//     empty (https://no-color.org — presence, not content, is the signal);
+//   - w is not a terminal (e.g. output is redirected to a file or piped).
+func NewRenderer(w io.Writer, noColor bool) *Renderer {
+	_, noColorSet := os.LookupEnv("NO_COLOR")
+	plain := noColor || noColorSet || !isTerminal(w)
+	return &Renderer{plain: plain}
+}
+
+// isTerminal reports whether w is a terminal. A non-*os.File writer (a
+// bytes.Buffer in a test, a pipe some other tool constructed) is never a
+// terminal.
+//
+// It is a package-level variable, not a plain function, so the renderer
+// test can stub it to exercise the TTY branch deterministically — there is
+// no portable way to fabricate a real terminal fd in a unit test without a
+// pty dependency this package has no other reason to take on.
+var isTerminal = func(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	fd := f.Fd()
+	return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
+}
+
+// Glyph returns the glyph for status: colored Unicode, or the ASCII
+// fallback, depending on how this Renderer was constructed. An out-of-range
+// status is treated as StatusFail — conservatively surfacing a problem is
+// safer than silently rendering nothing.
+func (r *Renderer) Glyph(status Status) string {
+	if r.plain {
+		switch status {
+		case StatusPass:
+			return glyphPassASCII
+		case StatusWarn:
+			return glyphWarnASCII
+		case StatusFail:
+			return glyphFailASCII
+		default:
+			return glyphFailASCII
+		}
+	}
+
+	switch status {
+	case StatusPass:
+		return ansiGreen + glyphPassUnicode + ansiReset
+	case StatusWarn:
+		return ansiYellow + glyphWarnUnicode + ansiReset
+	case StatusFail:
+		return ansiRed + glyphFailUnicode + ansiReset
+	default:
+		return ansiRed + glyphFailUnicode + ansiReset
+	}
+}
+
+// Color reports whether this Renderer applies ANSI color.
+func (r *Renderer) Color() bool { return !r.plain }
+
+// Glyphs reports whether this Renderer uses Unicode glyphs, as opposed to
+// the ASCII fallback.
+func (r *Renderer) Glyphs() bool { return !r.plain }

--- a/cmd/conduit/internal/ui/renderer_test.go
+++ b/cmd/conduit/internal/ui/renderer_test.go
@@ -1,0 +1,112 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ui
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+// withTerminal stubs the package's terminal-detection for the duration of a
+// test, restoring it on cleanup. It's the only portable way to exercise the
+// TTY branch without a real pty.
+func withTerminal(t *testing.T, tty bool) {
+	t.Helper()
+	orig := isTerminal
+	isTerminal = func(io.Writer) bool { return tty }
+	t.Cleanup(func() { isTerminal = orig })
+}
+
+func TestNewRenderer_TTYNoColorEnvUnset_UsesGlyphsAndColor(t *testing.T) {
+	is := is.New(t)
+	withTerminal(t, true)
+
+	r := NewRenderer(&bytes.Buffer{}, false)
+
+	is.True(r.Glyphs())
+	is.True(r.Color())
+	is.Equal(r.Glyph(StatusPass), ansiGreen+glyphPassUnicode+ansiReset)
+}
+
+func TestNewRenderer_NonTTY_UsesASCIIFallback(t *testing.T) {
+	is := is.New(t)
+	withTerminal(t, false)
+
+	r := NewRenderer(&bytes.Buffer{}, false)
+
+	is.True(!r.Glyphs())
+	is.True(!r.Color())
+	is.Equal(r.Glyph(StatusFail), glyphFailASCII)
+}
+
+func TestNewRenderer_NoColorFlag_UsesASCIIFallbackEvenOnTTY(t *testing.T) {
+	is := is.New(t)
+	withTerminal(t, true) // would otherwise select Unicode+color
+
+	r := NewRenderer(&bytes.Buffer{}, true) // --no-color
+
+	is.True(!r.Glyphs())
+	is.True(!r.Color())
+}
+
+func TestNewRenderer_NOCOLOREnv_UsesASCIIFallbackEvenOnTTY(t *testing.T) {
+	is := is.New(t)
+	withTerminal(t, true) // would otherwise select Unicode+color
+	t.Setenv("NO_COLOR", "")
+
+	r := NewRenderer(&bytes.Buffer{}, false)
+
+	is.True(!r.Glyphs())
+	is.True(!r.Color())
+}
+
+// TestNewRenderer_NOCOLOREnv_PresenceNotContent asserts NO_COLOR's *value*
+// doesn't matter, only whether it's set — per https://no-color.org, an
+// explicit empty value still means "no color".
+func TestNewRenderer_NOCOLOREnv_PresenceNotContent(t *testing.T) {
+	is := is.New(t)
+	withTerminal(t, true)
+	t.Setenv("NO_COLOR", "0") // a value some tools would misread as falsy
+
+	r := NewRenderer(&bytes.Buffer{}, false)
+
+	is.True(!r.Glyphs())
+	is.True(!r.Color())
+}
+
+func TestRenderer_Glyph_AllStatuses(t *testing.T) {
+	t.Run("unicode", func(t *testing.T) {
+		is := is.New(t)
+		withTerminal(t, true)
+		r := NewRenderer(&bytes.Buffer{}, false)
+
+		is.Equal(r.Glyph(StatusPass), ansiGreen+glyphPassUnicode+ansiReset)
+		is.Equal(r.Glyph(StatusWarn), ansiYellow+glyphWarnUnicode+ansiReset)
+		is.Equal(r.Glyph(StatusFail), ansiRed+glyphFailUnicode+ansiReset)
+	})
+
+	t.Run("ascii", func(t *testing.T) {
+		is := is.New(t)
+		withTerminal(t, false)
+		r := NewRenderer(&bytes.Buffer{}, false)
+
+		is.Equal(r.Glyph(StatusPass), glyphPassASCII)
+		is.Equal(r.Glyph(StatusWarn), glyphWarnASCII)
+		is.Equal(r.Glyph(StatusFail), glyphFailASCII)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/jpillora/backoff v1.0.0
 	github.com/klauspost/compress v1.19.0
 	github.com/matryer/is v1.4.1
+	github.com/mattn/go-isatty v0.0.22
 	github.com/neilotoole/slogt v1.1.0
 	github.com/piotrkowalczuk/promgrpc/v4 v4.3.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
@@ -204,7 +205,6 @@ require (
 	github.com/maratori/testpackage v1.1.1 // indirect
 	github.com/matoous/godox v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect
-	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mgechev/revive v1.7.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect

--- a/pkg/conduit/check/check.go
+++ b/pkg/conduit/check/check.go
@@ -1,0 +1,226 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+)
+
+// Status is a check's verdict.
+type Status string
+
+const (
+	// StatusPass means the check found nothing wrong.
+	StatusPass Status = "pass"
+	// StatusWarn means the check found something worth surfacing, but not
+	// severe enough to fail the run. A warning never contributes to
+	// Report.ExitCode on its own; a caller that wants warnings to escalate
+	// (e.g. a `--strict` flag) owns that decision, not this package.
+	StatusWarn Status = "warn"
+	// StatusFail means the check found a problem that should fail the run.
+	// Report.ExitCode aggregates exactly the Fail results.
+	StatusFail Status = "fail"
+)
+
+// Category groups CheckResults by the kind of thing they diagnose (e.g. for
+// human output grouping). These are the categories the generic constructors
+// in this package use; a caller supplying its own Checks (doctor's
+// config/store/network/plugin checks, for instance) is free to use its own
+// category strings.
+const (
+	CategoryToolchain  = "toolchain"
+	CategoryFilesystem = "filesystem"
+	CategoryNetwork    = "network"
+)
+
+// CheckResult is one check's outcome. Field set matches the CLI output
+// conventions' located-finding shape (see
+// docs/design-documents/20260707-cli-output-conventions.md): Code,
+// ConfigPath and Suggestion are what a `--json` consumer or the shared
+// cmd/conduit/internal/ui renderer key off of.
+type CheckResult struct {
+	// Name is the check's stable identifier. The runner fills this in from
+	// the originating Check.Name() if a Check's Run leaves it empty.
+	Name string `json:"name"`
+	// Status is the check's verdict.
+	Status Status `json:"status"`
+	// Message is a human-readable description of what the check found.
+	Message string `json:"message,omitempty"`
+	// Suggestion is a human-readable remediation hint, optional.
+	Suggestion string `json:"suggestion,omitempty"`
+	// Code is a registered conduiterr.Code reason (e.g. "common.unavailable"),
+	// set on Warn/Fail results so a --json consumer and Report.ExitCode have
+	// a stable, machine-actionable identity to key off of. Optional on Pass.
+	Code string `json:"code,omitempty"`
+	// ConfigPath is the conduit.yaml dotted key (or other config address
+	// space the caller uses) this result concerns, optional.
+	ConfigPath string `json:"configPath,omitempty"`
+	// Category groups this result for human output (e.g. "toolchain",
+	// "filesystem", "network"), optional.
+	Category string `json:"category,omitempty"`
+}
+
+// Check is a single diagnostic. Implementations should be side-effect-free
+// beyond the diagnostic itself (e.g. DirWritable creates and immediately
+// removes a probe file; it does not leave state behind).
+type Check interface {
+	// Name is the check's stable identifier. It must be available without
+	// running the check, since the runner uses it to label a result when Run
+	// panics before returning one.
+	Name() string
+	// Run executes the check. Implementations that do I/O (exec a binary,
+	// dial a network address, touch a filesystem path) should pass ctx
+	// through so the runner's per-check timeout (see Run) is honored.
+	Run(ctx context.Context) CheckResult
+}
+
+// TimeoutCheck is implemented by a Check that needs a timeout different from
+// the runner's default (see WithTimeout). Run checks for this interface
+// before falling back to the batch default, so a slow-by-nature check (a
+// network probe) can ask for a longer budget than a fast one without
+// changing the timeout for every other check in the same Report.
+type TimeoutCheck interface {
+	Check
+	// Timeout returns the maximum duration this check's Run is allowed to
+	// block. A duration <= 0 is treated the same as not implementing this
+	// interface (the batch default applies).
+	Timeout() time.Duration
+}
+
+// DefaultTimeout is the per-check timeout Run applies when neither a
+// TimeoutCheck override nor WithTimeout sets one.
+const DefaultTimeout = 10 * time.Second
+
+// Summary is the aggregate count across a Report's CheckResults.
+type Summary struct {
+	Total  int `json:"total"`
+	Passed int `json:"passed"`
+	Warned int `json:"warned"`
+	Failed int `json:"failed"`
+}
+
+// Report is the result of running a set of Checks.
+type Report struct {
+	Checks  []CheckResult `json:"checks"`
+	Summary Summary       `json:"summary"`
+}
+
+// runConfig holds Run's options.
+type runConfig struct {
+	timeout time.Duration
+}
+
+// Option configures Run.
+type Option func(*runConfig)
+
+// WithTimeout sets the default per-check timeout for a Run call. It applies
+// to every Check in the batch that does not implement TimeoutCheck. The
+// zero value (or omitting this option) uses DefaultTimeout.
+func WithTimeout(d time.Duration) Option {
+	return func(c *runConfig) { c.timeout = d }
+}
+
+// Run executes every Check and collects the results into a Report. It never
+// panics and never blocks past a check's timeout budget:
+//
+//   - Per-check recover(): a panicking Check.Run is converted into a
+//     StatusFail CheckResult (Code: conduiterr.CodeInternal's reason, i.e.
+//     "internal.error") instead of crashing the calling process. This
+//     isolation covers the panic happening synchronously inside Run; it does
+//     NOT cover a panic in a goroutine a Check spawns and does not join back
+//     before returning — Go's runtime has no way to recover across a
+//     goroutine boundary. A Check with that shape (e.g. a future check that
+//     dispenses a go-plugin, per the ADR's noted limitation) must isolate
+//     itself, e.g. by running in a subprocess with its own timeout and
+//     treating an abnormal child exit as Fail.
+//   - Per-check context timeout: each Check.Run is given a context derived
+//     from ctx with a deadline — the check's own TimeoutCheck.Timeout() if it
+//     implements that interface, else the Run call's WithTimeout option, else
+//     DefaultTimeout. A Check must itself honor ctx (pass it to
+//     exec.CommandContext, net.Dial, etc.) for the timeout to actually bound
+//     its execution; Run cannot force-abandon a check that ignores ctx and
+//     never returns.
+//
+// Checks run sequentially, in the order given. Ordering only affects
+// Report.Checks; it never affects Report.ExitCode (see its doc).
+func Run(ctx context.Context, checks []Check, opts ...Option) Report {
+	cfg := runConfig{timeout: DefaultTimeout}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	results := make([]CheckResult, 0, len(checks))
+	for _, c := range checks {
+		results = append(results, runOne(ctx, c, cfg.timeout))
+	}
+
+	return Report{Checks: results, Summary: summarize(results)}
+}
+
+// runOne runs a single check with panic isolation and a per-check timeout.
+func runOne(ctx context.Context, c Check, defaultTimeout time.Duration) (result CheckResult) {
+	name := c.Name()
+
+	defer func() {
+		if r := recover(); r != nil {
+			result = CheckResult{
+				Name:    name,
+				Status:  StatusFail,
+				Code:    conduiterr.CodeInternal.Reason(),
+				Message: fmt.Sprintf("check %q panicked: %v", name, r),
+			}
+		}
+	}()
+
+	timeout := defaultTimeout
+	if tc, ok := c.(TimeoutCheck); ok {
+		if t := tc.Timeout(); t > 0 {
+			timeout = t
+		}
+	}
+
+	checkCtx := ctx
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		checkCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	result = c.Run(checkCtx)
+	if result.Name == "" {
+		result.Name = name
+	}
+	return result
+}
+
+// summarize computes a Summary over results.
+func summarize(results []CheckResult) Summary {
+	s := Summary{Total: len(results)}
+	for _, r := range results {
+		switch r.Status {
+		case StatusPass:
+			s.Passed++
+		case StatusWarn:
+			s.Warned++
+		case StatusFail:
+			s.Failed++
+		}
+	}
+	return s
+}

--- a/pkg/conduit/check/check.go
+++ b/pkg/conduit/check/check.go
@@ -137,25 +137,30 @@ func WithTimeout(d time.Duration) Option {
 }
 
 // Run executes every Check and collects the results into a Report. It never
-// panics and never blocks past a check's timeout budget:
+// panics itself, and it bounds each check's execution with a context
+// deadline — though whether that deadline actually stops a slow check is up
+// to that check (see the second bullet):
 //
-//   - Per-check recover(): a panicking Check.Run is converted into a
-//     StatusFail CheckResult (Code: conduiterr.CodeInternal's reason, i.e.
-//     "internal.error") instead of crashing the calling process. This
-//     isolation covers the panic happening synchronously inside Run; it does
-//     NOT cover a panic in a goroutine a Check spawns and does not join back
-//     before returning — Go's runtime has no way to recover across a
-//     goroutine boundary. A Check with that shape (e.g. a future check that
-//     dispenses a go-plugin, per the ADR's noted limitation) must isolate
-//     itself, e.g. by running in a subprocess with its own timeout and
-//     treating an abnormal child exit as Fail.
+//   - Per-check recover(): a panic from either Check.Name() or Check.Run is
+//     converted into a StatusFail CheckResult (Code: conduiterr.CodeInternal's
+//     reason, i.e. "internal.error") instead of crashing the calling
+//     process — the defer is registered before either method is called, so
+//     both are covered, not just Run. This isolation covers a panic
+//     happening synchronously inside those calls; it does NOT cover a panic
+//     in a goroutine a Check spawns and does not join back before
+//     returning — Go's runtime has no way to recover across a goroutine
+//     boundary. A Check with that shape (e.g. a future check that dispenses
+//     a go-plugin, per the ADR's noted limitation) must isolate itself,
+//     e.g. by running in a subprocess with its own timeout and treating an
+//     abnormal child exit as Fail.
 //   - Per-check context timeout: each Check.Run is given a context derived
 //     from ctx with a deadline — the check's own TimeoutCheck.Timeout() if it
 //     implements that interface, else the Run call's WithTimeout option, else
-//     DefaultTimeout. A Check must itself honor ctx (pass it to
-//     exec.CommandContext, net.Dial, etc.) for the timeout to actually bound
-//     its execution; Run cannot force-abandon a check that ignores ctx and
-//     never returns.
+//     DefaultTimeout. This only bounds Run's wall-clock time if the Check
+//     itself honors ctx (passing it to exec.CommandContext, net.Dial, etc.);
+//     Run has no way to force-abandon a check that ignores ctx and blocks
+//     forever — the deadline is advisory to the check, not a guillotine Run
+//     enforces from outside.
 //
 // Checks run sequentially, in the order given. Ordering only affects
 // Report.Checks; it never affects Report.ExitCode (see its doc).
@@ -174,8 +179,15 @@ func Run(ctx context.Context, checks []Check, opts ...Option) Report {
 }
 
 // runOne runs a single check with panic isolation and a per-check timeout.
+//
+// The defer/recover is registered before anything else, including the call
+// to c.Name() below: Name() is caller-supplied code too, and a panic there
+// (before the deferred recover exists) would otherwise escape uncaught and
+// take down the whole Run() call — the exact isolation failure this
+// function exists to prevent. name starts at a fallback label so the
+// recovered CheckResult is never blank if Name() itself is what panicked.
 func runOne(ctx context.Context, c Check, defaultTimeout time.Duration) (result CheckResult) {
-	name := c.Name()
+	name := "unknown"
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -187,6 +199,8 @@ func runOne(ctx context.Context, c Check, defaultTimeout time.Duration) (result 
 			}
 		}
 	}()
+
+	name = c.Name()
 
 	timeout := defaultTimeout
 	if tc, ok := c.(TimeoutCheck); ok {

--- a/pkg/conduit/check/check_test.go
+++ b/pkg/conduit/check/check_test.go
@@ -43,6 +43,17 @@ type timeoutCheck struct {
 
 func (c timeoutCheck) Timeout() time.Duration { return c.timeout }
 
+// panicNameCheck panics from Name() itself, not from Run — a narrower case
+// than TestRun_PanicIsolated's, since a panicking Name() can happen before
+// any recover() has been registered if the runner isn't careful about
+// ordering (see TestRun_PanicIsolated_FromName).
+type panicNameCheck struct{}
+
+func (panicNameCheck) Name() string { panic("name boom") }
+func (panicNameCheck) Run(context.Context) check.CheckResult {
+	return check.CheckResult{Status: check.StatusPass}
+}
+
 func TestRun_PanicIsolated(t *testing.T) {
 	is := is.New(t)
 
@@ -71,6 +82,36 @@ func TestRun_PanicIsolated(t *testing.T) {
 	// The panic must not have prevented the next check from running (that's
 	// the whole point of per-check isolation, not just "the process didn't
 	// crash").
+	is.Equal(report.Checks[1].Name, "fine")
+	is.Equal(report.Checks[1].Status, check.StatusPass)
+}
+
+// TestRun_PanicIsolated_FromName is the regression test for a bug caught in
+// review: an earlier version of runOne called c.Name() before registering
+// the deferred recover(), so a panic from Name() itself escaped uncaught and
+// crashed the whole Run() call — the exact failure mode per-check isolation
+// exists to prevent, and worse than a panic from Run because it would also
+// abort every check after the panicking one, not just that one check.
+func TestRun_PanicIsolated_FromName(t *testing.T) {
+	is := is.New(t)
+
+	fine := fnCheck{
+		name: "fine",
+		run: func(context.Context) check.CheckResult {
+			return check.CheckResult{Status: check.StatusPass}
+		},
+	}
+
+	report := check.Run(context.Background(), []check.Check{panicNameCheck{}, fine})
+
+	is.Equal(len(report.Checks), 2)
+	is.Equal(report.Checks[0].Status, check.StatusFail)
+	is.Equal(report.Checks[0].Code, "internal.error")
+	is.True(strings.Contains(report.Checks[0].Message, "name boom"))
+	is.Equal(report.Checks[0].Name, "unknown") // Name() panicked before it could report its own name
+
+	// The panic in the first check's Name() must not have prevented the
+	// second check from running at all.
 	is.Equal(report.Checks[1].Name, "fine")
 	is.Equal(report.Checks[1].Status, check.StatusPass)
 }

--- a/pkg/conduit/check/check_test.go
+++ b/pkg/conduit/check/check_test.go
@@ -1,0 +1,167 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit/pkg/conduit/check"
+	"github.com/matryer/is"
+)
+
+// fnCheck adapts a name and a Run function to check.Check, for tests that
+// need a bespoke check without a dedicated type.
+type fnCheck struct {
+	name string
+	run  func(ctx context.Context) check.CheckResult
+}
+
+func (c fnCheck) Name() string                              { return c.name }
+func (c fnCheck) Run(ctx context.Context) check.CheckResult { return c.run(ctx) }
+
+// timeoutCheck additionally implements check.TimeoutCheck, so it can request
+// its own per-check timeout independent of the batch default.
+type timeoutCheck struct {
+	fnCheck
+	timeout time.Duration
+}
+
+func (c timeoutCheck) Timeout() time.Duration { return c.timeout }
+
+func TestRun_PanicIsolated(t *testing.T) {
+	is := is.New(t)
+
+	panicking := fnCheck{
+		name: "panics",
+		run: func(context.Context) check.CheckResult {
+			panic("boom")
+		},
+	}
+	fine := fnCheck{
+		name: "fine",
+		run: func(context.Context) check.CheckResult {
+			return check.CheckResult{Status: check.StatusPass}
+		},
+	}
+
+	report := check.Run(context.Background(), []check.Check{panicking, fine})
+
+	is.Equal(len(report.Checks), 2)
+
+	is.Equal(report.Checks[0].Name, "panics")
+	is.Equal(report.Checks[0].Status, check.StatusFail)
+	is.Equal(report.Checks[0].Code, "internal.error")
+	is.True(strings.Contains(report.Checks[0].Message, "boom"))
+
+	// The panic must not have prevented the next check from running (that's
+	// the whole point of per-check isolation, not just "the process didn't
+	// crash").
+	is.Equal(report.Checks[1].Name, "fine")
+	is.Equal(report.Checks[1].Status, check.StatusPass)
+}
+
+func TestRun_NameDefaultedFromCheck(t *testing.T) {
+	is := is.New(t)
+
+	c := fnCheck{
+		name: "unnamed-result",
+		run: func(context.Context) check.CheckResult {
+			// Deliberately leave Name unset on the returned result.
+			return check.CheckResult{Status: check.StatusPass}
+		},
+	}
+
+	report := check.Run(context.Background(), []check.Check{c})
+	is.Equal(report.Checks[0].Name, "unnamed-result")
+}
+
+func TestRun_RespectsCheckOwnTimeout(t *testing.T) {
+	is := is.New(t)
+
+	c := timeoutCheck{
+		fnCheck: fnCheck{
+			name: "slow",
+			run: func(ctx context.Context) check.CheckResult {
+				select {
+				case <-ctx.Done():
+					return check.CheckResult{Status: check.StatusFail, Message: "timed out"}
+				case <-time.After(2 * time.Second):
+					return check.CheckResult{Status: check.StatusPass, Message: "finished"}
+				}
+			},
+		},
+		timeout: 20 * time.Millisecond,
+	}
+
+	start := time.Now()
+	// The batch default is deliberately huge; only the check's own
+	// TimeoutCheck.Timeout() should apply.
+	report := check.Run(context.Background(), []check.Check{c}, check.WithTimeout(time.Hour))
+	elapsed := time.Since(start)
+
+	is.Equal(report.Checks[0].Status, check.StatusFail)
+	is.Equal(report.Checks[0].Message, "timed out")
+	// Generous upper bound so this isn't flaky under CI load, but tight
+	// enough to prove the 20ms per-check timeout fired instead of the 1h
+	// batch default (which would make this test hang for an hour).
+	is.True(elapsed < 5*time.Second)
+}
+
+func TestRun_BatchDefaultTimeoutApplies(t *testing.T) {
+	is := is.New(t)
+
+	c := fnCheck{
+		name: "slow",
+		run: func(ctx context.Context) check.CheckResult {
+			select {
+			case <-ctx.Done():
+				return check.CheckResult{Status: check.StatusFail, Message: "timed out"}
+			case <-time.After(2 * time.Second):
+				return check.CheckResult{Status: check.StatusPass, Message: "finished"}
+			}
+		},
+	}
+
+	report := check.Run(context.Background(), []check.Check{c}, check.WithTimeout(20*time.Millisecond))
+
+	is.Equal(report.Checks[0].Status, check.StatusFail)
+	is.Equal(report.Checks[0].Message, "timed out")
+}
+
+func TestRun_Summary(t *testing.T) {
+	is := is.New(t)
+
+	checks := []check.Check{
+		fnCheck{name: "p1", run: func(context.Context) check.CheckResult { return check.CheckResult{Status: check.StatusPass} }},
+		fnCheck{name: "p2", run: func(context.Context) check.CheckResult { return check.CheckResult{Status: check.StatusPass} }},
+		fnCheck{name: "w1", run: func(context.Context) check.CheckResult { return check.CheckResult{Status: check.StatusWarn} }},
+		fnCheck{name: "f1", run: func(context.Context) check.CheckResult { return check.CheckResult{Status: check.StatusFail} }},
+	}
+
+	report := check.Run(context.Background(), checks)
+
+	is.Equal(report.Summary, check.Summary{Total: 4, Passed: 2, Warned: 1, Failed: 1})
+}
+
+func TestRun_Empty(t *testing.T) {
+	is := is.New(t)
+
+	report := check.Run(context.Background(), nil)
+	is.Equal(len(report.Checks), 0)
+	is.Equal(report.Summary, check.Summary{})
+}

--- a/pkg/conduit/check/checks.go
+++ b/pkg/conduit/check/checks.go
@@ -1,0 +1,239 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+)
+
+// versionPattern extracts the first dotted version number (X.Y or X.Y.Z) from
+// a version command's output. It is deliberately tool-agnostic: `go version`
+// prints "go version go1.23.4 darwin/arm64", `git --version` prints "git
+// version 2.43.0", `docker --version` prints "Docker version 24.0.7, build
+// afdd53b" — the version number is always the first token matching this
+// shape, whatever surrounds it.
+var versionPattern = regexp.MustCompile(`\d+\.\d+(\.\d+)?`)
+
+// BinaryOnPath returns a Check that verifies name is on PATH, and — when
+// minVersion is non-empty — that running "name --version" reports a version
+// at or above minVersion (parsed as semver; a missing patch component is
+// treated as .0). A missing binary or a too-old version is StatusFail with
+// Category CategoryToolchain and Code conduiterr.CodeUnavailable's reason:
+// this is an environment-of-execution problem (install/upgrade the tool),
+// not a config validation error. If the binary is present but its version
+// can't be determined or parsed, the check is StatusWarn rather than Fail —
+// an unparsable `--version` output is a weaker signal than a confirmed
+// absence or a confirmed too-old version.
+func BinaryOnPath(name, minVersion string) Check {
+	return binaryOnPathCheck{name: name, minVersion: minVersion}
+}
+
+type binaryOnPathCheck struct {
+	name       string
+	minVersion string
+}
+
+func (c binaryOnPathCheck) Name() string { return "binary_on_path:" + c.name }
+
+func (c binaryOnPathCheck) Run(ctx context.Context) CheckResult {
+	path, err := exec.LookPath(c.name)
+	if err != nil {
+		return CheckResult{
+			Status:     StatusFail,
+			Category:   CategoryToolchain,
+			Code:       conduiterr.CodeUnavailable.Reason(),
+			Message:    fmt.Sprintf("%s not found on PATH", c.name),
+			Suggestion: fmt.Sprintf("install %s and ensure it is on PATH", c.name),
+		}
+	}
+
+	if c.minVersion == "" {
+		return CheckResult{
+			Status:   StatusPass,
+			Category: CategoryToolchain,
+			Message:  fmt.Sprintf("%s found at %s", c.name, path),
+		}
+	}
+
+	out, err := exec.CommandContext(ctx, c.name, "--version").CombinedOutput() //nolint:gosec // c.name is a caller-supplied toolchain binary (e.g. "go", "git", "docker"), not untrusted runtime input
+	if err != nil {
+		// Not every tool accepts "--version" the same way (notably `go`,
+		// which requires the "version" subcommand instead and exits nonzero
+		// on the flag form) — retry with the subcommand form before giving up.
+		var altErr error
+		out, altErr = exec.CommandContext(ctx, c.name, "version").CombinedOutput() //nolint:gosec // same as above
+		if altErr != nil {
+			return CheckResult{
+				Status:   StatusWarn,
+				Category: CategoryToolchain,
+				Message:  fmt.Sprintf("found %s at %s but could not determine its version (tried %q and %q): %v", c.name, path, c.name+" --version", c.name+" version", err),
+			}
+		}
+	}
+
+	match := versionPattern.FindString(string(out))
+	if match == "" {
+		return CheckResult{
+			Status:   StatusWarn,
+			Category: CategoryToolchain,
+			Message:  fmt.Sprintf("found %s at %s but could not parse a version from %q", c.name, path, strings.TrimSpace(string(out))),
+		}
+	}
+
+	got, err := semver.NewVersion(match)
+	if err != nil {
+		return CheckResult{
+			Status:   StatusWarn,
+			Category: CategoryToolchain,
+			Message:  fmt.Sprintf("found %s at %s but could not parse version %q: %v", c.name, path, match, err),
+		}
+	}
+
+	want, err := semver.NewVersion(c.minVersion)
+	if err != nil {
+		// A malformed minVersion is a bug in the caller's check
+		// configuration, not something the environment can fix.
+		return CheckResult{
+			Status:   StatusFail,
+			Category: CategoryToolchain,
+			Code:     conduiterr.CodeInternal.Reason(),
+			Message:  fmt.Sprintf("invalid minVersion %q configured for the %s check: %v", c.minVersion, c.name, err),
+		}
+	}
+
+	if got.LessThan(want) {
+		return CheckResult{
+			Status:     StatusFail,
+			Category:   CategoryToolchain,
+			Code:       conduiterr.CodeUnavailable.Reason(),
+			Message:    fmt.Sprintf("%s version %s is older than the required %s", c.name, got, want),
+			Suggestion: fmt.Sprintf("upgrade %s to %s or newer", c.name, want),
+		}
+	}
+
+	return CheckResult{
+		Status:   StatusPass,
+		Category: CategoryToolchain,
+		Message:  fmt.Sprintf("%s %s found at %s", c.name, got, path),
+	}
+}
+
+// DirWritable returns a Check that verifies path exists (creating it via
+// MkdirAll if not) and is writable, by creating and immediately removing a
+// probe file inside it. configKey is the conduit.yaml dotted key (or other
+// config address) path is sourced from, carried on a Fail result's
+// ConfigPath. A Fail here is treated as a config validation problem (Category
+// CategoryFilesystem, Code conduiterr.CodeInvalidArgument's reason) rather
+// than an environment one: the fix this check suggests is "point the config
+// at a writable directory", which is a config-level remediation even when
+// the underlying cause is a permissions or disk problem.
+func DirWritable(path, configKey string) Check {
+	return dirWritableCheck{path: path, configKey: configKey}
+}
+
+type dirWritableCheck struct {
+	path      string
+	configKey string
+}
+
+func (c dirWritableCheck) Name() string { return "dir_writable:" + c.path }
+
+func (c dirWritableCheck) Run(_ context.Context) CheckResult {
+	if err := os.MkdirAll(c.path, 0o755); err != nil {
+		return CheckResult{
+			Status:     StatusFail,
+			Category:   CategoryFilesystem,
+			Code:       conduiterr.CodeInvalidArgument.Reason(),
+			ConfigPath: c.configKey,
+			Message:    fmt.Sprintf("%s does not exist and could not be created: %v", c.path, err),
+			Suggestion: fmt.Sprintf("create %s or point %s at a writable directory", c.path, c.configKey),
+		}
+	}
+
+	f, err := os.CreateTemp(c.path, ".conduit-check-*")
+	if err != nil {
+		return CheckResult{
+			Status:     StatusFail,
+			Category:   CategoryFilesystem,
+			Code:       conduiterr.CodeInvalidArgument.Reason(),
+			ConfigPath: c.configKey,
+			Message:    fmt.Sprintf("%s is not writable: %v", c.path, err),
+			Suggestion: fmt.Sprintf("check permissions on %s or point %s at a writable directory", c.path, c.configKey),
+		}
+	}
+	name := f.Name()
+	_ = f.Close()
+	_ = os.Remove(name)
+
+	return CheckResult{
+		Status:     StatusPass,
+		Category:   CategoryFilesystem,
+		ConfigPath: c.configKey,
+		Message:    fmt.Sprintf("%s is writable", c.path),
+	}
+}
+
+// AddrBindable returns a Check that verifies a TCP listener can be opened on
+// addr (e.g. "127.0.0.1:8080"), then immediately closes it. configKey is the
+// conduit.yaml dotted key addr is sourced from, carried on a Fail result's
+// ConfigPath. A Fail here — the address is already bound, or otherwise
+// can't be listened on — is Category CategoryNetwork, Code
+// conduiterr.CodeUnavailable's reason: this mirrors how the CLI's own
+// deterministic exit-code classifier already tags "listen address already in
+// use" as an environment failure (see pkg/foundation/cerrors/conduiterr's
+// CodeUnavailable doc), not a config validation error — the address itself
+// may be perfectly valid, just occupied right now.
+func AddrBindable(addr, configKey string) Check {
+	return addrBindableCheck{addr: addr, configKey: configKey}
+}
+
+type addrBindableCheck struct {
+	addr      string
+	configKey string
+}
+
+func (c addrBindableCheck) Name() string { return "addr_bindable:" + c.addr }
+
+func (c addrBindableCheck) Run(ctx context.Context) CheckResult {
+	var lc net.ListenConfig
+	ln, err := lc.Listen(ctx, "tcp", c.addr)
+	if err != nil {
+		return CheckResult{
+			Status:     StatusFail,
+			Category:   CategoryNetwork,
+			Code:       conduiterr.CodeUnavailable.Reason(),
+			ConfigPath: c.configKey,
+			Message:    fmt.Sprintf("cannot bind %s: %v", c.addr, err),
+			Suggestion: fmt.Sprintf("free up %s or point %s at a different address", c.addr, c.configKey),
+		}
+	}
+	_ = ln.Close()
+
+	return CheckResult{
+		Status:     StatusPass,
+		Category:   CategoryNetwork,
+		ConfigPath: c.configKey,
+		Message:    fmt.Sprintf("%s is available", c.addr),
+	}
+}

--- a/pkg/conduit/check/checks_test.go
+++ b/pkg/conduit/check/checks_test.go
@@ -1,0 +1,145 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check_test
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/conduit/check"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/matryer/is"
+)
+
+func TestBinaryOnPath_Missing(t *testing.T) {
+	is := is.New(t)
+
+	c := check.BinaryOnPath("conduit-check-definitely-not-a-real-binary", "")
+	result := check.Run(context.Background(), []check.Check{c}).Checks[0]
+
+	is.Equal(result.Status, check.StatusFail)
+	is.Equal(result.Category, check.CategoryToolchain)
+	is.Equal(result.Code, conduiterr.CodeUnavailable.Reason())
+}
+
+func TestBinaryOnPath_PresentNoVersionCheck(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on a POSIX shell being on PATH")
+	}
+	is := is.New(t)
+
+	c := check.BinaryOnPath("sh", "")
+	result := check.Run(context.Background(), []check.Check{c}).Checks[0]
+
+	is.Equal(result.Status, check.StatusPass)
+	is.Equal(result.Category, check.CategoryToolchain)
+}
+
+// TestBinaryOnPath_MinVersion exercises the real version-parsing path
+// against the `go` binary running this test — it must be new enough to
+// satisfy an ancient minVersion, and can never satisfy an impossible one.
+func TestBinaryOnPath_MinVersion(t *testing.T) {
+	t.Run("satisfied", func(t *testing.T) {
+		is := is.New(t)
+		c := check.BinaryOnPath("go", "1.0.0")
+		result := check.Run(context.Background(), []check.Check{c}).Checks[0]
+		is.Equal(result.Status, check.StatusPass)
+	})
+
+	t.Run("not_satisfied", func(t *testing.T) {
+		is := is.New(t)
+		c := check.BinaryOnPath("go", "99.0.0")
+		result := check.Run(context.Background(), []check.Check{c}).Checks[0]
+		is.Equal(result.Status, check.StatusFail)
+		is.Equal(result.Code, conduiterr.CodeUnavailable.Reason())
+	})
+}
+
+func TestDirWritable_Writable(t *testing.T) {
+	is := is.New(t)
+
+	dir := t.TempDir()
+	c := check.DirWritable(dir, "db.badger.path")
+	result := check.Run(context.Background(), []check.Check{c}).Checks[0]
+
+	is.Equal(result.Status, check.StatusPass)
+	is.Equal(result.Category, check.CategoryFilesystem)
+	is.Equal(result.ConfigPath, "db.badger.path")
+}
+
+func TestDirWritable_CreatesMissingDir(t *testing.T) {
+	is := is.New(t)
+
+	dir := filepath.Join(t.TempDir(), "nested", "does-not-exist-yet")
+	c := check.DirWritable(dir, "db.badger.path")
+	result := check.Run(context.Background(), []check.Check{c}).Checks[0]
+
+	is.Equal(result.Status, check.StatusPass)
+	fi, err := os.Stat(dir)
+	is.NoErr(err)
+	is.True(fi.IsDir())
+}
+
+func TestDirWritable_NotWritable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission checks don't apply when running as root")
+	}
+	is := is.New(t)
+
+	parent := t.TempDir()
+	target := filepath.Join(parent, "readonly")
+	is.NoErr(os.Mkdir(target, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(target, 0o755) }) // let t.TempDir's own cleanup remove it
+
+	c := check.DirWritable(target, "db.badger.path")
+	result := check.Run(context.Background(), []check.Check{c}).Checks[0]
+
+	is.Equal(result.Status, check.StatusFail)
+	is.Equal(result.Category, check.CategoryFilesystem)
+	is.Equal(result.Code, conduiterr.CodeInvalidArgument.Reason())
+	is.Equal(result.ConfigPath, "db.badger.path")
+}
+
+func TestAddrBindable_Available(t *testing.T) {
+	is := is.New(t)
+
+	c := check.AddrBindable("127.0.0.1:0", "api.grpc.address")
+	result := check.Run(context.Background(), []check.Check{c}).Checks[0]
+
+	is.Equal(result.Status, check.StatusPass)
+	is.Equal(result.Category, check.CategoryNetwork)
+	is.Equal(result.ConfigPath, "api.grpc.address")
+}
+
+func TestAddrBindable_InUse(t *testing.T) {
+	is := is.New(t)
+
+	var lc net.ListenConfig
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	is.NoErr(err)
+	defer ln.Close()
+
+	c := check.AddrBindable(ln.Addr().String(), "api.grpc.address")
+	result := check.Run(context.Background(), []check.Check{c}).Checks[0]
+
+	is.Equal(result.Status, check.StatusFail)
+	is.Equal(result.Category, check.CategoryNetwork)
+	is.Equal(result.Code, conduiterr.CodeUnavailable.Reason())
+	is.Equal(result.ConfigPath, "api.grpc.address")
+}

--- a/pkg/conduit/check/doc.go
+++ b/pkg/conduit/check/doc.go
@@ -1,0 +1,43 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package check is the neutral diagnostic engine shared by `conduit doctor`
+// and the `connector|processor new` scaffold preflight (see
+// docs/architecture-decision-records/20260707-check-engine-shared-by-doctor-and-scaffold.md).
+// The two commands' check SETS are disjoint by design — doctor asks "would
+// `conduit run` succeed here?" (config, store, API address, plugins),
+// scaffolding asks "can I build a new connector here?" (Go/git/docker on
+// PATH) — but they share this package's mechanism: the Check interface, the
+// CheckResult/Report/Status types, the panic-isolating runner, exit-code
+// aggregation, and a few generic, reusable check constructors.
+//
+// # Invariants
+//
+//   - This package MUST NOT import cobra or ecdysis, and MUST NOT call
+//     os.Exit. It is consumed by CLI commands, but it is not itself a CLI
+//     concern — that keeps it usable from a future MCP doctor tool and from
+//     tests without dragging in command-line machinery.
+//   - Run isolates a panicking Check: recover() converts it into a Fail
+//     CheckResult (Code: internal.error) rather than crashing the calling
+//     process. This does not extend to goroutines a Check spawns itself and
+//     does not join back before Run returns — see Run's doc for the limit.
+//   - Report.ExitCode aggregates every Fail result to a single process exit
+//     code by synthesizing a *conduiterr.ConduitError per failing result and
+//     taking the worst (max) exitcode.ExitCode bucket across all of them
+//     (environment 3 > validation 2 > runtime 1 > ok 0). This is new
+//     aggregation logic owned by this package — it is NOT free reuse of
+//     exitcode.ExitCode's single-error classifier (which only sees the first
+//     error in a chain), and it deliberately does not use cerrors.Join,
+//     which would report only the first error's exit code, not the worst.
+package check

--- a/pkg/conduit/check/exitcode.go
+++ b/pkg/conduit/check/exitcode.go
@@ -1,0 +1,79 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"github.com/conduitio/conduit/pkg/conduit/exitcode"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+)
+
+// ExitCode reduces every Fail result in the Report to a single process exit
+// code, per the CLI output conventions' multi-result rule: take the WORST
+// (max) exitcode.ExitCode bucket across all failing results, not the first.
+//
+// This is deliberately not "classify one synthesized error": each Fail
+// result is turned into its own *conduiterr.ConduitError (via
+// conduiterr.LookupCode on the result's Code, falling back to
+// conduiterr.CodeUnknown for an unregistered or empty Code) and classified
+// independently with exitcode.ExitCode; ExitCode returns the largest bucket
+// seen. Concretely: a report with one Fail whose Code maps to
+// conduiterr.CodeUnavailable (environment, bucket 3) and another Fail whose
+// Code maps to conduiterr.CodeInvalidArgument (validation, bucket 2) always
+// returns 3, regardless of which result appears first in Report.Checks.
+// cerrors.Join (or any other "join all errors, classify once" approach) is
+// deliberately not used here: errors.As over a joined tree returns the
+// first match in the chain, which would silently prefer whichever failure
+// happened to be joined first instead of the worst one.
+//
+// Warn and Pass results never contribute — Report.ExitCode only escalates on
+// Fail. A caller implementing `--strict` (warnings escalate to failure) must
+// do that upstream, by changing the affected results' Status to StatusFail
+// before calling ExitCode, not by this package inferring it.
+//
+// An empty Report (or one with no Fail results) returns exitcode.OK. A
+// Report with at least one Fail result NEVER returns exitcode.OK, even in
+// the pathological case where every failing result's Code happens to
+// resolve to a gRPC category exitcode.ExitCode itself maps to OK
+// (codes.OK/codes.Canceled — which no well-behaved registered
+// conduiterr.Code should ever use, per that package's own registry
+// discipline, but this method does not trust callers to have gotten that
+// right): a Fail is definitionally not OK, so the aggregate floors at
+// exitcode.Runtime in that case instead of silently reporting success.
+func (r Report) ExitCode() int {
+	worst := exitcode.OK
+	hasFail := false
+
+	for _, cr := range r.Checks {
+		if cr.Status != StatusFail {
+			continue
+		}
+		hasFail = true
+
+		code, ok := conduiterr.LookupCode(cr.Code)
+		if !ok {
+			code = conduiterr.CodeUnknown
+		}
+
+		ce := conduiterr.New(code, cr.Message)
+		if ec := exitcode.ExitCode(ce); ec > worst {
+			worst = ec
+		}
+	}
+
+	if hasFail && worst == exitcode.OK {
+		return exitcode.Runtime
+	}
+	return worst
+}

--- a/pkg/conduit/check/exitcode_test.go
+++ b/pkg/conduit/check/exitcode_test.go
@@ -29,6 +29,14 @@ func TestReport_ExitCode_Empty(t *testing.T) {
 	is.Equal(check.Report{}.ExitCode(), exitcode.OK)
 }
 
+// canceledTestCode is registered at package-var-init time, per
+// conduiterr.Register's own documented invariant ("MUST be called only from
+// a package-level var initializer... calling Register after program start
+// or from a goroutine is a data race") — not inside the test function body
+// that uses it, matching the convention pkg/conduit/exitcode's own test
+// suite (testCodes) already establishes.
+var canceledTestCode = conduiterr.Register("test.check.exitcode.canceled", codes.Canceled)
+
 // TestReport_ExitCode_FailNeverReportsOK guards the pathological case where
 // a Fail result's Code resolves to a gRPC category exitcode.ExitCode itself
 // treats as OK (codes.Canceled) — something no well-behaved registered
@@ -38,10 +46,8 @@ func TestReport_ExitCode_Empty(t *testing.T) {
 func TestReport_ExitCode_FailNeverReportsOK(t *testing.T) {
 	is := is.New(t)
 
-	canceledCode := conduiterr.Register("test.check.exitcode.canceled", codes.Canceled)
-
 	r := check.Report{Checks: []check.CheckResult{
-		{Name: "misbehaving", Status: check.StatusFail, Code: canceledCode.Reason()},
+		{Name: "misbehaving", Status: check.StatusFail, Code: canceledTestCode.Reason()},
 	}}
 
 	is.Equal(r.ExitCode(), exitcode.Runtime)

--- a/pkg/conduit/check/exitcode_test.go
+++ b/pkg/conduit/check/exitcode_test.go
@@ -1,0 +1,151 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check_test
+
+import (
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/conduit/check"
+	"github.com/conduitio/conduit/pkg/conduit/exitcode"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/matryer/is"
+	"google.golang.org/grpc/codes"
+)
+
+func TestReport_ExitCode_Empty(t *testing.T) {
+	is := is.New(t)
+	is.Equal(check.Report{}.ExitCode(), exitcode.OK)
+}
+
+// TestReport_ExitCode_FailNeverReportsOK guards the pathological case where
+// a Fail result's Code resolves to a gRPC category exitcode.ExitCode itself
+// treats as OK (codes.Canceled) — something no well-behaved registered
+// conduiterr.Code should do, but this method must not trust that. A Fail is
+// definitionally not OK; ExitCode must floor at exitcode.Runtime instead of
+// silently reporting success.
+func TestReport_ExitCode_FailNeverReportsOK(t *testing.T) {
+	is := is.New(t)
+
+	canceledCode := conduiterr.Register("test.check.exitcode.canceled", codes.Canceled)
+
+	r := check.Report{Checks: []check.CheckResult{
+		{Name: "misbehaving", Status: check.StatusFail, Code: canceledCode.Reason()},
+	}}
+
+	is.Equal(r.ExitCode(), exitcode.Runtime)
+}
+
+func TestReport_ExitCode_AllPass(t *testing.T) {
+	is := is.New(t)
+
+	r := check.Report{Checks: []check.CheckResult{
+		{Name: "a", Status: check.StatusPass},
+		{Name: "b", Status: check.StatusPass},
+	}}
+	is.Equal(r.ExitCode(), exitcode.OK)
+}
+
+// TestReport_ExitCode_WarnDoesNotEscalate asserts a Warn-only report exits
+// OK: only Fail results feed the aggregation (a `--strict` flag that wants
+// warnings to fail the run is the caller's job, not this package's).
+func TestReport_ExitCode_WarnDoesNotEscalate(t *testing.T) {
+	is := is.New(t)
+
+	r := check.Report{Checks: []check.CheckResult{
+		{Name: "a", Status: check.StatusWarn, Code: conduiterr.CodeUnavailable.Reason()},
+	}}
+	is.Equal(r.ExitCode(), exitcode.OK)
+}
+
+// TestReport_ExitCode_UnregisteredCodeFallsBackToUnknown asserts a Fail
+// result whose Code isn't a registered conduiterr.Code reason still
+// classifies (as Runtime, via conduiterr.CodeUnknown) instead of panicking
+// or silently being skipped.
+func TestReport_ExitCode_UnregisteredCodeFallsBackToUnknown(t *testing.T) {
+	is := is.New(t)
+
+	r := check.Report{Checks: []check.CheckResult{
+		{Name: "a", Status: check.StatusFail, Code: "not.a.registered.reason"},
+	}}
+	is.Equal(r.ExitCode(), exitcode.Runtime)
+}
+
+// TestReport_ExitCode_MaxNotFirst is the load-bearing test for the ADR's
+// aggregation rule: given a Fail@Unavailable (environment, bucket 3) and a
+// Fail@InvalidArgument (validation, bucket 2) in the same Report, ExitCode
+// must return 3 — the WORST bucket — regardless of which result appears
+// first in Report.Checks. A "classify the first error" implementation (e.g.
+// cerrors.Join + a single exitcode.ExitCode call, which errors.As would
+// resolve to whichever error was joined first) would return 2 when the
+// validation failure happens to be listed first; this test fails that
+// implementation in one of its two orderings.
+func TestReport_ExitCode_MaxNotFirst(t *testing.T) {
+	envFail := check.CheckResult{
+		Name:   "env",
+		Status: check.StatusFail,
+		Code:   conduiterr.CodeUnavailable.Reason(), // -> exitcode.Environment (3)
+	}
+	validationFail := check.CheckResult{
+		Name:   "validation",
+		Status: check.StatusFail,
+		Code:   conduiterr.CodeInvalidArgument.Reason(), // -> exitcode.Validation (2)
+	}
+
+	// Sanity check the two codes actually land in the buckets this test
+	// depends on, so a future change to the registry's gRPC categories fails
+	// loudly here instead of silently degrading this test to a tautology.
+	is := is.New(t)
+	is.Equal(exitcode.ExitCode(conduiterr.New(conduiterr.CodeUnavailable, "x")), exitcode.Environment)
+	is.Equal(exitcode.ExitCode(conduiterr.New(conduiterr.CodeInvalidArgument, "x")), exitcode.Validation)
+
+	t.Run("environment_first", func(t *testing.T) {
+		is := is.New(t)
+		r := check.Report{Checks: []check.CheckResult{envFail, validationFail}}
+		is.Equal(r.ExitCode(), exitcode.Environment)
+	})
+
+	t.Run("validation_first", func(t *testing.T) {
+		is := is.New(t)
+		r := check.Report{Checks: []check.CheckResult{validationFail, envFail}}
+		is.Equal(r.ExitCode(), exitcode.Environment)
+	})
+}
+
+// TestReport_ExitCode_MaxAcrossAllThreeBuckets exercises a Report carrying
+// one Fail per non-OK bucket (Runtime, Validation, Environment) in every
+// permutation of Checks order, asserting ExitCode always returns Environment
+// (the max of {1,2,3}).
+func TestReport_ExitCode_MaxAcrossAllThreeBuckets(t *testing.T) {
+	runtimeFail := check.CheckResult{Name: "runtime", Status: check.StatusFail, Code: conduiterr.CodeInternal.Reason()}
+	validationFail := check.CheckResult{Name: "validation", Status: check.StatusFail, Code: conduiterr.CodeInvalidArgument.Reason()}
+	envFail := check.CheckResult{Name: "env", Status: check.StatusFail, Code: conduiterr.CodeUnavailable.Reason()}
+
+	orderings := map[string][]check.CheckResult{
+		"runtime_validation_env": {runtimeFail, validationFail, envFail},
+		"runtime_env_validation": {runtimeFail, envFail, validationFail},
+		"validation_runtime_env": {validationFail, runtimeFail, envFail},
+		"validation_env_runtime": {validationFail, envFail, runtimeFail},
+		"env_runtime_validation": {envFail, runtimeFail, validationFail},
+		"env_validation_runtime": {envFail, validationFail, runtimeFail},
+	}
+
+	for name, checks := range orderings {
+		t.Run(name, func(t *testing.T) {
+			is := is.New(t)
+			r := check.Report{Checks: checks}
+			is.Equal(r.ExitCode(), exitcode.Environment)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Ships the shared foundations that `pipelines validate`, `doctor`, and
`connector|processor new` (v0.17 "CLI as product") will all build on, built
first so the three commands can't drift onto private output formats — per
[`docs/design-documents/20260707-cli-output-conventions.md`](../blob/docs/v0.17-first-wave-design/docs/design-documents/20260707-cli-output-conventions.md)
and
[`docs/architecture-decision-records/20260707-check-engine-shared-by-doctor-and-scaffold.md`](../blob/docs/v0.17-first-wave-design/docs/architecture-decision-records/20260707-check-engine-shared-by-doctor-and-scaffold.md)
(both on branch `docs/v0.17-first-wave-design`, #2571 — not yet merged; this
PR implements to that spec but doesn't depend on merge order).

**No `validate`/`doctor`/`connector new` commands land in this PR.** Foundations
only, so the three commands can build against a stable, already-reviewed
surface instead of each inventing their own envelope/exit-code/glyph logic.

### 1. `pkg/conduit/check` — the neutral check engine (per the ADR)

No cobra/ecdysis imports, no `os.Exit`.

- `Status` (`pass|warn|fail`), `CheckResult{Name, Status, Message, Suggestion, Code, ConfigPath, Category}` (field order matches the ADR), `Check` interface, `Report{Checks, Summary}`.
- `Run(ctx, checks []Check, opts ...Option) Report` — per-check `recover()` turns a panic into a `Fail` (`code: internal.error`) instead of crashing the process; per-check context timeout (a `TimeoutCheck` override, else the batch default via `WithTimeout`, else `DefaultTimeout`).
- `Report.ExitCode() int` — aggregates every `Fail` result to ONE exit code: synthesizes a `*conduiterr.ConduitError` per failing result via `conduiterr.LookupCode`, classifies each independently with `exitcode.ExitCode`, and returns the **MAX** bucket (env 3 > validation 2 > runtime 1). This is new aggregation logic, not `cerrors.Join` + classify-once (which would silently prefer whichever failure happened to be joined first). Also floors at `Runtime` instead of `OK` if a `Fail`'s `Code` ever resolves to the `Canceled`/`OK` gRPC category — a `Fail` can never silently report success, even from a misbehaving caller.
- Generic, reusable check constructors doctor and scaffold preflight will both compose: `BinaryOnPath(name, minVersion)`, `DirWritable(path, configKey)`, `AddrBindable(addr, configKey)`.

### 2. `cmd/conduit/internal/ui` — shared human-rendering helper (conventions §2)

- `Renderer`: owns TTY/`--no-color`/`NO_COLOR` detection + glyph/color selection (Unicode+ANSI on a color TTY, ASCII `[OK]`/`[WARN]`/`[FAIL]` otherwise).
- `RenderFinding(w, glyph, code, configPath, message, suggestion)`: the canonical located-finding layout, byte-verified against the conventions doc's own example.

### 3. `cmd/conduit/cecdysis` — offline result decorator + shared `--json` envelope

- `CommandWithResult` / `CommandWithResultDecorator`: the offline sibling of `CommandWithExecuteWithClientResultDecorator` (no API client dial), for commands like `doctor` and `pipelines validate` whose own checks are the thing being run.
- Marshals the shared `Result{command, ok, summary, result, error}` envelope, lowerCamelCase, matching existing protojson output.
- Sets `SilenceErrors`/`SilenceUsage` structurally (every command using this decorator gets it, not opt-in) so cobra never double-prints — including for an error from an *earlier* decorator in the chain, not just from `ExecuteWithResult` itself (see self-review below).
- Registered in `cmd/conduit/cli/cli.go` alongside the existing client decorators.

## Adversarial self-review

Found two real gaps before opening this PR, both now covered by regression tests:

1. **`Report.ExitCode()` could return `OK` despite a `Fail` being present.** If a `Fail` result's `Code` happened to resolve to the `Canceled`/`OK` gRPC category (something no well-behaved registered `conduiterr.Code` should do, but the method shouldn't trust callers on), the aggregation would silently report success. Fixed to floor at `Runtime` whenever any `Fail` is present. See `TestReport_ExitCode_FailNeverReportsOK`.
2. **`CommandWithResultDecorator` only rendered `ExecuteWithResult`'s own error.** An error from an *earlier* decorator in the chain (e.g. a future confirm/prompt step on a scaffold command, or `ecdysis.CommandWithExecuteDecorator` if a command implements both) would exit nonzero with **no output at all**, under both `--json` and human mode, since `SilenceErrors` suppresses cobra's own printing and nothing else was rendering it. Fixed to render that path identically to a hard `ExecuteWithResult` failure. See `TestCommandWithResultDecorator_PriorDecoratorFailure_StillRendered` and its `--json` counterpart.

The MAX-not-first aggregation is tested with both orderings of a
`Fail@Unavailable` (env, 3) + `Fail@InvalidArgument` (validation, 2) pair, and
with all six permutations of a three-bucket `Fail` set (runtime/validation/env)
— always exits 3/the max, never order-dependent.

## Exported surface for the next agents (validate/doctor/scaffold)

```go
package check // pkg/conduit/check

type Status string
const (StatusPass Status = "pass"; StatusWarn Status = "warn"; StatusFail Status = "fail")

const (CategoryToolchain = "toolchain"; CategoryFilesystem = "filesystem"; CategoryNetwork = "network")

type CheckResult struct {
    Name, Message, Suggestion, Code, ConfigPath, Category string
    Status Status
}

type Check interface {
    Name() string
    Run(ctx context.Context) CheckResult
}
type TimeoutCheck interface { Check; Timeout() time.Duration }

type Summary struct{ Total, Passed, Warned, Failed int }
type Report struct {
    Checks  []CheckResult
    Summary Summary
}
func (r Report) ExitCode() int

const DefaultTimeout = 10 * time.Second
type Option func(*runConfig)
func WithTimeout(d time.Duration) Option
func Run(ctx context.Context, checks []Check, opts ...Option) Report

func BinaryOnPath(name, minVersion string) Check
func DirWritable(path, configKey string) Check
func AddrBindable(addr, configKey string) Check
```

```go
package cecdysis // cmd/conduit/cecdysis

type Result struct {
    Command string
    OK      bool
    Summary any
    Result  any
    Error   *ResultError
}
type ResultError struct { Code, Message, Suggestion, ConfigPath string; Fix any }

type Outcome struct { OK bool; Summary, Result any }
type CommandWithResult interface {
    ecdysis.Command
    ResultCommand() string
    ExecuteWithResult(ctx context.Context) (Outcome, error)
    Render(outcome Outcome) string
}
type CommandWithResultDecorator struct{}
```

```go
package ui // cmd/conduit/internal/ui

type Status int
const (StatusPass Status = iota; StatusWarn; StatusFail)
func NewRenderer(w io.Writer, noColor bool) *Renderer
func (r *Renderer) Glyph(status Status) string
func (r *Renderer) Color() bool
func (r *Renderer) Glyphs() bool
func RenderFinding(w io.Writer, glyph, code, configPath, message, suggestion string)
```

## Verification

- `go build ./...` — clean
- `go test ./pkg/conduit/check/... ./cmd/conduit/internal/ui/... ./cmd/conduit/cecdysis/... -race -count=1` — green
- `go test ./... -race -count=1` — green (full repo, unaffected)
- `golangci-lint run` — 0 issues, both scoped to the new packages and repo-wide
- `go mod tidy` — promotes `github.com/mattn/go-isatty` from indirect to direct (already vendored; used for TTY detection in `ui.Renderer`). No other dependency changes.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/conduit/check/... ./cmd/conduit/internal/ui/... ./cmd/conduit/cecdysis/... -race -count=1`
- [x] `go test ./... -race -count=1`
- [x] `golangci-lint run` (repo-wide)
- [ ] Human review of the `Report.ExitCode()` aggregation semantics and the `CommandWithResult` envelope shape, since this is the surface `validate`/`doctor`/scaffold will all build against

Tier 2. No breaking changes (new packages + one additive decorator registration).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01Tapg9dLWXKMZJoL65R24vd