### PR TITLE
feat(cli): add conduit pipelines validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,38 @@ signal, so a forced kill is distinguishable from an ordinary classified exit cod
 See [ADR: deterministic CLI exit codes](docs/architecture-decision-records/20260706-deterministic-cli-exit-codes.md)
 for the full mapping and rationale, and `pkg/conduit/exitcode` for the implementation.
 
+## Validating pipeline configs
+
+`conduit pipelines validate <path>` (alias: `conduit pipeline validate`) statically checks one
+pipeline config file, or every `.yml`/`.yaml` file in a directory (not recursed), without starting
+Conduit or contacting a running instance — it's fully offline, so it's safe to run in CI or before
+`conduit run` with no server anywhere nearby.
+
+```console
+$ conduit pipelines validate pipelines/orders.yaml
+✗ pipelines/orders.yaml
+✗ config.field_required   /connectors/0/plugin
+    connector "orders:postgres": "plugin" is mandatory
+    → set connectors[0].plugin (e.g. "builtin:postgres")
+
+Summary: 1 files · 0 passed · 1 failed · 1 problems
+Fix the ✗ items above, then re-run.
+```
+
+(the connector's ID is shown enriched — `<pipelineID>:<connectorID>` — since validation runs after the same
+default-enrichment step `conduit run` applies; `--json`'s `configPath` still points at your original
+`connectors[0]`.)
+
+Every problem in every file is reported — a bad file never stops the rest from being checked.
+Exits `0` if every pipeline is valid, `2` otherwise (see Exit codes above). Add `--json` for the
+structured `{command, ok, summary, result, error}` envelope, or `-q/--quiet` to suppress passing
+(`✓`) lines and show only failures and the summary.
+
+`lint` (advisory warnings, e.g. deprecated fields) and `dry-run` (shows the enriched pipeline graph
+and optionally resolves builtin plugin references) share the same engine and are planned as
+follow-ups — see
+[the design doc](docs/design-documents/20260707-cli-pipeline-validate.md).
+
 ## Documentation
 
 To learn more about how to use Conduit

--- a/cmd/conduit/cecdysis/result.go
+++ b/cmd/conduit/cecdysis/result.go
@@ -75,6 +75,28 @@ type Outcome struct {
 	OK      bool
 	Summary any
 	Result  any
+
+	// ExitErr, when non-nil, is returned by CommandWithResultDecorator after
+	// it has already rendered this Outcome (JSON or human) — purely so the
+	// process gets a correctly classified nonzero exit code (via
+	// pkg/conduit/exitcode, applied where cmd.Execute()'s returned error
+	// reaches cmd/conduit/cli) for a domain failure (OK:false) that is NOT a
+	// hard command failure.
+	//
+	// This exists because ecdysis routes the process exit code through
+	// cmd.Execute()'s returned error, and CommandWithResult's contract keeps
+	// domain findings out of that error (they belong in Summary/Result with
+	// the envelope's error field staying null, per CLI output conventions
+	// §1) — so there is no other channel back to the process exit code for
+	// "the run completed and found problems." ExitErr is never rendered
+	// itself (RunE returns it after Render/marshal has already written the
+	// full Outcome to output) and never appears in the --json envelope.
+	//
+	// A command with findings synthesizes this via its own classification
+	// logic (see docs/design-documents/20260707-cli-output-conventions.md
+	// §4: reducing N findings to one exit code is new aggregation logic each
+	// command owns, not something this package does on a command's behalf).
+	ExitErr error
 }
 
 // CommandWithResult can be implemented by a command that needs the shared
@@ -167,11 +189,16 @@ func (CommandWithResultDecorator) Decorate(_ *ecdysis.Ecdysis, cmd *cobra.Comman
 			// stdout" envelope on stderr instead. Write to OutOrStdout
 			// explicitly everywhere in this file instead.
 			fmt.Fprintln(cmd.OutOrStdout(), string(b))
-			return nil
+			// outcome.ExitErr (nil for most commands) is returned, not
+			// swallowed, AFTER the envelope above is already written —
+			// see Outcome.ExitErr's doc: this is how a domain failure
+			// (OK:false, Error:null in the envelope just emitted) still
+			// gives the process a nonzero, correctly classified exit code.
+			return outcome.ExitErr
 		}
 
 		fmt.Fprint(cmd.OutOrStdout(), v.Render(outcome))
-		return nil
+		return outcome.ExitErr
 	}
 
 	return nil

--- a/cmd/conduit/cecdysis/result_test.go
+++ b/cmd/conduit/cecdysis/result_test.go
@@ -37,6 +37,12 @@ import (
 // set, so cobra never prints a second, duplicate "Error: ..." line over it.
 type resultTestCmd struct {
 	fail bool
+	// exitErr, when set, is carried on a successful (err == nil)
+	// ExecuteWithResult return via Outcome.ExitErr — the "domain failure,
+	// not a hard command failure" case Outcome.ExitErr's doc describes:
+	// findings-with-problems still render as OK:false/Error:null, but the
+	// process should still exit nonzero.
+	exitErr error
 }
 
 func (c *resultTestCmd) Usage() string         { return "resulttestcmd" }
@@ -50,9 +56,10 @@ func (c *resultTestCmd) ExecuteWithResult(context.Context) (cecdysis.Outcome, er
 		return cecdysis.Outcome{}, err
 	}
 	return cecdysis.Outcome{
-		OK:      true,
+		OK:      c.exitErr == nil,
 		Summary: map[string]any{"count": 3},
 		Result:  map[string]any{"detail": "all good"},
+		ExitErr: c.exitErr,
 	}, nil
 }
 
@@ -292,4 +299,74 @@ func TestCommandWithResultDecorator_JSONFlagRegistered(t *testing.T) {
 	is := is.New(t)
 	cmd := newEcdysis().MustBuildCobraCommand(&resultTestCmd{})
 	is.True(cmd.Flags().Lookup("json") != nil)
+}
+
+// TestCommandWithResultDecorator_OutcomeExitErr_JSON is the load-bearing
+// contract test for Outcome.ExitErr, added for `pipelines validate`: a
+// domain failure (findings, not a hard command failure) still renders the
+// full Outcome — OK:false, Error:null, Summary/Result intact — exactly like
+// TestCommandWithResultDecorator_JSON_Success, but cmd.Execute() returns a
+// non-nil error afterwards so the process exit code (via
+// pkg/conduit/exitcode, applied in cmd/conduit/cli) still classifies as
+// something other than 0.
+func TestCommandWithResultDecorator_OutcomeExitErr_JSON(t *testing.T) {
+	is := is.New(t)
+
+	exitErr := conduiterr.New(conduiterr.CodeInvalidArgument, "2 problems found")
+	cmd := newEcdysis().MustBuildCobraCommand(&resultTestCmd{exitErr: exitErr})
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{"--json"})
+
+	err := cmd.Execute()
+	is.True(err != nil) // exit-code classification, per Outcome.ExitErr's doc
+	is.Equal(err, error(exitErr))
+
+	var got cecdysis.Result
+	is.NoErr(json.Unmarshal(out.Bytes(), &got))
+	is.Equal(got.Command, "test.command")
+	is.True(!got.OK)
+	is.True(got.Error == nil) // findings, not a hard failure — the envelope stays clean
+	summary, ok := got.Summary.(map[string]any)
+	is.True(ok)
+	is.Equal(summary["count"], float64(3)) // Summary/Result still fully rendered
+
+	// ExitErr must never leak into the rendered output itself.
+	is.True(!strings.Contains(out.String(), "2 problems found"))
+	is.Equal(errOut.String(), "")
+}
+
+// TestCommandWithResultDecorator_OutcomeExitErr_Human is the human-output
+// analogue: Render's output is written in full, then the nonzero exit error
+// is returned silently (SilenceErrors means cobra prints nothing more for
+// it) — no duplicate/extra text appears.
+func TestCommandWithResultDecorator_OutcomeExitErr_Human(t *testing.T) {
+	is := is.New(t)
+
+	exitErr := conduiterr.New(conduiterr.CodeInvalidArgument, "2 problems found")
+	cmd := newEcdysis().MustBuildCobraCommand(&resultTestCmd{exitErr: exitErr})
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	is.True(err != nil)
+	is.Equal(err, error(exitErr))
+	is.Equal(out.String(), "OK=false\n") // Render still ran normally
+	is.Equal(errOut.String(), "")        // no duplicate/extra error text
+}
+
+// TestCommandWithResultDecorator_NilExitErr_StillExitsZero guards the
+// default case: a command that never sets Outcome.ExitErr (every command
+// before `pipelines validate`) is unaffected — cmd.Execute() still returns
+// nil on a successful, OK:true run.
+func TestCommandWithResultDecorator_NilExitErr_StillExitsZero(t *testing.T) {
+	is := is.New(t)
+	cmd := newEcdysis().MustBuildCobraCommand(&resultTestCmd{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{})
+	is.NoErr(cmd.Execute())
 }

--- a/cmd/conduit/internal/validate/doc.go
+++ b/cmd/conduit/internal/validate/doc.go
@@ -1,0 +1,43 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package validate is the shared, offline engine behind `conduit pipelines
+// validate` (and, in a future PR, `lint` and `dry-run`), per
+// docs/design-documents/20260707-cli-pipeline-validate.md. It runs the same
+// parse -> enrich -> validate pipeline pkg/provisioning.Service uses at
+// startup (see service.go's provisionPipeline), but never dials the Conduit
+// API and never fails fast: every finding across every resolved file is
+// collected into one Report, which both the human renderer and the --json
+// envelope (cmd/conduit/root/pipelines/validate.go) marshal from the same
+// data.
+//
+// # Invariants this package must hold
+//
+//   - Offline: Run never constructs a gRPC/API client and never touches
+//     anything but the local filesystem. A command built on this package is
+//     safe to run with no Conduit server anywhere nearby.
+//   - Collect-all, never fail-fast: a parse failure, a validation error, or a
+//     cross-file duplicate ID in one file must not stop findings from being
+//     collected for the other files (or the other pipelines in the same
+//     file).
+//   - Every finding is walked from an UNWRAPPED cerrors.Join via
+//     cerrors.ForEach — never from an error that has itself been re-wrapped
+//     with "%w" first. cerrors.ForEach only flattens a Join's immediate
+//     Unwrap() []error; wrapping it again (e.g. cerrors.Errorf("...: %w",
+//     joinedErr)) hides that shape behind a single-error Unwrap() error,
+//     and ForEach then treats the whole Join as one finding instead of N.
+//     This was flagged in the design doc's review as the top masked-bug
+//     risk; findingsFromError and the tests in engine_test.go exist
+//     specifically to keep it from regressing.
+package validate

--- a/cmd/conduit/internal/validate/engine.go
+++ b/cmd/conduit/internal/validate/engine.go
@@ -1,0 +1,273 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/provisioning"
+	"github.com/conduitio/conduit/pkg/provisioning/config"
+	"github.com/conduitio/conduit/pkg/provisioning/config/yaml"
+)
+
+// Run resolves path (a single .yml/.yaml file or a directory of them) and
+// runs the offline parse -> enrich -> validate pipeline over every file it
+// finds, collecting every finding — parse failures, field-validation
+// errors, and cross-file/-document duplicate pipeline IDs — across every
+// file. It never fails fast: one bad file never stops the others from being
+// checked.
+//
+// Run returns a non-nil error only when path itself can't be resolved at
+// all (e.g. it does not exist) — that is a hard failure the caller (the
+// pipelines validate command) should render as a top-level command error,
+// not a Finding, since there is no file to attach it to. Everything else —
+// including every file being unparseable — comes back as findings inside a
+// (possibly all-failing) Report, with a nil error.
+func Run(ctx context.Context, path string) (Report, error) {
+	files, err := config.ResolveFiles(path)
+	if err != nil {
+		return Report{}, err
+	}
+	sort.Strings(files) // deterministic order, independent of directory-read order
+
+	frs := make([]fileState, len(files))
+	for i, f := range files {
+		frs[i] = validateFile(ctx, f)
+	}
+
+	checkCrossFileDuplicateIDs(frs)
+
+	return buildReport(frs), nil
+}
+
+// fileState is the engine's working representation of one resolved file: the
+// enriched pipelines it parsed successfully (used for cross-file duplicate-ID
+// detection, which needs every file's pipeline IDs at once) plus the
+// findings collected so far. buildReport converts this into the public
+// FileReport once every file (and the cross-file pass) has run.
+type fileState struct {
+	path      string
+	pipelines []config.Pipeline
+	findings  []Finding
+}
+
+// validateFile runs parse -> enrich -> validate (in that order — enrichment
+// mutates connector/processor IDs that validation checks, matching
+// pkg/provisioning.Service.provisionPipeline's ordering at service.go:279-280)
+// over a single file, collecting every finding along the way.
+func validateFile(ctx context.Context, path string) fileState {
+	fs := fileState{path: path}
+
+	f, err := os.Open(path)
+	if err != nil {
+		ce := conduiterr.Wrap(config.CodeParseError, fmt.Sprintf("could not open file %q: %v", path, err), err)
+		ce.Suggestion = "check that the file exists and is readable"
+		fs.findings = append(fs.findings, findingFromError(ce))
+		return fs
+	}
+	defer f.Close()
+
+	parser := yaml.NewParser(log.Nop())
+	pipelines, err := parser.Parse(ctx, f)
+	// err here is parser.Parse's raw cerrors.Join of per-document failures
+	// (see parser.go: `return configs.ToConfig(), err`, no extra "%w" wrap) —
+	// walk it directly with cerrors.ForEach. Wrapping it first (e.g. via
+	// cerrors.Errorf("...: %w", err)) would collapse every finding into one;
+	// see this package's doc.go and TestValidateFile_ParseErrors_AllFindings.
+	if err != nil {
+		cerrors.ForEach(err, func(e error) {
+			fs.findings = append(fs.findings, findingFromError(e))
+		})
+	}
+
+	for _, p := range pipelines {
+		enriched := config.Enrich(p)
+		fs.pipelines = append(fs.pipelines, enriched)
+
+		// config.Validate also returns a raw cerrors.Join — same rule as
+		// above, walk it directly, do not wrap it first.
+		if verr := config.Validate(enriched); verr != nil {
+			cerrors.ForEach(verr, func(e error) {
+				fs.findings = append(fs.findings, findingFromError(e))
+			})
+		}
+	}
+
+	return fs
+}
+
+// findingFromError converts one element of a cerrors.ForEach walk into a
+// Finding. A *conduiterr.ConduitError (every config.Validate error, and any
+// error this package itself wraps with a Code) carries its own code,
+// configPath, and suggestion through as-is. A plain error (a YAML syntax or
+// unrecognized-version failure from the parser, which has no per-field
+// configPath to attach) still gets a stable code so no finding is ever
+// uncoded — see design doc AC-5, "unparseable/unknown-version -> exit 2
+// coded finding, not panic".
+func findingFromError(e error) Finding {
+	if ce, ok := conduiterr.Get(e); ok {
+		return Finding{
+			Severity:   SeverityError,
+			Code:       ce.Code.Reason(),
+			Message:    ce.Message,
+			ConfigPath: ce.ConfigPath,
+			Suggestion: ce.Suggestion,
+			Fix:        ce.Fix,
+		}
+	}
+
+	ce := conduiterr.Wrap(config.CodeParseError, e.Error(), e)
+	if ce.Suggestion == "" {
+		ce.Suggestion = `fix the YAML syntax, or set "version" to a supported pipeline config version`
+	}
+	return Finding{
+		Severity:   SeverityError,
+		Code:       ce.Code.Reason(),
+		Message:    ce.Message,
+		ConfigPath: ce.ConfigPath,
+		Suggestion: ce.Suggestion,
+		Fix:        ce.Fix,
+	}
+}
+
+// checkCrossFileDuplicateIDs is new code, not a reuse of
+// pkg/provisioning.Service.findDuplicateIDs: that method returns a bare
+// index map and a sentinel error (ErrDuplicatedPipelineID) suited to
+// provisioning's "skip the duplicates, keep going" recovery, not a coded,
+// located Finding. This walks every file's successfully-parsed (and
+// enriched — though enrichment never touches the pipeline's own top-level
+// ID, so parsed vs. enriched makes no difference here) pipeline IDs at once
+// and appends a provisioning.CodePipelineIDDuplicate Finding, with a
+// configPath into that file's own "pipelines" list, to every file that
+// contributes an occurrence of a duplicated ID — including two different
+// files sharing one ID, which findDuplicateIDs was never asked to locate
+// (it only ever saw the flattened, already-merged list).
+func checkCrossFileDuplicateIDs(frs []fileState) {
+	type loc struct {
+		fileIdx, pipeIdx int
+	}
+	byID := map[string][]loc{}
+	for fi, fr := range frs {
+		for pi, p := range fr.pipelines {
+			if p.ID == "" {
+				continue // already reported via config.CodeFieldRequired; don't double up
+			}
+			byID[p.ID] = append(byID[p.ID], loc{fileIdx: fi, pipeIdx: pi})
+		}
+	}
+
+	// Sort IDs for deterministic finding order across runs.
+	ids := make([]string, 0, len(byID))
+	for id := range byID {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	for _, id := range ids {
+		locs := byID[id]
+		if len(locs) < 2 {
+			continue
+		}
+		sort.Slice(locs, func(i, j int) bool {
+			if locs[i].fileIdx != locs[j].fileIdx {
+				return frs[locs[i].fileIdx].path < frs[locs[j].fileIdx].path
+			}
+			return locs[i].pipeIdx < locs[j].pipeIdx
+		})
+
+		files := make([]string, 0, len(locs))
+		for _, l := range locs {
+			files = append(files, frs[l.fileIdx].path)
+		}
+
+		for _, l := range locs {
+			ce := conduiterr.New(provisioning.CodePipelineIDDuplicate,
+				fmt.Sprintf("pipeline %q: id is used by %d pipelines (%s)", id, len(locs), strings.Join(files, ", ")))
+			ce.ConfigPath = fmt.Sprintf("/pipelines/%d/id", l.pipeIdx)
+			ce.Suggestion = fmt.Sprintf("rename this pipeline's id or the other pipeline(s) sharing %q", id)
+
+			frs[l.fileIdx].findings = append(frs[l.fileIdx].findings, Finding{
+				Severity:   SeverityError,
+				Code:       ce.Code.Reason(),
+				Message:    ce.Message,
+				ConfigPath: ce.ConfigPath,
+				Suggestion: ce.Suggestion,
+			})
+		}
+	}
+}
+
+// buildReport converts the engine's working fileState slice into the public
+// Report: findings sorted by configPath within each file (the design doc's
+// ordering guarantee), plus the report-wide Summary rollup.
+func buildReport(frs []fileState) Report {
+	report := Report{Files: make([]FileReport, len(frs))}
+	report.Summary.Files = len(frs)
+
+	for i, fr := range frs {
+		sort.SliceStable(fr.findings, func(a, b int) bool {
+			return fr.findings[a].ConfigPath < fr.findings[b].ConfigPath
+		})
+
+		ids := make([]string, 0, len(fr.pipelines))
+		for _, p := range fr.pipelines {
+			ids = append(ids, p.ID)
+		}
+
+		findings := fr.findings
+		if findings == nil {
+			// A nil slice marshals to JSON `null`; a --json consumer
+			// iterating result.files[].findings shouldn't have to special-case
+			// "no findings" as null vs. an empty array.
+			findings = []Finding{}
+		}
+
+		report.Files[i] = FileReport{
+			Path:      fr.path,
+			OK:        len(fr.findings) == 0,
+			Pipelines: ids,
+			Findings:  findings,
+		}
+
+		report.Summary.Pipelines += len(ids)
+		for _, find := range fr.findings {
+			switch find.Severity {
+			case SeverityWarning:
+				report.Summary.Warnings++
+			case SeverityError:
+				report.Summary.Errors++
+			default:
+				// Every Finding this package constructs sets Severity
+				// explicitly (findingFromError and
+				// checkCrossFileDuplicateIDs both always use SeverityError;
+				// `lint`, in a future PR, will be the first caller to ever
+				// produce SeverityWarning). An unset/unknown value is a bug
+				// in a finding constructor, not a real severity — counting
+				// it as an error is the conservative choice (never silently
+				// under-report a problem into exit 0).
+				report.Summary.Errors++
+			}
+		}
+	}
+
+	return report
+}

--- a/cmd/conduit/internal/validate/engine_test.go
+++ b/cmd/conduit/internal/validate/engine_test.go
@@ -1,0 +1,318 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/provisioning"
+	"github.com/conduitio/conduit/pkg/provisioning/config"
+	"github.com/matryer/is"
+)
+
+// sharedTestdataDir points at the existing provisioning parser testdata
+// (pipelines1-success.yml, pipelines4-invalid-yaml.yml, ...), per the task's
+// instruction to reuse it rather than fork a parallel fixture set for
+// parser-level scenarios (invalid YAML, an empty file). This package's own
+// testdata/ only adds fixtures those files don't cover: field-validation
+// errors, an unrecognized version, and cross-file duplicate pipeline IDs.
+const sharedTestdataDir = "../../../../pkg/provisioning/config/yaml/v2/testdata"
+
+// TestRun_ValidFile_NoFindings covers AC-1: a valid file is OK with zero
+// findings.
+func TestRun_ValidFile_NoFindings(t *testing.T) {
+	is := is.New(t)
+
+	report, err := Run(context.Background(), "testdata/valid.yaml")
+	is.NoErr(err)
+	is.True(report.OK())
+	is.Equal(report.Summary.Files, 1)
+	is.Equal(report.Summary.Errors, 0)
+	is.Equal(len(report.Files), 1)
+	is.True(report.Files[0].OK)
+	is.Equal(len(report.Files[0].Findings), 0)
+	is.Equal(report.Files[0].Pipelines, []string{"valid-pipeline"})
+}
+
+// TestRun_FileWithFieldErrors_AllFindingsPresent covers AC-2: every one of
+// the N errors in a file is present, not just the first (the fail-fast /
+// ForEach-collapse risk this whole PR exists to guard against), each with a
+// non-empty code, configPath, message, and suggestion.
+func TestRun_FileWithFieldErrors_AllFindingsPresent(t *testing.T) {
+	is := is.New(t)
+
+	report, err := Run(context.Background(), "testdata/errors.yaml")
+	is.NoErr(err)
+	is.True(!report.OK())
+	is.Equal(len(report.Files), 1)
+
+	fr := report.Files[0]
+	is.True(!fr.OK)
+	// 5 independent field problems: invalid status, empty connector id,
+	// invalid connector type, missing connector plugin, duplicate connector
+	// id — see testdata/errors.yaml's comment-free but deliberate shape.
+	is.Equal(len(fr.Findings), 5)
+	is.Equal(report.Summary.Errors, 5)
+
+	wantPaths := map[string]bool{
+		"/status":              false,
+		"/connectors/0/id":     false,
+		"/connectors/0/type":   false,
+		"/connectors/0/plugin": false,
+		"/connectors/2/id":     false,
+	}
+	for _, f := range fr.Findings {
+		is.True(f.Code != "")
+		is.True(f.ConfigPath != "")
+		is.True(f.Message != "")
+		is.True(f.Suggestion != "")
+		is.Equal(f.Severity, SeverityError)
+		if _, ok := wantPaths[f.ConfigPath]; ok {
+			wantPaths[f.ConfigPath] = true
+		}
+	}
+	for _, seen := range wantPaths {
+		is.True(seen) // want a finding at every expected configPath
+	}
+}
+
+// TestRun_Offline_NoDial documents and exercises the offline invariant: Run
+// takes a plain path and never touches the network — no api.Client, no gRPC
+// dial, anywhere in its call graph (validateFile only ever calls os.Open,
+// the yaml parser, config.Enrich, and config.Validate). A run against a
+// local file succeeding with no server, no address flag, and no client
+// construction anywhere in this package is the structural proof.
+func TestRun_Offline_NoDial(t *testing.T) {
+	is := is.New(t)
+
+	report, err := Run(context.Background(), "testdata/valid.yaml")
+	is.NoErr(err)
+	is.True(report.OK())
+}
+
+// TestRun_UnparseableYAML covers AC-5 (unparseable -> exit-2-coded finding,
+// not a panic) using the shared parser testdata's malformed-indentation
+// fixture.
+func TestRun_UnparseableYAML(t *testing.T) {
+	is := is.New(t)
+
+	report, err := Run(context.Background(), sharedTestdataDir+"/pipelines4-invalid-yaml.yml")
+	is.NoErr(err) // a bad file is a Finding, not a hard Run error
+	is.True(!report.OK())
+	is.Equal(len(report.Files), 1)
+	is.True(!report.Files[0].OK)
+	is.True(len(report.Files[0].Findings) >= 1)
+	for _, f := range report.Files[0].Findings {
+		is.Equal(f.Code, config.CodeParseError.Reason())
+		is.True(f.Message != "")
+		is.True(f.Suggestion != "")
+	}
+}
+
+// TestRun_UnknownVersion covers the other half of AC-5: a recognized-shape
+// document whose version is not just outdated but entirely unrecognized
+// (parseVersion has no changelog entry for major version "99") is a coded
+// finding, not a panic or an uncoded error.
+func TestRun_UnknownVersion(t *testing.T) {
+	is := is.New(t)
+
+	report, err := Run(context.Background(), "testdata/unknown-version.yaml")
+	is.NoErr(err)
+	is.True(!report.OK())
+	is.Equal(len(report.Files), 1)
+	is.True(len(report.Files[0].Findings) >= 1)
+	is.Equal(report.Files[0].Findings[0].Code, config.CodeParseError.Reason())
+}
+
+// TestRun_EmptyFile covers the design doc's failure-mode note: an empty
+// file/dir is "0 pipelines checked", not an error.
+func TestRun_EmptyFile(t *testing.T) {
+	is := is.New(t)
+
+	report, err := Run(context.Background(), sharedTestdataDir+"/pipelines3-empty.yml")
+	is.NoErr(err)
+	is.True(report.OK())
+	is.Equal(report.Summary.Pipelines, 0)
+	is.Equal(len(report.Files), 1)
+	is.True(report.Files[0].OK)
+}
+
+// TestRun_EmptyDirectory covers the same failure mode for a directory with
+// no matching .yml/.yaml files at all.
+func TestRun_EmptyDirectory(t *testing.T) {
+	is := is.New(t)
+
+	dir := t.TempDir()
+	report, err := Run(context.Background(), dir)
+	is.NoErr(err)
+	is.True(report.OK())
+	is.Equal(report.Summary.Files, 0)
+	is.Equal(len(report.Files), 0)
+}
+
+// TestRun_Directory_Aggregates covers AC-4: every .yml/.yaml file in the
+// directory is checked (not recursed into subdirectories, and non-YAML
+// files are ignored), passing files are reported alongside failing ones,
+// and the run-wide Summary aggregates correctly.
+func TestRun_Directory_Aggregates(t *testing.T) {
+	is := is.New(t)
+
+	report, err := Run(context.Background(), "testdata/dir")
+	is.NoErr(err)
+	is.True(!report.OK()) // fail1.yaml has findings
+
+	is.Equal(report.Summary.Files, 3) // pass1, pass2, fail1 — not notes.txt or nested/ignored.yaml
+	is.Equal(report.Summary.Errors, 2)
+
+	byPath := map[string]FileReport{}
+	for _, f := range report.Files {
+		byPath[f.Path] = f
+	}
+	is.True(byPath["testdata/dir/pass1.yaml"].OK)
+	is.True(byPath["testdata/dir/pass2.yaml"].OK)
+	is.True(!byPath["testdata/dir/fail1.yaml"].OK)
+	is.Equal(len(byPath["testdata/dir/fail1.yaml"].Findings), 2)
+}
+
+// TestRun_CrossFileDuplicateID covers AC (from the task): two files sharing
+// a pipeline ID both fail, with the dup-ID code. This is the "new code, not
+// reuse" duplicate-ID detection the design doc's review called out — unlike
+// pkg/provisioning.Service.findDuplicateIDs (a same-process, flattened,
+// bare-sentinel check), this must locate the collision *per file* with a
+// real code and configPath.
+func TestRun_CrossFileDuplicateID(t *testing.T) {
+	is := is.New(t)
+
+	report, err := Run(context.Background(), "testdata/dup")
+	is.NoErr(err)
+	is.True(!report.OK())
+	is.Equal(len(report.Files), 2)
+
+	for _, f := range report.Files {
+		is.True(!f.OK)
+		is.Equal(len(f.Findings), 1)
+		find := f.Findings[0]
+		is.Equal(find.Code, provisioning.CodePipelineIDDuplicate.Reason())
+		is.Equal(find.ConfigPath, "/pipelines/0/id")
+		is.True(find.Suggestion != "")
+		is.True(find.Message != "")
+	}
+}
+
+// TestRun_SameFileDuplicateID covers the same detection logic on a single
+// file with two pipeline *documents* (YAML `---`-separated) sharing an ID —
+// a distinct path through checkCrossFileDuplicateIDs from
+// TestRun_CrossFileDuplicateID (one fileIdx, two pipeIdx, instead of two
+// fileIdx), using the shared parser testdata's dedicated fixture for this
+// shape.
+func TestRun_SameFileDuplicateID(t *testing.T) {
+	is := is.New(t)
+
+	report, err := Run(context.Background(), sharedTestdataDir+"/pipelines2-duplicate-pipeline-id.yml")
+	is.NoErr(err)
+	is.True(!report.OK())
+	is.Equal(len(report.Files), 1)
+
+	fr := report.Files[0]
+	is.Equal(len(fr.Pipelines), 3) // pipeline1, pipeline2, pipeline1 (dup)
+
+	var dupFindings []Finding
+	for _, f := range fr.Findings {
+		if f.Code == provisioning.CodePipelineIDDuplicate.Reason() {
+			dupFindings = append(dupFindings, f)
+		}
+	}
+	is.Equal(len(dupFindings), 2) // one per occurrence of "pipeline1"
+	is.Equal(dupFindings[0].ConfigPath, "/pipelines/0/id")
+	is.Equal(dupFindings[1].ConfigPath, "/pipelines/2/id")
+}
+
+// TestCheckCrossFileDuplicateIDs_EmptyIDNotDoubleReported proves an empty
+// pipeline ID (already reported separately via config.CodeFieldRequired at
+// "/id") is never also treated as a "duplicate" against other empty-ID
+// pipelines — that would be a confusing, redundant second finding for the
+// same root cause.
+func TestCheckCrossFileDuplicateIDs_EmptyIDNotDoubleReported(t *testing.T) {
+	is := is.New(t)
+
+	frs := []fileState{
+		{path: "a.yaml", pipelines: []config.Pipeline{{ID: ""}}},
+		{path: "b.yaml", pipelines: []config.Pipeline{{ID: ""}}},
+	}
+	checkCrossFileDuplicateIDs(frs)
+
+	is.Equal(len(frs[0].findings), 0)
+	is.Equal(len(frs[1].findings), 0)
+}
+
+// TestValidateFile_ForEachUnwrappedJoin_YieldsAllFindings is the load-bearing
+// regression test for the design review's top masked-bug risk: validateFile
+// must call cerrors.ForEach on config.Validate's and parser.Parse's raw
+// (unwrapped) cerrors.Join return value. Re-wrapping that Join with "%w"
+// before walking it (e.g. `cerrors.Errorf("invalid pipeline config: %w",
+// err)`, which is exactly what pkg/provisioning.Service.provisionPipeline
+// does at service.go:282 for its own, different purpose) hides the Join's
+// Unwrap() []error shape behind a single-error Unwrap() error, and
+// cerrors.ForEach then treats the whole thing as ONE error instead of N.
+//
+// This test proves both directions: ForEach over the raw Join yields every
+// error (proving validateFile's actual behavior via testdata/errors.yaml,
+// asserted again here for this specific invariant), and ForEach over a
+// re-wrapped Join collapses to one (proving what would go wrong if a future
+// change added a wrap before the ForEach call in engine.go).
+func TestValidateFile_ForEachUnwrappedJoin_YieldsAllFindings(t *testing.T) {
+	is := is.New(t)
+
+	cfg := config.Pipeline{
+		ID:     "p1",
+		Status: "bogus",
+		Connectors: []config.Connector{
+			{ID: "", Type: "bogus-type"},
+		},
+	}
+	joined := config.Validate(cfg)
+	is.True(joined != nil)
+
+	var viaUnwrapped []error
+	cerrors.ForEach(joined, func(e error) { viaUnwrapped = append(viaUnwrapped, e) })
+	is.True(len(viaUnwrapped) >= 4) // status, id, type, plugin are all independent findings
+
+	// The masked-bug scenario: wrap the Join with "%w" before walking it.
+	rewrapped := cerrors.Errorf("invalid pipeline config: %w", joined)
+	var viaRewrapped []error
+	cerrors.ForEach(rewrapped, func(e error) { viaRewrapped = append(viaRewrapped, e) })
+	is.Equal(len(viaRewrapped), 1) // collapsed — this is the bug this package's engine.go must not have
+}
+
+// TestExitError_NoFindings_ReturnsFalse and
+// TestExitError_WithFindings_ReturnsValidationCode cover the exit-code
+// aggregation the CLI output conventions §4 requires commands to own
+// explicitly.
+func TestExitError_NoFindings_ReturnsFalse(t *testing.T) {
+	is := is.New(t)
+	_, ok := ExitError([]FileReport{{OK: true}})
+	is.True(!ok)
+}
+
+func TestExitError_WithFindings_ReturnsValidationCode(t *testing.T) {
+	is := is.New(t)
+	err, ok := ExitError([]FileReport{
+		{Findings: []Finding{{Severity: SeverityError, Code: config.CodeFieldRequired.Reason()}}},
+	})
+	is.True(ok)
+	is.True(err != nil)
+}

--- a/cmd/conduit/internal/validate/exitcode.go
+++ b/cmd/conduit/internal/validate/exitcode.go
@@ -1,0 +1,90 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"fmt"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"google.golang.org/grpc/codes"
+)
+
+// bucketRank orders the three pkg/conduit/exitcode buckets a Finding's code
+// can fall into: Environment(3) > Validation(2) > Runtime(1) — OK/Canceled
+// fold into Runtime here since a Finding, by construction, always
+// represents a problem and never carries one of those two codes. This
+// deliberately duplicates (a small slice of) exitcode's own
+// codes.Code-to-bucket mapping rather than importing and calling it, per the
+// CLI output conventions §4: "this is new aggregation logic, NOT free reuse
+// of the single-error classifier; own it explicitly" — exitcode.ExitCode
+// classifies one error, but a validate run must reduce N findings' worth of
+// codes to the single worst one before there is an error to classify at
+// all, which is a different operation exitcode has no entry point for. The
+// switch is written to exhaustively cover every codes.Code value (mirroring
+// exitcode.fromGRPCCode's own shape) rather than falling through a default,
+// so a future grpc/codes addition fails the exhaustive linter here too,
+// the same way it would in exitcode.
+func bucketRank(c conduiterr.Code) int {
+	switch c.GRPCCode() {
+	case codes.OK, codes.Canceled:
+		return 1 // Runtime — not expected on a Finding's code, see doc above
+	case codes.InvalidArgument, codes.NotFound, codes.AlreadyExists,
+		codes.FailedPrecondition, codes.OutOfRange:
+		return 2 // Validation
+	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted,
+		codes.Unauthenticated, codes.PermissionDenied:
+		return 3 // Environment
+	case codes.Internal, codes.Unknown, codes.DataLoss, codes.Aborted, codes.Unimplemented:
+		return 1 // Runtime
+	default:
+		return 1 // Runtime
+	}
+}
+
+// ExitError synthesizes a *conduiterr.ConduitError from the worst-bucket
+// code across every error-severity Finding in files, or returns (nil,
+// false) if there are none. It exists purely so a command's ExecuteWithResult
+// has an error to hand cecdysis for classifying the process exit code (via
+// pkg/conduit/exitcode) even though a validation run with findings is not
+// itself a "hard command failure" per the CLI output conventions envelope
+// (ok:false, error:null) — see cecdysis.Outcome.ExitErr's doc for how that
+// reconciliation works structurally.
+func ExitError(files []FileReport) (error, bool) {
+	var worst conduiterr.Code
+	haveWorst := false
+	count := 0
+
+	for _, f := range files {
+		for _, find := range f.Findings {
+			if find.Severity != SeverityError {
+				continue
+			}
+			count++
+			code, ok := conduiterr.LookupCode(find.Code)
+			if !ok {
+				code = conduiterr.CodeUnknown
+			}
+			if !haveWorst || bucketRank(code) > bucketRank(worst) {
+				worst = code
+				haveWorst = true
+			}
+		}
+	}
+
+	if !haveWorst {
+		return nil, false
+	}
+	return conduiterr.New(worst, fmt.Sprintf("%d problem(s) found", count)), true
+}

--- a/cmd/conduit/internal/validate/report.go
+++ b/cmd/conduit/internal/validate/report.go
@@ -1,0 +1,85 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import "github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+
+// Severity is a Finding's severity. `validate` only ever produces
+// SeverityError findings (it is errors-only, per the CLI output
+// conventions' `--strict` row: validate has no `--strict` flag because it
+// has nothing for `--strict` to escalate). SeverityWarning exists so the
+// same Finding shape carries `lint`'s advisory findings without a second
+// type, once that verb ships.
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+)
+
+// Finding is one located problem in a pipeline config file: the shared
+// "located finding" shape from the CLI output conventions (§1.1), reused
+// verbatim so `pipelines validate` and a future `doctor`/`lint` render and
+// marshal identically.
+type Finding struct {
+	Severity   Severity        `json:"severity"`
+	Code       string          `json:"code"`
+	Message    string          `json:"message"`
+	ConfigPath string          `json:"configPath,omitempty"`
+	Suggestion string          `json:"suggestion,omitempty"`
+	Fix        *conduiterr.Fix `json:"fix,omitempty"`
+}
+
+// FileReport is one resolved file's outcome: every pipeline ID found in it
+// (enriched, i.e. after config.Enrich — connector/processor IDs are already
+// pipelineID-prefixed by the time a caller sees this) and every Finding
+// collected while parsing, enriching, and validating it. OK is true iff
+// Findings is empty.
+type FileReport struct {
+	Path      string    `json:"path"`
+	OK        bool      `json:"ok"`
+	Pipelines []string  `json:"pipelines"`
+	Findings  []Finding `json:"findings"`
+}
+
+// Summary is the report-wide rollup `pipelines validate` renders as its
+// "Summary: ..." line and emits as the --json envelope's `summary` field.
+type Summary struct {
+	Files     int `json:"files"`
+	Pipelines int `json:"pipelines"`
+	Errors    int `json:"errors"`
+	Warnings  int `json:"warnings"`
+}
+
+// Result is the --json envelope's `result` payload for `pipelines
+// validate`: every resolved file's report, in the same (sorted-by-path)
+// order Run produced them in.
+type Result struct {
+	Files []FileReport `json:"files"`
+}
+
+// Report is Run's return value: every file's outcome plus the rollup
+// Summary. OK reports the run-wide verdict (CLI output conventions §1's
+// envelope `ok` field) — true iff no file has any error-severity finding.
+type Report struct {
+	Summary Summary
+	Files   []FileReport
+}
+
+// OK reports whether every resolved file passed (no error-severity
+// findings). A directory with zero matching files is OK — per the design
+// doc's failure modes, an empty directory is "0 pipelines checked", not an
+// error.
+func (r Report) OK() bool { return r.Summary.Errors == 0 }

--- a/cmd/conduit/internal/validate/testdata/dir/fail1.yaml
+++ b/cmd/conduit/internal/validate/testdata/dir/fail1.yaml
@@ -1,0 +1,7 @@
+version: 2.2
+pipelines:
+  - id: dir-fail-1
+    status: running
+    connectors:
+      - id: src
+        type: bogus-type

--- a/cmd/conduit/internal/validate/testdata/dir/nested/ignored.yaml
+++ b/cmd/conduit/internal/validate/testdata/dir/nested/ignored.yaml
@@ -1,0 +1,3 @@
+version: 2.2
+pipelines:
+  - id: nested-should-be-ignored

--- a/cmd/conduit/internal/validate/testdata/dir/notes.txt
+++ b/cmd/conduit/internal/validate/testdata/dir/notes.txt
@@ -1,0 +1,1 @@
+not a pipeline config, must be ignored by directory resolution

--- a/cmd/conduit/internal/validate/testdata/dir/pass1.yaml
+++ b/cmd/conduit/internal/validate/testdata/dir/pass1.yaml
@@ -1,0 +1,8 @@
+version: 2.2
+pipelines:
+  - id: dir-pass-1
+    status: running
+    connectors:
+      - id: src
+        type: source
+        plugin: builtin:generator

--- a/cmd/conduit/internal/validate/testdata/dir/pass2.yaml
+++ b/cmd/conduit/internal/validate/testdata/dir/pass2.yaml
@@ -1,0 +1,8 @@
+version: 2.2
+pipelines:
+  - id: dir-pass-2
+    status: stopped
+    connectors:
+      - id: dst
+        type: destination
+        plugin: builtin:log

--- a/cmd/conduit/internal/validate/testdata/dup/dup-a.yaml
+++ b/cmd/conduit/internal/validate/testdata/dup/dup-a.yaml
@@ -1,0 +1,11 @@
+version: 2.2
+pipelines:
+  - id: shared-pipeline
+    status: running
+    connectors:
+      - id: src
+        type: source
+        plugin: builtin:generator
+      - id: dst
+        type: destination
+        plugin: builtin:log

--- a/cmd/conduit/internal/validate/testdata/dup/dup-b.yaml
+++ b/cmd/conduit/internal/validate/testdata/dup/dup-b.yaml
@@ -1,0 +1,11 @@
+version: 2.2
+pipelines:
+  - id: shared-pipeline
+    status: running
+    connectors:
+      - id: src2
+        type: source
+        plugin: builtin:generator
+      - id: dst2
+        type: destination
+        plugin: builtin:log

--- a/cmd/conduit/internal/validate/testdata/errors.yaml
+++ b/cmd/conduit/internal/validate/testdata/errors.yaml
@@ -1,0 +1,13 @@
+version: 2.2
+pipelines:
+  - id: broken-pipeline
+    status: bogus-status
+    connectors:
+      - id: ""
+        type: bogus-type
+      - id: dup-conn
+        type: source
+        plugin: builtin:generator
+      - id: dup-conn
+        type: source
+        plugin: builtin:generator

--- a/cmd/conduit/internal/validate/testdata/unknown-version.yaml
+++ b/cmd/conduit/internal/validate/testdata/unknown-version.yaml
@@ -1,0 +1,8 @@
+version: 99.0
+pipelines:
+  - id: p1
+    status: running
+    connectors:
+      - id: src
+        type: source
+        plugin: builtin:generator

--- a/cmd/conduit/internal/validate/testdata/valid.yaml
+++ b/cmd/conduit/internal/validate/testdata/valid.yaml
@@ -1,0 +1,13 @@
+version: 2.2
+pipelines:
+  - id: valid-pipeline
+    status: running
+    name: valid-pipeline
+    description: a clean pipeline with no findings
+    connectors:
+      - id: src
+        type: source
+        plugin: builtin:generator
+      - id: dst
+        type: destination
+        plugin: builtin:log

--- a/cmd/conduit/root/pipelines/pipelines.go
+++ b/cmd/conduit/root/pipelines/pipelines.go
@@ -33,6 +33,7 @@ func (c *PipelinesCommand) SubCommands() []ecdysis.Command {
 		&InitCommand{},
 		&ListCommand{},
 		&DescribeCommand{},
+		&ValidateCommand{},
 	}
 }
 

--- a/cmd/conduit/root/pipelines/validate.go
+++ b/cmd/conduit/root/pipelines/validate.go
@@ -1,0 +1,197 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelines
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/cmd/conduit/internal/ui"
+	"github.com/conduitio/conduit/cmd/conduit/internal/validate"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/ecdysis"
+)
+
+var (
+	_ cecdysis.CommandWithResult = (*ValidateCommand)(nil)
+	_ ecdysis.CommandWithDocs    = (*ValidateCommand)(nil)
+	_ ecdysis.CommandWithFlags   = (*ValidateCommand)(nil)
+	_ ecdysis.CommandWithArgs    = (*ValidateCommand)(nil)
+)
+
+// ValidateArgs holds ValidateCommand's positional argument.
+type ValidateArgs struct {
+	// Path is a single .yml/.yaml pipeline config file, or a directory of
+	// them (not recursed).
+	Path string
+}
+
+// ValidateFlags holds ValidateCommand's flags. There is deliberately no
+// --strict flag here (CLI output conventions §3): validate is errors-only,
+// so there is nothing for --strict to escalate; that flag belongs to the
+// future `lint`/`dry-run` verbs, which also report advisory warnings.
+type ValidateFlags struct {
+	Quiet   bool `long:"quiet" short:"q" usage:"suppress passing/OK lines and progress chrome; print only failures and the summary"`
+	NoColor bool `long:"no-color" usage:"disable colored/glyph output even on a color-capable terminal"`
+}
+
+// ValidateCommand implements `conduit pipelines validate <path>`: offline,
+// static verification of one or more pipeline config files. See
+// docs/design-documents/20260707-cli-pipeline-validate.md and
+// cmd/conduit/internal/validate for the engine this is a thin cobra shell
+// over.
+type ValidateCommand struct {
+	args  ValidateArgs
+	flags ValidateFlags
+
+	// renderer is constructed in ExecuteWithResult (where the real output
+	// stream and --no-color are available via the cobra command in ctx) and
+	// used by Render, which cecdysis.CommandWithResultDecorator calls
+	// afterwards on the same command value with no ctx of its own.
+	renderer *ui.Renderer
+}
+
+func (c *ValidateCommand) Usage() string { return "validate <path>" }
+
+func (c *ValidateCommand) Docs() ecdysis.Docs {
+	return ecdysis.Docs{
+		Short: "Validate one or more pipeline configuration files",
+		Long: `Runs the same offline parse, enrich, and validate steps 'conduit run' uses to
+load pipeline configuration files, without starting Conduit or dialing its API — this command
+never requires (or contacts) a running Conduit instance.
+
+<path> is a single .yml/.yaml file, or a directory of them (not recursed into
+subdirectories). Every problem found is reported — a bad file, or a bad pipeline within a
+file, never stops the rest from being checked. Exits 0 if every pipeline is valid, 2
+otherwise.`,
+		Example: "conduit pipelines validate pipelines/orders.yaml\n" +
+			"conduit pipelines validate ./pipelines --json\n" +
+			"conduit pipeline validate ./pipelines --quiet",
+	}
+}
+
+func (c *ValidateCommand) Flags() []ecdysis.Flag {
+	return ecdysis.BuildFlags(&c.flags)
+}
+
+func (c *ValidateCommand) Args(args []string) error {
+	if len(args) == 0 {
+		return cerrors.Errorf("requires a path to a pipeline config file or directory")
+	}
+	if len(args) > 1 {
+		return cerrors.Errorf("too many arguments")
+	}
+	c.args.Path = args[0]
+	return nil
+}
+
+func (c *ValidateCommand) ResultCommand() string { return "pipelines.validate" }
+
+// ExecuteWithResult runs the offline validate engine and translates its
+// Report into the shared cecdysis.Outcome envelope. A non-nil error return
+// here is reserved for a HARD failure — path itself couldn't be resolved at
+// all (e.g. it doesn't exist) — never for findings within files that did
+// resolve; see validate.Run's doc.
+func (c *ValidateCommand) ExecuteWithResult(ctx context.Context) (cecdysis.Outcome, error) {
+	c.renderer = ui.NewRenderer(rendererOutput(ctx), c.flags.NoColor)
+
+	report, err := validate.Run(ctx, c.args.Path)
+	if err != nil {
+		return cecdysis.Outcome{}, conduiterr.Wrap(conduiterr.CodeInvalidArgument,
+			fmt.Sprintf("could not resolve path %q: %v", c.args.Path, err), err)
+	}
+
+	outcome := cecdysis.Outcome{
+		OK:      report.OK(),
+		Summary: report.Summary,
+		Result:  validate.Result{Files: report.Files},
+	}
+	if !report.OK() {
+		// See CLI output conventions §4 and cecdysis.Outcome.ExitErr's doc:
+		// a validation run that finds problems is still OK:false/error:null
+		// in the rendered envelope — ExitErr is a side channel purely for
+		// the process exit code, not part of what gets rendered.
+		if exitErr, ok := validate.ExitError(report.Files); ok {
+			outcome.ExitErr = exitErr
+		}
+	}
+	return outcome, nil
+}
+
+// Render returns the human-readable rendering of a validate run: one line
+// per file (✓/✗ <path>), every finding under a failing file rendered via
+// ui.RenderFinding, and a summary line.
+func (c *ValidateCommand) Render(outcome cecdysis.Outcome) string {
+	summary, _ := outcome.Summary.(validate.Summary)
+	result, _ := outcome.Result.(validate.Result)
+
+	if c.renderer == nil {
+		// Defensive only: cecdysis.CommandWithResultDecorator always calls
+		// ExecuteWithResult (which sets c.renderer unconditionally, as its
+		// first statement) before ever calling Render on the same command
+		// value, so this is unreached in the real command pipeline. It
+		// exists so a test that constructs a ValidateCommand and calls
+		// Render directly, without going through ExecuteWithResult first,
+		// gets plain ASCII output instead of a nil-pointer panic.
+		c.renderer = ui.NewRenderer(io.Discard, true)
+	}
+
+	var b strings.Builder
+	for _, f := range result.Files {
+		if f.OK {
+			if !c.flags.Quiet {
+				fmt.Fprintf(&b, "%s %s\n", c.renderer.Glyph(ui.StatusPass), f.Path)
+			}
+			continue
+		}
+
+		fmt.Fprintf(&b, "%s %s\n", c.renderer.Glyph(ui.StatusFail), f.Path)
+		for _, finding := range f.Findings {
+			ui.RenderFinding(&b, c.renderer.Glyph(ui.StatusFail), finding.Code, finding.ConfigPath, finding.Message, finding.Suggestion)
+		}
+		fmt.Fprintln(&b)
+	}
+
+	passed := 0
+	for _, f := range result.Files {
+		if f.OK {
+			passed++
+		}
+	}
+	fmt.Fprintf(&b, "Summary: %d files · %d passed · %d failed · %d problems\n",
+		summary.Files, passed, summary.Files-passed, summary.Errors)
+
+	if summary.Errors > 0 {
+		fmt.Fprintln(&b, "Fix the ✗ items above, then re-run.")
+	}
+
+	return b.String()
+}
+
+// rendererOutput returns the cobra command's stdout stream so ui.NewRenderer
+// can detect whether it's a color-capable TTY, falling back to io.Discard
+// (never a terminal, so ui.NewRenderer's plain-ASCII path) if ctx carries no
+// cobra command — defensive for direct engine/unit-test callers that don't
+// go through the full ecdysis command pipeline.
+func rendererOutput(ctx context.Context) io.Writer {
+	if cmd := ecdysis.CobraCmdFromContext(ctx); cmd != nil {
+		return cmd.OutOrStdout()
+	}
+	return io.Discard
+}

--- a/cmd/conduit/root/pipelines/validate_test.go
+++ b/cmd/conduit/root/pipelines/validate_test.go
@@ -1,0 +1,226 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelines
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/pkg/conduit/exitcode"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/provisioning/config"
+	"github.com/conduitio/ecdysis"
+	json "github.com/goccy/go-json"
+	"github.com/matryer/is"
+)
+
+func newValidateEcdysis() *ecdysis.Ecdysis {
+	return ecdysis.New(ecdysis.WithDecorators(cecdysis.CommandWithResultDecorator{}))
+}
+
+func TestValidateCommand_Args_NoPath(t *testing.T) {
+	is := is.New(t)
+	c := &ValidateCommand{}
+	err := c.Args([]string{})
+	is.True(err != nil)
+}
+
+func TestValidateCommand_Args_TooMany(t *testing.T) {
+	is := is.New(t)
+	c := &ValidateCommand{}
+	err := c.Args([]string{"a", "b"})
+	is.True(err != nil)
+}
+
+// TestValidateCommand_ValidFile_JSON covers AC-1 and AC-6: a valid file
+// exits 0 with ok:true and no findings, and the --json output round-trips
+// as a single well-formed envelope object.
+func TestValidateCommand_ValidFile_JSON(t *testing.T) {
+	is := is.New(t)
+
+	cmd := newValidateEcdysis().MustBuildCobraCommand(&ValidateCommand{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"../../internal/validate/testdata/valid.yaml", "--json"})
+
+	err := cmd.Execute()
+	is.NoErr(err)
+	is.Equal(exitcode.ExitCode(err), exitcode.OK)
+
+	var got cecdysis.Result
+	is.NoErr(json.Unmarshal(out.Bytes(), &got))
+	is.Equal(got.Command, "pipelines.validate")
+	is.True(got.OK)
+	is.True(got.Error == nil)
+}
+
+// TestValidateCommand_FileWithErrors_JSON covers AC-2 and AC-6: every
+// finding is present in the --json result, with a registered code, and the
+// process exit code classifies as Validation (2) via
+// pkg/conduit/exitcode — even though ExecuteWithResult itself returns a nil
+// error (see cecdysis.Outcome.ExitErr's doc for why that still yields a
+// nonzero process exit code).
+func TestValidateCommand_FileWithErrors_JSON(t *testing.T) {
+	is := is.New(t)
+
+	cmd := newValidateEcdysis().MustBuildCobraCommand(&ValidateCommand{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"../../internal/validate/testdata/errors.yaml", "--json"})
+
+	err := cmd.Execute()
+	is.True(err != nil) // RunE returns outcome.ExitErr for classification
+	is.Equal(exitcode.ExitCode(err), exitcode.Validation)
+
+	var got cecdysis.Result
+	is.NoErr(json.Unmarshal(out.Bytes(), &got))
+	is.Equal(got.Command, "pipelines.validate")
+	is.True(!got.OK)
+	is.True(got.Error == nil) // findings, not a hard command failure — CLI output conventions §1
+
+	resultBytes, merr := json.Marshal(got.Result)
+	is.NoErr(merr)
+	var result struct {
+		Files []struct {
+			Path      string `json:"path"`
+			OK        bool   `json:"ok"`
+			Pipelines []string
+			Findings  []struct {
+				Severity   string `json:"severity"`
+				Code       string `json:"code"`
+				Message    string `json:"message"`
+				ConfigPath string `json:"configPath"`
+				Suggestion string `json:"suggestion"`
+			} `json:"findings"`
+		} `json:"files"`
+	}
+	is.NoErr(json.Unmarshal(resultBytes, &result))
+	is.Equal(len(result.Files), 1)
+	is.Equal(len(result.Files[0].Findings), 5)
+	for _, f := range result.Files[0].Findings {
+		is.True(f.Code != "")
+		is.True(f.ConfigPath != "")
+		is.True(f.Message != "")
+		is.True(f.Suggestion != "")
+		// code == registered reason (AC-6)
+		_, ok := conduiterr.LookupCode(f.Code)
+		is.True(ok)
+	}
+}
+
+// TestValidateCommand_FileWithErrors_Human covers the human-rendering path:
+// every finding renders via ui.RenderFinding (glyph + code + configPath,
+// message, suggestion), and no bare "(exit 2)" appears in the output per
+// CLI output conventions §2.
+func TestValidateCommand_FileWithErrors_Human(t *testing.T) {
+	is := is.New(t)
+
+	cmd := newValidateEcdysis().MustBuildCobraCommand(&ValidateCommand{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"../../internal/validate/testdata/errors.yaml"})
+
+	err := cmd.Execute()
+	is.True(err != nil)
+	is.Equal(exitcode.ExitCode(err), exitcode.Validation)
+
+	got := out.String()
+	is.True(strings.Contains(got, config.CodeFieldInvalid.Reason()))
+	is.True(strings.Contains(got, "/status"))
+	is.True(!strings.Contains(got, "(exit 2)")) // never print the exit code in human output
+	is.True(strings.Contains(got, "Summary:"))
+}
+
+// TestValidateCommand_Directory_ShowsPassingFiles covers the directory
+// aggregation + "passing files shown as ✓ <file>" requirement.
+func TestValidateCommand_Directory_ShowsPassingFiles(t *testing.T) {
+	is := is.New(t)
+
+	cmd := newValidateEcdysis().MustBuildCobraCommand(&ValidateCommand{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"../../internal/validate/testdata/dir"})
+
+	err := cmd.Execute()
+	is.True(err != nil) // fail1.yaml has findings
+	is.Equal(exitcode.ExitCode(err), exitcode.Validation)
+
+	got := out.String()
+	is.True(strings.Contains(got, "pass1.yaml"))
+	is.True(strings.Contains(got, "pass2.yaml"))
+	is.True(strings.Contains(got, "fail1.yaml"))
+	is.True(strings.Contains(got, "Summary: 3 files"))
+}
+
+// TestValidateCommand_Quiet_SuppressesPassingLines covers the -q/--quiet
+// flag: passing-file lines are suppressed, failures and the summary remain.
+func TestValidateCommand_Quiet_SuppressesPassingLines(t *testing.T) {
+	is := is.New(t)
+
+	cmd := newValidateEcdysis().MustBuildCobraCommand(&ValidateCommand{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"../../internal/validate/testdata/dir", "--quiet"})
+
+	err := cmd.Execute()
+	is.True(err != nil)
+
+	got := out.String()
+	is.True(!strings.Contains(got, "pass1.yaml"))
+	is.True(!strings.Contains(got, "pass2.yaml"))
+	is.True(strings.Contains(got, "fail1.yaml")) // failures still shown
+	is.True(strings.Contains(got, "Summary:"))
+}
+
+// TestValidateCommand_CrossFileDuplicateID_JSON covers the cross-file
+// duplicate pipeline ID acceptance case end to end through the command.
+func TestValidateCommand_CrossFileDuplicateID_JSON(t *testing.T) {
+	is := is.New(t)
+
+	cmd := newValidateEcdysis().MustBuildCobraCommand(&ValidateCommand{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"../../internal/validate/testdata/dup", "--json"})
+
+	err := cmd.Execute()
+	is.True(err != nil)
+	is.Equal(exitcode.ExitCode(err), exitcode.Validation)
+
+	is.True(strings.Contains(out.String(), `"provisioning.pipeline_id_duplicate"`))
+}
+
+// TestValidateCommand_NonexistentPath_HardFailure covers a HARD command
+// failure (the given path doesn't resolve to anything) rendering through
+// the envelope's error field, still classified as Validation (2) — bad
+// input on the caller's side, not an environment problem.
+func TestValidateCommand_NonexistentPath_HardFailure(t *testing.T) {
+	is := is.New(t)
+
+	cmd := newValidateEcdysis().MustBuildCobraCommand(&ValidateCommand{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"testdata/does-not-exist.yaml", "--json"})
+
+	err := cmd.Execute()
+	is.True(err != nil)
+	is.Equal(exitcode.ExitCode(err), exitcode.Validation)
+
+	var got cecdysis.Result
+	is.NoErr(json.Unmarshal(out.Bytes(), &got))
+	is.True(!got.OK)
+	is.True(got.Error != nil)
+}

--- a/docs/design-documents/20260707-cli-output-conventions.md
+++ b/docs/design-documents/20260707-cli-output-conventions.md
@@ -1,0 +1,121 @@
+# CLI output & result conventions (v0.17 "CLI as product")
+
+## Summary
+
+The shared contract every new v0.17 command (`pipelines validate|lint|dry-run`,
+`doctor`, `connector|processor new`) MUST follow, so the CLI reads as one product
+and an MCP layer can wrap all of them uniformly. Both the technical and UX reviews
+of the v0.17 plans converged on this: without a single contract, three commands
+drift into three private output formats and three incompatible JSON shapes.
+
+This is a convention doc, not a feature. It is the reference the command design
+docs point at.
+
+## 1. The `--json` envelope (one shape, all commands)
+
+Every command's `--json` output is a single JSON object to stdout with this
+top-level shape, **lowerCamelCase throughout** (matching existing protojson output
+like `createdAt`):
+
+```json
+{
+  "command": "pipelines.validate",   // stable dotted discriminator, ALWAYS present
+  "ok": false,                       // the verdict, ALWAYS present on every command
+  "summary": { "...": 0 },           // command-specific counts
+  "result": { "...": "..." },        // command-specific payload
+  "error": null                      // null on success; set on a HARD command failure
+}
+```
+
+- `ok` and `error` are present on **all** commands — an agent writes one
+  success check (`.ok`) for every tool.
+- `error` is for a hard command failure (bad input, preflight failure, crash), NOT
+  for domain findings. A validation run that finds problems is `ok:false` with the
+  problems in `result`/`summary` and `error:null` — the run itself succeeded.
+- `command` is the dotted path (`pipelines.validate`, `doctor`, `connector.new`).
+
+### Shared sub-objects (reused across commands)
+
+A **located finding / check result** (the §1.1 structured-error shape):
+
+```json
+{ "severity": "error|warning|pass|warn|fail",
+  "code": "config.field_required",
+  "message": "...",
+  "configPath": "/connectors/0/plugin",   // conduit.yaml dotted key OR pipeline JSON pointer — see note
+  "suggestion": "set connectors[0].plugin (e.g. \"builtin:postgres\")",
+  "fix": { "configPath": "...", "op": "set", "value": "" } }   // optional, powers future `repair`
+```
+
+The **`error`** object uses the same fields (`code`, `message`, `suggestion?`,
+`configPath?`, `fix?`) — it maps onto `conduiterr.ConduitError`. Scaffolding's
+error MUST carry `suggestion` (its human output already shows remediation text);
+a bare `{code,message}` is non-conformant.
+
+> **`configPath` note:** its *syntax* legitimately varies — a `conduit.yaml` dotted
+> key (`db.badger.path`) for doctor, a pipeline-doc JSON pointer
+> (`/connectors/0/plugin`) for validate. Same field, two address spaces; document
+> this on the field, do not invent two field names.
+
+## 2. Human output conventions
+
+- **Glyphs:** `✓` pass · `⚠` warn · `✗` fail. ASCII fallback `[OK]` / `[WARN]` /
+  `[FAIL]` when not a TTY, `--no-color`, or `NO_COLOR` is set.
+- **A located finding renders identically across commands** (one template — the
+  reviews flagged doctor's `└`-line vs validate's inline pointer as divergent):
+
+  ```
+  ✗ config.field_required   /connectors/0/plugin
+      connector "pg-source": "plugin" is mandatory
+      → set connectors[0].plugin (e.g. "builtin:postgres")
+  ```
+
+  glyph + code + configPath on line 1; message indented 4; `→ suggestion`
+  indented 4. No separate `└` line.
+- **Summary line:** `Summary: N passed · N warnings · N failed` (or `N files · …`
+  for directory runs). Where an action is needed, follow with ONE imperative line
+  (`Fix the ✗ items above, then re-run.`). **Never print the exit code** in human
+  output (the shell has `$?`).
+- **A single shared helper** (`cmd/conduit/internal/ui`) owns glyph-vs-ASCII
+  selection, `NO_COLOR`/`--no-color`/TTY detection, and color. No command
+  hand-rolls glyph logic.
+
+## 3. Flags (org-wide vocabulary — same meaning everywhere)
+
+| Flag | Meaning | Commands |
+| --- | --- | --- |
+| `--json` | machine output (envelope §1). Canonical usage string `"output the result as JSON"`. | all |
+| `-q, --quiet` | suppress passing/OK lines + progress chrome; print only warnings, failures, and the summary. Exit code unchanged. | all |
+| `--strict` | warnings escalate to failure (exit 2). | `lint`, `dry-run` (NOT `validate` — it is errors-only) |
+| `--check <name>` (repeatable) | select which checks run. Reserved org-wide for this meaning — do NOT reuse `--check*` for a boolean toggle. | `doctor` |
+| `-y, --yes`, `--force` | non-interactive confirm / overwrite (never silently clobber). | mutating commands (scaffolding) |
+
+Validate's builtin-plugin resolution toggle is `--resolve-plugins` (NOT
+`--check-plugins`, which collides with `doctor --check`).
+
+## 4. Exit codes — always via `pkg/conduit/exitcode`
+
+Every command routes its exit through `exitcode.ExitCode` (0 ok · 1 runtime · 2
+config/validation · 3 environment). No command invents "a distinct exit code."
+Multi-result commands (doctor, validate) that must reduce N findings to one exit
+code take the **worst** (max) bucket — this is *new* aggregation logic, NOT free
+reuse of the single-error classifier; own it explicitly (synthesize a
+`*conduiterr.ConduitError` per failing result, classify each, take the max;
+environment 3 > validation 2 > runtime 1).
+
+## 5. Cobra hygiene
+
+Every command sets `SilenceErrors` **and** `SilenceUsage` and renders its own
+error output — otherwise cobra prints a duplicate `Error:` line over the report
+and, under `--json`, corrupts the single-object stdout with a stderr `Error:`.
+Fold this into the shared offline `CommandWithResult` decorator so it is structural.
+
+Under `--json`, commands MUST NOT stream human progress/`✓` lines (they would
+precede/corrupt the single JSON object) — capture progress in `result.steps[]`.
+
+## Related
+
+- Execution plan §3 (CLI as product), §2 (MCP wraps these 1:1).
+- `20260707-cli-pipeline-validate.md`, `20260707-cli-doctor.md`,
+  `20260707-connector-processor-scaffolding.md` (the commands this governs).
+- `pkg/conduit/exitcode`, `pkg/foundation/cerrors/conduiterr` (the backbone).

--- a/docs/design-documents/20260707-cli-pipeline-validate.md
+++ b/docs/design-documents/20260707-cli-pipeline-validate.md
@@ -1,0 +1,161 @@
+# CLI: `conduit pipeline validate | lint | dry-run`
+
+## Summary
+
+The keystone of the v0.17 "CLI as product" work (execution plan §3): static,
+**offline** verification of pipeline config files. It is a thin shell over the
+machinery `conduit run`'s provisioning path already uses
+(`parser.Parse → config.Enrich → config.Validate`), surfacing the `config.*`
+`ConduitError` codes + JSON-pointer `configPath` from #2529, with `--json` and the
+deterministic exit codes (validation failure → exit 2). Tier 2.
+
+## Context — the reuse surface (everything needed already exists)
+
+| Capability | Where | Note |
+| --- | --- | --- |
+| YAML parse + version dispatch | `pkg/provisioning/config/yaml/parser.go:72` | Offline; collects all per-doc errors, no fail-fast (#2255) |
+| Default enrichment | `pkg/provisioning/config/enrich.go:20` | Rewrites connector/processor IDs to `pipelineID:connectorID` (`:71,95`) |
+| Static field/ref/type validation | `pkg/provisioning/config/validate.go:35` | Collects every error via `cerrors.Join`, no fail-fast |
+| Stable codes + `configPath` | `pkg/provisioning/config/codes.go:26` | `config.field_required/_invalid/_too_long/_id_duplicate` (#2529) |
+| Exit-code classification | `pkg/conduit/exitcode` | `InvalidArgument → 2` automatically |
+| Walk a joined error | `pkg/foundation/cerrors/cerrors.go:135` (`ForEach`) | needed — `conduiterr.Get` returns only the FIRST error |
+| Dir-vs-file `.yml/.yaml` filtering | `pkg/provisioning/service.go:177,217` | correct semantics already |
+| Group aliases singular | `cmd/conduit/root/pipelines/pipelines.go:29` (`Aliases: ["pipeline"]`) | both `pipeline` and `pipelines` resolve |
+
+### Two gaps this plan must close (both additive, Tier 2)
+
+1. **`Suggestion` is never populated** — `fieldError` (`codes.go:35`) takes no
+   suggestion; the field exists on `ConduitError` but ships empty. The graded UX
+   needs it → extend the domain validators to attach suggestions (so API/MCP get
+   them too).
+2. **Lint warnings are collected then discarded** — `ParseConfigurations` logs
+   warnings (`parser.go:146`) and never returns them; the `warning` type is
+   unexported (`linter.go:118`). `lint` needs the parser to expose them.
+
+## Decision — verb design
+
+- **`validate <file|dir>`** — Parse → Enrich → Validate. Static correctness only,
+  pass/fail, fully offline, exit 0 or 2. Ships first (the ~90% case).
+- **`lint <file|dir>`** — validate + advisory warnings (deprecated/renamed/unknown
+  fields, version fallback). Warnings are advisory: exit 0 unless `--strict`. Needs
+  gap-2 refactor.
+- **`dry-run <file|dir>`** — validate + report the **enriched** graph (final IDs,
+  injected DLQ defaults, worker counts) + optional builtin plugin-ref resolution
+  (`connector.plugin_not_found`). No side effects, no server. Standalone plugin
+  refs are marked "not statically verifiable" (advisory), not failed.
+
+**Shipping order:** validate first (zero refactor beyond suggestions); lint +
+dry-run in a second PR. All three share ONE internal engine so verb parity is
+structural, not copy-paste. Register as subcommands of the existing
+`PipelinesCommand`; the group already aliases `pipeline`, so no naming decision.
+
+## CLI UX & ergonomics
+
+```
+conduit pipelines validate <path> [flags]   # alias: conduit pipeline validate ...
+conduit pipelines lint     <path> [flags]
+conduit pipelines dry-run  <path> [flags]
+```
+
+`<path>` = one `.yml/.yaml` file OR a directory (recursed one level for
+`.yml/.yaml`). No `--config.path`/gRPC flag — these are **offline** and must never
+dial the API.
+
+Flags: `--json` (all), `--strict` (lint/validate: warnings → exit 2),
+`--check-plugins` (dry-run, default on), `-q/--quiet`.
+
+**FAIL output — collect all, never fail-fast:**
+
+```
+✗ pipelines/orders.yaml
+
+  config.field_required   /connectors/0/plugin
+    connector "pg-source": "plugin" is mandatory
+    → set connectors[0].plugin (e.g. "builtin:postgres")
+
+  config.id_duplicate     /connectors/2/id
+    connector "pg-source": "id" must be unique
+    → rename one of the connectors sharing id "pg-source"
+
+3 problems in 1 file. (exit 2)
+```
+
+One block per finding, ordered by `configPath`: line 1 = `code` + `configPath`,
+line 2 = validator `Message` (verbatim), line 3 = `→ Suggestion`. Directory input
+groups blocks under `✗ <file>` headers. `lint` renders warnings identically with
+`⚠`. The command sets `SilenceErrors` so cobra doesn't print a duplicate `Error:`
+over the report.
+
+**`--json` schema** (offline struct, not protojson): `{verb, ok, summary:{files,
+pipelines, errors, warnings}, files:[{path, ok, pipelines[], findings:[{severity,
+code, configPath, message, suggestion, fix?, line?, column?}]}]}`. Every field maps
+to an existing source (`code`←`Code.reason`, `configPath`←`ConfigPath`,
+`message`←`Message`, `suggestion`←`Suggestion` after gap 1, `fix`←`Fix` for the
+future `repair` verb, `line/column`←`warning{}` for lint).
+
+Exit codes: 0 clean; 2 any validation/parse/path error; warnings-only → 0 (2 under
+`--strict`); dry-run builtin plugin-not-found → 2 (`NotFound → Validation`).
+
+## File-level plan
+
+- New: `cmd/conduit/root/pipelines/{validate,lint,dry_run}.go` (+ tests); register
+  in `pipelines.go` `SubCommands()`.
+- New shared engine `cmd/conduit/internal/validate/` — one `Run(paths, opts)
+  Report` (resolve files → parse → enrich → validate → walk with `cerrors.ForEach`
+  → `[]Finding`); both human render and `--json` marshal the one type.
+- New offline result decorator `CommandWithResult` in
+  `cmd/conduit/cecdysis/decorators.go` (the offline sibling of the client-result
+  decorator — no API client). Register in `cli.go`.
+- Refactors (additive): populate `Suggestion` in the provisioning validators;
+  expose parser warnings; extract the dir/file resolution helper.
+
+## Acceptance criteria
+
+1. valid file → exit 0, `✓` per pipeline, "no problems"; `--json` `ok:true`, no findings.
+2. file with N errors → exit 2; ALL N appear (not fail-fast) in human + json, each
+   with non-empty code/configPath/message/suggestion.
+3. **offline**: works with no server, no gRPC dial (assert no dial).
+4. directory → checks every `.yml/.yaml`, aggregates per file, exit 2 if any error.
+5. unparseable/unknown-version → exit 2 coded finding, not panic/exit 1.
+6. `--json` valid on pass and fail, matches the schema; `code` == registered reason.
+7. `lint` deprecated field → warning w/ line+column, exit 0; `--strict` → exit 2.
+8. error + warning in one file → exit 2 (error dominates), both rendered.
+9. `dry-run` valid → exit 0, shows enriched IDs + DLQ defaults; `--check-plugins`
+   unknown builtin → exit 2; standalone ref → advisory, not a false fail.
+10. `SilenceErrors` set — no duplicate cobra `Error:` line over the report.
+
+## Failure modes
+
+- **Enrich-before-validate order** must match `service.go:279-280` (enrichment
+  mutates IDs) or validation diverges from `run`. Dry-run displays enriched IDs.
+- Using `conduiterr.Get` instead of `cerrors.ForEach` silently drops all but the
+  first finding (AC-2 guards this).
+- Exposing warnings must NOT change `run` behavior (additive API only).
+- dry-run standalone plugin false-negatives → scope `--check-plugins` to builtins.
+- empty file/dir → exit 0 "0 pipelines checked", not an error.
+
+## Optimization
+
+Maximal reuse: validation logic, codes, `configPath`, exit-code mapping,
+file resolution, `--json` decorator all exist. New code = the three command shells,
+one shared render/JSON struct, the offline decorator, two additive refactors. Do
+NOT write a second YAML schema, code set, `configPath` scheme, or exit-code map —
+that forks the contract the API/MCP already speak (`status.go`).
+
+## Related
+
+- Execution plan §3 (CLI as product). #2529 (config codes). `pkg/conduit/exitcode`.
+- Feeds MCP's `validate` tool (§2) and `conduit generate` (v0.19, validate-gated).
+
+## Review outcome (2026-07-07) — SOUND-WITH-CONCERNS
+
+Must-fix during implementation:
+- **Cross-file duplicate-ID detection is NEW code, not reuse** — `findDuplicateIDs`
+  (`service.go:100`) is outside `parse→enrich→validate` and returns a bare sentinel.
+  Give it a `provisioning.pipeline_id_duplicate` code + `configPath`.
+- **Call `cerrors.ForEach` on the UNWRAPPED Join**, never on an outer `%w` wrap — a
+  re-wrapped Join collapses N findings to one (masked-bug risk).
+- Populate `Suggestion` in the provisioning validators; expose parser warnings.
+- Adopt the shared contract in `20260707-cli-output-conventions.md` (envelope,
+  `--resolve-plugins` not `--check-plugins`, `--strict` on lint/dry-run only,
+  `SilenceErrors`, no `(exit 2)` in human output, dir-run shows passing `✓` files).

--- a/pkg/provisioning/codes.go
+++ b/pkg/provisioning/codes.go
@@ -1,0 +1,35 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioning
+
+import (
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"google.golang.org/grpc/codes"
+)
+
+// CodePipelineIDDuplicate is raised when two pipeline documents — in the same
+// file or across files — declare the same pipeline ID.
+//
+// It is distinct from config.CodeIDDuplicate, which config.Validate raises
+// for a connector/processor ID collision *within* a single pipeline
+// document: that check has the whole document in hand. A pipeline-ID
+// collision spans documents (and files), which config.Validate never sees
+// (it validates one config.Pipeline at a time) — detecting it is the job of
+// whatever collects pipelines across a directory: today that's
+// Service.findDuplicateIDs (a bare sentinel, ErrDuplicatedPipelineID, since
+// it only needs to skip the offending pipelines during provisioning) and the
+// offline `conduit pipelines validate` engine (cmd/conduit/internal/validate,
+// which needs a real code + configPath per finding for its report).
+var CodePipelineIDDuplicate = conduiterr.Register("provisioning.pipeline_id_duplicate", codes.InvalidArgument)

--- a/pkg/provisioning/config/codes.go
+++ b/pkg/provisioning/config/codes.go
@@ -27,13 +27,21 @@ var (
 	CodeFieldInvalid  = conduiterr.Register("config.field_invalid", codes.InvalidArgument)
 	CodeFieldTooLong  = conduiterr.Register("config.field_too_long", codes.InvalidArgument)
 	CodeIDDuplicate   = conduiterr.Register("config.id_duplicate", codes.InvalidArgument)
+	// CodeParseError is raised when a pipeline config document can't be parsed
+	// at all (invalid YAML, unrecognized version). It exists for offline
+	// consumers (cmd/conduit/internal/validate) that need a stable code for
+	// parser failures, which the parser itself returns as plain errors since
+	// it has no per-field configPath to attach at that stage.
+	CodeParseError = conduiterr.Register("config.parse_error", codes.InvalidArgument)
 )
 
-// fieldError builds a ConduitError carrying a machine-actionable code and the
-// JSON-pointer path to the offending field. The sentinel is kept in the chain so
-// existing errors.Is checks (ErrMandatoryField, ErrInvalidField, …) still hold.
-func fieldError(code conduiterr.Code, configPath, msg string, sentinel error) error {
+// fieldError builds a ConduitError carrying a machine-actionable code, the
+// JSON-pointer path to the offending field, and a human-readable suggestion for
+// how to fix it. The sentinel is kept in the chain so existing errors.Is checks
+// (ErrMandatoryField, ErrInvalidField, …) still hold.
+func fieldError(code conduiterr.Code, configPath, msg, suggestion string, sentinel error) error {
 	e := conduiterr.Wrap(code, msg, sentinel)
 	e.ConfigPath = configPath
+	e.Suggestion = suggestion
 	return e
 }

--- a/pkg/provisioning/config/files.go
+++ b/pkg/provisioning/config/files.go
@@ -1,0 +1,79 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+)
+
+// ResolveFiles resolves path into the pipeline configuration file(s) it
+// refers to: path itself, if it names a file (any extension — a caller that
+// points directly at a file is assumed to have chosen it deliberately), or
+// every direct child of path (not recursed) whose name ends in .yml or
+// .yaml, if path names a directory.
+//
+// This is the single implementation of "what is a pipeline config path"
+// shared by config-file provisioning (pkg/provisioning.Service, which reads
+// pipelines at startup) and the offline `conduit pipelines
+// validate|lint|dry-run` commands (cmd/conduit/internal/validate), so the
+// two surfaces can never drift on the answer.
+func ResolveFiles(path string) ([]string, error) {
+	if path == "" {
+		return nil, cerrors.New("pipeline path cannot be empty")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, cerrors.Errorf("failed to stat path %q: %w", path, err)
+	}
+	if !info.IsDir() {
+		return []string{path}, nil
+	}
+
+	return YAMLFilesInDir(path)
+}
+
+// YAMLFilesInDir returns every direct child of dir (not recursed) whose name
+// ends in .yml or .yaml (case-insensitive).
+func YAMLFilesInDir(dir string) ([]string, error) {
+	dirEntries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, cerrors.Errorf("could not read directory %q: %w", dir, err)
+	}
+
+	var files []string
+	for _, e := range dirEntries {
+		filePath := filepath.Join(dir, e.Name())
+		if IsYAMLFile(filePath) {
+			files = append(files, filePath)
+		}
+	}
+	return files, nil
+}
+
+// IsYAMLFile reports whether path names a regular file with a .yml or .yaml
+// extension (case-insensitive).
+func IsYAMLFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	ext := strings.ToLower(filepath.Ext(path))
+	return ext == ".yml" || ext == ".yaml"
+}

--- a/pkg/provisioning/config/files_test.go
+++ b/pkg/provisioning/config/files_test.go
@@ -1,0 +1,93 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+func TestResolveFiles_EmptyPath(t *testing.T) {
+	is := is.New(t)
+	_, err := ResolveFiles("")
+	is.True(err != nil)
+	is.True(err.Error() == "pipeline path cannot be empty")
+}
+
+func TestResolveFiles_NonexistentPath(t *testing.T) {
+	is := is.New(t)
+	_, err := ResolveFiles(filepath.Join(t.TempDir(), "does-not-exist.yaml"))
+	is.True(err != nil)
+}
+
+func TestResolveFiles_SingleFile_AnyExtension(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	f := filepath.Join(dir, "pipeline.txt") // deliberately not .yml/.yaml
+	is.NoErr(os.WriteFile(f, []byte("version: 2.2\n"), 0o600))
+
+	got, err := ResolveFiles(f)
+	is.NoErr(err)
+	is.Equal(got, []string{f})
+}
+
+func TestResolveFiles_Directory_OnlyYAMLNotRecursed(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+
+	yml := filepath.Join(dir, "a.yml")
+	yaml := filepath.Join(dir, "b.yaml")
+	txt := filepath.Join(dir, "c.txt")
+	is.NoErr(os.WriteFile(yml, []byte(""), 0o600))
+	is.NoErr(os.WriteFile(yaml, []byte(""), 0o600))
+	is.NoErr(os.WriteFile(txt, []byte(""), 0o600))
+
+	nested := filepath.Join(dir, "nested")
+	is.NoErr(os.Mkdir(nested, 0o750))
+	is.NoErr(os.WriteFile(filepath.Join(nested, "d.yaml"), []byte(""), 0o600))
+
+	got, err := ResolveFiles(dir)
+	is.NoErr(err)
+	is.Equal(len(got), 2)
+	for _, f := range got {
+		is.True(f == yml || f == yaml)
+	}
+}
+
+func TestResolveFiles_EmptyDirectory(t *testing.T) {
+	is := is.New(t)
+	got, err := ResolveFiles(t.TempDir())
+	is.NoErr(err)
+	is.Equal(len(got), 0)
+}
+
+func TestIsYAMLFile(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+
+	yml := filepath.Join(dir, "a.YML") // case-insensitive
+	is.NoErr(os.WriteFile(yml, []byte(""), 0o600))
+	is.True(IsYAMLFile(yml))
+
+	txt := filepath.Join(dir, "a.txt")
+	is.NoErr(os.WriteFile(txt, []byte(""), 0o600))
+	is.True(!IsYAMLFile(txt))
+
+	is.True(!IsYAMLFile(filepath.Join(dir, "does-not-exist.yaml")))
+	is.True(!IsYAMLFile(dir)) // a directory is not a regular file
+}

--- a/pkg/provisioning/config/validate.go
+++ b/pkg/provisioning/config/validate.go
@@ -30,24 +30,30 @@ const (
 )
 
 // Validate validates config field values for a pipeline. Each error carries a
-// ConduitError code and a JSON-pointer configPath to the offending field; the
-// original sentinel stays in the chain for backward-compatible errors.Is checks.
+// ConduitError code, a JSON-pointer configPath to the offending field, and a
+// Suggestion for how to fix it; the original sentinel stays in the chain for
+// backward-compatible errors.Is checks.
 func Validate(cfg Pipeline) error {
 	var errs []error
 	if cfg.ID == "" {
-		errs = append(errs, fieldError(CodeFieldRequired, "/id", "id is mandatory", ErrMandatoryField))
+		errs = append(errs, fieldError(CodeFieldRequired, "/id", "id is mandatory",
+			`set "id" to a unique pipeline identifier`, ErrMandatoryField))
 	}
 	if len(cfg.ID) > pipeline.IDLengthLimit {
-		errs = append(errs, fieldError(CodeFieldTooLong, "/id", pipeline.ErrIDOverLimit.Error(), pipeline.ErrIDOverLimit))
+		errs = append(errs, fieldError(CodeFieldTooLong, "/id", pipeline.ErrIDOverLimit.Error(),
+			fmt.Sprintf("shorten \"id\" to at most %d characters", pipeline.IDLengthLimit), pipeline.ErrIDOverLimit))
 	}
 	if len(cfg.Name) > pipeline.NameLengthLimit {
-		errs = append(errs, fieldError(CodeFieldTooLong, "/name", pipeline.ErrNameOverLimit.Error(), pipeline.ErrNameOverLimit))
+		errs = append(errs, fieldError(CodeFieldTooLong, "/name", pipeline.ErrNameOverLimit.Error(),
+			fmt.Sprintf("shorten \"name\" to at most %d characters", pipeline.NameLengthLimit), pipeline.ErrNameOverLimit))
 	}
 	if len(cfg.Description) > pipeline.DescriptionLengthLimit {
-		errs = append(errs, fieldError(CodeFieldTooLong, "/description", pipeline.ErrDescriptionOverLimit.Error(), pipeline.ErrDescriptionOverLimit))
+		errs = append(errs, fieldError(CodeFieldTooLong, "/description", pipeline.ErrDescriptionOverLimit.Error(),
+			fmt.Sprintf("shorten \"description\" to at most %d characters", pipeline.DescriptionLengthLimit), pipeline.ErrDescriptionOverLimit))
 	}
 	if cfg.Status != StatusRunning && cfg.Status != StatusStopped {
-		errs = append(errs, fieldError(CodeFieldInvalid, "/status", `"status" is invalid`, ErrInvalidField))
+		errs = append(errs, fieldError(CodeFieldInvalid, "/status", `"status" is invalid`,
+			fmt.Sprintf("set \"status\" to %q or %q", StatusRunning, StatusStopped), ErrInvalidField))
 	}
 
 	errs = append(errs, validateConnectors(cfg.Connectors)...)
@@ -64,29 +70,36 @@ func validateConnectors(mp []Connector) []error {
 	for i, cfg := range mp {
 		path := fmt.Sprintf("/connectors/%d", i)
 		if cfg.ID == "" {
-			errs = append(errs, fieldError(CodeFieldRequired, path+"/id", fmt.Sprintf("connector %d: id is mandatory", i+1), ErrMandatoryField))
+			errs = append(errs, fieldError(CodeFieldRequired, path+"/id", fmt.Sprintf("connector %d: id is mandatory", i+1),
+				fmt.Sprintf("set connectors[%d].id", i), ErrMandatoryField))
 		}
 		if len(cfg.ID) > connector.IDLengthLimit {
-			errs = append(errs, fieldError(CodeFieldTooLong, path+"/id", fmt.Sprintf("connector %q: %s", cfg.ID, connector.ErrIDOverLimit), connector.ErrIDOverLimit))
+			errs = append(errs, fieldError(CodeFieldTooLong, path+"/id", fmt.Sprintf("connector %q: %s", cfg.ID, connector.ErrIDOverLimit),
+				fmt.Sprintf("shorten connectors[%d].id to at most %d characters", i, connector.IDLengthLimit), connector.ErrIDOverLimit))
 		}
 		if len(cfg.Name) > connector.NameLengthLimit {
-			errs = append(errs, fieldError(CodeFieldTooLong, path+"/name", fmt.Sprintf("connector %q: %s", cfg.ID, connector.ErrNameOverLimit), connector.ErrNameOverLimit))
+			errs = append(errs, fieldError(CodeFieldTooLong, path+"/name", fmt.Sprintf("connector %q: %s", cfg.ID, connector.ErrNameOverLimit),
+				fmt.Sprintf("shorten connectors[%d].name to at most %d characters", i, connector.NameLengthLimit), connector.ErrNameOverLimit))
 		}
 		if cfg.Plugin == "" {
-			errs = append(errs, fieldError(CodeFieldRequired, path+"/plugin", fmt.Sprintf(`connector %q: "plugin" is mandatory`, cfg.ID), ErrMandatoryField))
+			errs = append(errs, fieldError(CodeFieldRequired, path+"/plugin", fmt.Sprintf(`connector %q: "plugin" is mandatory`, cfg.ID),
+				fmt.Sprintf("set connectors[%d].plugin (e.g. \"builtin:postgres\")", i), ErrMandatoryField))
 		}
 		if cfg.Type == "" {
-			errs = append(errs, fieldError(CodeFieldRequired, path+"/type", fmt.Sprintf(`connector %q: "type" is mandatory`, cfg.ID), ErrMandatoryField))
+			errs = append(errs, fieldError(CodeFieldRequired, path+"/type", fmt.Sprintf(`connector %q: "type" is mandatory`, cfg.ID),
+				fmt.Sprintf("set connectors[%d].type to %q or %q", i, TypeSource, TypeDestination), ErrMandatoryField))
 		}
 		if cfg.Type != "" && cfg.Type != TypeSource && cfg.Type != TypeDestination {
-			errs = append(errs, fieldError(CodeFieldInvalid, path+"/type", fmt.Sprintf(`connector %q: "type" is invalid`, cfg.ID), ErrInvalidField))
+			errs = append(errs, fieldError(CodeFieldInvalid, path+"/type", fmt.Sprintf(`connector %q: "type" is invalid`, cfg.ID),
+				fmt.Sprintf("set connectors[%d].type to %q or %q", i, TypeSource, TypeDestination), ErrInvalidField))
 		}
 
 		// nested processor errors already carry their own /connectors/i/processors/j path
 		errs = append(errs, validateProcessors(cfg.Processors, path+"/processors")...)
 
 		if ids[cfg.ID] {
-			errs = append(errs, fieldError(CodeIDDuplicate, path+"/id", fmt.Sprintf(`connector %q: "id" must be unique`, cfg.ID), ErrDuplicateID))
+			errs = append(errs, fieldError(CodeIDDuplicate, path+"/id", fmt.Sprintf(`connector %q: "id" must be unique`, cfg.ID),
+				fmt.Sprintf("rename one of the connectors sharing id %q", cfg.ID), ErrDuplicateID))
 		}
 		ids[cfg.ID] = true
 	}
@@ -102,16 +115,20 @@ func validateProcessors(mp []Processor, pathPrefix string) []error {
 	for i, cfg := range mp {
 		path := fmt.Sprintf("%s/%d", pathPrefix, i)
 		if cfg.ID == "" {
-			errs = append(errs, fieldError(CodeFieldRequired, path+"/id", fmt.Sprintf("processor %d: id is mandatory", i+1), ErrMandatoryField))
+			errs = append(errs, fieldError(CodeFieldRequired, path+"/id", fmt.Sprintf("processor %d: id is mandatory", i+1),
+				fmt.Sprintf("set %s/%d.id", pathPrefix, i), ErrMandatoryField))
 		}
 		if cfg.Plugin == "" {
-			errs = append(errs, fieldError(CodeFieldRequired, path+"/plugin", fmt.Sprintf(`processor %q: "plugin" is mandatory`, cfg.ID), ErrMandatoryField))
+			errs = append(errs, fieldError(CodeFieldRequired, path+"/plugin", fmt.Sprintf(`processor %q: "plugin" is mandatory`, cfg.ID),
+				fmt.Sprintf("set %s/%d.plugin (e.g. \"js\")", pathPrefix, i), ErrMandatoryField))
 		}
 		if cfg.Workers < 0 {
-			errs = append(errs, fieldError(CodeFieldInvalid, path+"/workers", fmt.Sprintf(`processor %q: "workers" can't be negative`, cfg.ID), ErrInvalidField))
+			errs = append(errs, fieldError(CodeFieldInvalid, path+"/workers", fmt.Sprintf(`processor %q: "workers" can't be negative`, cfg.ID),
+				fmt.Sprintf("set %s/%d.workers to zero or a positive number", pathPrefix, i), ErrInvalidField))
 		}
 		if ids[cfg.ID] {
-			errs = append(errs, fieldError(CodeIDDuplicate, path+"/id", fmt.Sprintf(`processor %q: "id" must be unique`, cfg.ID), ErrDuplicateID))
+			errs = append(errs, fieldError(CodeIDDuplicate, path+"/id", fmt.Sprintf(`processor %q: "id" must be unique`, cfg.ID),
+				fmt.Sprintf("rename one of the processors sharing id %q", cfg.ID), ErrDuplicateID))
 		}
 		ids[cfg.ID] = true
 	}

--- a/pkg/provisioning/config/validate_test.go
+++ b/pkg/provisioning/config/validate_test.go
@@ -72,8 +72,26 @@ func TestValidate_ConfigPathAndCode(t *testing.T) {
 			is.True(ok) // carries a ConduitError
 			is.Equal(ce.Code.Reason(), tc.wantCode.Reason())
 			is.Equal(ce.ConfigPath, tc.wantPath)
+			is.True(ce.Suggestion != "") // every validation error carries a remediation hint
 		})
 	}
+}
+
+// TestValidate_ConnectorMissingPlugin_SuggestionMatchesDesignExample locks in
+// the exact suggestion wording from
+// docs/design-documents/20260707-cli-pipeline-validate.md's FAIL output
+// example, so `pipelines validate`'s rendered output stays in sync with the
+// design doc it was reviewed against.
+func TestValidate_ConnectorMissingPlugin_SuggestionMatchesDesignExample(t *testing.T) {
+	is := is.New(t)
+	cfg := Pipeline{ID: "pipeline1", Status: StatusRunning, Connectors: []Connector{{ID: "pg-source", Type: TypeSource}}}
+
+	err := Validate(cfg)
+	is.True(err != nil)
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Suggestion, `set connectors[0].plugin (e.g. "builtin:postgres")`)
 }
 
 func TestValidator_MandatoryFields(t *testing.T) {

--- a/pkg/provisioning/service.go
+++ b/pkg/provisioning/service.go
@@ -17,10 +17,8 @@ package provisioning
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"slices"
 	"sort"
-	"strings"
 
 	"github.com/conduitio/conduit-commons/database"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
@@ -174,58 +172,25 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 // we assume that the user is intentionally using this file.
 // If the given path is a directory, then this method returns all entries in the directory
 // that are not directories themselves, and that have their names end in yml or yaml.
+//
+// The resolution logic itself lives in config.ResolveFiles, shared with the
+// offline `conduit pipelines validate|lint|dry-run` commands
+// (cmd/conduit/internal/validate) so the two surfaces can't drift on what "a
+// pipeline config path" means; this method only adds the service's own
+// logging and error-wrapping conventions.
 func (s *Service) getPipelineConfigFiles(ctx context.Context, path string) ([]string, error) {
-	if path == "" {
-		return nil, cerrors.Errorf("failed to read pipelines folder %q: %w", path, cerrors.New("pipeline path cannot be empty"))
-	}
-
 	s.logger.Debug(ctx).
 		Str("pipelines_path", path).
 		Msg("loading pipeline configuration files")
 
-	info, err := os.Stat(path)
-	if err != nil {
-		return nil, cerrors.Errorf("failed to stat pipelines path %q: %w", path, err)
-	}
-	if !info.IsDir() {
-		return []string{path}, nil
-	}
-
-	return s.getYamlFilesFromDir(ctx, path)
-}
-
-func (s *Service) getYamlFilesFromDir(ctx context.Context, path string) ([]string, error) {
-	dirEntries, err := os.ReadDir(path)
+	files, err := config.ResolveFiles(path)
 	if err != nil {
 		s.logger.Warn(ctx).
 			Err(err).
-			Msg("could not read pipelines directory")
-		return nil, err
+			Msg("could not resolve pipeline config files")
+		return nil, cerrors.Errorf("failed to read pipelines folder %q: %w", path, err)
 	}
-
-	var files []string
-	for _, dirEntry := range dirEntries {
-		filePath := filepath.Join(path, dirEntry.Name())
-		if s.isYamlFile(filePath) {
-			files = append(files, filePath)
-		}
-	}
-
 	return files, nil
-}
-
-func (s *Service) isYamlFile(path string) bool {
-	info, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-	if !info.Mode().IsRegular() {
-		return false
-	}
-
-	// Check if it's a YAML file
-	ext := strings.ToLower(filepath.Ext(path))
-	return ext == ".yml" || ext == ".yaml"
 }
 
 func (s *Service) parsePipelineConfigFile(ctx context.Context, path string) ([]config.Pipeline, error) {


### PR DESCRIPTION
## Summary

Implements `conduit pipelines validate <path>` (alias `conduit pipeline validate`) per
`docs/design-documents/20260707-cli-pipeline-validate.md`, built on the shared v0.17
"CLI as product" foundations merged in #2572 (`cecdysis.CommandWithResult`, `cmd/conduit/internal/ui`,
`pkg/conduit/exitcode`) and the contract in `docs/design-documents/20260707-cli-output-conventions.md`.

- Offline `parse -> enrich -> validate` over `pkg/provisioning/config` — the same machinery
  `conduit run`'s provisioning path uses, never dials the API.
- Shared engine in `cmd/conduit/internal/validate` (`Run`, one `Report` type both the human
  renderer and `--json` marshal from) — designed so `lint`/`dry-run` can reuse it in a follow-up
  PR, per the design doc's shipping order.
- Registered on the existing `PipelinesCommand` (`pipeline`/`pipelines` alias already in place).
- Collects **every** finding across every resolved file — no fail-fast. Each finding carries
  `code` + `configPath` + `message` + `suggestion`.
- Directory input aggregates every `.yml`/`.yaml` file (not recursed), showing passing files too
  (`✓ <file>`). `-q/--quiet` suppresses passing/progress lines only, not failures or the summary.
- Exit 0 clean, 2 on any finding, via `pkg/conduit/exitcode`. No `--strict` (validate is
  errors-only, per the conventions doc — that flag belongs to `lint`/`dry-run`).

### Review-flagged must-fixes (from the design doc's review outcome)

- **`cerrors.ForEach` on the unwrapped `cerrors.Join`.** `config.Validate` and the yaml parser
  both already return a raw `cerrors.Join(...)`; the engine walks that directly, never after
  re-wrapping it with `%w` (which would collapse N findings into one — this was called out as
  the top masked-bug risk). See `TestValidateFile_ForEachUnwrappedJoin_YieldsAllFindings`, which
  proves both directions.
- **Cross-file/-document duplicate pipeline ID detection is new engine code**
  (`checkCrossFileDuplicateIDs`), not a reuse of `provisioning.Service.findDuplicateIDs`'s bare
  sentinel (`ErrDuplicatedPipelineID`) — that method is a same-process, flattened, skip-and-continue
  check suited to provisioning's recovery path. The new engine code needed a real, located
  finding, so it's new: a new `provisioning.CodePipelineIDDuplicate` code + a `configPath` into
  the offending file's own `pipelines` list, reported against **every** file/document that
  contributes an occurrence.
- **Populated `Suggestion`** in every `pkg/provisioning/config` validator — `fieldError` took no
  suggestion before this PR and always shipped one empty. Additive; the connector-missing-plugin
  and connector-id-duplicate suggestions match the design doc's own FAIL-output example verbatim
  (locked in by a dedicated test).
- **Enrich before Validate**, matching `service.go`'s provisioning order (`provisionPipeline`).

### Supporting refactor

Extracted `config.ResolveFiles` (+ `YAMLFilesInDir`, `IsYAMLFile`) as the single
file/directory-resolution implementation shared by `pkg/provisioning.Service` (config-file
provisioning at startup) and this new offline command — `Service.getPipelineConfigFiles` now
delegates to it instead of carrying its own private copy. Existing `provisioning` tests
(`TestService_getYamlFiles*`, `TestService_Init_Delete`) still pass unmodified.

### Additive change to `cecdysis`

`cecdysis.Outcome` gained an `ExitErr` field, and `CommandWithResultDecorator`'s success path
now returns it instead of unconditionally `nil`. This was necessary, not optional: per the CLI
output conventions, a validation run that finds problems is `ok:false`/`error:null` — the run
itself succeeded, so `ExecuteWithResult` must return a nil error (that's the documented contract
for "domain failure" vs. "hard command failure"). But `cmd/conduit/cli` derives the process exit
code entirely from `cmd.Execute()`'s returned error, and the pre-existing decorator's success
path always returned `nil` regardless of `Outcome.OK` — so without this change, `validate` could
never exit non-zero on a finding. `ExitErr` is returned *after* the envelope/human output is
already written, is never itself rendered, and is nil (today's default behavior, unchanged) for
every other command using this decorator. Covered by three new tests in `cecdysis/result_test.go`
(JSON path, human path, and the nil-ExitErr default-unaffected case).

## Adversarial self-review

- Re-read the diff hunting for the ForEach/re-wrap masked-bug specifically — `validateFile` in
  `engine.go` calls `cerrors.ForEach` directly on `parser.Parse`'s and `config.Validate`'s return
  values, with no `cerrors.Errorf("...: %w", err)` wrap anywhere in between. Added the dedicated
  regression test rather than trusting a read-through alone.
- Verified end-to-end with the built binary (not just unit tests): single valid file, single file
  with 5 field errors, a directory with 2 passing + 1 failing file, two files sharing a pipeline
  ID, `--json`, `--quiet` — confirmed exit codes (`0`/`2`) and rendered output match by hand before
  trusting the test suite.
- Confirmed the offline invariant structurally, not just by a passing test: grepped
  `cmd/conduit/internal/validate` and `cmd/conduit/root/pipelines/validate.go` for any
  `api.Client`/gRPC dial — none exists; the only `grpc` import is `codes` (for classification
  constants), not a client.
- Checked for a nil-pointer risk in `ValidateCommand.Render` (`c.renderer` is set in
  `ExecuteWithResult`, called before `Render` by the same decorator) — unreachable in the real
  command pipeline, but hardened with a defensive fallback anyway in case a future test calls
  `Render` directly.
- Fixed a minor UX rough edge caught while manually verifying `--json` output: `findings` was
  serializing as JSON `null` (not `[]`) for a passing file, which would make a naive `--json`
  consumer iterating `result.files[].findings` need to special-case `null`. Now always `[]` when
  empty.
- The cross-file duplicate-ID message initially rendered a Go `%v` slice (`[a.yaml b.yaml]`);
  fixed to a comma-joined string before finalizing.

## Test plan

- [x] `go build ./...`
- [x] `go test ./cmd/conduit/... ./pkg/provisioning/... -race -count=1` — green
- [x] `golangci-lint run ./cmd/... ./pkg/provisioning/...` — 0 issues
- [x] `TestValidateFile_ForEachUnwrappedJoin_YieldsAllFindings` — proves the ForEach-on-unwrapped-Join
      invariant both ways (raw Join → all findings; re-wrapped Join → collapses to 1, documenting
      exactly the bug this guards against)
- [x] `TestRun_CrossFileDuplicateID` / `TestRun_SameFileDuplicateID` — two files, and two documents
      in one file, sharing a pipeline ID both get the dup-ID code
- [x] `TestRun_Offline_NoDial` + structural grep confirmation — no API client anywhere in the call
      graph
- [x] `TestValidateCommand_FileWithErrors_JSON` — all 5 findings present in `--json`, each with
      non-empty code/configPath/message/suggestion, `code` == a registered `conduiterr` reason
- [x] `TestValidateCommand_Directory_ShowsPassingFiles` / `_Quiet_SuppressesPassingLines`
- [x] `TestValidateCommand_NonexistentPath_HardFailure` — unresolvable path is a HARD failure
      (envelope `error` set), still classified as exit 2
- [x] Manual run of the built binary against every fixture in `cmd/conduit/internal/validate/testdata/`

Tier 2. Roadmap: execution plan §3 (CLI as product). `lint`/`dry-run` follow in a second PR per
the design doc's shipping order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tapg9dLWXKMZJoL65R24vd