### PR TITLE
test(lifecycle-poc): fix CI flake in TestServiceLifecycle_PipelineError/PipelineStop

### DIFF
--- a/pkg/lifecycle-poc/funnel/worker.go
+++ b/pkg/lifecycle-poc/funnel/worker.go
@@ -208,14 +208,22 @@ func (w *Worker) Stop(ctx context.Context) error {
 	}
 	defer release()
 
-	// Lock acquired, teardown the source and set stop to true to signal the
-	// worker it should stop processing, since it won't be able to deliver
-	// any acks.
-	err = w.tearDownSource(ctx)
-	if err != nil {
+	// Lock acquired: no batch is currently being processed, but a new batch's
+	// first task can already be blocked in (or about to start) a source Read,
+	// unprotected by processingLock by design (see doTask) so a slow Read
+	// doesn't hold up Stop. Set stop *before* tearing down the source: doTask
+	// only treats a plugin.ErrPluginNotRunning from that Read as a graceful
+	// stop when w.stop.Load() is already true (see doTask's IsFirst check). If
+	// tearDownSource ran first, a Read racing the teardown could observe the
+	// torn-down plugin (ErrPluginNotRunning) before this flag flips, and get
+	// misreported as a real failure instead of a graceful stop — confirmed by
+	// repro under `-race -count=800` (pkg/lifecycle-poc/service_test.go
+	// TestServiceLifecycle_PipelineStop flaking with "failed to read from
+	// source: plugin is not running").
+	w.stop.Store(true)
+	if err := w.tearDownSource(ctx); err != nil {
 		return cerrors.Errorf("failed to tear down source: %w", err)
 	}
-	w.stop.Store(true)
 	return nil
 }
 

--- a/pkg/lifecycle-poc/service.go
+++ b/pkg/lifecycle-poc/service.go
@@ -56,6 +56,15 @@ type Service struct {
 	handlers         []FailureHandler
 	runningPipelines *csync.Map[string, *runnablePipeline]
 
+	// terminalErrors holds the terminal error of a pipeline after it has stopped
+	// and been removed from runningPipelines, so WaitPipeline can still report it
+	// to a caller that races the pipeline's own cleanup goroutine. Written before
+	// the runningPipelines entry is deleted; cleared when the pipeline is started
+	// again. Ports the fix applied to the sibling pkg/lifecycle package for the
+	// same WaitPipeline lookup-after-delete race — see
+	// docs/design-documents/20260706-forceful-stop-test-determinism.md.
+	terminalErrors *csync.Map[string, error]
+
 	isGracefulShutdown atomic.Bool
 	metricsDisabled    bool
 }
@@ -76,6 +85,7 @@ func NewService(
 		connectorPlugins: connectorPlugins,
 		pipelines:        pipelines,
 		runningPipelines: csync.NewMap[string, *runnablePipeline](),
+		terminalErrors:   csync.NewMap[string, error](),
 		metricsDisabled:  metricsDisabled,
 	}
 }
@@ -160,6 +170,10 @@ func (s *Service) Start(
 	if err != nil {
 		return cerrors.Errorf("could not build tasks for pipeline %s: %w", pl.ID, err)
 	}
+
+	// A new run supersedes any terminal error recorded by a previous run of this
+	// pipeline, so a later WaitPipeline can't return a stale result.
+	s.terminalErrors.Delete(pipelineID)
 
 	s.logger.Trace(ctx).Str(log.PipelineIDField, pl.ID).Msg("running pipeline")
 
@@ -281,13 +295,33 @@ func (s *Service) waitInternal() error {
 	return cerrors.Join(errs...)
 }
 
-// WaitPipeline blocks until the pipeline with the given ID is stopped.
+// WaitPipeline blocks until the pipeline with the given ID is stopped, and
+// returns the pipeline's terminal error (nil on a graceful stop).
+//
+// It is safe to call before, during, or after the pipeline's own cleanup: while
+// the pipeline is running it waits on the tomb; if the pipeline has already
+// stopped and removed itself from runningPipelines, it returns the recorded
+// terminal error instead of a false nil. Returns nil for an ID that never ran.
+//
+// Without this fallback there is a time-of-check/time-of-use race: the cleanup
+// goroutine (runPipeline) can call runningPipelines.Delete(id) between this
+// method's lookup and return, in which case a naive "!ok -> return nil" drops
+// the terminal error the caller was waiting for. See
+// docs/design-documents/20260706-forceful-stop-test-determinism.md, which
+// diagnosed and fixed the identical bug in the sibling pkg/lifecycle package.
 func (s *Service) WaitPipeline(id string) error {
 	p, ok := s.runningPipelines.Get(id)
-	if !ok || p.t == nil {
-		return nil
+	if ok && p.t != nil {
+		return p.t.Wait()
 	}
-	return p.t.Wait()
+	// The pipeline already cleaned itself up (or never started under this ID).
+	// terminalErrors is written before the runningPipelines entry is deleted, so
+	// if the pipeline ran and stopped, its terminal error is here — recovering
+	// the result the lookup above would otherwise have lost to the cleanup race.
+	if err, ok := s.terminalErrors.Get(id); ok {
+		return err
+	}
+	return nil
 }
 
 // buildRunnablePipeline will build and connect all tasks configured in the pipeline.
@@ -575,6 +609,31 @@ func (s *Service) runPipeline(rp *runnablePipeline) error {
 
 	var workersWg sync.WaitGroup
 
+	// startupDone is closed once the initial "running" status write below has
+	// fully completed. The cleanup goroutine waits on it before writing its own
+	// terminal status to the same *pipeline.Instance.
+	//
+	// pipeline.Service.UpdateStatus is not safe to call concurrently for the same
+	// ID: SetStatus is lock-guarded, but the errMsg field write and the store's
+	// JSON-encode of the whole instance for persistence are not. With the mocks
+	// used in tests there is no real I/O delay, so the worker can run to
+	// completion and the cleanup goroutine can reach its own UpdateStatus call
+	// while the initial UpdateStatus(StatusRunning) call below is still in
+	// flight, corrupting whichever field loses the race and, worst case,
+	// clobbering a correct terminal status back to "running" — confirmed by
+	// repro: `-race -shuffle=on -count=1500` under CPU load caught the two
+	// UpdateStatus calls racing on the same struct.
+	//
+	// Both t.Go calls below stay adjacent (nothing slow between them) so
+	// tomb.alive reaches 2 before either goroutine can possibly finish; ordering
+	// the UpdateStatus calls via this channel instead of via t.Go call order
+	// avoids a second bug that surfaced when this was first tried by
+	// interleaving a synchronous UpdateStatus between the two t.Go calls: if the
+	// worker finishes before that call returns, tomb.alive can hit 0 before the
+	// cleanup goroutine is even registered, and the later t.Go panics with
+	// "tomb.Go called after all goroutines terminated".
+	startupDone := make(chan struct{})
+
 	// TODO(multi-connector): when we have multiple connectors spawn a worker for each source
 	workersWg.Add(1)
 	rp.t.Go(func() error {
@@ -586,17 +645,36 @@ func (s *Service) runPipeline(rp *runnablePipeline) error {
 		closeErr := rp.w.Close(context.Background())
 		err := cerrors.Join(doErr, closeErr)
 		if err != nil {
-			return cerrors.Errorf("worker stopped with error: %w", err)
+			err = cerrors.Errorf("worker stopped with error: %w", err)
+			// Record the reason on the tomb synchronously, before returning (and
+			// thus before the deferred workersWg.Done() above fires). Without
+			// this, tomb.v2 only records a t.Go'd function's return value in its
+			// *own* post-return bookkeeping (t.run, after f() returns) — which
+			// races the cleanup goroutine below waking from workersWg.Wait() and
+			// reading rp.t.Err(). Losing that race makes the cleanup goroutine
+			// observe tomb.ErrStillAlive for a pipeline that actually died with a
+			// fatal error, misreporting it as gracefully stopped (status
+			// UserStopped/SystemStopped instead of Degraded, dropping the error
+			// entirely) — confirmed by repro under `-race -count=500`. Kill is
+			// idempotent and safe to call here: t.run's own kill(err) call after
+			// this function returns is then a no-op (reason already set).
+			rp.t.Kill(err)
+			return err
 		}
 
 		return nil
 	})
+
 	rp.t.Go(func() error {
 		// Use fresh context for cleanup function, otherwise the updated status
 		// will potentially fail to be stored.
 		ctx := context.Background()
 
 		workersWg.Wait()
+		// Wait for the initial StatusRunning write below to fully finish before
+		// this goroutine writes its own terminal status to the same
+		// *pipeline.Instance. See the comment on startupDone above.
+		<-startupDone
 		err := rp.t.Err()
 
 		switch err {
@@ -647,6 +725,12 @@ func (s *Service) runPipeline(rp *runnablePipeline) error {
 			Str(log.PipelineIDField, rp.pipeline.ID).
 			Msg("pipeline stopped")
 
+		// Record the terminal error before removing the pipeline from
+		// runningPipelines, so a WaitPipeline caller that races this cleanup still
+		// sees the result instead of a false nil (ordering matters: set before
+		// delete leaves no window where neither is observable).
+		s.terminalErrors.Set(rp.pipeline.ID, err)
+
 		// confirmed that all nodes stopped, we can now remove the pipeline from the running pipelines
 		s.runningPipelines.Delete(rp.pipeline.ID)
 
@@ -654,7 +738,14 @@ func (s *Service) runPipeline(rp *runnablePipeline) error {
 		return err
 	})
 
-	return s.pipelines.UpdateStatus(ctx, rp.pipeline.ID, pipeline.StatusRunning, "")
+	// Both goroutines are now registered (tomb.alive holds them alive regardless
+	// of how fast either finishes), so it's now safe to make the potentially slow
+	// UpdateStatus call and then release the cleanup goroutine to make its own.
+	// close(startupDone) unconditionally, including on error, so the cleanup
+	// goroutine (already blocked on it) is never left hanging.
+	err = s.pipelines.UpdateStatus(ctx, rp.pipeline.ID, pipeline.StatusRunning, "")
+	close(startupDone)
+	return err
 }
 
 // notify notifies all registered FailureHandlers about an error.

--- a/pkg/lifecycle-poc/service_test.go
+++ b/pkg/lifecycle-poc/service_test.go
@@ -15,6 +15,7 @@
 package lifecycle
 
 import (
+	"bytes"
 	"context"
 	"reflect"
 	"strconv"
@@ -263,8 +264,12 @@ func TestServiceLifecycle_PipelineSuccess(t *testing.T) {
 	)
 	is.NoErr(err)
 
-	// wait for pipeline to finish consuming records from the source
-	time.Sleep(100 * time.Millisecond)
+	// Wait for the source to have acked every record before stopping: stopping
+	// earlier races Worker.Stop against the in-flight batch loop and can leave
+	// some of the 10 records undelivered, which fails the asserterDestination /
+	// SourcePluginWithAcks mock expectations in t.Cleanup with an unrelated-looking
+	// error. See waitForRecordsAcked.
+	waitForRecordsAcked(t, source, wantRecords)
 
 	is.Equal(pipeline.StatusRunning, pl.GetStatus())
 	is.Equal("", pl.Error)
@@ -283,6 +288,13 @@ func TestServiceLifecycle_PipelineError(t *testing.T) {
 	logger := log.Test(t)
 	db := &inmemory.DB{}
 	persister := connector.NewPersister(logger, db, time.Second, 3)
+	// Without this, the persister's background flush timer can fire after this
+	// test function returns and log via logger (log.Test(t), backed by t.Log),
+	// which panics ("Log in goroutine after ... has completed") and can corrupt
+	// unrelated concurrently-scheduled tests in the same process. Confirmed by
+	// repro under `-race -shuffle=on -count=1500` under CPU load; the race
+	// detector flags the underlying unsynchronized access to testing.T state.
+	defer persister.Wait()
 
 	ps := pipeline.NewService(logger, db)
 
@@ -377,6 +389,11 @@ func TestServiceLifecycle_PipelineStop(t *testing.T) {
 	logger := log.New(zerolog.Nop())
 	db := &inmemory.DB{}
 	persister := connector.NewPersister(logger, db, time.Second, 3)
+	// See the comment on the equivalent defer in TestServiceLifecycle_PipelineError:
+	// without waiting, the persister's background flush goroutine can outlive this
+	// test function (goroutine leak); harmless here since the logger is a no-op and
+	// db is test-local, but kept consistent with the other tests in this file.
+	defer persister.Wait()
 
 	ps := pipeline.NewService(logger, db)
 
@@ -423,8 +440,12 @@ func TestServiceLifecycle_PipelineStop(t *testing.T) {
 	)
 	is.NoErr(err)
 
-	// wait for pipeline to finish consuming records from the source
-	time.Sleep(100 * time.Millisecond)
+	// Wait for the source to have acked every record before stopping: stopping
+	// earlier races Worker.Stop against the in-flight batch loop and can leave
+	// some of the 10 records undelivered, which fails the asserterDestination /
+	// SourcePluginWithAcks mock expectations in t.Cleanup with an unrelated-looking
+	// error. See waitForRecordsAcked.
+	waitForRecordsAcked(t, source, wantRecords)
 	err = ls.StopAll(ctx, false)
 	is.NoErr(err)
 
@@ -434,6 +455,39 @@ func TestServiceLifecycle_PipelineStop(t *testing.T) {
 
 	is.Equal(pipeline.StatusSystemStopped, pl.GetStatus())
 	is.Equal("", pl.Error)
+}
+
+// waitForRecordsAcked blocks until the source connector has acked through the
+// position of the last of the given records (or returns immediately if records
+// is empty). It fails the test if that doesn't happen within the timeout.
+//
+// This is the deterministic replacement for a fixed time.Sleep used to let
+// records "finish flowing" before a test stops the pipeline: a sleep is a
+// guess at a duration, and under CI load the guess can be wrong, causing
+// Worker.Stop to cut the pipeline off mid-delivery. Source.Ack persists the
+// last acked position on connector.Instance.State (see pkg/connector/source.go),
+// which is exported and lock-guarded via the embedded sync.RWMutex, so it's a
+// legitimate, non-invasive observation point — no product code changes needed.
+func waitForRecordsAcked(t *testing.T, source *connector.Instance, records []opencdc.Record) {
+	t.Helper()
+	if len(records) == 0 {
+		return
+	}
+	want := records[len(records)-1].Position
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		source.RLock()
+		state, ok := source.State.(connector.SourceState)
+		source.RUnlock()
+		if ok && bytes.Equal(state.Position, want) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for source to ack all %d records (last acked state: %+v)", len(records), source.State)
+		}
+		time.Sleep(time.Millisecond)
+	}
 }
 
 func generateRecords(count int) []opencdc.Record {


### PR DESCRIPTION
## Summary

Fixes the CI flake noted on #2534 that failed the `test` job on PRs #2576 and
#2577 (`TestServiceLifecycle_PipelineError`, `TestServiceLifecycle_PipelineStop`
in `pkg/lifecycle-poc/service_test.go`).

**Risk tier: Tier 1** (pipeline lifecycle / status-reporting correctness in the
data-path-adjacent `pkg/lifecycle-poc` package — the arch-v2 successor to
`pkg/lifecycle`). Human sign-off required before merge per the standing policy.
Not merging this myself — opening for review as requested.

## What was actually wrong

The starting hypothesis (a raw `time.Sleep(100ms)` used as synchronization) was
correct but incomplete. Digging into *why* the flake also produced a bare status
mismatch (`SystemStopped != Running`) turned up **four distinct, real
concurrency bugs** in product code, each found and fixed via `-race
-shuffle=on` repetition — not just a test-timing issue.

### 1. Test-side: sleep-based sync (the originally-suspected cause)

`TestServiceLifecycle_PipelineStop` (and sibling `PipelineSuccess`) slept 100ms
to let 10 records "finish flowing" before calling `Stop`/`StopAll`. Under CI
load 100ms isn't always enough, so the stop call races the data path,
under-delivers records, and fails the source/destination mocks' record-count
assertions in `t.Cleanup` with an unrelated-looking error.

**Fix:** replaced both sleeps with `waitForRecordsAcked`, which polls the
source connector's exported, lock-guarded `State` field (set by `Source.Ack`)
until every record has actually been acked, instead of guessing a duration.

### 2. `WaitPipeline` lookup-after-delete race (service.go)

`WaitPipeline` looked up the pipeline in `runningPipelines` and returned a bare
`nil` if not found — but the cleanup goroutine deletes the entry *after*
finishing, so a caller racing that cleanup could get a false `nil` instead of
the pipeline's terminal error. This is the **identical bug already diagnosed
and fixed** in the sibling `pkg/lifecycle` package (see
`docs/design-documents/20260706-forceful-stop-test-determinism.md`, filed as
#2521) — it just hadn't been ported to `pkg/lifecycle-poc`. Ported the same
`terminalErrors`-map fix here.

### 3. tomb.Kill ordering race on a fatal worker error (service.go)

The worker goroutine's error only got recorded on the tomb via tomb.v2's own
post-return bookkeeping (`t.run`, after `f()` returns) — which races the
cleanup goroutine waking from `workersWg.Wait()` and reading `rp.t.Err()`.
Losing that race made a **fatal stop get reported as a clean graceful stop**
(reproduced locally as `Degraded != UserStopped`). Fixed by calling
`rp.t.Kill(err)` synchronously before returning from the worker goroutine.

### 4. `UpdateStatus` concurrency on the same `*pipeline.Instance` — the actual root cause of the CI-observed "SystemStopped != Running"

`runPipeline`'s own initial `UpdateStatus(StatusRunning)` call and the cleanup
goroutine's terminal `UpdateStatus` call are **not safe to run concurrently**
on the same instance: `SetStatus` is lock-guarded, but the `Error` field write
and the store's JSON-encode of the whole struct for persistence are not. With
mocks providing zero I/O latency, the cleanup goroutine could reach its own
`UpdateStatus` call while the initial one was still mid-flight (both goroutines
were already registered via `tomb.Go` *before* the initial call ran) and win
the race — **clobbering a correct terminal status back to "running"**. This is
confirmed by an actual `-race` **DATA RACE** report (not just a logic bug), and
it's the mechanism that best explains the exact CI symptom.

Fix: gate the cleanup goroutine's `UpdateStatus` call on a channel closed only
after the initial one fully completes. Both `tomb.Go` registrations stay
adjacent (nothing slow between them) so `tomb.alive` reaches 2 before either
goroutine can finish — a naive first attempt that moved the initial
`UpdateStatus` call *between* the two `tomb.Go` calls introduced a *different*
bug (`tomb.Go called after all goroutines terminated` panic) when the worker
finished before that call returned.

### 5. `Worker.Stop` teardown-before-stop-flag race (funnel/worker.go)

`Stop` tore down the source (which nils the plugin) *before* setting
`w.stop`, so a concurrent `Read()` racing the stop could observe
`plugin.ErrPluginNotRunning` before `doTask`'s graceful-stop check
(`w.stop.Load()`) saw `stop=true`, misreporting a graceful stop as a real
failure (reproduced as `"failed to read from source: plugin is not running"`).
Fixed by setting `w.stop` before tearing down.

### 6. Missing `persister.Wait()` (test hygiene)

`PipelineError` and `PipelineStop` were missing the `defer persister.Wait()`
that `PipelineSuccess` already had. Without it, the persister's background
flush goroutine can log via `log.Test(t)` *after* the test function returns,
which **panics** (`Log in goroutine after ... has completed`) and can corrupt
whatever test happens to be running concurrently in the same process — this
alone could plausibly explain some of the wider "unrelated" CI flakiness.
Confirmed by an actual panic + race report during repro.

## Verification (exact commands, all `pkg/lifecycle-poc/`)

```
go test ./pkg/lifecycle-poc/ -run 'TestServiceLifecycle' -race -count=500
→ 0 failures (ok, 9-11s)

for i in $(seq 1 3); do yes >/dev/null & done
go test ./pkg/lifecycle-poc/ -run 'TestServiceLifecycle' -count=300
→ 0 failures (ok), load generators killed after

go test ./pkg/lifecycle-poc/... -race -shuffle=on -count=50
→ 0 failures (ok, both pkg/lifecycle-poc and pkg/lifecycle-poc/funnel)
```

Each of the four product-side bugs was independently reproduced *before* its
fix (bare status mismatches, a real data race report, and a real panic — logs
available on request) and confirmed gone after. All three commands above were
also run a second time for confidence, still clean.

```
go build ./...            → clean
golangci-lint run ./pkg/lifecycle-poc/... → 0 issues
go test ./pkg/conduit/...  → ok (sole external consumer of lifecycle-poc.Service)
```

## Failure-mode analysis (Tier 1 requirement)

- **What could this break:** all four product fixes are in `pkg/lifecycle-poc`,
  which is gated behind a feature flag and not yet the default engine
  (`pkg/lifecycle` is still primary). Blast radius is limited to that package
  and its direct consumer in `pkg/conduit/runtime.go`.
- **Which metric/alert would show a regression:** pipeline status
  (`StatusRunning`/`StatusDegraded`/etc.) reported via the API/CLI would be
  wrong, or `WaitPipeline` callers (including graceful shutdown) would hang or
  return stale results. No production traffic depends on `pkg/lifecycle-poc`
  yet, so live-system risk is effectively zero right now; the value is
  fixing arch-v2 before it becomes the default.
- **Rollback:** revert this commit; no serialized format or public contract
  changes.

## Not fixed here (flagged, out of scope for a flaky-test PR)

- `pkg/lifecycle-poc`'s force-stop path kills the tomb with a bare
  `pipeline.ErrForceStop` instead of `cerrors.FatalError(...)` like
  `pkg/lifecycle` does — meaning a force-stopped pipeline in lifecycle-poc
  hits the "recovery not implemented" no-op branch below instead of being
  reported `Degraded`.
- The "recovery not implemented" branch in the cleanup goroutine's switch is a
  complete no-op (all commented out, `TODO`) — a pipeline that stops with a
  non-fatal, non-recognized-as-graceful error is left at status `Running`
  forever, with no terminal status ever recorded. This is a real correctness
  gap (an operator would see a dead pipeline reported as running) but fixing
  it means either implementing recovery or deciding what the interim
  behavior should be — a design decision beyond this PR's scope.
- Under **much** heavier artificial stress than requested (6x `yes` loaders +
  `-shuffle=on -count=1500`, well beyond the specified bar) I intermittently
  saw a mock-helper assertion (`pkg/plugin/connector/mock/source.go:116`,
  `done.Load()`) fail — a background mock goroutine's last few non-blocking
  instructions hadn't been scheduled by the time `t.Cleanup` ran. This did
  **not** reproduce at the requested stress levels (all three verification
  commands above, run twice, were clean) and touches shared mock
  infrastructure used well beyond this package, so I left it alone rather
  than risk a wider, rushed change.

## Self-review

Re-read the diff hunting for error paths, concurrency, and resource cleanup:

- `close(startupDone)` in `runPipeline` is unconditional (both the success and
  `UpdateStatus`-error paths reach it), so the cleanup goroutine — already
  blocked on `<-startupDone` — can never hang waiting for it.
- Both `tomb.Go` registrations for the worker and cleanup goroutines stay
  textually adjacent with nothing slow between them, so `tomb.alive` can't
  reach 0 (and panic on the next `Go` call) before the cleanup goroutine is
  registered.
- `rp.t.Kill(err)` called manually from inside the worker goroutine before
  returning is idempotent with tomb.v2's own subsequent `kill(err)` call for
  the same goroutine (verified against the vendored tomb.v2 source: a second
  `kill` call on an already-non-`ErrStillAlive` reason is a no-op).
- `Worker.Stop`'s reordering (`w.stop.Store(true)` before `tearDownSource`)
  only tightens an existing signal; nothing else in the codepath depended on
  the old order (checked all `w.stop.Load()` call sites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tapg9dLWXKMZJoL65R24vd