### PR TITLE
feat(cli): add conduit pipelines lint (validate + advisory warnings)

### DIFF
--- a/cmd/conduit/internal/validate/engine.go
+++ b/cmd/conduit/internal/validate/engine.go
@@ -43,6 +43,23 @@ import (
 // including every file being unparseable — comes back as findings inside a
 // (possibly all-failing) Report, with a nil error.
 func Run(ctx context.Context, path string) (Report, error) {
+	return RunWithOptions(ctx, path, Options{})
+}
+
+// Options selects which additional, opt-in checks the engine runs on top of
+// the always-on parse -> enrich -> validate. The zero value is exactly
+// `pipelines validate` (errors only, offline). `pipelines lint` sets Warnings;
+// `pipelines dry-run` will set ResolvePlugins.
+type Options struct {
+	// Warnings surfaces the parser's advisory warnings (deprecated/renamed/
+	// unknown fields, version fallback) as SeverityWarning findings. `lint`
+	// sets this; `validate` does not (it is errors-only).
+	Warnings bool
+}
+
+// RunWithOptions is Run with the opt-in checks in opts. Run(ctx, path) is
+// RunWithOptions(ctx, path, Options{}).
+func RunWithOptions(ctx context.Context, path string, opts Options) (Report, error) {
 	files, err := config.ResolveFiles(path)
 	if err != nil {
 		return Report{}, err
@@ -51,13 +68,22 @@ func Run(ctx context.Context, path string) (Report, error) {
 
 	frs := make([]fileState, len(files))
 	for i, f := range files {
-		frs[i] = validateFile(ctx, f)
+		frs[i] = validateFile(ctx, f, opts)
 	}
 
 	checkCrossFileDuplicateIDs(frs)
 
 	return buildReport(frs), nil
 }
+
+// CodeLintWarning is the stable code carried by every advisory `lint` warning
+// finding. The parser's warnings (deprecated/renamed/unknown fields, version
+// fallback) don't carry per-field conduiterr codes, so lint attaches this one
+// so a --json consumer can still filter on `code`. It is advisory-only:
+// warnings never affect the exit code unless `lint --strict` is set (see
+// ExitErrorStrict), so this code never flows through ExitError's bucket
+// classification.
+const CodeLintWarning = "config.lint_warning"
 
 // fileState is the engine's working representation of one resolved file: the
 // enriched pipelines it parsed successfully (used for cross-file duplicate-ID
@@ -74,7 +100,7 @@ type fileState struct {
 // mutates connector/processor IDs that validation checks, matching
 // pkg/provisioning.Service.provisionPipeline's ordering at service.go:279-280)
 // over a single file, collecting every finding along the way.
-func validateFile(ctx context.Context, path string) fileState {
+func validateFile(ctx context.Context, path string, opts Options) fileState {
 	fs := fileState{path: path}
 
 	f, err := os.Open(path)
@@ -87,12 +113,25 @@ func validateFile(ctx context.Context, path string) fileState {
 	defer f.Close()
 
 	parser := yaml.NewParser(log.Nop())
-	pipelines, err := parser.Parse(ctx, f)
-	// err here is parser.Parse's raw cerrors.Join of per-document failures
-	// (see parser.go: `return configs.ToConfig(), err`, no extra "%w" wrap) —
-	// walk it directly with cerrors.ForEach. Wrapping it first (e.g. via
-	// cerrors.Errorf("...: %w", err)) would collapse every finding into one;
-	// see this package's doc.go and TestValidateFile_ParseErrors_AllFindings.
+
+	// Both Parse and ParseWithWarnings return the same []config.Pipeline and the
+	// same raw cerrors.Join of per-document failures — the only difference is
+	// ParseWithWarnings also returns the advisory warnings the run path only
+	// logs (see parser.go). lint asks for them; validate does not.
+	var pipelines []config.Pipeline
+	if opts.Warnings {
+		var warns []yaml.Warning
+		pipelines, warns, err = parser.ParseWithWarnings(ctx, f)
+		for _, w := range warns {
+			fs.findings = append(fs.findings, warningFinding(w))
+		}
+	} else {
+		pipelines, err = parser.Parse(ctx, f)
+	}
+	// err here is the parser's raw cerrors.Join of per-document failures (no
+	// extra "%w" wrap) — walk it directly with cerrors.ForEach. Wrapping it
+	// first (e.g. via cerrors.Errorf("...: %w", err)) would collapse every
+	// finding into one; see doc.go and TestValidateFile_ParseErrors_AllFindings.
 	if err != nil {
 		cerrors.ForEach(err, func(e error) {
 			fs.findings = append(fs.findings, findingFromError(e))
@@ -146,6 +185,22 @@ func findingFromError(e error) Finding {
 		ConfigPath: ce.ConfigPath,
 		Suggestion: ce.Suggestion,
 		Fix:        ce.Fix,
+	}
+}
+
+// warningFinding converts one parser Warning into an advisory (SeverityWarning)
+// Finding. Warnings locate by line/column in the source file rather than by a
+// config-path JSON pointer, and carry the fixed CodeLintWarning code (the
+// parser's warnings have no per-field conduiterr code of their own). A warning
+// never affects the exit code unless `lint --strict` is set.
+func warningFinding(w yaml.Warning) Finding {
+	return Finding{
+		Severity:   SeverityWarning,
+		Code:       CodeLintWarning,
+		Message:    w.Message,
+		ConfigPath: w.Field,
+		Line:       w.Line,
+		Column:     w.Column,
 	}
 }
 

--- a/cmd/conduit/internal/validate/exitcode.go
+++ b/cmd/conduit/internal/validate/exitcode.go
@@ -88,3 +88,30 @@ func ExitError(files []FileReport) (error, bool) {
 	}
 	return conduiterr.New(worst, fmt.Sprintf("%d problem(s) found", count)), true
 }
+
+// ExitErrorStrict is ExitError with `lint --strict` semantics. Error findings
+// still dominate and bucket as usual; additionally, when strict is true, a
+// warning-only run yields a Validation(2) error so `lint --strict` fails on
+// warnings alone. Without strict, warnings never affect the exit code (they are
+// invisible to ExitError, which only ever counts SeverityError findings).
+func ExitErrorStrict(files []FileReport, strict bool) (error, bool) {
+	if err, ok := ExitError(files); ok {
+		return err, true // error findings dominate regardless of --strict
+	}
+	if !strict {
+		return nil, false
+	}
+	warnings := 0
+	for _, f := range files {
+		for _, find := range f.Findings {
+			if find.Severity == SeverityWarning {
+				warnings++
+			}
+		}
+	}
+	if warnings == 0 {
+		return nil, false
+	}
+	return conduiterr.New(conduiterr.CodeInvalidArgument,
+		fmt.Sprintf("%d warning(s) treated as errors (--strict)", warnings)), true
+}

--- a/cmd/conduit/internal/validate/lint_test.go
+++ b/cmd/conduit/internal/validate/lint_test.go
@@ -1,0 +1,121 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/matryer/is"
+)
+
+// AC-1: lint surfaces a deprecated-field warning as an advisory
+// SeverityWarning finding located by line and column; warnings alone do not
+// fail the run (report.OK() stays true).
+func TestRunWithOptions_Warnings_SurfacesLocatedWarning(t *testing.T) {
+	is := is.New(t)
+
+	report, err := RunWithOptions(context.Background(), "testdata/warning.yaml", Options{Warnings: true})
+	is.NoErr(err)
+	is.True(report.OK())                 // warnings never fail without --strict
+	is.Equal(report.Summary.Errors, 0)   // no errors
+	is.Equal(report.Summary.Warnings, 1) // exactly one warning
+	is.Equal(len(report.Files), 1)       //
+	is.Equal(len(report.Files[0].Findings), 1)
+
+	w := report.Files[0].Findings[0]
+	is.Equal(w.Severity, SeverityWarning)
+	is.Equal(w.Code, CodeLintWarning)
+	is.True(w.Line > 0)   // located by line...
+	is.True(w.Column > 0) // ...and column
+	is.True(w.Message != "")
+}
+
+// validate (Options{}) is errors-only: the same file lint flags a warning on
+// produces zero findings under validate, proving the warning channel is opt-in.
+func TestRun_ValidateMode_IgnoresWarnings(t *testing.T) {
+	is := is.New(t)
+
+	report, err := Run(context.Background(), "testdata/warning.yaml")
+	is.NoErr(err)
+	is.True(report.OK())
+	is.Equal(report.Summary.Warnings, 0)
+	is.Equal(report.Summary.Errors, 0)
+	is.Equal(len(report.Files[0].Findings), 0)
+}
+
+// AC-3: a file with both a validation error and an advisory warning surfaces
+// both; the error dominates the verdict (report.OK() is false).
+func TestRunWithOptions_ErrorAndWarning_Both(t *testing.T) {
+	is := is.New(t)
+
+	report, err := RunWithOptions(context.Background(), "testdata/warning-and-error.yaml", Options{Warnings: true})
+	is.NoErr(err)
+	is.True(!report.OK()) // the error fails the run
+	is.Equal(report.Summary.Errors, 1)
+	is.Equal(report.Summary.Warnings, 1)
+
+	var sawErr, sawWarn bool
+	for _, f := range report.Files[0].Findings {
+		switch f.Severity {
+		case SeverityError:
+			sawErr = true
+		case SeverityWarning:
+			sawWarn = true
+		}
+	}
+	is.True(sawErr)
+	is.True(sawWarn)
+}
+
+// AC-2: ExitErrorStrict is the exit-code side of lint's --strict. Errors always
+// yield an exit error; warnings do so only under --strict.
+func TestExitErrorStrict(t *testing.T) {
+	warnOnly := []FileReport{{Findings: []Finding{{Severity: SeverityWarning, Code: CodeLintWarning}}}}
+	errOnly := []FileReport{{Findings: []Finding{{Severity: SeverityError, Code: "config.field_required"}}}}
+	clean := []FileReport{{Findings: []Finding{}}}
+
+	cases := []struct {
+		name    string
+		files   []FileReport
+		strict  bool
+		wantErr bool
+		// wantBucket is the grpc-derived bucket the synthesized error must fall
+		// into (2 = Validation) when wantErr is true; 0 means "don't check".
+		wantValidation bool
+	}{
+		{"warnings, not strict → no exit error", warnOnly, false, false, false},
+		{"warnings, strict → validation error", warnOnly, true, true, true},
+		{"errors, not strict → exit error", errOnly, false, true, false},
+		{"errors, strict → exit error", errOnly, true, true, false},
+		{"clean, strict → no exit error", clean, true, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			err, ok := ExitErrorStrict(tc.files, tc.strict)
+			is.Equal(ok, tc.wantErr)
+			if tc.wantErr {
+				is.True(err != nil)
+			}
+			if tc.wantValidation {
+				ce, got := conduiterr.Get(err)
+				is.True(got)
+				is.Equal(bucketRank(ce.Code), 2) // Validation
+			}
+		})
+	}
+}

--- a/cmd/conduit/internal/validate/report.go
+++ b/cmd/conduit/internal/validate/report.go
@@ -40,6 +40,11 @@ type Finding struct {
 	ConfigPath string          `json:"configPath,omitempty"`
 	Suggestion string          `json:"suggestion,omitempty"`
 	Fix        *conduiterr.Fix `json:"fix,omitempty"`
+	// Line and Column locate an advisory `lint` warning in the source file
+	// (1-based; 0 = unknown). They are only ever set on SeverityWarning
+	// findings surfaced by the parser — error findings locate via ConfigPath.
+	Line   int `json:"line,omitempty"`
+	Column int `json:"column,omitempty"`
 }
 
 // FileReport is one resolved file's outcome: every pipeline ID found in it

--- a/cmd/conduit/internal/validate/testdata/warning-and-error.yaml
+++ b/cmd/conduit/internal/validate/testdata/warning-and-error.yaml
@@ -1,0 +1,9 @@
+version: "2.2"
+pipelines:
+  - id: mixed-pipeline
+    connectors:
+      - id: c1
+        type: source
+    processors:
+      - id: proc1
+        type: base64.encode

--- a/cmd/conduit/internal/validate/testdata/warning.yaml
+++ b/cmd/conduit/internal/validate/testdata/warning.yaml
@@ -1,0 +1,10 @@
+version: "2.2"
+pipelines:
+  - id: warn-pipeline
+    connectors:
+      - id: c1
+        type: source
+        plugin: builtin:generator
+    processors:
+      - id: proc1
+        type: base64.encode

--- a/cmd/conduit/root/pipelines/lint.go
+++ b/cmd/conduit/root/pipelines/lint.go
@@ -1,0 +1,220 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelines
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/cmd/conduit/internal/ui"
+	"github.com/conduitio/conduit/cmd/conduit/internal/validate"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/ecdysis"
+)
+
+var (
+	_ cecdysis.CommandWithResult = (*LintCommand)(nil)
+	_ ecdysis.CommandWithDocs    = (*LintCommand)(nil)
+	_ ecdysis.CommandWithFlags   = (*LintCommand)(nil)
+	_ ecdysis.CommandWithArgs    = (*LintCommand)(nil)
+)
+
+// LintArgs holds LintCommand's positional argument.
+type LintArgs struct {
+	// Path is a single .yml/.yaml pipeline config file, or a directory of
+	// them (not recursed).
+	Path string
+}
+
+// LintFlags holds LintCommand's flags. Unlike validate, lint reports advisory
+// warnings, so it has a --strict flag to escalate them to failures (CLI output
+// conventions §3).
+type LintFlags struct {
+	Strict  bool `long:"strict" usage:"treat advisory warnings as failures (exit 2)"`
+	Quiet   bool `long:"quiet" short:"q" usage:"suppress passing/OK lines and progress chrome; print only warnings, failures, and the summary"`
+	NoColor bool `long:"no-color" usage:"disable colored/glyph output even on a color-capable terminal"`
+}
+
+// LintCommand implements `conduit pipelines lint <path>`: everything validate
+// checks, plus the parser's advisory warnings (deprecated/renamed/unknown
+// fields, version fallback). Warnings are advisory — exit 0 unless --strict.
+// Offline, like validate. See
+// docs/design-documents/20260708-cli-pipeline-inspect-lint-dryrun.md.
+type LintCommand struct {
+	args  LintArgs
+	flags LintFlags
+
+	renderer *ui.Renderer
+}
+
+func (c *LintCommand) Usage() string { return "lint <path>" }
+
+func (c *LintCommand) Docs() ecdysis.Docs {
+	return ecdysis.Docs{
+		Short: "Lint one or more pipeline configuration files (validate + advisory warnings)",
+		Long: `Runs everything 'conduit pipelines validate' checks, and additionally reports the
+parser's advisory warnings — deprecated or renamed fields, unrecognized fields, and pipeline
+config version fallbacks — located by line and column. Like validate, lint is fully offline and
+never contacts a running Conduit instance.
+
+Warnings are advisory: lint exits 0 when a file has only warnings, unless --strict is set, which
+escalates warnings to failures (exit 2). Validation errors always fail (exit 2).
+
+See also 'conduit pipelines validate' (errors only) and 'conduit pipelines dry-run' (validate plus
+the enriched pipeline graph).`,
+		Example: "conduit pipelines lint pipelines/orders.yaml\n" +
+			"conduit pipelines lint ./pipelines --strict\n" +
+			"conduit pipeline lint ./pipelines --json",
+	}
+}
+
+func (c *LintCommand) Flags() []ecdysis.Flag { return ecdysis.BuildFlags(&c.flags) }
+
+func (c *LintCommand) Args(args []string) error {
+	if len(args) == 0 {
+		return cerrors.Errorf("requires a path to a pipeline config file or directory")
+	}
+	if len(args) > 1 {
+		return cerrors.Errorf("too many arguments")
+	}
+	c.args.Path = args[0]
+	return nil
+}
+
+func (c *LintCommand) ResultCommand() string { return "pipelines.lint" }
+
+// ExecuteWithResult runs the offline validate engine with warnings enabled and
+// translates its Report into the shared cecdysis.Outcome envelope. As with
+// validate, a non-nil error return is reserved for a hard failure (path can't
+// be resolved at all), never for findings within resolved files.
+func (c *LintCommand) ExecuteWithResult(ctx context.Context) (cecdysis.Outcome, error) {
+	c.renderer = ui.NewRenderer(rendererOutput(ctx), c.flags.NoColor)
+
+	report, err := validate.RunWithOptions(ctx, c.args.Path, validate.Options{Warnings: true})
+	if err != nil {
+		return cecdysis.Outcome{}, conduiterr.Wrap(conduiterr.CodeInvalidArgument,
+			fmt.Sprintf("could not resolve path %q: %v", c.args.Path, err), err)
+	}
+
+	// OK is the envelope verdict: errors always fail; warnings fail only under
+	// --strict.
+	ok := report.Summary.Errors == 0
+	if c.flags.Strict && report.Summary.Warnings > 0 {
+		ok = false
+	}
+
+	outcome := cecdysis.Outcome{
+		OK:      ok,
+		Summary: report.Summary,
+		Result:  validate.Result{Files: report.Files},
+	}
+	if !ok {
+		if exitErr, has := validate.ExitErrorStrict(report.Files, c.flags.Strict); has {
+			outcome.ExitErr = exitErr
+		}
+	}
+	return outcome, nil
+}
+
+// Render renders a lint run: ✓ for clean files, ⚠ for warning-only files, ✗ for
+// files with errors, each finding under it (errors and warnings), and a summary.
+func (c *LintCommand) Render(outcome cecdysis.Outcome) string {
+	summary, _ := outcome.Summary.(validate.Summary)
+	result, _ := outcome.Result.(validate.Result)
+
+	if c.renderer == nil {
+		c.renderer = ui.NewRenderer(io.Discard, true)
+	}
+
+	var b strings.Builder
+	passed, warned, failed := 0, 0, 0
+	for _, f := range result.Files {
+		status, glyph := fileStatus(c.renderer, f)
+		switch status {
+		case ui.StatusPass:
+			passed++
+			if !c.flags.Quiet {
+				fmt.Fprintf(&b, "%s %s\n", glyph, f.Path)
+			}
+			continue
+		case ui.StatusWarn:
+			warned++
+		case ui.StatusFail:
+			failed++
+		}
+
+		fmt.Fprintf(&b, "%s %s\n", glyph, f.Path)
+		for _, finding := range f.Findings {
+			fg := c.renderer.Glyph(ui.StatusFail)
+			if finding.Severity == validate.SeverityWarning {
+				fg = c.renderer.Glyph(ui.StatusWarn)
+			}
+			ui.RenderFinding(&b, fg, finding.Code, findingLocation(finding), finding.Message, finding.Suggestion)
+		}
+		fmt.Fprintln(&b)
+	}
+
+	fmt.Fprintf(&b, "Summary: %d files · %d passed · %d warned · %d failed · %d errors · %d warnings\n",
+		summary.Files, passed, warned, failed, summary.Errors, summary.Warnings)
+
+	switch {
+	case summary.Errors > 0:
+		fmt.Fprintln(&b, "Fix the ✗ items above, then re-run.")
+	case c.flags.Strict && summary.Warnings > 0:
+		fmt.Fprintln(&b, "Warnings failed the run (--strict). Address the ⚠ items above.")
+	}
+
+	return b.String()
+}
+
+// fileStatus classifies one file report for rendering: fail if it has any
+// error, warn if it has only warnings, pass if it has no findings.
+func fileStatus(r *ui.Renderer, f validate.FileReport) (ui.Status, string) {
+	hasErr := false
+	hasWarn := false
+	for _, find := range f.Findings {
+		switch find.Severity {
+		case validate.SeverityError:
+			hasErr = true
+		case validate.SeverityWarning:
+			hasWarn = true
+		}
+	}
+	switch {
+	case hasErr:
+		return ui.StatusFail, r.Glyph(ui.StatusFail)
+	case hasWarn:
+		return ui.StatusWarn, r.Glyph(ui.StatusWarn)
+	default:
+		return ui.StatusPass, r.Glyph(ui.StatusPass)
+	}
+}
+
+// findingLocation returns the config-path pointer for an error finding, or a
+// "line:column" location for a warning (which locates in the source file, not
+// by a config-path pointer).
+func findingLocation(f validate.Finding) string {
+	if f.Severity == validate.SeverityWarning && f.Line > 0 {
+		if f.ConfigPath != "" {
+			return fmt.Sprintf("%s (line %d:%d)", f.ConfigPath, f.Line, f.Column)
+		}
+		return fmt.Sprintf("line %d:%d", f.Line, f.Column)
+	}
+	return f.ConfigPath
+}

--- a/cmd/conduit/root/pipelines/pipelines.go
+++ b/cmd/conduit/root/pipelines/pipelines.go
@@ -34,6 +34,7 @@ func (c *PipelinesCommand) SubCommands() []ecdysis.Command {
 		&ListCommand{},
 		&DescribeCommand{},
 		&ValidateCommand{},
+		&LintCommand{},
 	}
 }
 

--- a/pkg/provisioning/config/yaml/parse_warnings_test.go
+++ b/pkg/provisioning/config/yaml/parse_warnings_test.go
@@ -1,0 +1,72 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yaml
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/matryer/is"
+)
+
+// TestParseWithWarnings_MatchesParse is the AC-4 guard for `pipelines lint`:
+// exposing the parser's warnings must NOT change the run/provisioning parse
+// path. ParseWithWarnings must return exactly the same pipelines and the same
+// error as Parse for the same input — it only additionally returns the warnings
+// that Parse's callers (via ParseConfigurations) merely log. TestParser_V1_Warnings
+// separately locks that ParseConfigurations still logs those warnings unchanged.
+func TestParseWithWarnings_MatchesParse(t *testing.T) {
+	is := is.New(t)
+	// pipelines1-success.yml is the fixture TestParser_V1_Warnings uses; it
+	// parses successfully AND triggers several advisory warnings.
+	const fixture = "./v1/testdata/pipelines1-success.yml"
+
+	parseFile := func() ([]any, error) {
+		f, err := os.Open(fixture)
+		is.NoErr(err)
+		defer f.Close()
+		pipelines, err := NewParser(log.Nop()).Parse(context.Background(), f)
+		anys := make([]any, len(pipelines))
+		for i, p := range pipelines {
+			anys[i] = p
+		}
+		return anys, err
+	}
+
+	parsePipelines, parseErr := parseFile()
+
+	f, err := os.Open(fixture)
+	is.NoErr(err)
+	defer f.Close()
+	withWarnPipelines, warns, withWarnErr := NewParser(log.Nop()).ParseWithWarnings(context.Background(), f)
+
+	// Same error outcome.
+	is.Equal(parseErr == nil, withWarnErr == nil)
+
+	// Same pipelines (identical parse result — run path unchanged).
+	is.Equal(len(parsePipelines), len(withWarnPipelines))
+	for i := range parsePipelines {
+		is.True(reflect.DeepEqual(parsePipelines[i], withWarnPipelines[i]))
+	}
+
+	// And ParseWithWarnings additionally surfaces the advisory warnings.
+	is.True(len(warns) > 0)
+	for _, w := range warns {
+		is.True(w.Message != "") // every warning carries a message
+	}
+}

--- a/pkg/provisioning/config/yaml/parser.go
+++ b/pkg/provisioning/config/yaml/parser.go
@@ -77,7 +77,48 @@ func (p *Parser) Parse(ctx context.Context, reader io.Reader) ([]config.Pipeline
 	return configs.ToConfig(), err
 }
 
+// Warning is one advisory lint finding surfaced by ParseWithWarnings — a
+// deprecated/renamed/unknown field or a version fallback, located by line and
+// column. It is the exported view of the parser's internal warning type so the
+// `pipelines lint` engine can render the warnings that the run/provisioning
+// path only logs.
+type Warning struct {
+	Field   string
+	Line    int
+	Column  int
+	Value   string
+	Message string
+}
+
+// ParseWithWarnings is Parse plus the advisory warnings the parser would
+// otherwise only log. It is additive and offline: the run/provisioning path
+// keeps using Parse/ParseConfigurations (which continue to log warnings), so
+// exposing warnings here changes no run behavior — it only gives `pipelines
+// lint` a return channel for the warnings it renders.
+func (p *Parser) ParseWithWarnings(ctx context.Context, reader io.Reader) ([]config.Pipeline, []Warning, error) {
+	configs, warn, err := p.parse(ctx, reader)
+	warn = warn.Sort()
+	ws := make([]Warning, len(warn))
+	for i, w := range warn {
+		ws[i] = Warning{Field: w.field, Line: w.line, Column: w.column, Value: w.value, Message: w.message}
+	}
+	return configs.ToConfig(), ws, err
+}
+
+// ParseConfigurations parses every pipeline configuration document in reader
+// and logs any advisory warnings — the historical behavior the run/provisioning
+// path relies on. lint uses ParseWithWarnings instead to render them.
 func (p *Parser) ParseConfigurations(ctx context.Context, reader io.Reader) (Configurations, error) {
+	configs, warn, err := p.parse(ctx, reader)
+	// sort warnings and log them (unchanged run behavior)
+	warn.Sort().Log(ctx, p.logger)
+	return configs, err
+}
+
+// parse is the shared parse loop for ParseConfigurations (which logs the
+// returned warnings) and ParseWithWarnings (which returns them to the caller).
+// It never logs, so the caller decides the warnings' fate.
+func (p *Parser) parse(ctx context.Context, reader io.Reader) (Configurations, warnings, error) {
 	// we redirect everything read from reader to buffer with TeeReader, so that
 	// we can first parse the version of the file and choose what type we
 	// actually need to parse the configuration
@@ -142,9 +183,7 @@ func (p *Parser) ParseConfigurations(ctx context.Context, reader io.Reader) (Con
 		configs = append(configs, cfg)
 	}
 
-	// sort warnings and log them
-	warn.Sort().Log(ctx, p.logger)
-	return configs, cerrors.Join(errs...)
+	return configs, warn, cerrors.Join(errs...)
 }
 
 // parseVersion will return the version that should be used to parse the


### PR DESCRIPTION
Wave 2, verb 1 of 3. `conduit pipelines lint <path>` — everything `validate` checks plus the parser's advisory warnings (deprecated/renamed/unknown fields, version fallback), located by line+column. Advisory: exit 0 unless `--strict` (exit 2). Offline.

**Reuse:** extends the merged `cmd/conduit/internal/validate` engine (`RunWithOptions(Options{Warnings})`); shares the `--json` envelope, glyphs, and exit routing.

**Additive parser change (AC-4):** `ParseWithWarnings` returns the warnings `Parse`/`ParseConfigurations` only log — the run/provisioning path is unchanged. Guarded by `TestParseWithWarnings_MatchesParse` (identical pipelines+error) + the existing `TestParser_V1_Warnings` (logging unchanged).

**ACs covered:** AC-1 (located warning, exit 0), AC-2 (`--strict` → exit 2), AC-3 (error+warning both shown, error dominates), AC-4 (run unchanged), AC-7 (offline — the engine already asserts no dial). Verified by hand end-to-end (warning → ⚠/exit 0, --strict → exit 2, --json envelope).

Design: `docs/design-documents/20260708-cli-pipeline-inspect-lint-dryrun.md`. Tier 2.

Note: implemented inline because the background-agent infra was stalling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)