### PR TITLE
feat(cli): add conduit pipelines dry-run (enriched graph + plugin resolution)

### DIFF
--- a/cmd/conduit/internal/validate/dryrun_test.go
+++ b/cmd/conduit/internal/validate/dryrun_test.go
@@ -1,0 +1,96 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/matryer/is"
+)
+
+// builtinsForTest is the injected builtin set the dry-run command would build
+// from builtin.DefaultBuiltinConnectors (full path + short name).
+var builtinsForTest = map[string]struct{}{
+	"generator": {},
+	"github.com/conduitio/conduit-connector-generator": {},
+}
+
+// AC-5: dry-run exposes the fully-enriched pipeline graph — final IDs
+// (pipelineID:connectorID) and injected DLQ defaults — on FileReport.Enriched.
+func TestRunWithOptions_Enriched_ExposesGraph(t *testing.T) {
+	is := is.New(t)
+
+	report, err := RunWithOptions(context.Background(), "testdata/goodplugin.yaml", Options{Enriched: true})
+	is.NoErr(err)
+	is.Equal(len(report.Files), 1)
+	is.Equal(len(report.Files[0].Enriched), 1)
+
+	p := report.Files[0].Enriched[0]
+	is.Equal(p.ID, "good-plugin-pipeline")
+	is.Equal(len(p.Connectors), 1)
+	is.Equal(p.Connectors[0].ID, "good-plugin-pipeline:c1") // enriched, pipelineID-prefixed
+	is.True(p.DLQ.Plugin != "")                             // DLQ default injected
+}
+
+// validate/lint leave Enriched nil (it is dry-run-only).
+func TestRun_ValidateMode_NoEnriched(t *testing.T) {
+	is := is.New(t)
+
+	report, err := Run(context.Background(), "testdata/goodplugin.yaml")
+	is.NoErr(err)
+	is.Equal(len(report.Files[0].Enriched), 0)
+}
+
+// AC-6: --resolve-plugins flags an unknown builtin as connector.plugin_not_found
+// (codes.NotFound -> exit 2 via bucketRank).
+func TestRunWithOptions_ResolvePlugins_UnknownBuiltin(t *testing.T) {
+	is := is.New(t)
+
+	report, err := RunWithOptions(context.Background(), "testdata/badplugin.yaml",
+		Options{ResolvePlugins: true, BuiltinPlugins: builtinsForTest})
+	is.NoErr(err)
+	is.True(!report.OK())
+	is.Equal(report.Summary.Errors, 1)
+
+	f := report.Files[0].Findings[0]
+	is.Equal(f.Severity, SeverityError)
+	is.Equal(f.Code, conduiterr.CodeConnectorPluginNotFound.Reason())
+	is.Equal(bucketRank(conduiterr.CodeConnectorPluginNotFound), 2) // Validation -> exit 2
+}
+
+// AC-6: a known builtin resolves cleanly.
+func TestRunWithOptions_ResolvePlugins_KnownBuiltin_OK(t *testing.T) {
+	is := is.New(t)
+
+	report, err := RunWithOptions(context.Background(), "testdata/goodplugin.yaml",
+		Options{ResolvePlugins: true, BuiltinPlugins: builtinsForTest})
+	is.NoErr(err)
+	is.True(report.OK())
+	is.Equal(report.Summary.Errors, 0)
+}
+
+// AC-6: a standalone plugin reference is advisory — not statically verifiable,
+// never a false failure — so resolution produces no finding for it.
+func TestRunWithOptions_ResolvePlugins_Standalone_Advisory(t *testing.T) {
+	is := is.New(t)
+
+	report, err := RunWithOptions(context.Background(), "testdata/standalone-plugin.yaml",
+		Options{ResolvePlugins: true, BuiltinPlugins: builtinsForTest})
+	is.NoErr(err)
+	is.True(report.OK())
+	is.Equal(report.Summary.Errors, 0)
+}

--- a/cmd/conduit/internal/validate/engine.go
+++ b/cmd/conduit/internal/validate/engine.go
@@ -24,6 +24,7 @@ import (
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/plugin"
 	"github.com/conduitio/conduit/pkg/provisioning"
 	"github.com/conduitio/conduit/pkg/provisioning/config"
 	"github.com/conduitio/conduit/pkg/provisioning/config/yaml"
@@ -49,12 +50,31 @@ func Run(ctx context.Context, path string) (Report, error) {
 // Options selects which additional, opt-in checks the engine runs on top of
 // the always-on parse -> enrich -> validate. The zero value is exactly
 // `pipelines validate` (errors only, offline). `pipelines lint` sets Warnings;
-// `pipelines dry-run` will set ResolvePlugins.
+// `pipelines dry-run` sets Enriched and ResolvePlugins.
 type Options struct {
 	// Warnings surfaces the parser's advisory warnings (deprecated/renamed/
 	// unknown fields, version fallback) as SeverityWarning findings. `lint`
 	// sets this; `validate` does not (it is errors-only).
 	Warnings bool
+
+	// Enriched exposes each file's fully-enriched pipeline configs (final IDs,
+	// injected DLQ defaults, worker counts) on FileReport.Enriched. `dry-run`
+	// sets this; validate/lint leave it off so their --json is unchanged.
+	Enriched bool
+
+	// ResolvePlugins checks every connector's plugin reference: a builtin
+	// (`builtin:...`) ref whose plugin is not in BuiltinPlugins is a
+	// connector.plugin_not_found error finding; a standalone/any ref is left
+	// advisory ("not statically verifiable"), never a false failure. `dry-run`
+	// sets this. The engine stays offline: BuiltinPlugins is injected by the
+	// command (from the builtin registry) rather than imported here.
+	ResolvePlugins bool
+
+	// BuiltinPlugins is the set of resolvable builtin connector references —
+	// both full module paths (github.com/conduitio/conduit-connector-<name>)
+	// and their short names (<name>) — supplied by the dry-run command from
+	// builtin.DefaultBuiltinConnectors. Only consulted when ResolvePlugins.
+	BuiltinPlugins map[string]struct{}
 }
 
 // RunWithOptions is Run with the opt-in checks in opts. Run(ctx, path) is
@@ -73,7 +93,7 @@ func RunWithOptions(ctx context.Context, path string, opts Options) (Report, err
 
 	checkCrossFileDuplicateIDs(frs)
 
-	return buildReport(frs), nil
+	return buildReport(frs, opts), nil
 }
 
 // CodeLintWarning is the stable code carried by every advisory `lint` warning
@@ -149,9 +169,46 @@ func validateFile(ctx context.Context, path string, opts Options) fileState {
 				fs.findings = append(fs.findings, findingFromError(e))
 			})
 		}
+
+		if opts.ResolvePlugins {
+			fs.findings = append(fs.findings, resolvePluginRefs(enriched, opts.BuiltinPlugins)...)
+		}
 	}
 
 	return fs
+}
+
+// resolvePluginRefs is the dry-run --resolve-plugins check: every connector's
+// plugin reference is classified by plugin.FullName. A builtin ref
+// (`builtin:...`) whose plugin name (or full module path) is not in builtins is
+// a connector.plugin_not_found error finding (codes.NotFound -> exit 2). A
+// standalone or unqualified ("any") ref is left alone — it points at a plugin
+// binary that isn't loaded during an offline dry-run, so it is "not statically
+// verifiable", never a false failure (design doc). configPath points at the
+// connector's plugin field within the file's pipelines list.
+func resolvePluginRefs(p config.Pipeline, builtins map[string]struct{}) []Finding {
+	var findings []Finding
+	for ci, conn := range p.Connectors {
+		fn := plugin.FullName(conn.Plugin)
+		if fn.PluginType() != plugin.PluginTypeBuiltin {
+			continue // standalone/any: not statically verifiable, advisory-by-omission
+		}
+		name := fn.PluginName()
+		if _, ok := builtins[name]; ok {
+			continue
+		}
+		if _, ok := builtins[conn.Plugin]; ok {
+			continue
+		}
+		findings = append(findings, Finding{
+			Severity:   SeverityError,
+			Code:       conduiterr.CodeConnectorPluginNotFound.Reason(),
+			Message:    fmt.Sprintf("connector %q: builtin plugin %q is not available", conn.ID, conn.Plugin),
+			ConfigPath: fmt.Sprintf("/pipelines/connectors/%d/plugin", ci),
+			Suggestion: "check the plugin name, or use a standalone plugin path; run `conduit connectors list` to see available builtins",
+		})
+	}
+	return findings
 }
 
 // findingFromError converts one element of a cerrors.ForEach walk into a
@@ -274,7 +331,7 @@ func checkCrossFileDuplicateIDs(frs []fileState) {
 // buildReport converts the engine's working fileState slice into the public
 // Report: findings sorted by configPath within each file (the design doc's
 // ordering guarantee), plus the report-wide Summary rollup.
-func buildReport(frs []fileState) Report {
+func buildReport(frs []fileState, opts Options) Report {
 	report := Report{Files: make([]FileReport, len(frs))}
 	report.Summary.Files = len(frs)
 
@@ -301,6 +358,9 @@ func buildReport(frs []fileState) Report {
 			OK:        len(fr.findings) == 0,
 			Pipelines: ids,
 			Findings:  findings,
+		}
+		if opts.Enriched {
+			report.Files[i].Enriched = fr.pipelines
 		}
 
 		report.Summary.Pipelines += len(ids)

--- a/cmd/conduit/internal/validate/report.go
+++ b/cmd/conduit/internal/validate/report.go
@@ -14,7 +14,10 @@
 
 package validate
 
-import "github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+import (
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/provisioning/config"
+)
 
 // Severity is a Finding's severity. `validate` only ever produces
 // SeverityError findings (it is errors-only, per the CLI output
@@ -57,6 +60,11 @@ type FileReport struct {
 	OK        bool      `json:"ok"`
 	Pipelines []string  `json:"pipelines"`
 	Findings  []Finding `json:"findings"`
+	// Enriched is the fully-enriched configuration (final connector/processor
+	// IDs, injected DLQ defaults, worker counts) of each pipeline in this file.
+	// It is only populated by `pipelines dry-run` (Options.Enriched); validate
+	// and lint leave it nil so their --json output is unchanged.
+	Enriched []config.Pipeline `json:"enriched,omitempty"`
 }
 
 // Summary is the report-wide rollup `pipelines validate` renders as its

--- a/cmd/conduit/internal/validate/testdata/badplugin.yaml
+++ b/cmd/conduit/internal/validate/testdata/badplugin.yaml
@@ -1,0 +1,7 @@
+version: "2.2"
+pipelines:
+  - id: bad-plugin-pipeline
+    connectors:
+      - id: c1
+        type: source
+        plugin: builtin:doesnotexist

--- a/cmd/conduit/internal/validate/testdata/goodplugin.yaml
+++ b/cmd/conduit/internal/validate/testdata/goodplugin.yaml
@@ -1,0 +1,7 @@
+version: "2.2"
+pipelines:
+  - id: good-plugin-pipeline
+    connectors:
+      - id: c1
+        type: source
+        plugin: builtin:generator

--- a/cmd/conduit/internal/validate/testdata/standalone-plugin.yaml
+++ b/cmd/conduit/internal/validate/testdata/standalone-plugin.yaml
@@ -1,0 +1,7 @@
+version: "2.2"
+pipelines:
+  - id: standalone-pipeline
+    connectors:
+      - id: c1
+        type: source
+        plugin: standalone:mycustom

--- a/cmd/conduit/root/pipelines/dry_run.go
+++ b/cmd/conduit/root/pipelines/dry_run.go
@@ -1,0 +1,198 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelines
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/cmd/conduit/internal/ui"
+	"github.com/conduitio/conduit/cmd/conduit/internal/validate"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/plugin/connector/builtin"
+	"github.com/conduitio/ecdysis"
+)
+
+var (
+	_ cecdysis.CommandWithResult = (*DryRunCommand)(nil)
+	_ ecdysis.CommandWithDocs    = (*DryRunCommand)(nil)
+	_ ecdysis.CommandWithFlags   = (*DryRunCommand)(nil)
+	_ ecdysis.CommandWithArgs    = (*DryRunCommand)(nil)
+)
+
+// DryRunArgs holds DryRunCommand's positional argument.
+type DryRunArgs struct {
+	Path string
+}
+
+// DryRunFlags holds DryRunCommand's flags.
+type DryRunFlags struct {
+	ResolvePlugins bool `long:"resolve-plugins" usage:"check that referenced builtin plugins exist (standalone plugins stay advisory)"`
+	Quiet          bool `long:"quiet" short:"q" usage:"suppress passing/OK lines and progress chrome; print only problems and the summary"`
+	NoColor        bool `long:"no-color" usage:"disable colored/glyph output even on a color-capable terminal"`
+}
+
+// DryRunCommand implements `conduit pipelines dry-run <path>`: everything
+// validate checks, then reports the fully-enriched pipeline graph (final
+// connector/processor IDs, injected DLQ defaults, worker counts) that 'conduit
+// run' would actually load, and (with --resolve-plugins, default on) checks
+// that referenced builtin plugins exist. Offline, no side effects. See
+// docs/design-documents/20260708-cli-pipeline-inspect-lint-dryrun.md.
+type DryRunCommand struct {
+	args  DryRunArgs
+	flags DryRunFlags
+
+	renderer *ui.Renderer
+}
+
+func (c *DryRunCommand) Usage() string { return "dry-run <path>" }
+
+func (c *DryRunCommand) Docs() ecdysis.Docs {
+	return ecdysis.Docs{
+		Short: "Show the enriched pipeline graph 'conduit run' would load, without running it",
+		Long: `Runs everything 'conduit pipelines validate' checks, then reports the fully-enriched
+pipeline graph that 'conduit run' would actually load: final connector and processor IDs, injected
+dead-letter-queue defaults, and worker counts. With --resolve-plugins (default on) it also checks
+that every referenced builtin plugin exists — an unknown builtin fails (exit 2). Standalone plugin
+references are left advisory ("not statically verifiable"), never a false failure, since the plugin
+binary isn't loaded during an offline dry-run.
+
+Fully offline with no side effects — like validate and lint, it never contacts a running Conduit.
+
+See also 'conduit pipelines validate' (errors only) and 'conduit pipelines lint' (advisory warnings).`,
+		Example: "conduit pipelines dry-run pipelines/orders.yaml\n" +
+			"conduit pipelines dry-run ./pipelines --resolve-plugins=false\n" +
+			"conduit pipeline dry-run ./pipelines --json",
+	}
+}
+
+func (c *DryRunCommand) Flags() []ecdysis.Flag {
+	// --resolve-plugins defaults on. ecdysis.BuildFlags ignores a `default:`
+	// struct tag for bools, so set the default explicitly via SetDefault.
+	flags := ecdysis.BuildFlags(&c.flags)
+	flags.SetDefault("resolve-plugins", true)
+	return flags
+}
+
+func (c *DryRunCommand) Args(args []string) error {
+	if len(args) == 0 {
+		return cerrors.Errorf("requires a path to a pipeline config file or directory")
+	}
+	if len(args) > 1 {
+		return cerrors.Errorf("too many arguments")
+	}
+	c.args.Path = args[0]
+	return nil
+}
+
+func (c *DryRunCommand) ResultCommand() string { return "pipelines.dry-run" }
+
+// ExecuteWithResult runs the offline validate engine with enriched-graph
+// exposure and (optionally) plugin resolution, translating its Report into the
+// shared cecdysis.Outcome envelope.
+func (c *DryRunCommand) ExecuteWithResult(ctx context.Context) (cecdysis.Outcome, error) {
+	c.renderer = ui.NewRenderer(rendererOutput(ctx), c.flags.NoColor)
+
+	report, err := validate.RunWithOptions(ctx, c.args.Path, validate.Options{
+		Enriched:       true,
+		ResolvePlugins: c.flags.ResolvePlugins,
+		BuiltinPlugins: builtinPluginSet(),
+	})
+	if err != nil {
+		return cecdysis.Outcome{}, conduiterr.Wrap(conduiterr.CodeInvalidArgument,
+			fmt.Sprintf("could not resolve path %q: %v", c.args.Path, err), err)
+	}
+
+	outcome := cecdysis.Outcome{
+		OK:      report.OK(),
+		Summary: report.Summary,
+		Result:  validate.Result{Files: report.Files},
+	}
+	if !report.OK() {
+		if exitErr, ok := validate.ExitError(report.Files); ok {
+			outcome.ExitErr = exitErr
+		}
+	}
+	return outcome, nil
+}
+
+// Render renders a dry-run: per file, the ✗ findings (validation + unresolved
+// builtin plugins) if any, then the enriched pipeline graph.
+func (c *DryRunCommand) Render(outcome cecdysis.Outcome) string {
+	summary, _ := outcome.Summary.(validate.Summary)
+	result, _ := outcome.Result.(validate.Result)
+
+	if c.renderer == nil {
+		c.renderer = ui.NewRenderer(io.Discard, true)
+	}
+
+	var b strings.Builder
+	passed := 0
+	for _, f := range result.Files {
+		if f.OK {
+			passed++
+			if !c.flags.Quiet {
+				fmt.Fprintf(&b, "%s %s\n", c.renderer.Glyph(ui.StatusPass), f.Path)
+			}
+		} else {
+			fmt.Fprintf(&b, "%s %s\n", c.renderer.Glyph(ui.StatusFail), f.Path)
+			for _, finding := range f.Findings {
+				ui.RenderFinding(&b, c.renderer.Glyph(ui.StatusFail), finding.Code, finding.ConfigPath, finding.Message, finding.Suggestion)
+			}
+		}
+
+		// The enriched graph: what `conduit run` would actually load.
+		for _, p := range f.Enriched {
+			fmt.Fprintf(&b, "  pipeline %s\n", p.ID)
+			for _, conn := range p.Connectors {
+				fmt.Fprintf(&b, "    %-11s %-24s %s\n", conn.Type, conn.ID, conn.Plugin)
+			}
+			dlq := p.DLQ.Plugin
+			if dlq == "" {
+				dlq = "(none)"
+			}
+			fmt.Fprintf(&b, "    DLQ         %s\n", dlq)
+		}
+		if len(f.Enriched) > 0 {
+			fmt.Fprintln(&b)
+		}
+	}
+
+	fmt.Fprintf(&b, "Summary: %d files · %d passed · %d failed · %d problems\n",
+		summary.Files, passed, summary.Files-passed, summary.Errors)
+	if summary.Errors > 0 {
+		fmt.Fprintln(&b, "Fix the ✗ items above, then re-run.")
+	}
+	return b.String()
+}
+
+// builtinPluginSet returns the set of resolvable builtin connector references,
+// as both full module paths (github.com/conduitio/conduit-connector-<name>) and
+// their short names (<name>), derived from builtin.DefaultBuiltinConnectors so
+// it stays in sync with the actual builtin set. Injected into the validate
+// engine so the engine itself stays offline and decoupled from the registry.
+func builtinPluginSet() map[string]struct{} {
+	set := make(map[string]struct{}, len(builtin.DefaultBuiltinConnectors)*2)
+	for fullPath := range builtin.DefaultBuiltinConnectors {
+		set[fullPath] = struct{}{}
+		set[strings.TrimPrefix(path.Base(fullPath), "conduit-connector-")] = struct{}{}
+	}
+	return set
+}

--- a/cmd/conduit/root/pipelines/pipelines.go
+++ b/cmd/conduit/root/pipelines/pipelines.go
@@ -35,6 +35,7 @@ func (c *PipelinesCommand) SubCommands() []ecdysis.Command {
 		&DescribeCommand{},
 		&ValidateCommand{},
 		&LintCommand{},
+		&DryRunCommand{},
 	}
 }
 


### PR DESCRIPTION
Wave 2, verb 2 of 3. `conduit pipelines dry-run <path>` — validate + the fully-enriched graph 'conduit run' would load (final IDs, DLQ defaults, worker counts) + builtin plugin resolution (`--resolve-plugins`, default on). Offline, no side effects.

**Reuse:** extends the merged `cmd/conduit/internal/validate` engine (`Options{Enriched, ResolvePlugins}`). The builtin set is injected from `builtin.DefaultBuiltinConnectors` (full path + short name) by the command, so the engine stays offline and decoupled from the registry.

**ACs covered:** AC-5 (enriched IDs + DLQ defaults exposed), AC-6 (unknown builtin → `connector.plugin_not_found`/exit 2; known builtin ok; standalone → advisory, no false-fail), AC-7 (offline). `--resolve-plugins` defaults on via `Flags.SetDefault` (ecdysis ignores `default:` tags for bools). Verified by hand: unknown builtin → exit 2, `--resolve-plugins=false` → exit 0, valid → enriched graph/exit 0.

Design: `docs/design-documents/20260708-cli-pipeline-inspect-lint-dryrun.md`. Tier 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)