### PR TITLE
feat(cli): dry-run --resolve-plugins also resolves processor plugins

### DIFF
--- a/cmd/conduit/internal/validate/dryrun_test.go
+++ b/cmd/conduit/internal/validate/dryrun_test.go
@@ -94,3 +94,40 @@ func TestRunWithOptions_ResolvePlugins_Standalone_Advisory(t *testing.T) {
 	is.True(report.OK())
 	is.Equal(report.Summary.Errors, 0)
 }
+
+// processorBuiltinsForTest is the injected builtin processor set the dry-run
+// command builds from builtin.DefaultBuiltinProcessors (keys are the names).
+var processorBuiltinsForTest = map[string]struct{}{"json.decode": {}}
+
+// AC-6 (processors): --resolve-plugins flags an unknown builtin PROCESSOR as
+// processor.plugin_not_found (codes.NotFound -> exit 2), not just connectors.
+func TestRunWithOptions_ResolvePlugins_UnknownBuiltinProcessor(t *testing.T) {
+	is := is.New(t)
+
+	report, err := RunWithOptions(context.Background(), "testdata/badprocessor.yaml",
+		Options{ResolvePlugins: true, BuiltinPlugins: builtinsForTest, BuiltinProcessors: processorBuiltinsForTest})
+	is.NoErr(err)
+	is.True(!report.OK())
+	is.Equal(report.Summary.Errors, 1)
+
+	var f Finding
+	for _, ff := range report.Files[0].Findings {
+		if ff.Code == conduiterr.CodeProcessorPluginNotFound.Reason() {
+			f = ff
+		}
+	}
+	is.Equal(f.Severity, SeverityError)
+	is.Equal(f.Code, conduiterr.CodeProcessorPluginNotFound.Reason())
+	is.Equal(bucketRank(conduiterr.CodeProcessorPluginNotFound), 2) // Validation -> exit 2
+}
+
+// A known builtin processor resolves cleanly.
+func TestRunWithOptions_ResolvePlugins_KnownBuiltinProcessor_OK(t *testing.T) {
+	is := is.New(t)
+
+	report, err := RunWithOptions(context.Background(), "testdata/goodprocessor.yaml",
+		Options{ResolvePlugins: true, BuiltinPlugins: builtinsForTest, BuiltinProcessors: processorBuiltinsForTest})
+	is.NoErr(err)
+	is.True(report.OK())
+	is.Equal(report.Summary.Errors, 0)
+}

--- a/cmd/conduit/internal/validate/engine.go
+++ b/cmd/conduit/internal/validate/engine.go
@@ -62,12 +62,13 @@ type Options struct {
 	// sets this; validate/lint leave it off so their --json is unchanged.
 	Enriched bool
 
-	// ResolvePlugins checks every connector's plugin reference: a builtin
-	// (`builtin:...`) ref whose plugin is not in BuiltinPlugins is a
-	// connector.plugin_not_found error finding; a standalone/any ref is left
-	// advisory ("not statically verifiable"), never a false failure. `dry-run`
-	// sets this. The engine stays offline: BuiltinPlugins is injected by the
-	// command (from the builtin registry) rather than imported here.
+	// ResolvePlugins checks every connector AND processor plugin reference: a
+	// builtin (`builtin:...`) ref whose plugin is not in BuiltinPlugins /
+	// BuiltinProcessors is a connector.plugin_not_found / processor.plugin_not_found
+	// error finding; a standalone/any ref is left advisory ("not statically
+	// verifiable"), never a false failure. `dry-run` sets this. The engine stays
+	// offline: the builtin sets are injected by the command (from the builtin
+	// registries) rather than imported here.
 	ResolvePlugins bool
 
 	// BuiltinPlugins is the set of resolvable builtin connector references —
@@ -75,6 +76,12 @@ type Options struct {
 	// and their short names (<name>) — supplied by the dry-run command from
 	// builtin.DefaultBuiltinConnectors. Only consulted when ResolvePlugins.
 	BuiltinPlugins map[string]struct{}
+
+	// BuiltinProcessors is the set of resolvable builtin processor plugin names
+	// (e.g. "json.decode", "field.set") — the keys of
+	// builtin.DefaultBuiltinProcessors, supplied by the dry-run command. Only
+	// consulted when ResolvePlugins.
+	BuiltinProcessors map[string]struct{}
 }
 
 // RunWithOptions is Run with the opt-in checks in opts. Run(ctx, path) is
@@ -171,7 +178,7 @@ func validateFile(ctx context.Context, path string, opts Options) fileState {
 		}
 
 		if opts.ResolvePlugins {
-			fs.findings = append(fs.findings, resolvePluginRefs(enriched, opts.BuiltinPlugins)...)
+			fs.findings = append(fs.findings, resolvePluginRefs(enriched, opts)...)
 		}
 	}
 
@@ -186,29 +193,55 @@ func validateFile(ctx context.Context, path string, opts Options) fileState {
 // binary that isn't loaded during an offline dry-run, so it is "not statically
 // verifiable", never a false failure (design doc). configPath points at the
 // connector's plugin field within the file's pipelines list.
-func resolvePluginRefs(p config.Pipeline, builtins map[string]struct{}) []Finding {
+func resolvePluginRefs(p config.Pipeline, opts Options) []Finding {
 	var findings []Finding
+	add := func(f Finding, ok bool) {
+		if ok {
+			findings = append(findings, f)
+		}
+	}
 	for ci, conn := range p.Connectors {
-		fn := plugin.FullName(conn.Plugin)
-		if fn.PluginType() != plugin.PluginTypeBuiltin {
-			continue // standalone/any: not statically verifiable, advisory-by-omission
+		add(builtinRefFinding(conn.Plugin, conn.ID,
+			fmt.Sprintf("/pipelines/connectors/%d/plugin", ci),
+			conduiterr.CodeConnectorPluginNotFound.Reason(), "connector", opts.BuiltinPlugins))
+		// processors attached to a connector
+		for pi, proc := range conn.Processors {
+			add(builtinRefFinding(proc.Plugin, proc.ID,
+				fmt.Sprintf("/pipelines/connectors/%d/processors/%d/plugin", ci, pi),
+				conduiterr.CodeProcessorPluginNotFound.Reason(), "processor", opts.BuiltinProcessors))
 		}
-		name := fn.PluginName()
-		if _, ok := builtins[name]; ok {
-			continue
-		}
-		if _, ok := builtins[conn.Plugin]; ok {
-			continue
-		}
-		findings = append(findings, Finding{
-			Severity:   SeverityError,
-			Code:       conduiterr.CodeConnectorPluginNotFound.Reason(),
-			Message:    fmt.Sprintf("connector %q: builtin plugin %q is not available", conn.ID, conn.Plugin),
-			ConfigPath: fmt.Sprintf("/pipelines/connectors/%d/plugin", ci),
-			Suggestion: "check the plugin name, or use a standalone plugin path; run `conduit connectors list` to see available builtins",
-		})
+	}
+	// pipeline-level processors
+	for pi, proc := range p.Processors {
+		add(builtinRefFinding(proc.Plugin, proc.ID,
+			fmt.Sprintf("/pipelines/processors/%d/plugin", pi),
+			conduiterr.CodeProcessorPluginNotFound.Reason(), "processor", opts.BuiltinProcessors))
 	}
 	return findings
+}
+
+// builtinRefFinding classifies one plugin reference. A builtin (`builtin:...`)
+// ref whose plugin name (or full ref) is not in builtins yields a not-found
+// Finding (ok=true); a standalone/"any" ref, or a resolvable builtin, yields
+// none. kind ("connector"/"processor") shapes the message + suggestion.
+func builtinRefFinding(pluginRef, id, configPath, code, kind string, builtins map[string]struct{}) (Finding, bool) {
+	fn := plugin.FullName(pluginRef)
+	if fn.PluginType() != plugin.PluginTypeBuiltin {
+		return Finding{}, false // standalone/any: not statically verifiable, advisory-by-omission
+	}
+	if _, ok := builtins[fn.PluginName()]; ok {
+		return Finding{}, false
+	}
+	if _, ok := builtins[pluginRef]; ok {
+		return Finding{}, false
+	}
+	return Finding{
+		Severity:   SeverityError,
+		Code:       code,
+		Message:    fmt.Sprintf("%s %q: builtin plugin %q is not available", kind, id, pluginRef),
+		ConfigPath: configPath,
+		Suggestion: fmt.Sprintf("check the plugin name, or use a standalone plugin path; run `conduit %s-plugins list` to see available builtins", kind),
+	}, true
 }
 
 // findingFromError converts one element of a cerrors.ForEach walk into a

--- a/cmd/conduit/internal/validate/testdata/badprocessor.yaml
+++ b/cmd/conduit/internal/validate/testdata/badprocessor.yaml
@@ -1,0 +1,10 @@
+version: "2.2"
+pipelines:
+  - id: bad-processor-pipeline
+    connectors:
+      - id: c1
+        type: source
+        plugin: builtin:generator
+    processors:
+      - id: proc1
+        plugin: builtin:doesnotexist

--- a/cmd/conduit/internal/validate/testdata/goodprocessor.yaml
+++ b/cmd/conduit/internal/validate/testdata/goodprocessor.yaml
@@ -1,0 +1,10 @@
+version: "2.2"
+pipelines:
+  - id: good-processor-pipeline
+    connectors:
+      - id: c1
+        type: source
+        plugin: builtin:generator
+    processors:
+      - id: proc1
+        plugin: builtin:json.decode

--- a/cmd/conduit/root/pipelines/dry_run.go
+++ b/cmd/conduit/root/pipelines/dry_run.go
@@ -27,6 +27,7 @@ import (
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/plugin/connector/builtin"
+	procbuiltin "github.com/conduitio/conduit/pkg/plugin/processor/builtin"
 	"github.com/conduitio/ecdysis"
 )
 
@@ -111,9 +112,10 @@ func (c *DryRunCommand) ExecuteWithResult(ctx context.Context) (cecdysis.Outcome
 	c.renderer = ui.NewRenderer(rendererOutput(ctx), c.flags.NoColor)
 
 	report, err := validate.RunWithOptions(ctx, c.args.Path, validate.Options{
-		Enriched:       true,
-		ResolvePlugins: c.flags.ResolvePlugins,
-		BuiltinPlugins: builtinPluginSet(),
+		Enriched:          true,
+		ResolvePlugins:    c.flags.ResolvePlugins,
+		BuiltinPlugins:    builtinPluginSet(),
+		BuiltinProcessors: builtinProcessorSet(),
 	})
 	if err != nil {
 		return cecdysis.Outcome{}, conduiterr.Wrap(conduiterr.CodeInvalidArgument,
@@ -193,6 +195,19 @@ func builtinPluginSet() map[string]struct{} {
 	for fullPath := range builtin.DefaultBuiltinConnectors {
 		set[fullPath] = struct{}{}
 		set[strings.TrimPrefix(path.Base(fullPath), "conduit-connector-")] = struct{}{}
+	}
+	return set
+}
+
+// builtinProcessorSet returns the set of resolvable builtin processor plugin
+// names (e.g. "json.decode", "field.set") — the keys of
+// builtin.DefaultBuiltinProcessors, which are already the plugin names a config
+// references (unlike connectors, whose keys are full module paths). Injected
+// into the validate engine so it stays offline/decoupled from the registry.
+func builtinProcessorSet() map[string]struct{} {
+	set := make(map[string]struct{}, len(procbuiltin.DefaultBuiltinProcessors))
+	for name := range procbuiltin.DefaultBuiltinProcessors {
+		set[name] = struct{}{}
 	}
 	return set
 }

--- a/pkg/provisioning/config/yaml/parse_warnings_test.go
+++ b/pkg/provisioning/config/yaml/parse_warnings_test.go
@@ -15,6 +15,7 @@
 package yaml
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"reflect"
@@ -24,6 +25,7 @@ import (
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/provisioning/config"
 	"github.com/matryer/is"
+	"github.com/rs/zerolog"
 )
 
 // TestParseWithWarnings_MatchesParse is the AC-4 guard for `pipelines lint`:
@@ -94,4 +96,50 @@ func normalizePipelines(ps []config.Pipeline) {
 			sort.Slice(conn.Processors, func(a, b int) bool { return conn.Processors[a].ID < conn.Processors[b].ID })
 		}
 	}
+}
+
+// TestParser_WarningsExposure_DoesNotChangeRunBehavior is the stronger AC-4
+// guard (carried forward from the closed #2592): it asserts byte-for-byte that
+// the run path (Parse -> ParseConfigurations, what conduit run uses) still LOGS
+// the same warnings, while the new lint/dry-run path (ParseWithWarnings) RETURNS
+// those same warnings and logs nothing. Unlike TestParseWithWarnings_MatchesParse
+// (which compares parsed pipelines), this one locks the observable side effect —
+// logging — that the warnings-exposure refactor must not change.
+func TestParser_WarningsExposure_DoesNotChangeRunBehavior(t *testing.T) {
+	is := is.New(t)
+	const fixture = "./v1/testdata/pipelines1-success.yml"
+
+	// The run path must keep logging warnings and must keep NOT returning them.
+	var runLog bytes.Buffer
+	runFile, err := os.Open(fixture)
+	is.NoErr(err)
+	defer runFile.Close()
+	runPipelines, err := NewParser(log.New(zerolog.New(&runLog))).Parse(context.Background(), runFile)
+	is.NoErr(err)
+	is.True(len(runPipelines) > 0)
+
+	wantRunLog := `{"level":"warn","component":"yaml.Parser","line":5,"column":5,"field":"unknownField","message":"field unknownField not found in type v1.Pipeline"}
+{"level":"warn","component":"yaml.Parser","line":17,"column":9,"field":"processors","message":"the order of processors is non-deterministic in configuration files with version 1.x, please upgrade to version 2.x"}
+{"level":"warn","component":"yaml.Parser","line":23,"column":5,"field":"processors","message":"the order of processors is non-deterministic in configuration files with version 1.x, please upgrade to version 2.x"}
+{"level":"warn","component":"yaml.Parser","line":30,"column":5,"field":"dead-letter-queue","message":"field dead-letter-queue was introduced in version 1.1, please update the pipeline config version"}
+{"level":"warn","component":"yaml.Parser","line":38,"column":1,"field":"version","value":"1.12","message":"unrecognized version 1.12, falling back to parser version 1.1"}
+{"level":"warn","component":"yaml.Parser","line":51,"column":9,"field":"processors","message":"the order of processors is non-deterministic in configuration files with version 1.x, please upgrade to version 2.x"}
+`
+	is.Equal(runLog.String(), wantRunLog) // run's logged warnings unchanged by the refactor
+
+	// The new lint/dry-run channel: same file, ParseWithWarnings — returns the
+	// warnings instead of logging them, and logs nothing itself.
+	var lintLog bytes.Buffer
+	lintFile, err := os.Open(fixture)
+	is.NoErr(err)
+	defer lintFile.Close()
+	lintPipelines, warnings, err := NewParser(log.New(zerolog.New(&lintLog))).ParseWithWarnings(context.Background(), lintFile)
+	is.NoErr(err)
+	is.Equal(len(lintPipelines), len(runPipelines)) // same parse result
+	is.Equal(len(warnings), 6)                      // same 6 warnings, returned not logged
+	is.Equal(lintLog.String(), "")                  // ParseWithWarnings never logs on its own
+
+	is.Equal(warnings[0].Line, 5)
+	is.Equal(warnings[0].Column, 5)
+	is.Equal(warnings[0].Field, "unknownField")
 }


### PR DESCRIPTION
Focused enhancement salvaging the genuine delta from the closed #2592 (a duplicate of the merged lint #2584 / dry-run #2585).

**Two pieces:**
1. **Processor plugin resolution** — the merged `dry-run` resolved only *connector* plugin refs; an unknown builtin *processor* ref slipped through. Now `--resolve-plugins` also checks pipeline-level + connector-nested processor refs against `builtin.DefaultBuiltinProcessors`, emitting `processor.plugin_not_found` (exit 2); standalone/any refs stay advisory. Same `plugin.FullName` classification as the connector path.
2. **Stronger byte-for-byte AC-4 test** — `TestParser_WarningsExposure_DoesNotChangeRunBehavior` asserts the run path's logged warnings are byte-for-byte unchanged and `ParseWithWarnings` returns (not logs) them.

Tested: unknown builtin processor → `processor.plugin_not_found`/exit 2; known → ok; verified by hand + unit tests. Tier 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)