### PR TITLE
fix(provisioning): wrap ApplyPlan's importPipeline in a DB transaction

### DIFF
--- a/docs/design-documents/20260708-live-server-deploy-apply.md
+++ b/docs/design-documents/20260708-live-server-deploy-apply.md
@@ -117,8 +117,8 @@ human path. This is the enforced gate the MCP design deferred to #2588.
 **Tier 1** (mutates live pipelines on the data path + API contract). Requires:
 the kill-mid-apply recovery test (AC-6), the drain-no-loss test (AC-3), rollback
 (AC-5), stale-hash (AC-4), the enforced-gate test (AC-7), human sign-off, and a
-failure-mode analysis in the PR. Chaos suite: add the stop-drain-restart-under-load
-- kill-mid-apply case.
+failure-mode analysis in the PR. Chaos suite: add a stop-drain-restart-under-load
+and kill-mid-apply case.
 
 ## Scope boundary
 

--- a/docs/design-documents/20260708-live-server-deploy-apply.md
+++ b/docs/design-documents/20260708-live-server-deploy-apply.md
@@ -1,0 +1,135 @@
+# Live-server deploy/apply — apply to a running pipeline (issue #2588)
+
+## Summary
+
+Give `deploy`/`apply` (CLI and MCP) a path through a **running** Conduit server so
+they can apply changes to a **live** pipeline — the server gracefully
+stops-drains-restarts it via its lifecycle service — instead of the Wave-2
+standalone path that refuses any running pipeline and only works against a
+stopped BadgerDB store. This lifts the Badger-only default-deny for the
+server-reachable case and completes the MCP north-star (agent → _running_
+pipeline in one session) and the CLI apply-to-running story, both from the **same**
+new API surface. **Tier 1** — it mutates live pipelines (stop-drain-restart on
+the data path) and adds two API RPCs.
+
+## Context — what exists vs what's missing
+
+| Piece | State |
+| --- | --- |
+| `provisioning.Service.Plan` / `ApplyPlan` | exist (Wave 2, `plan.go`); `ApplyPlan` **refuses** a running pipeline (`isRunningStatus`, `plan.go:26`) |
+| `provisioning.Service` holds `lifecycleService` | yes (`service.go:40,62`), and already calls `Start` (`service.go:272`) |
+| `lifecycleService` = `Start(ctx,id)` / `Stop(ctx,id,force)` / `Init` | yes (`runtime.go:113`) — `Stop(...,false)` is the graceful (SIGTERM-style) drain |
+| `runtime.ProvisionService` (the live server's, with lifecycle) | yes (`runtime.go:90,282`) |
+| API `PipelineService` RPCs | CreatePipeline/UpdatePipeline/Delete/Start/Stop (`api.proto:302`) — **no Plan/Apply** |
+| CLI `deploy`/`apply`, MCP `deploy`/`apply` | standalone-only (`NewLocalService`, Badger, stopped) |
+
+**Missing:** (1) API `PlanPipeline` + `ApplyPipeline` RPCs; (2) an apply path that
+**stop-drains-restarts** a running pipeline instead of refusing; (3) CLI/MCP
+client logic to prefer the live server when reachable.
+
+## Decision
+
+### 1. Two additive API RPCs (no breaking change)
+
+`PipelineService.PlanPipeline(config) → Diff{changes, hash}` (read-only) and
+`ApplyPipeline(config, hash) → Diff+result` (mutating). Additive to `api.proto` —
+existing RPCs untouched, so N/N+1 compatible; the proto change is flagged +
+regenerated (`make proto-generate`). Server handlers call the live
+`runtime.ProvisionService` (which has the lifecycle) — the same `Plan`/apply
+engine the CLI standalone path uses, so the diff/hash/rollback semantics are
+identical; only the _reachability_ (live server vs local store) differs.
+
+### 2. Apply-to-running = graceful stop-drain-restart (the Tier-1 core)
+
+Add `ProvisionService.ApplyPlanLive(ctx, desired, hash)` (or a mode on
+`ApplyPlan`) used only by the server handler, which HAS a running lifecycle:
+
+- Recompute + verify the hash (stale → `plan_stale`, as now).
+- If the target pipeline is **running** and the diff's effect is `restart`:
+  `lifecycleService.Stop(ctx, id, false)` — **graceful drain** (invariant 7: in-flight
+  records finish + checkpoint before teardown) → wait for stopped → `importPipeline`
+  (apply the actions, inheriting the reverse-order rollback) → `lifecycleService.Start(ctx, id)`
+  (resumes from the checkpointed position — invariant 2, at-least-once).
+- If the diff is `in_place`-only (no restart-class change): apply without a
+  stop (future optimization; Wave-of-#2588 may still stop-restart for safety and
+  defer true in-place to §4 hot-reload — decide in review).
+- On any failure after Stop, the pipeline is left **stopped** with the rollback
+  applied and a clear error — never half-mutated-and-running. A crash between
+  Stop and Start is recoverable: the pipeline is stopped + the store is
+  consistent (importPipeline is transactional-per-action), and a restart
+  re-resumes from the last checkpoint.
+
+The standalone `ApplyPlan` keeps refusing running pipelines (it has no lifecycle
+to drive) — unchanged.
+
+### 3. CLI + MCP: prefer the live server, fall back to standalone
+
+`deploy`/`apply` (and the MCP tools) try the API first (a server is reachable) →
+use `PlanPipeline`/`ApplyPipeline` (works against running pipelines, any store).
+If no server is reachable → the Wave-2 standalone path (Badger, stopped). The
+verb's behavior is identical; only the transport differs. MCP inherits this by
+wrapping the same client logic.
+
+### 4. Enforced human-sign-off on data-path apply-to-running
+
+Now that apply _can_ mutate a running pipeline, the MCP review's open item
+becomes real: an `ApplyPipeline` whose diff touches ack/position/checkpoint-adjacent
+config on a **running** pipeline must not proceed autonomously. Enforce at the
+API layer: such an apply requires an explicit operator-authorization token/flag
+(server-side `--allow-live-data-path-apply` or a per-call signed authorization),
+NOT an agent-passable arg. Absent it → refuse with a coded error directing to the
+human path. This is the enforced gate the MCP design deferred to #2588.
+
+## Failure modes (Tier 1 — enumerate)
+
+- **Drain incompleteness:** `Stop(...,false)` must fully drain + checkpoint before
+  importPipeline; if Stop returns before drain, in-flight records could be lost
+  (invariant 3). Verify Stop's drain semantics; test with in-flight load.
+- **Crash between Stop and Start:** pipeline left stopped, store consistent,
+  re-resumes from checkpoint on next start — kill-mid-apply recovery test.
+- **Rollback of a running-pipeline apply:** if importPipeline fails mid-sequence,
+  reverse rollback runs while the pipeline is stopped; then it stays stopped
+  (not auto-restarted into a rolled-back state) with a clear error.
+- **Stale hash across the stop window:** recompute+verify the hash after Stop but
+  before importPipeline (state can't change while stopped + single-writer).
+- **Concurrent applies / apply-during-manual-stop:** per-pipeline provisioning
+  lock; second apply sees a changed hash or the lock.
+- **Restart failure:** apply succeeded but Start fails → pipeline stopped with the
+  new (valid) config + a surfaced error; operator/agent can Start.
+
+## Acceptance criteria
+
+1. `PlanPipeline` RPC returns the same `Diff`+hash as the CLI standalone `deploy` for the same config; no mutation.
+2. `ApplyPipeline` against a **stopped** pipeline applies (like standalone) and the store reflects it.
+3. `ApplyPipeline` against a **running** pipeline with a `restart` diff: gracefully stops (drains — asserted no
+   in-flight record loss), applies, restarts; the pipeline is running the new config, resumed from checkpoint.
+4. Stale hash → `plan_stale`, no mutation, pipeline still running unchanged.
+5. Partial-apply failure on a running pipeline → rollback, pipeline left stopped, coded error, no data loss.
+6. **kill-mid-apply** (SIGKILL between Stop and Start / mid-import) → recoverable: store consistent, restart resumes
+   from checkpoint, no records lost/duplicated beyond at-least-once.
+7. Data-path diff on a running pipeline without operator authorization → refused (enforced gate), not applied.
+8. CLI `apply` uses the API when a server is reachable, standalone when not — same result shape; asserted both paths.
+9. MCP `apply` (with `--allow-mutations`) against a running server applies to a running pipeline (the north-star E2E).
+10. `api.proto` change is additive; generated code regenerates clean; existing RPCs unaffected.
+
+## Risk tier & tests
+
+**Tier 1** (mutates live pipelines on the data path + API contract). Requires:
+the kill-mid-apply recovery test (AC-6), the drain-no-loss test (AC-3), rollback
+(AC-5), stale-hash (AC-4), the enforced-gate test (AC-7), human sign-off, and a
+failure-mode analysis in the PR. Chaos suite: add the stop-drain-restart-under-load
+- kill-mid-apply case.
+
+## Scope boundary
+
+Delivers: the two API RPCs, server-side stop-drain-restart apply, CLI/MCP
+live-server preference with standalone fallback, and the enforced data-path gate.
+Deferred: true in-place live hot-swap (no stop) → §4 hot-reload; multi-pipeline
+transactional apply; the `repair` tool.
+
+## Related
+
+- Issue #2588; the Wave-2 deploy/apply design (`20260708-cli-pipeline-deploy-apply.md`)
+  and the MCP design (`20260708-mcp-server.md`, whose deferred data-path gate lands here).
+- Execution plan §2 (MCP `deploy_pipeline`), §4 (hot-reload).
+- `provisioning.Service.Plan`/`ApplyPlan`, the `lifecycleService`, `api.proto`.

--- a/pkg/provisioning/plan.go
+++ b/pkg/provisioning/plan.go
@@ -237,8 +237,26 @@ func (s *Service) ApplyPlan(ctx context.Context, desired config.Pipeline, hash s
 		return fresh, ce
 	}
 
-	if err := s.importPipeline(ctx, desired, pipeline.ProvisionTypeConfig); err != nil {
+	// Wrap the apply in a single DB transaction, exactly as provisionPipeline
+	// does (service.go). Without it, importPipeline's actions each commit their
+	// own writes (and a single action can write more than once, e.g.
+	// createPipelineAction does Create then UpdateDLQ), so a crash — or an error
+	// whose in-process reverse rollback itself fails — could leave the store
+	// partially mutated with no recovery on restart. The transaction makes apply
+	// all-or-nothing: on any error we return before Commit and the deferred
+	// Discard drops every write. Invariant 5: state writes are atomic.
+	txn, importCtx, err := s.db.NewTransaction(ctx, true)
+	if err != nil {
+		return fresh, cerrors.Errorf("could not create db transaction: %w", err)
+	}
+	defer txn.Discard()
+
+	if err := s.importPipeline(importCtx, desired, pipeline.ProvisionTypeConfig); err != nil {
 		return fresh, err
+	}
+
+	if err := txn.Commit(); err != nil {
+		return fresh, cerrors.Errorf("could not commit db transaction: %w", err)
 	}
 	return fresh, nil
 }

--- a/pkg/provisioning/plan_test.go
+++ b/pkg/provisioning/plan_test.go
@@ -243,10 +243,13 @@ func TestApplyPlan_MatchingHash_Executes(t *testing.T) {
 
 	desired := config.Pipeline{ID: "p1", Name: "orders", DLQ: dlqFixture()}
 
-	pipSrv.EXPECT().Get(ctx, "p1").Return(nil, pipeline.ErrInstanceNotFound).AnyTimes()
-	pipSrv.EXPECT().Create(ctx, "p1", gomock.Any(), pipeline.ProvisionTypeConfig).
+	// apply wraps importPipeline in a DB transaction (plan.go), so the writes
+	// inside it run with the transactional ctx, not the plain ctx Plan uses —
+	// match gomock.Any() on ctx rather than pinning the transaction plumbing.
+	pipSrv.EXPECT().Get(gomock.Any(), "p1").Return(nil, pipeline.ErrInstanceNotFound).AnyTimes()
+	pipSrv.EXPECT().Create(gomock.Any(), "p1", gomock.Any(), pipeline.ProvisionTypeConfig).
 		Return(&pipeline.Instance{ID: "p1"}, nil)
-	pipSrv.EXPECT().UpdateDLQ(ctx, "p1", gomock.Any()).Return(&pipeline.Instance{ID: "p1"}, nil)
+	pipSrv.EXPECT().UpdateDLQ(gomock.Any(), "p1", gomock.Any()).Return(&pipeline.Instance{ID: "p1"}, nil)
 
 	diff, err := srv.Plan(ctx, desired)
 	is.NoErr(err)
@@ -254,6 +257,40 @@ func TestApplyPlan_MatchingHash_Executes(t *testing.T) {
 	applied, err := srv.ApplyPlan(ctx, desired, diff.Hash)
 	is.NoErr(err)
 	is.Equal(applied.Hash, diff.Hash)
+}
+
+// TestApplyPlan_WrapsImportInTransaction is the regression test for the
+// crash-safety fix (#2588 review): apply must run importPipeline inside a single
+// DB transaction (invariant 5 — state writes are atomic), exactly as
+// provisionPipeline does, so a crash or a failed in-process rollback can't leave
+// the store partially mutated. It captures the ctx importPipeline's Create runs
+// with: under the fix that is the transactional child ctx, distinct from the
+// plain ctx handed to ApplyPlan. Removing the transaction wrapping regresses the
+// captured ctx back to the plain ctx and fails this test.
+func TestApplyPlan_WrapsImportInTransaction(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	srv, pipSrv, _, _, _, _ := newTestService(ctrl, log.Nop())
+
+	desired := config.Pipeline{ID: "p1", Name: "orders", DLQ: dlqFixture()}
+	pipSrv.EXPECT().Get(gomock.Any(), "p1").Return(nil, pipeline.ErrInstanceNotFound).AnyTimes()
+
+	var createCtx context.Context
+	pipSrv.EXPECT().Create(gomock.Any(), "p1", gomock.Any(), pipeline.ProvisionTypeConfig).
+		DoAndReturn(func(c context.Context, _ string, _ pipeline.Config, _ pipeline.ProvisionType) (*pipeline.Instance, error) {
+			createCtx = c
+			return &pipeline.Instance{ID: "p1"}, nil
+		})
+	pipSrv.EXPECT().UpdateDLQ(gomock.Any(), "p1", gomock.Any()).Return(&pipeline.Instance{ID: "p1"}, nil)
+
+	diff, err := srv.Plan(ctx, desired)
+	is.NoErr(err)
+	_, err = srv.ApplyPlan(ctx, desired, diff.Hash)
+	is.NoErr(err)
+
+	is.True(createCtx != nil) // importPipeline ran
+	is.True(createCtx != ctx) // ...under the transactional ctx, not the plain one
 }
 
 // TestApplyPlan_StaleHash_RefusedNoMutation is the regression test for AC-7:
@@ -316,17 +353,19 @@ func TestApplyPlan_PartialFailure_RollsBackPrefix(t *testing.T) {
 		},
 	}
 
-	pipSrv.EXPECT().Get(ctx, "p1").Return(nil, pipeline.ErrInstanceNotFound).AnyTimes()
+	// apply wraps importPipeline in a DB transaction (plan.go), so calls inside
+	// it run with the transactional ctx — match gomock.Any() on ctx.
+	pipSrv.EXPECT().Get(gomock.Any(), "p1").Return(nil, pipeline.ErrInstanceNotFound).AnyTimes()
 
 	// Pipeline create (and its rollback, a Delete) succeeds; the connector
 	// create that follows fails, forcing a rollback of the pipeline create.
-	pipSrv.EXPECT().Create(ctx, "p1", gomock.Any(), pipeline.ProvisionTypeConfig).
+	pipSrv.EXPECT().Create(gomock.Any(), "p1", gomock.Any(), pipeline.ProvisionTypeConfig).
 		Return(&pipeline.Instance{ID: "p1"}, nil)
-	pipSrv.EXPECT().UpdateDLQ(ctx, "p1", gomock.Any()).Return(&pipeline.Instance{ID: "p1"}, nil)
-	pipSrv.EXPECT().AddConnector(ctx, "p1", "p1:conn:src").Return(&pipeline.Instance{ID: "p1"}, nil)
+	pipSrv.EXPECT().UpdateDLQ(gomock.Any(), "p1", gomock.Any()).Return(&pipeline.Instance{ID: "p1"}, nil)
+	pipSrv.EXPECT().AddConnector(gomock.Any(), "p1", "p1:conn:src").Return(&pipeline.Instance{ID: "p1"}, nil)
 
 	wantErr := cerrors.New("forced connector create failure")
-	connSrv.EXPECT().Create(ctx, "p1:conn:src", gomock.Any(), "builtin:generator", "p1", gomock.Any(), gomock.Any()).
+	connSrv.EXPECT().Create(gomock.Any(), "p1:conn:src", gomock.Any(), "builtin:generator", "p1", gomock.Any(), gomock.Any()).
 		Return(nil, wantErr)
 
 	// rollbackActions rolls back the whole executed-plus-failed prefix in
@@ -334,8 +373,8 @@ func TestApplyPlan_PartialFailure_RollsBackPrefix(t *testing.T) {
 	// failed createConnectorAction is rolled back first (its own comment:
 	// "ignore instance not found errors, this means the action failed to
 	// create the connector in the first place"), then the pipeline create.
-	connSrv.EXPECT().Delete(ctx, "p1:conn:src", gomock.Any()).Return(connector.ErrInstanceNotFound)
-	pipSrv.EXPECT().Delete(ctx, "p1").Return(nil)
+	connSrv.EXPECT().Delete(gomock.Any(), "p1:conn:src", gomock.Any()).Return(connector.ErrInstanceNotFound)
+	pipSrv.EXPECT().Delete(gomock.Any(), "p1").Return(nil)
 
 	diff, err := srv.Plan(ctx, desired)
 	is.NoErr(err)


### PR DESCRIPTION
**Tier 1 (state atomicity).** Crash-safety fix for the already-merged deploy/apply (#2586), surfaced by the #2588 design review and authorized to land now.

## The bug
`ApplyPlan` called `importPipeline` with a plain context, unlike `provisionPipeline` which wraps it in `s.db.NewTransaction`. A single action writes more than once (e.g. `createPipelineAction` = Create + UpdateDLQ), and actions aren't individually atomic, so a crash mid-apply — or an error whose in-process reverse rollback itself fails — could leave the store partially mutated with **no recovery on restart** (rollback only fires on in-process Go errors, never a crash).

## The fix
Wrap the apply in one DB transaction, exactly as `provisionPipeline` already does: on any error, return before `Commit` and the deferred `Discard` drops every write. Invariant 5 (state writes are atomic).

## Failure-mode analysis
- **What it fixes:** crash / rollback-failure mid-apply no longer leaves partial state — the transaction is all-or-nothing.
- **What it can't fix here:** apply-to-a-running-pipeline (still refused; that's #2588). This is purely the standalone/stopped path's atomicity.
- **Rollback:** the in-process reverse rollback still runs on error; the transaction Discard is the belt-and-suspenders that also covers a crash or a failed rollback.
- **Metric/alert:** none new; a partial-state corruption would previously show as a pipeline that won't load. **Roll back:** revert the transaction wrapping (no format/schema change).

## Test
`TestApplyPlan_WrapsImportInTransaction` — verified to **fail without the fix** (importPipeline runs with the plain ctx → captured ctx == plain ctx) and pass with it. Existing ApplyPlan tests updated to match the transactional ctx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)