### PR TITLE
feat(lifecycle,provisioning): StopAndWait + ApplyPlanLive (PR1 of #2588)

### DIFF
--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -113,6 +113,13 @@ type Runtime struct {
 type lifecycleService interface {
 	Start(ctx context.Context, pipelineID string) error
 	Stop(ctx context.Context, pipelineID string, force bool) error
+	// StopAndWait is required so this interface stays a superset of
+	// provisioning.LifecycleService (Go requires that for the implicit
+	// interface-to-interface assignment in newRuntime below to type-check).
+	// See lifecycle.Service.StopAndWait's doc for what it guarantees, and
+	// lifecycle-poc(pkg/lifecycle-poc).Service.StopAndWait for why the
+	// Preview.PipelineArchV2 implementation always refuses.
+	StopAndWait(ctx context.Context, pipelineID string) error
 	Init(ctx context.Context) error
 }
 

--- a/pkg/connector/persister.go
+++ b/pkg/connector/persister.go
@@ -175,6 +175,34 @@ func (p *Persister) Wait() {
 	p.flushWg.Wait()
 }
 
+// WaitPendingWrites blocks until every flush already triggered (via Flush, the
+// bundle-count threshold, the delay timer, or ConnectorStopped) has finished
+// writing to the store — but, unlike Wait, it does NOT block on connWg (every
+// connector across the whole process reaching ConnectorStopped).
+//
+// This distinction matters for a caller that only wants to know "has this
+// pipeline's already-triggered write actually landed durably", not "has every
+// connector in the process stopped running": since the persister's batching is
+// shared across all pipelines, connWg only reaches zero once every connector
+// on every pipeline has stopped, so calling Wait from a single pipeline's
+// stop-and-drain path would deadlock for as long as any other pipeline stays
+// running. WaitPendingWrites has no such coupling — it only observes flushWg,
+// which a connector's own ConnectorStopped call already increments
+// synchronously (see triggerFlush) before that call returns. A caller that
+// calls WaitPendingWrites strictly after learning (e.g. via a WaitGroup/tomb
+// join) that ConnectorStopped has already been called for the connector it
+// cares about is guaranteed to observe that connector's flush complete: the
+// Add(1) happened-before the Wait() call by construction, and sync.WaitGroup
+// cannot miss a Done that was already pending when Wait was entered.
+//
+// Used by lifecycle.Service.StopAndWait to await durability (invariant 1/3)
+// after a pipeline has fully drained, without deadlocking on unrelated running
+// pipelines. See docs/design-documents/20260708-live-server-deploy-apply.md,
+// "Review outcome & required rework", blocker 1.
+func (p *Persister) WaitPendingWrites() {
+	p.flushWg.Wait()
+}
+
 // Flush will trigger a goroutine that persists any in-memory data to the store.
 // To wait for the changes to be actually persisted you need to call Wait.
 func (p *Persister) Flush(ctx context.Context) {

--- a/pkg/connector/service.go
+++ b/pkg/connector/service.go
@@ -91,6 +91,22 @@ func (s *Service) Check(ctx context.Context) error {
 	return s.store.db.Ping(ctx)
 }
 
+// WaitPersisted blocks until every connector position/state write already
+// queued for persistence (via a connector's Ack -> Persister.Persist, or the
+// final flush a connector's Teardown triggers via Persister.ConnectorStopped)
+// has been durably committed to the store.
+//
+// It deliberately does not take a pipeline or connector ID: the persister
+// batches writes across every connector in the process, so there is no
+// narrower durability signal to observe than "the batch(es) already in
+// flight have landed" — see Persister.WaitPendingWrites's doc for why that is
+// still a precise, non-deadlocking signal for a caller that already knows
+// (e.g. via lifecycle.Service.WaitPipeline) that the connector it cares about
+// has stopped and thus already triggered its final flush.
+func (s *Service) WaitPersisted() {
+	s.persister.WaitPendingWrites()
+}
+
 // List returns a map of Instances keyed by their ID. Instances do not
 // necessarily have a running plugin associated with them.
 func (s *Service) List(context.Context) map[string]*Instance {

--- a/pkg/lifecycle-poc/codes.go
+++ b/pkg/lifecycle-poc/codes.go
@@ -1,0 +1,32 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lifecycle
+
+import (
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"google.golang.org/grpc/codes"
+)
+
+// CodeStopAndWaitUnsupported is raised by StopAndWait, which this
+// (Preview.PipelineArchV2 / "funnel") lifecycle implementation does not yet
+// provide. See StopAndWait's doc for why: the sibling pkg/lifecycle package's
+// Stop/WaitPipeline drain semantics were audited for the Tier-1 live-apply
+// review (docs/design-documents/20260708-live-server-deploy-apply.md, "Open
+// parity item") and found safe to build StopAndWait on top of; this
+// experimental worker/funnel architecture has not had the equivalent audit.
+// Rather than guess at its drain semantics, StopAndWait refuses outright so
+// provisioning.Service.ApplyPlanLive can never apply-to-running under an
+// unaudited stop path.
+var CodeStopAndWaitUnsupported = conduiterr.Register("lifecycle_v2.stop_and_wait_unsupported", codes.Unimplemented)

--- a/pkg/lifecycle-poc/service.go
+++ b/pkg/lifecycle-poc/service.go
@@ -26,6 +26,7 @@ import (
 	"github.com/conduitio/conduit-commons/csync"
 	"github.com/conduitio/conduit/pkg/connector"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/foundation/metrics/measure"
 	"github.com/conduitio/conduit/pkg/lifecycle-poc/funnel"
@@ -322,6 +323,34 @@ func (s *Service) WaitPipeline(id string) error {
 		return err
 	}
 	return nil
+}
+
+// StopAndWait exists to satisfy the LifecycleService interfaces shared with
+// the sibling pkg/lifecycle package (see provisioning.LifecycleService and
+// conduit.Runtime's lifecycleService) but is intentionally unimplemented
+// here: it always refuses with a CodeStopAndWaitUnsupported error.
+//
+// This is a deliberate Tier-1 safety guard, not a TODO. The Stop-and-restart
+// primitive backing provisioning.Service.ApplyPlanLive (stop-drain-restart on
+// the data path) requires a proven quiescence+durability guarantee — see
+// pkg/lifecycle.Service.StopAndWait's doc. That guarantee was established by
+// auditing pkg/lifecycle's specific Stop/WaitPipeline/Persister interaction
+// (docs/design-documents/20260708-live-server-deploy-apply.md, "Review
+// outcome & required rework"). This package's funnel.Worker-based Stop has a
+// different implementation and has not had the equivalent audit. Silently
+// building StopAndWait on top of an unaudited stop path here would let
+// ApplyPlanLive apply-to-running under Preview.PipelineArchV2 without the
+// safety case the design review actually verified — exactly the class of bug
+// blocker 1 found in the original (pre-rework) design. Refusing outright, so
+// ApplyPlanLive's error surfaces immediately instead of silently risking
+// data loss, is intentional until this architecture's drain semantics get
+// the same audit (tracked as the design doc's "Open parity item").
+func (s *Service) StopAndWait(context.Context, string) error {
+	ce := conduiterr.New(CodeStopAndWaitUnsupported,
+		"live apply (stop-drain-restart of a running pipeline) is not supported under the "+
+			"experimental Preview.PipelineArchV2 lifecycle service")
+	ce.Suggestion = "disable Preview.PipelineArchV2, or stop the pipeline manually before applying changes"
+	return ce
 }
 
 // buildRunnablePipeline will build and connect all tasks configured in the pipeline.

--- a/pkg/lifecycle-poc/stop_and_wait_test.go
+++ b/pkg/lifecycle-poc/stop_and_wait_test.go
@@ -1,0 +1,51 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lifecycle
+
+import (
+	"context"
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/google/uuid"
+	"github.com/matryer/is"
+	"github.com/rs/zerolog"
+)
+
+// TestServiceLifecycle_StopAndWait_Unsupported is the parity guard regression
+// test called out in
+// docs/design-documents/20260708-live-server-deploy-apply.md's "Open parity
+// item": this (Preview.PipelineArchV2 / "funnel") lifecycle implementation's
+// Stop/drain semantics have not been audited the way pkg/lifecycle's were for
+// the Tier-1 live-apply review, so StopAndWait must always refuse rather than
+// silently building provisioning.Service.ApplyPlanLive's stop-drain-restart
+// on top of an unaudited stop path. This pins that refusal — and its stable
+// error code — so a future change can't accidentally make it a silent no-op
+// or delegate to Stop.
+func TestServiceLifecycle_StopAndWait_Unsupported(t *testing.T) {
+	is := is.New(t)
+
+	logger := log.New(zerolog.Nop())
+	ls := NewService(logger, testConnectorService{}, testProcessorService{}, testConnectorPluginService{}, testPipelineService{}, true)
+
+	err := ls.StopAndWait(context.Background(), uuid.NewString())
+	is.True(err != nil)
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code.Reason(), CodeStopAndWaitUnsupported.Reason())
+	is.True(ce.Suggestion != "")
+}

--- a/pkg/lifecycle/service.go
+++ b/pkg/lifecycle/service.go
@@ -119,10 +119,14 @@ type runnablePipeline struct {
 	recoveryAttempts *atomic.Int64
 }
 
-// ConnectorService can fetch and create a connector instance.
+// ConnectorService can fetch and create a connector instance, and report when
+// every position/state write already queued for persistence has been
+// durably committed — see WaitPersisted's doc and StopAndWait, which relies
+// on it to await durability after a pipeline has fully drained.
 type ConnectorService interface {
 	Get(ctx context.Context, id string) (*connector.Instance, error)
 	Create(ctx context.Context, id string, t connector.Type, plugin string, pipelineID string, cfg connector.Config, p connector.ProvisionType) (*connector.Instance, error)
+	WaitPersisted()
 }
 
 // ProcessorService can fetch a processor instance and make a runnable processor from it.
@@ -427,6 +431,56 @@ func (s *Service) WaitPipeline(id string) error {
 	if err, ok := s.terminalErrors.Get(id); ok {
 		return err
 	}
+	return nil
+}
+
+// StopAndWait gracefully stops the pipeline with the given ID and blocks
+// until it has reached full quiescence: every node goroutine has exited
+// (drain complete — see stream.SourceNode.Run's openMsgTracker.Wait(), which
+// keeps the source's Teardown from running until every in-flight message has
+// been acked or nacked end-to-end) AND every connector position/state write
+// that drain triggered has been durably flushed to the store.
+//
+// Callers MUST use StopAndWait instead of Stop when they intend to mutate the
+// pipeline's stored connectors/processors/config immediately afterward (e.g.
+// provisioning.Service.ApplyPlanLive's stop-drain-restart). Stop(ctx, id,
+// false) alone only injects a stop-control-message into the source node and
+// returns — it does not wait for the drain, let alone the position flush, to
+// complete. Racing a mutation against that in-flight drain could tear down or
+// reconfigure a connector while old goroutines are still mid-flight,
+// corrupting acks or losing the final position write.
+//
+// Invariant 1 (never ack upstream before the downstream write is durable) and
+// invariant 3 (at-least-once: no path may drop a record without delivering or
+// DLQ-routing it) are why StopAndWait blocks on both signals rather than just
+// the first: WaitPipeline alone proves every record was acked end-to-end, but
+// says nothing about whether the resulting position write actually reached
+// disk — connector.Persister batches and flushes asynchronously, so without
+// the second wait a caller could observe a "stopped" pipeline whose last
+// checkpoint is still only in memory, and mutate/restart it into that gap.
+// See docs/design-documents/20260708-live-server-deploy-apply.md, "Review
+// outcome & required rework", blocker 1, which traced this exact race in the
+// original (pre-rework) design.
+//
+// StopAndWait requires the pipeline to already be running (it delegates to
+// Stop, which returns pipeline.ErrPipelineNotRunning-coded errors otherwise)
+// and only ever stops gracefully — there is no forceful variant, since a
+// forceful stop provides none of the drain/flush guarantees a caller needing
+// this primitive is asking for.
+func (s *Service) StopAndWait(ctx context.Context, pipelineID string) error {
+	if err := s.Stop(ctx, pipelineID, false); err != nil {
+		return cerrors.Errorf("could not stop pipeline %s: %w", pipelineID, err)
+	}
+
+	if err := s.WaitPipeline(pipelineID); err != nil {
+		return cerrors.Errorf("pipeline %s did not stop gracefully: %w", pipelineID, err)
+	}
+
+	// Invariant 1/3: do not return — and thus do not let a caller mutate or
+	// tear down this pipeline's connectors — until every position/state write
+	// the drain above already triggered is durably persisted.
+	s.connectors.WaitPersisted()
+
 	return nil
 }
 

--- a/pkg/lifecycle/service_test.go
+++ b/pkg/lifecycle/service_test.go
@@ -1081,6 +1081,25 @@ func (s testConnectorService) Create(context.Context, string, connector.Type, st
 	return s[testDLQID], nil
 }
 
+// WaitPersisted is a no-op here: none of the existing tests using
+// testConnectorService directly exercise StopAndWait's durability wait (they
+// assert on WaitPipeline/Stop instead). Tests that do need a real durability
+// signal use testConnectorServiceWithPersister below, which forwards to the
+// real *connector.Persister the test's connectors were actually Init'd with.
+func (s testConnectorService) WaitPersisted() {}
+
+// testConnectorServiceWithPersister wraps testConnectorService and forwards
+// WaitPersisted to the real persister backing its connectors, for tests that
+// must observe actual durability (StopAndWait's drain-and-persist guarantee).
+type testConnectorServiceWithPersister struct {
+	testConnectorService
+	persister *connector.Persister
+}
+
+func (s testConnectorServiceWithPersister) WaitPersisted() {
+	s.persister.WaitPendingWrites()
+}
+
 // testProcessorService fulfills the ProcessorService interface.
 type testProcessorService map[string]*processor.Instance
 

--- a/pkg/lifecycle/stop_and_wait_test.go
+++ b/pkg/lifecycle/stop_and_wait_test.go
@@ -1,0 +1,165 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lifecycle
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/database"
+	"github.com/conduitio/conduit-commons/database/inmemory"
+	"github.com/conduitio/conduit/pkg/connector"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/pipeline"
+	"github.com/google/uuid"
+	"github.com/matryer/is"
+	"github.com/rs/zerolog"
+	"go.uber.org/mock/gomock"
+)
+
+// delayingDB wraps a database.DB and adds a fixed delay before every
+// NewTransaction call completes, simulating a slow store. It exists purely so
+// tests can deterministically observe whether a caller actually waited for a
+// persister flush to land, rather than merely getting lucky with in-memory
+// timing: connector.Persister.flushNow commits its batch via NewTransaction
+// (see persister.go), so delaying it here makes "StopAndWait returned before
+// the flush committed" a hard, always-reproducing failure instead of an
+// occasional flake.
+type delayingDB struct {
+	database.DB
+	delay time.Duration
+}
+
+func (d *delayingDB) NewTransaction(ctx context.Context, update bool) (database.Transaction, context.Context, error) {
+	time.Sleep(d.delay)
+	return d.DB.NewTransaction(ctx, update)
+}
+
+// TestServiceLifecycle_StopAndWait_DrainsAndPersists is the regression test
+// for the Tier-1 rework in
+// docs/design-documents/20260708-live-server-deploy-apply.md ("Review
+// outcome & required rework", blocker 1): Stop(ctx, id, false) alone only
+// injects a stop-control-message into the source node and returns — it does
+// not wait for the pipeline to drain, let alone for the resulting position
+// write to be durably flushed. StopAndWait must block on both, and this test
+// proves it does by reading the connector's position directly back out of
+// the store (not the in-memory Instance, which would reflect the write
+// whether or not it ever reached the store) immediately after StopAndWait
+// returns.
+//
+// The persister's flush is made artificially slow via delayingDB, and the
+// bundle-count/delay thresholds are set so high that the *only* flush that
+// happens during the test is the one ConnectorStopped triggers during
+// teardown — so a StopAndWait that returned before that flush landed would
+// deterministically read a stale (pre-flush, "key not found") result here,
+// not just flake occasionally.
+func TestServiceLifecycle_StopAndWait_DrainsAndPersists(t *testing.T) {
+	is := is.New(t)
+	ctx, killAll := context.WithCancel(context.Background())
+	defer killAll()
+	logger := log.Test(t)
+
+	const flushDelay = 200 * time.Millisecond
+	db := &delayingDB{DB: &inmemory.DB{}, delay: flushDelay}
+	persister := connector.NewPersister(logger, db, time.Hour, 10000)
+
+	ps := pipeline.NewService(logger, db)
+	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
+	is.NoErr(err)
+
+	ctrl := gomock.NewController(t)
+	wantRecords := generateRecords(5)
+	source, srcDispenser := asserterSource(ctrl, persister, wantRecords, nil, true, 1)
+	destination, destDispenser := asserterDestination(ctrl, persister, wantRecords, 1)
+	dlq, dlqDispenser := asserterDestination(ctrl, persister, nil, 1)
+	pl.DLQ.Plugin = dlq.Plugin
+
+	pl, err = ps.AddConnector(ctx, pl.ID, source.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, destination.ID)
+	is.NoErr(err)
+
+	ls := NewService(
+		logger,
+		testErrRecoveryCfg(),
+		testConnectorServiceWithPersister{
+			testConnectorService: testConnectorService{
+				source.ID:      source,
+				destination.ID: destination,
+				testDLQID:      dlq,
+			},
+			persister: persister,
+		},
+		testProcessorService{},
+		testConnectorPluginService{
+			source.Plugin:      srcDispenser,
+			destination.Plugin: destDispenser,
+			dlq.Plugin:         dlqDispenser,
+		}, ps)
+
+	err = ls.Start(ctx, pl.ID)
+	is.NoErr(err)
+
+	// Let all 5 records flow end to end (source -> destination -> ack back to
+	// source) before stopping. asserterSource/asserterDestination assert an
+	// exact record match on teardown, so this synchronization is required for
+	// the test itself to pass, independent of what we're proving here.
+	time.Sleep(100 * time.Millisecond)
+
+	start := time.Now()
+	err = ls.StopAndWait(ctx, pl.ID)
+	is.NoErr(err)
+	elapsed := time.Since(start)
+
+	// StopAndWait must have actually blocked until the delayed flush
+	// committed, not returned as soon as the drain finished.
+	is.True(elapsed >= flushDelay)
+
+	is.Equal(pipeline.StatusUserStopped, pl.GetStatus())
+
+	// The durability assertion: read the source's position directly from the
+	// store. If StopAndWait returned before WaitPersisted's flush actually
+	// landed, this read (immediately following StopAndWait with no
+	// intervening sleep) would race the still-in-flight write.
+	store := connector.NewStore(db, logger)
+	got, err := store.Get(ctx, source.ID)
+	is.NoErr(err)
+	wantState := connector.SourceState{Position: wantRecords[len(wantRecords)-1].Position}
+	is.Equal(got.State, wantState)
+}
+
+// TestServiceLifecycle_StopAndWait_NotRunning confirms StopAndWait propagates
+// Stop's error (rather than e.g. blocking forever) when the pipeline isn't
+// running — the same precondition Stop itself enforces.
+func TestServiceLifecycle_StopAndWait_NotRunning(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	logger := log.New(zerolog.Nop())
+
+	ls := NewService(
+		logger,
+		testErrRecoveryCfg(),
+		testConnectorService{},
+		testProcessorService{},
+		testConnectorPluginService{},
+		testPipelineService{},
+	)
+
+	err := ls.StopAndWait(ctx, uuid.NewString())
+	is.True(err != nil)
+	is.True(cerrors.Is(err, pipeline.ErrPipelineNotRunning)) // sentinel still in the chain
+}

--- a/pkg/provisioning/apply_plan_live_test.go
+++ b/pkg/provisioning/apply_plan_live_test.go
@@ -229,15 +229,24 @@ func TestApplyPlanLive_StaleHash_RefusedNoMutation_RunningPipeline(t *testing.T)
 }
 
 // TestApplyPlanLive_ImportFails_RunningPipeline_LeftStopped is the regression
-// test for AC-5/AC-6 against a running pipeline: once StopAndWait has
-// succeeded, the pipeline is stopped. If the transactional import then fails
-// (importPipeline's own reverse rollback already ran — see
-// TestApplyPlan_PartialFailure_RollsBackPrefix for that invariant pinned at
-// the import layer), ApplyPlanLive must surface the error and must NOT call
-// Start — no Start expectation is set on lifecycleSrv, so gomock fails the
-// test if it's called. The pipeline is left stopped (StopAndWait already ran,
-// Start never does), matching the design doc's "never auto-start into a
-// half-applied or rolled-back state."
+// test for AC-5 (partial-apply failure leaves the running pipeline stopped, not
+// half-applied-and-running): once StopAndWait has succeeded, the pipeline is
+// stopped. If the transactional import then fails (importPipeline's own reverse
+// rollback already ran — see TestApplyPlan_PartialFailure_RollsBackPrefix for
+// that invariant pinned at the import layer), ApplyPlanLive must surface the
+// error and must NOT call Start — no Start expectation is set on lifecycleSrv,
+// so gomock fails the test if it's called. The pipeline is left stopped
+// (StopAndWait already ran, Start never does), matching the design doc's "never
+// auto-start into a half-applied or rolled-back state."
+//
+// This is the control-flow half of AC-6, NOT a real crash-recovery test. A true
+// SIGKILL-mid-apply test belongs to the Phase-2 chaos suite (see CLAUDE.md's
+// process-maturity table — chaos is not yet a live gate), so it is deliberately
+// deferred, not claimed here. Crash safety in PR1 rests on two things that ARE
+// verified: the DB-transaction atomicity of importPipeline (#2595, tested
+// separately) and StopAndWait's durable-checkpoint guarantee
+// (TestServiceLifecycle_StopAndWait_DrainsAndPersists); this test pins the
+// leave-stopped control flow on top of them.
 func TestApplyPlanLive_ImportFails_RunningPipeline_LeftStopped(t *testing.T) {
 	is := is.New(t)
 	ctx := context.Background()

--- a/pkg/provisioning/apply_plan_live_test.go
+++ b/pkg/provisioning/apply_plan_live_test.go
@@ -1,0 +1,330 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioning
+
+import (
+	"context"
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/connector"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/pipeline"
+	"github.com/conduitio/conduit/pkg/provisioning/config"
+	"github.com/conduitio/conduit/pkg/provisioning/mock"
+	"github.com/matryer/is"
+	"go.uber.org/mock/gomock"
+)
+
+// expectExportRunning is expectExport's counterpart for a RUNNING pipeline.
+// It can't reuse expectExport as-is: expectExport registers its own
+// AnyTimes() pipSrv.Get(gomock.Any(), cfg.ID) expectation returning a
+// non-running instance, and gomock's callSet.FindMatch resolves a method's
+// expected calls in registration order, returning the first match — so a
+// second, more specific Get expectation registered afterward (e.g. "running
+// this time") would never be reached; the first AnyTimes() wildcard always
+// wins. Every ApplyPlanLive test against a running pipeline therefore needs
+// its own single Get registration, already running, serving both Plan's
+// Export call and ApplyPlanLive's own running-status check.
+func expectExportRunning(pipSrv *mock.PipelineService, connSrv *mock.ConnectorService, procSrv *mock.ProcessorService, cfg config.Pipeline) *pipeline.Instance {
+	connIDs := make([]string, len(cfg.Connectors))
+	for i, c := range cfg.Connectors {
+		connIDs[i] = c.ID
+	}
+	procIDs := make([]string, len(cfg.Processors))
+	for i, p := range cfg.Processors {
+		procIDs[i] = p.ID
+	}
+
+	instance := &pipeline.Instance{
+		ID:           cfg.ID,
+		Config:       pipeline.Config{Name: cfg.Name, Description: cfg.Description},
+		ConnectorIDs: connIDs,
+		ProcessorIDs: procIDs,
+	}
+	if cfg.DLQ.WindowSize != nil && cfg.DLQ.WindowNackThreshold != nil {
+		instance.DLQ = pipeline.DLQ{
+			Plugin:              cfg.DLQ.Plugin,
+			Settings:            cfg.DLQ.Settings,
+			WindowSize:          *cfg.DLQ.WindowSize,
+			WindowNackThreshold: *cfg.DLQ.WindowNackThreshold,
+		}
+	}
+	instance.SetStatus(pipeline.StatusRunning)
+	pipSrv.EXPECT().Get(gomock.Any(), cfg.ID).Return(instance, nil).AnyTimes()
+
+	for _, c := range cfg.Connectors {
+		procIDsForConn := make([]string, len(c.Processors))
+		for i, p := range c.Processors {
+			procIDsForConn[i] = p.ID
+		}
+		connInstance := &connector.Instance{
+			ID:           c.ID,
+			Type:         connTypeOf(c.Type),
+			Plugin:       c.Plugin,
+			PipelineID:   cfg.ID,
+			Config:       connector.Config{Name: c.Name, Settings: c.Settings},
+			ProcessorIDs: procIDsForConn,
+		}
+		connSrv.EXPECT().Get(gomock.Any(), c.ID).Return(connInstance, nil).AnyTimes()
+		for _, p := range c.Processors {
+			procSrv.EXPECT().Get(gomock.Any(), p.ID).Return(processorInstanceFor(p), nil).AnyTimes()
+		}
+	}
+	for _, p := range cfg.Processors {
+		procSrv.EXPECT().Get(gomock.Any(), p.ID).Return(processorInstanceFor(p), nil).AnyTimes()
+	}
+
+	return instance
+}
+
+// settingsUpdateFixture returns an old/desired config.Pipeline pair whose
+// only difference is a single connector setting — the same EffectInPlace
+// shape as TestPlan_SettingsUpdate_InPlace — for tests that need *some*
+// non-empty diff against a running pipeline without the added complexity of
+// a restart-class (delete+create) change.
+func settingsUpdateFixture() (old, desired config.Pipeline) {
+	old = config.Pipeline{
+		ID:  "p1",
+		DLQ: dlqFixture(),
+		Connectors: []config.Connector{
+			{ID: "p1:conn:src", Type: config.TypeSource, Plugin: "builtin:postgres", Settings: map[string]string{"table": "users"}},
+		},
+	}
+	desired = old
+	desired.Connectors = []config.Connector{
+		{ID: "p1:conn:src", Type: config.TypeSource, Plugin: "builtin:postgres", Settings: map[string]string{"table": "orders_v2"}},
+	}
+	return old, desired
+}
+
+// TestApplyPlanLive_RunningPipeline_StopsAppliesRestarts is the regression
+// test for AC-3's control flow (the real drain-and-persist guarantee itself
+// is proven at the primitive level by
+// TestServiceLifecycle_StopAndWait_DrainsAndPersists in pkg/lifecycle):
+// against a running pipeline, ApplyPlanLive must call StopAndWait, then run
+// the import, then Start — in that order — rather than ApplyPlan's "refuse"
+// behavior.
+//
+// This also pins the scope decision documented on ApplyPlanLive: the diff
+// here is EffectInPlace-only (a connector settings change), yet ApplyPlanLive
+// still goes through the full stop-drain-restart because it doesn't branch on
+// Effect (see plan.go's "Scope decision" doc).
+func TestApplyPlanLive_RunningPipeline_StopsAppliesRestarts(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	srv, pipSrv, connSrv, procSrv, _, lifecycleSrv := newTestService(ctrl, log.Nop())
+
+	old, desired := settingsUpdateFixture()
+	expectExportRunning(pipSrv, connSrv, procSrv, old)
+
+	var order []string
+	lifecycleSrv.EXPECT().StopAndWait(gomock.Any(), "p1").DoAndReturn(func(context.Context, string) error {
+		order = append(order, "stop")
+		return nil
+	})
+	connSrv.EXPECT().Update(gomock.Any(), "p1:conn:src", "builtin:postgres", connector.Config{Settings: map[string]string{"table": "orders_v2"}}).
+		DoAndReturn(func(context.Context, string, string, connector.Config) (*connector.Instance, error) {
+			order = append(order, "import")
+			return &connector.Instance{ID: "p1:conn:src"}, nil
+		})
+	lifecycleSrv.EXPECT().Start(gomock.Any(), "p1").DoAndReturn(func(context.Context, string) error {
+		order = append(order, "start")
+		return nil
+	})
+
+	diff, err := srv.Plan(ctx, desired)
+	is.NoErr(err)
+	is.True(!diff.Empty())
+	is.Equal(diff.Changes[0].Effect, EffectInPlace) // sanity: this is the in-place-only case
+
+	applied, err := srv.ApplyPlanLive(ctx, desired, diff.Hash)
+	is.NoErr(err)
+	is.Equal(applied.Hash, diff.Hash)
+	is.Equal(order, []string{"stop", "import", "start"})
+}
+
+// TestApplyPlanLive_StoppedPipeline_NoLifecycleCalls confirms ApplyPlanLive
+// behaves exactly like ApplyPlan when the pipeline isn't running: no
+// StopAndWait/Start expectation is set on lifecycleSrv, so gomock fails the
+// test if ApplyPlanLive calls either.
+func TestApplyPlanLive_StoppedPipeline_NoLifecycleCalls(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	srv, pipSrv, _, _, _, _ := newTestService(ctrl, log.Nop())
+
+	desired := config.Pipeline{ID: "p1", Name: "orders", DLQ: dlqFixture()}
+
+	pipSrv.EXPECT().Get(gomock.Any(), "p1").Return(nil, pipeline.ErrInstanceNotFound).AnyTimes()
+	pipSrv.EXPECT().Create(gomock.Any(), "p1", gomock.Any(), pipeline.ProvisionTypeConfig).
+		Return(&pipeline.Instance{ID: "p1"}, nil)
+	pipSrv.EXPECT().UpdateDLQ(gomock.Any(), "p1", gomock.Any()).Return(&pipeline.Instance{ID: "p1"}, nil)
+
+	diff, err := srv.Plan(ctx, desired)
+	is.NoErr(err)
+
+	applied, err := srv.ApplyPlanLive(ctx, desired, diff.Hash)
+	is.NoErr(err)
+	is.Equal(applied.Hash, diff.Hash)
+}
+
+// TestApplyPlanLive_Idempotent_NoOp is the regression test for AC-8's
+// live-apply counterpart: an empty diff against a running pipeline is a
+// no-op, and — just like ApplyPlan — skips the running-pipeline handling
+// entirely, so no StopAndWait/Start call happens (no expectation is set).
+func TestApplyPlanLive_Idempotent_NoOp(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	srv, pipSrv, connSrv, procSrv, _, _ := newTestService(ctrl, log.Nop())
+
+	current := config.Pipeline{ID: "p1", Name: "orders", DLQ: dlqFixture()}
+	expectExportRunning(pipSrv, connSrv, procSrv, current)
+
+	diff, err := srv.Plan(ctx, current)
+	is.NoErr(err)
+	is.True(diff.Empty())
+
+	applied, err := srv.ApplyPlanLive(ctx, current, diff.Hash)
+	is.NoErr(err)
+	is.True(applied.Empty())
+}
+
+// TestApplyPlanLive_StaleHash_RefusedNoMutation_RunningPipeline is the
+// regression test for AC-4 against a running pipeline: a stale hash is
+// refused with CodePlanStale before ApplyPlanLive even checks whether the
+// pipeline is running, let alone calls StopAndWait — no expectation is set on
+// lifecycleSrv, connSrv, or procSrv, so gomock fails the test if anything
+// more is attempted.
+func TestApplyPlanLive_StaleHash_RefusedNoMutation_RunningPipeline(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	srv, pipSrv, connSrv, procSrv, _, _ := newTestService(ctrl, log.Nop())
+
+	desired := config.Pipeline{ID: "p1", Name: "orders", DLQ: dlqFixture()}
+	expectExportRunning(pipSrv, connSrv, procSrv, desired)
+
+	_, err := srv.ApplyPlanLive(ctx, desired, "not-a-real-hash")
+	is.True(err != nil)
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code.Reason(), CodePlanStale.Reason())
+}
+
+// TestApplyPlanLive_ImportFails_RunningPipeline_LeftStopped is the regression
+// test for AC-5/AC-6 against a running pipeline: once StopAndWait has
+// succeeded, the pipeline is stopped. If the transactional import then fails
+// (importPipeline's own reverse rollback already ran — see
+// TestApplyPlan_PartialFailure_RollsBackPrefix for that invariant pinned at
+// the import layer), ApplyPlanLive must surface the error and must NOT call
+// Start — no Start expectation is set on lifecycleSrv, so gomock fails the
+// test if it's called. The pipeline is left stopped (StopAndWait already ran,
+// Start never does), matching the design doc's "never auto-start into a
+// half-applied or rolled-back state."
+func TestApplyPlanLive_ImportFails_RunningPipeline_LeftStopped(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	srv, pipSrv, connSrv, procSrv, _, lifecycleSrv := newTestService(ctrl, log.Nop())
+
+	old, desired := settingsUpdateFixture()
+	expectExportRunning(pipSrv, connSrv, procSrv, old)
+
+	lifecycleSrv.EXPECT().StopAndWait(gomock.Any(), "p1").Return(nil)
+
+	wantErr := cerrors.New("forced connector update failure")
+	// Do (new settings) fails; importPipeline then rolls back the failed
+	// action too (see import.go's importPipeline: rollbackActions includes
+	// the failed action itself), which retries Update with the old settings —
+	// a second, distinct call to the same method, so it needs its own
+	// expectation.
+	connSrv.EXPECT().Update(gomock.Any(), "p1:conn:src", "builtin:postgres", connector.Config{Settings: map[string]string{"table": "orders_v2"}}).
+		Return(nil, wantErr)
+	connSrv.EXPECT().Update(gomock.Any(), "p1:conn:src", "builtin:postgres", connector.Config{Settings: map[string]string{"table": "users"}}).
+		Return(&connector.Instance{ID: "p1:conn:src"}, nil)
+	// No lifecycleSrv.EXPECT().Start(...) — gomock fails the test if apply
+	// attempts to restart after a failed import.
+
+	diff, err := srv.Plan(ctx, desired)
+	is.NoErr(err)
+
+	_, err = srv.ApplyPlanLive(ctx, desired, diff.Hash)
+	is.True(err != nil) // the import failure must be surfaced, not swallowed
+}
+
+// TestApplyPlanLive_RestartFails_LeftStoppedWithNewConfig is the regression
+// test for the design doc's "Restart failure" failure mode: the import
+// commits successfully (the new config is durable), but Start itself then
+// fails — e.g. because the new plugin path is bad. ApplyPlanLive must surface
+// that error clearly (rather than silently dropping it or retrying) and must
+// leave the pipeline stopped with the new config already applied; it must not
+// attempt a second Start.
+func TestApplyPlanLive_RestartFails_LeftStoppedWithNewConfig(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	srv, pipSrv, connSrv, procSrv, _, lifecycleSrv := newTestService(ctrl, log.Nop())
+
+	old, desired := settingsUpdateFixture()
+	expectExportRunning(pipSrv, connSrv, procSrv, old)
+
+	lifecycleSrv.EXPECT().StopAndWait(gomock.Any(), "p1").Return(nil)
+	connSrv.EXPECT().Update(gomock.Any(), "p1:conn:src", "builtin:postgres", gomock.Any()).
+		Return(&connector.Instance{ID: "p1:conn:src"}, nil)
+
+	wantErr := cerrors.New("forced start failure: bad plugin path")
+	lifecycleSrv.EXPECT().Start(gomock.Any(), "p1").Return(wantErr)
+
+	diff, err := srv.Plan(ctx, desired)
+	is.NoErr(err)
+
+	_, err = srv.ApplyPlanLive(ctx, desired, diff.Hash)
+	is.True(err != nil)
+	is.True(cerrors.Is(err, wantErr)) // the restart failure must still be reachable in the chain
+}
+
+// TestApplyPlanLive_StopAndWaitFails_NoMutation proves ApplyPlanLive never
+// attempts to mutate the pipeline's stored config if StopAndWait itself
+// fails. This is also the generic mechanism behind the lifecycle-poc parity
+// guard (pkg/lifecycle-poc.Service.StopAndWait always returns
+// CodeStopAndWaitUnsupported): ApplyPlanLive needs no poc-specific branch —
+// whatever error StopAndWait returns, for whatever reason, is surfaced here
+// and nothing downstream runs. No Create/Update/Delete/Start expectation is
+// set on any mock, so gomock fails the test if apply attempts anything beyond
+// StopAndWait itself.
+func TestApplyPlanLive_StopAndWaitFails_NoMutation(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	srv, pipSrv, connSrv, procSrv, _, lifecycleSrv := newTestService(ctrl, log.Nop())
+
+	old, desired := settingsUpdateFixture()
+	expectExportRunning(pipSrv, connSrv, procSrv, old)
+
+	wantErr := conduiterr.New(CodePlanStale, "stand-in for lifecycle_v2.CodeStopAndWaitUnsupported")
+	lifecycleSrv.EXPECT().StopAndWait(gomock.Any(), "p1").Return(wantErr)
+
+	diff, err := srv.Plan(ctx, desired)
+	is.NoErr(err)
+
+	_, err = srv.ApplyPlanLive(ctx, desired, diff.Hash)
+	is.True(err != nil)
+	is.True(cerrors.Is(err, wantErr))
+}

--- a/pkg/provisioning/interfaces.go
+++ b/pkg/provisioning/interfaces.go
@@ -74,4 +74,10 @@ type ConnectorPluginService interface {
 type LifecycleService interface {
 	Start(ctx context.Context, pipelineID string) error
 	Stop(ctx context.Context, pipelineID string, force bool) error
+	// StopAndWait gracefully stops the pipeline and blocks until it has fully
+	// drained and its connectors' positions are durably persisted — see
+	// lifecycle.Service.StopAndWait's doc. ApplyPlanLive relies on this
+	// (rather than Stop) to know it is safe to mutate a running pipeline's
+	// stored config; see docs/design-documents/20260708-live-server-deploy-apply.md.
+	StopAndWait(ctx context.Context, pipelineID string) error
 }

--- a/pkg/provisioning/mock/provisioning.go
+++ b/pkg/provisioning/mock/provisioning.go
@@ -1108,3 +1108,41 @@ func (c *LifecycleServiceStopCall) DoAndReturn(f func(context.Context, string, b
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// StopAndWait mocks base method.
+func (m *LifecycleService) StopAndWait(ctx context.Context, pipelineID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StopAndWait", ctx, pipelineID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StopAndWait indicates an expected call of StopAndWait.
+func (mr *LifecycleServiceMockRecorder) StopAndWait(ctx, pipelineID any) *LifecycleServiceStopAndWaitCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopAndWait", reflect.TypeOf((*LifecycleService)(nil).StopAndWait), ctx, pipelineID)
+	return &LifecycleServiceStopAndWaitCall{Call: call}
+}
+
+// LifecycleServiceStopAndWaitCall wrap *gomock.Call
+type LifecycleServiceStopAndWaitCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *LifecycleServiceStopAndWaitCall) Return(arg0 error) *LifecycleServiceStopAndWaitCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *LifecycleServiceStopAndWaitCall) Do(f func(context.Context, string) error) *LifecycleServiceStopAndWaitCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *LifecycleServiceStopAndWaitCall) DoAndReturn(f func(context.Context, string) error) *LifecycleServiceStopAndWaitCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}

--- a/pkg/provisioning/plan.go
+++ b/pkg/provisioning/plan.go
@@ -27,8 +27,17 @@
 // Invariant 7 (graceful shutdown / no silent mutation of live work): ApplyPlan
 // refuses to run against a pipeline that is currently running rather than
 // attempting an in-process stop-drain-restart (see the design doc's Failure
-// modes, option (a)) — the safe Wave-2 default. Callers that want to apply a
-// restart-class change to a running pipeline must stop it first.
+// modes, option (a)) — the safe Wave-2 default for the standalone (no live
+// lifecycle) case. Callers that want to apply a restart-class change to a
+// running pipeline via ApplyPlan must stop it first.
+//
+// ApplyPlanLive (added for issue #2588, see
+// docs/design-documents/20260708-live-server-deploy-apply.md) is the
+// live-server counterpart used only where a running lifecycle.Service is
+// available: instead of refusing, it drives lifecycleService.StopAndWait to
+// gracefully drain and durably checkpoint the pipeline before reusing the
+// same importPipeline path, then restarts it. ApplyPlan itself is unchanged
+// and keeps refusing running pipelines — it has no lifecycle to drive.
 package provisioning
 
 import (
@@ -237,27 +246,159 @@ func (s *Service) ApplyPlan(ctx context.Context, desired config.Pipeline, hash s
 		return fresh, ce
 	}
 
-	// Wrap the apply in a single DB transaction, exactly as provisionPipeline
-	// does (service.go). Without it, importPipeline's actions each commit their
-	// own writes (and a single action can write more than once, e.g.
-	// createPipelineAction does Create then UpdateDLQ), so a crash — or an error
-	// whose in-process reverse rollback itself fails — could leave the store
-	// partially mutated with no recovery on restart. The transaction makes apply
-	// all-or-nothing: on any error we return before Commit and the deferred
-	// Discard drops every write. Invariant 5: state writes are atomic.
+	if err := s.transactionalImport(ctx, desired); err != nil {
+		return fresh, err
+	}
+	return fresh, nil
+}
+
+// transactionalImport wraps importPipeline in a single DB transaction, exactly
+// as provisionPipeline does (service.go). Without it, importPipeline's actions
+// each commit their own writes (and a single action can write more than once,
+// e.g. createPipelineAction does Create then UpdateDLQ), so a crash — or an
+// error whose in-process reverse rollback itself fails — could leave the store
+// partially mutated with no recovery on restart. The transaction makes the
+// import all-or-nothing: on any error this returns before Commit and the
+// deferred Discard drops every write. Invariant 5: state writes are atomic.
+//
+// Shared by ApplyPlan and ApplyPlanLive so the two apply paths can't drift on
+// crash-safety — see docs/design-documents/20260708-live-server-deploy-apply.md,
+// "Review outcome & required rework", blocker 2 (landed as #2595).
+func (s *Service) transactionalImport(ctx context.Context, desired config.Pipeline) error {
 	txn, importCtx, err := s.db.NewTransaction(ctx, true)
 	if err != nil {
-		return fresh, cerrors.Errorf("could not create db transaction: %w", err)
+		return cerrors.Errorf("could not create db transaction: %w", err)
 	}
 	defer txn.Discard()
 
 	if err := s.importPipeline(importCtx, desired, pipeline.ProvisionTypeConfig); err != nil {
-		return fresh, err
+		return err
 	}
 
 	if err := txn.Commit(); err != nil {
-		return fresh, cerrors.Errorf("could not commit db transaction: %w", err)
+		return cerrors.Errorf("could not commit db transaction: %w", err)
 	}
+	return nil
+}
+
+// ApplyPlanLive is ApplyPlan's Tier-1 live-server counterpart (design doc §2,
+// as reworked): it recomputes and hash-verifies the plan exactly like
+// ApplyPlan, but where ApplyPlan refuses a running pipeline outright,
+// ApplyPlanLive drives the pipeline's own lifecycle to apply the change
+// safely:
+//
+//  1. If the pipeline is not currently running (or does not exist yet), this
+//     is identical to ApplyPlan's tail: transactionalImport and return. There
+//     is nothing live to disrupt.
+//  2. If the pipeline is running, ApplyPlanLive calls
+//     lifecycleService.StopAndWait (never Stop — see that method's doc for
+//     why: only StopAndWait proves the pipeline has fully drained AND its
+//     positions are durably persisted before anything mutates it).
+//  3. Once StopAndWait returns, transactionalImport runs exactly as in step 1
+//     — the pipeline is now stopped and quiescent, so this is safe.
+//  4. Only if the import commits does ApplyPlanLive call
+//     lifecycleService.Start to resume the pipeline under the new config,
+//     which resumes from the checkpointed position each connector's Open
+//     reads on startup (invariant 2: at-least-once).
+//
+// Failure handling (design doc "Failure modes" + AC-5/AC-6): on any error
+// after StopAndWait — whether the import fails (importPipeline's own reverse
+// rollback already ran, see import.go) or Start itself fails — ApplyPlanLive
+// returns the error and does NOT attempt to (re)start the pipeline. It is
+// left stopped rather than auto-started into a half-applied or just-rolled-
+// back state; an operator/agent can inspect the error and retry Start
+// explicitly once they've confirmed the pipeline's state. This is the
+// property that makes a crash between StopAndWait and Start (or mid-import)
+// recoverable: the transaction (step 3) makes the store consistent
+// (all-or-nothing), the pipeline is left stopped either way, and a subsequent
+// Start — whenever it happens — resumes from the last durable checkpoint.
+//
+// Scope decision (design doc §2, left open there — "may still stop-restart
+// for safety"): ApplyPlanLive does NOT branch on individual Changes' Effect
+// (EffectInPlace vs EffectRestart) — every non-empty Diff against a running
+// pipeline goes through the full stop-drain-restart, even a diff that is
+// EffectInPlace-only (e.g. a connector settings change). A finer-grained "no
+// stop needed for in-place-only changes" optimization is explicitly deferred
+// to true in-place hot-reload (§4 of the design doc, out of scope for
+// #2588 PR1): inventing a narrower classifier here, ahead of that design
+// work, risks silently under-draining a change that looks in-place but isn't
+// (see the design doc's Item 6 rework, which made the same conservative call
+// for the operator-authorization gate).
+func (s *Service) ApplyPlanLive(ctx context.Context, desired config.Pipeline, hash string) (Diff, error) {
+	fresh, err := s.Plan(ctx, desired)
+	if err != nil {
+		return Diff{}, err
+	}
+
+	if fresh.Hash != hash {
+		ce := conduiterr.New(CodePlanStale, fmt.Sprintf(
+			"plan for pipeline %q is stale: the presented hash %q does not match the current plan hash %q; "+
+				"the config file or the live pipeline state changed since the plan was computed", desired.ID, hash, fresh.Hash))
+		ce.Suggestion = "re-run 'conduit pipelines deploy' to compute a fresh plan, review it, then apply its hash"
+		return fresh, ce
+	}
+
+	if fresh.Empty() {
+		// Idempotent: desired already matches current state. Nothing to apply,
+		// so there is nothing that could disrupt a live pipeline here either.
+		return fresh, nil
+	}
+
+	current, err := s.pipelineService.Get(ctx, desired.ID)
+	if err != nil && !cerrors.Is(err, pipeline.ErrInstanceNotFound) {
+		return fresh, cerrors.Errorf("could not check whether pipeline %v is running: %w", desired.ID, err)
+	}
+	running := err == nil && isRunningStatus(current.GetStatus())
+
+	if !running {
+		// Nothing live to disrupt — identical to ApplyPlan's tail.
+		if err := s.transactionalImport(ctx, desired); err != nil {
+			return fresh, err
+		}
+		return fresh, nil
+	}
+
+	// Invariant 7 / Tier-1 safety: StopAndWait — not Stop — is the only
+	// primitive that proves the pipeline is fully drained and its positions
+	// are durably persisted before importPipeline runs against it. See
+	// lifecycle.Service.StopAndWait's doc and the design doc's blocker 1.
+	//
+	// KNOWN GAP (flagged, not fixed, in PR1 of #2588 — see the design doc's
+	// Failure modes, "Concurrent applies / apply-during-manual-stop", which
+	// calls for a per-pipeline provisioning lock this method does not yet
+	// take): between StopAndWait returning and transactionalImport/Start
+	// below, nothing prevents a concurrent caller from independently calling
+	// Start on this now-genuinely-stopped pipeline. If that happens, this
+	// method's own Start call below fails (Start refuses an
+	// already-running pipeline), the store nonetheless already has the new
+	// config (transactionalImport committed), and the concurrently-started
+	// pipeline keeps running with the connector instances it loaded before
+	// the mutation — a config-drift condition (not a data-loss one:
+	// invariants 1-3 aren't violated) until it's stopped and started again.
+	// Not reachable from outside this package in PR1 (no API/CLI/MCP surface
+	// calls ApplyPlanLive yet), so there is no live exploitability today —
+	// but a per-pipeline lock belongs in or before whichever PR first exposes
+	// this method to concurrent external callers (tracked for PR2).
+	if err := s.lifecycleService.StopAndWait(ctx, desired.ID); err != nil {
+		return fresh, cerrors.Errorf("could not stop pipeline %q to apply live changes: %w", desired.ID, err)
+	}
+
+	if err := s.transactionalImport(ctx, desired); err != nil {
+		// The pipeline is already stopped (StopAndWait above) and the
+		// transaction guarantees the store wasn't left partially mutated
+		// (invariant 5). Leave it stopped — do not attempt to restart into a
+		// half-applied or rolled-back state — and surface the error as-is.
+		return fresh, err
+	}
+
+	if err := s.lifecycleService.Start(ctx, desired.ID); err != nil {
+		// The new config is already durably committed; only the restart
+		// failed. Leave the pipeline stopped with the valid new config and
+		// surface the error so an operator/agent can retry Start once the
+		// underlying issue (e.g. a bad plugin path) is resolved.
+		return fresh, cerrors.Errorf("pipeline %q was updated but failed to restart, it remains stopped with the new config: %w", desired.ID, err)
+	}
+
 	return fresh, nil
 }
 
@@ -268,6 +409,24 @@ func (s *Service) ApplyPlan(ctx context.Context, desired config.Pipeline, hash s
 // or having partially failed into, an error), so the same invariant-7
 // concern applies — only a pipeline a human/system has actually stopped
 // (StatusUserStopped, StatusSystemStopped) is safe to mutate.
+//
+// KNOWN GAP (pre-existing, not introduced by ApplyPlanLive, flagged during
+// its review): a pipeline that reached StatusDegraded via a fatal error (or
+// exhausted error-recovery retries) has, by the time that status is visible
+// here, already removed itself from lifecycle.Service's runningPipelines —
+// see Service.runPipeline's cleanup goroutine in pkg/lifecycle/service.go,
+// which calls UpdateStatus(StatusDegraded, ...) and runningPipelines.Delete
+// in the same terminal step. So isRunningStatus correctly reports "true"
+// (there was live work, and the pipeline needs an explicit decision before
+// being mutated) but StopAndWait/Stop then fails with
+// pipeline.ErrPipelineNotRunning against that same pipeline, since it is no
+// longer registered as running. ApplyPlan has the identical dead end today
+// (refuses with CodePipelineRunning, but the suggested fix — "stop the
+// pipeline first" — also fails for the same reason). Fixing this requires
+// either excluding StatusDegraded here or making Stop/StopAndWait tolerant of
+// an already-self-stopped Degraded pipeline; out of scope for this change,
+// surfaced for an explicit decision rather than silently left as a
+// non-obvious dead end.
 func isRunningStatus(status pipeline.Status) bool {
 	switch status {
 	case pipeline.StatusRunning, pipeline.StatusRecovering, pipeline.StatusDegraded:


### PR DESCRIPTION
## Summary

**Risk tier: Tier 1 (data path). Needs human sign-off — do not merge on this review alone.**

**PR1 of the #2588 arc** (live-server apply to a running pipeline). Scope is the **engine only**: no API RPCs, no CLI/MCP wiring — that's PR2. Implements the corrected design from `docs/design-documents/20260708-live-server-deploy-apply.md`, specifically the **"Review outcome & required rework"** section (the Tier-1 design review found the original §2 raced an in-flight drain).

- `lifecycle.Service.StopAndWait(ctx, id) error` — `Stop(ctx,id,false)` → `WaitPipeline(id)` (all node goroutines exited, i.e. genuinely drained — not just "stop signal injected") → `connectors.WaitPersisted()` (blocks until the connector position/state flush that draining triggered is durably committed). Only after all three does it return.
- `provisioning.Service.ApplyPlanLive(ctx, desired, hash) (Diff, error)` — like `ApplyPlan` (recompute+verify hash → `plan_stale`; empty diff → no-op) but for a **running** pipeline: `StopAndWait` → `transactionalImport` (the `#2595` transactional path, factored out so `ApplyPlan` and `ApplyPlanLive` share it) → `Start`. Any error after `StopAndWait` leaves the pipeline **stopped** — never auto-restarted into a half-applied state. For a stopped pipeline, it's identical to `ApplyPlan`'s tail. The standalone `ApplyPlan` is **unchanged** and still refuses running pipelines outright (it has no lifecycle to drive).
- `pkg/lifecycle-poc` (the `Preview.PipelineArchV2` / funnel arch) gets a `StopAndWait` that **always refuses** with a coded error (`lifecycle_v2.stop_and_wait_unsupported`). Its Stop/drain semantics haven't had the audit `pkg/lifecycle`'s got in the design review — silently building on an unaudited stop path would reintroduce the exact class of bug the review found. `ApplyPlanLive` needs no poc-specific branch: whatever `StopAndWait` returns is surfaced as-is.

## How StopAndWait awaits durability

`connector.Persister.Wait()` (existing) blocks on `connWg` (every connector across the whole process reaching `ConnectorStopped`) **and** `flushWg`. Using it from a single pipeline's stop-and-drain path would deadlock for as long as *any other* pipeline stays running, since the persister batches writes across all pipelines.

New `Persister.WaitPendingWrites()` blocks **only** on `flushWg` — the flush(es) already triggered. A connector's own `Teardown` → `ConnectorStopped` → `triggerFlush` increments `flushWg` *synchronously* before returning, and that happens strictly before `SourceNode.Run()` returns (Teardown is called from `Run`'s deferred cleanup, after `openMsgTracker.Wait()` — i.e. after every in-flight message has been acked end-to-end), which is strictly before `WaitPipeline` unblocks. So by the time `StopAndWait` calls `WaitPersisted`, the flush for this pipeline's connectors has already been triggered, and `flushWg.Wait()` is guaranteed to observe it complete (`sync.WaitGroup` can't miss an `Add` that happened-before the `Wait` call). `connector.Service.WaitPersisted()` exposes this via the connector service already held by the lifecycle service — no persister handle is passed to provisioning, per the design doc.

## Test results

**Drain-no-loss (AC-3)** — `TestServiceLifecycle_StopAndWait_DrainsAndPersists` (`pkg/lifecycle`): runs a real pipeline (mocked plugins, real node goroutines, real `connector.Persister`, real `inmemory.DB` wrapped in a `delayingDB` that adds a 200ms delay to every `NewTransaction`, so a `StopAndWait` that returned early would deterministically read stale/missing state, not just flake). Asserts `StopAndWait` blocks for at least the flush delay and that the source's position, read directly back from the store, matches the last record. **Verified this test actually catches the regression**: temporarily removed the `WaitPersisted()` call from `StopAndWait` — the test failed immediately (not flakily); restored — it passes. `-race -count=20`: clean, no flakes.

**Kill-mid-apply (AC-6) / restart-failure / rollback** — proxied at the `provisioning` control-flow layer (real SIGKILL chaos infra isn't live yet per `CLAUDE.md`'s Process maturity table — "Chaos suite nightly — by Phase 2"), since the actual durability guarantee is proven at the `lifecycle` layer above and `#2595`'s transaction already proves the store is all-or-nothing:
  - `TestApplyPlanLive_ImportFails_RunningPipeline_LeftStopped` — import fails after `StopAndWait` succeeds → `Start` is never called (no mock expectation set, so gomock fails the test if it is) → error surfaced.
  - `TestApplyPlanLive_RestartFails_LeftStoppedWithNewConfig` — import commits, `Start` fails → error surfaced, pipeline left stopped with the new (valid) config, matching the design doc's "Restart failure" mode.
  - `TestApplyPlanLive_StopAndWaitFails_NoMutation` — `StopAndWait` itself fails → **no** Create/Update/Delete/Start call happens at all (this is also the generic mechanism the lifecycle-poc guard relies on).

**Stale-hash / rollback / running-left-stopped** — `TestApplyPlanLive_StaleHash_RefusedNoMutation_RunningPipeline` (AC-4), `TestApplyPlanLive_RunningPipeline_StopsAppliesRestarts` (AC-3 control-flow: asserts call order `stop → import → start`), `TestApplyPlanLive_StoppedPipeline_NoLifecycleCalls` / `TestApplyPlanLive_Idempotent_NoOp` (confirms parity with `ApplyPlan` and that no lifecycle calls happen when there's nothing live to disrupt).

**Lifecycle-poc parity** — `TestServiceLifecycle_StopAndWait_Unsupported` pins the refusal + its error code.

**Standalone `ApplyPlan` still refuses running pipelines** — unchanged, `TestApplyPlan_RunningPipeline_Refused` still passes.

`-count=20 -race` on both the `pkg/lifecycle` `StopAndWait` tests and the `pkg/provisioning` `ApplyPlanLive` tests: clean, no flakes. Full targeted suite (`./pkg/lifecycle/... ./pkg/lifecycle-poc/... ./pkg/provisioning/... ./pkg/connector/...`) green under `-race`. Full repo `go test ./...` green. `golangci-lint run ./pkg/lifecycle/... ./pkg/lifecycle-poc/... ./pkg/provisioning/... ./pkg/connector/... ./pkg/conduit/...`: 0 issues. `go generate ./...`: clean (only the expected `pkg/provisioning/mock/provisioning.go` diff, +`StopAndWait`).

## Adversarial self-review findings

1. **Does `StopAndWait` actually achieve quiescence+durability, and is there a window where `importPipeline` runs against a not-fully-stopped pipeline?** Traced the full happens-before chain: `Stop` injects → `SourceNode.Run`'s `openMsgTracker.Wait()` blocks until every in-flight message is acked end-to-end (pre-existing drain machinery) → deferred `Source.Teardown()` runs (still inside `Run`, before it returns) → `Teardown` calls `persister.ConnectorStopped()` → `triggerFlush` synchronously increments `flushWg` before `Run()` can return → node's `nodesWg.Done()` → `WaitPipeline`'s `tomb.Wait()` unblocks only after this → `WaitPersisted`/`flushWg.Wait()` is guaranteed to observe the already-incremented counter. No window found where `transactionalImport` can run before the pipeline is both drained and its position writes are durable.
2. **Doc-comment bug** — caught a stray blank line that would have detached `ApplyPlanLive`'s doc comment from the function in `go doc`. Fixed; verified with `go doc`.
3. **Regression-test validity** — didn't just trust the durability test; deliberately broke `StopAndWait` (removed the `WaitPersisted` call) and confirmed the test fails hard, then confirmed it passes again after restoring.
4. **`Persister.WaitPendingWrites` has no timeout/ctx** — inherited from the existing `Persister.Wait()`'s design (also no ctx, used unconditionally at process shutdown), not a new gap. A stuck store write for an *unrelated* pipeline could in principle block another pipeline's `StopAndWait` indefinitely, since the persister batches across all pipelines. Flagged, not fixed — would be scope creep for PR1 and is a pre-existing characteristic of the shared persister.
5. **No per-pipeline provisioning lock** — the design doc's Failure modes list "Concurrent applies / apply-during-manual-stop" as needing one; `ApplyPlanLive` doesn't take one. Between `StopAndWait` returning and `transactionalImport`/`Start`, a concurrent caller could independently `Start` the now-stopped pipeline, causing a config-drift (not data-loss — invariants 1-3 hold) condition. **Not reachable in PR1** — no API/CLI/MCP surface calls `ApplyPlanLive` yet. Flagged in code comments and here; belongs in or before whichever PR (likely PR2) first exposes this to concurrent external callers.
6. **Pre-existing `isRunningStatus`/`StatusDegraded` dead end** — a `Degraded` pipeline has already removed itself from `lifecycle.Service.runningPipelines` by the time its status is visible (see `runPipeline`'s cleanup goroutine), so `isRunningStatus` correctly reports it as "needs an explicit decision" but `StopAndWait`/`Stop` then fails with `ErrPipelineNotRunning` against it — a dead end. This is **identical, pre-existing behavior in `ApplyPlan`** (not introduced here); flagged in a code comment for an explicit decision rather than left as silent archaeology.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/lifecycle/... ./pkg/lifecycle-poc/... ./pkg/provisioning/... ./pkg/connector/... -race -count=1` — green
- [x] `go test ./pkg/lifecycle/... -run TestServiceLifecycle_StopAndWait -race -count=20` — green, no flakes
- [x] `go test ./pkg/provisioning/... -run TestApplyPlanLive -race -count=20` — green, no flakes
- [x] `go test ./... -count=1` (full repo) — green
- [x] `golangci-lint run` on all touched packages — 0 issues (36 pre-existing issues elsewhere in the repo, verified unrelated via `git stash -u`)
- [x] `go generate ./...` — clean, only the expected mock regen
- [x] Manually verified the new durability test fails without the fix and passes with it

## Roadmap

Phase 1/2 execution plan item: live-server deploy/apply (issue #2588), engine primitives half of the arc. PR2 will add the `PlanPipeline`/`ApplyPipeline` API RPCs, CLI/MCP live-server-preferred client logic, and the enforced operator-authorization gate for data-path applies to running pipelines (design doc §3-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tapg9dLWXKMZJoL65R24vd

---
## Tier-1 review outcome (SOUND-WITH-CONCERNS) + follow-ups

An independent Tier-1 data-integrity review **verified the core safety case in the code** (not just the comments): every link of the StopAndWait happens-before chain checks out — `WaitPipeline` unblocks only after all node goroutines incl. source `Teardown`; `openMsgTracker.Wait()` blocks teardown until every in-flight record is acked end-to-end; the position `Persist` happens-before the tracker decrement (reverse-order status handlers); `ConnectorStopped`→`triggerFlush`→`flushWg.Add(1)` runs synchronously before `Run` returns; and `WaitPersisted`(`flushWg`) is the correct durability wait (the post-WaitPipeline call ordering eliminates the buffered-but-not-triggered window). **No window found where a mutation races the drain** (invariants 1/3 upheld). `ApplyPlanLive` failure handling (leave-stopped, no auto-restart, transactional), the poc guard, and the `delayingDB` durability test (fails without `WaitPersisted`) all CONFIRMED.

**Concerns (documentation/process, addressed / tracked — not code):**
1. **AC-6 crash-recovery is deferred, not claimed** — corrected the test comment: what's delivered is the txn atomicity (#2595) + StopAndWait durable checkpoint + the leave-stopped control flow; a real SIGKILL test is Phase-2 chaos (per CLAUDE.md's maturity table).
2. **Per-pipeline provisioning lock is a HARD GATE on PR2** — `ApplyPlanLive` has no external caller in PR1 (verified), so the concurrent-Start / `!running` TOCTOU is unreachable now; it must land in PR2 (the API/CLI/MCP surface) before external exposure.
3. Minor deferrable: the `isRunningStatus`/`StatusDegraded` dead-end (fails closed, safe, pre-existing shared with `ApplyPlan`).