### PR TITLE
feat(mcp): harden HTTP transport (help text, auth logging, timeouts, bind warning) (§2)

### DIFF
--- a/cmd/conduit/root/mcp/http.go
+++ b/cmd/conduit/root/mcp/http.go
@@ -15,14 +15,17 @@
 package mcp
 
 import (
+	"context"
 	"crypto/subtle"
 	"crypto/tls"
+	"net"
 	"net/http"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/foundation/log"
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -36,7 +39,14 @@ const bearerPrefix = "Bearer "
 // transport that needs no auth (the agent owns that process); HTTP may be
 // reachable by anyone who can open a socket to it, so it never serves
 // without both checks passing.
-func (c *MCPCommand) newHTTPServer(srv *sdkmcp.Server) (*http.Server, error) {
+//
+// logger is used for the H-2/H-4 hardening additions (design doc
+// 20260712-mcp-http-transport.md, §Hardening plan): a startup line naming
+// the bound address and auth mode, a warning if the bind address is not
+// loopback-restricted, and (via newMCPHTTPHandler) a log line per rejected
+// auth attempt. Never pass anything derived from the token itself to logger
+// — see requireBearerToken's invariant comment (AC-8).
+func (c *MCPCommand) newHTTPServer(srv *sdkmcp.Server, logger log.CtxLogger) (*http.Server, error) {
 	if err := validateHTTPConfig(c.flags); err != nil {
 		return nil, err
 	}
@@ -51,11 +61,24 @@ func (c *MCPCommand) newHTTPServer(srv *sdkmcp.Server) (*http.Server, error) {
 		return nil, conduiterr.Wrap(conduiterr.CodeInvalidArgument, "could not load --tls-cert/--tls-key", err)
 	}
 
+	// H-4: TLS + a bearer token make a non-loopback bind *safe*, but a
+	// surprised operator exposing the MCP endpoint (a mutation-capable
+	// surface when --allow-mutations is set) to the network unintentionally
+	// is a real failure mode — surface it at startup instead of staying
+	// silent.
+	warnIfNonLoopback(logger, c.flags.HTTP)
+
 	// Bound the request body: a tool call carries a pipeline config (KBs), so a
 	// few MiB is generous. Without this an authenticated client could post an
 	// arbitrarily large body that is buffered/parsed in memory (a DoS vector,
 	// blast-radius-limited to token holders, but cheap to close).
-	handler := limitRequestBody(newMCPHTTPHandler(srv, token), maxRequestBodyBytes)
+	handler := limitRequestBody(newMCPHTTPHandler(srv, token, logger), maxRequestBodyBytes)
+
+	logger.Info(context.Background()).
+		Str("addr", c.flags.HTTP).
+		Str("auth", "bearer").
+		Bool("tls", true).
+		Msg("serving MCP over streamable HTTP")
 
 	return &http.Server{
 		Addr:      c.flags.HTTP,
@@ -65,7 +88,49 @@ func (c *MCPCommand) newHTTPServer(srv *sdkmcp.Server) (*http.Server, error) {
 		// request headers (a Slowloris-style attack) — required on any
 		// http.Server exposed beyond localhost.
 		ReadHeaderTimeout: 10 * time.Second,
+		// IdleTimeout (H-3) bounds how long a keep-alive connection may sit
+		// idle between requests. Streamable HTTP can hold a response open
+		// while streaming, so a blanket WriteTimeout would be wrong (it
+		// would sever a legitimately long-lived response); IdleTimeout only
+		// closes connections that are not in the middle of a request/
+		// response, which is safe and still closes out connection-
+		// exhaustion attempts that never send a next request.
+		IdleTimeout: idleTimeout,
 	}, nil
+}
+
+// idleTimeout bounds an idle (no in-flight request) keep-alive connection on
+// the --http listener (design doc H-3). 120s is generous for a legitimate
+// agent reusing a connection across tool calls while still reclaiming
+// connections an attacker opens and leaves idle.
+const idleTimeout = 120 * time.Second
+
+// warnIfNonLoopback logs a warning (design doc H-4) if addr — the --http
+// bind address — is not restricted to loopback. An empty host (e.g. ":8443")
+// binds all interfaces and counts as non-loopback. TLS and the bearer token
+// already make this safe; the warning exists so an operator who intended
+// `--http localhost:8443` and typo'd or defaulted to `--http :8443` notices
+// the wider exposure instead of discovering it later.
+func warnIfNonLoopback(logger log.CtxLogger, addr string) {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		// addr had no port (unusual for --http, but don't crash logging over
+		// it); fall back to treating the whole value as the host part.
+		host = addr
+	}
+
+	if host != "" {
+		if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+			return
+		}
+		if host == "localhost" {
+			return
+		}
+	}
+
+	logger.Warn(context.Background()).
+		Str("addr", addr).
+		Msg("--http is bound to a non-loopback address; the MCP server will be reachable from the network (TLS + bearer token are still required, but confirm this exposure is intentional)")
 }
 
 // maxRequestBodyBytes bounds an HTTP MCP request body. 4 MiB is generous for a
@@ -132,19 +197,31 @@ func loadBearerToken(path string) (string, error) {
 // middleware. getServer always returns srv (a single, already-built server
 // instance is fine to hand back for every session — see
 // mcp.NewStreamableHTTPHandler's doc).
-func newMCPHTTPHandler(srv *sdkmcp.Server, token string) http.Handler {
+func newMCPHTTPHandler(srv *sdkmcp.Server, token string, logger log.CtxLogger) http.Handler {
 	mcpHandler := sdkmcp.NewStreamableHTTPHandler(func(*http.Request) *sdkmcp.Server { return srv }, nil)
-	return requireBearerToken(token, mcpHandler)
+	return requireBearerToken(token, mcpHandler, logger)
 }
 
 // requireBearerToken wraps next with constant-time bearer-token
 // authentication (design doc §5: "a bearer token, compared constant-time").
 // A missing/malformed Authorization header or a token that doesn't match is
-// rejected with 401 before next ever sees the request.
-func requireBearerToken(token string, next http.Handler) http.Handler {
+// rejected with 401 before next ever sees the request; the rejection is
+// logged (design doc H-2/AC-10) so brute-force/probing attempts against the
+// token are observable instead of invisible.
+func requireBearerToken(token string, next http.Handler, logger log.CtxLogger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		presented, ok := strings.CutPrefix(r.Header.Get("Authorization"), bearerPrefix)
 		if !ok || !constantTimeEqual(presented, token) {
+			// Invariant (AC-8): never log the presented credential or the
+			// configured token — only request metadata an operator needs to
+			// spot brute-forcing (method/path/remote addr), never the
+			// secret the log line exists to protect.
+			logger.Warn(r.Context()).
+				Str("method", r.Method).
+				Str("path", r.URL.Path).
+				Str("remote_addr", r.RemoteAddr).
+				Str("outcome", "unauthorized").
+				Msg("rejected MCP HTTP request: missing or invalid bearer token")
 			w.Header().Set("WWW-Authenticate", `Bearer realm="conduit-mcp"`)
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return

--- a/cmd/conduit/root/mcp/http_test.go
+++ b/cmd/conduit/root/mcp/http_test.go
@@ -15,6 +15,7 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -23,15 +24,20 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	mcpengine "github.com/conduitio/conduit/cmd/conduit/internal/mcp"
+	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/matryer/is"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rs/zerolog"
 )
 
 // TestValidateHTTPConfig_RefusesWithoutTokenOrTLS is the AC-8 config-gate
@@ -76,7 +82,7 @@ func TestNewHTTPServer_RefusesWithoutTokenOrTLS(t *testing.T) {
 	srv := mcpengine.NewServer(mcpengine.Config{})
 
 	c := &MCPCommand{flags: MCPFlags{HTTP: ":0"}}
-	_, err := c.newHTTPServer(srv)
+	_, err := c.newHTTPServer(srv, log.Nop())
 	is.True(err != nil)
 }
 
@@ -97,10 +103,112 @@ func TestNewHTTPServer_WithTokenAndTLS_Succeeds(t *testing.T) {
 		TLSKey:    keyPath,
 	}}
 
-	httpSrv, err := c.newHTTPServer(srv)
+	httpSrv, err := c.newHTTPServer(srv, log.Nop())
 	is.NoErr(err)
 	is.True(httpSrv.TLSConfig != nil)
 	is.Equal(len(httpSrv.TLSConfig.Certificates), 1)
+}
+
+// TestNewHTTPServer_SetsIdleTimeout is the H-3 hardening regression test:
+// the --http server bounds idle keep-alive connections (design doc
+// §Hardening plan, "no IdleTimeout ... an authenticated (or handshaking)
+// client could hold connections open"). No WriteTimeout/ReadTimeout is
+// asserted here — streamable HTTP can legitimately hold a response open
+// while streaming, so those would be wrong to set (see http.go's comment).
+func TestNewHTTPServer_SetsIdleTimeout(t *testing.T) {
+	is := is.New(t)
+
+	tokenPath := writeTestToken(t, "s3cr3t-token")
+	certPath, keyPath := writeTestCert(t)
+
+	srv := mcpengine.NewServer(mcpengine.Config{})
+	c := &MCPCommand{flags: MCPFlags{
+		HTTP:      "127.0.0.1:0",
+		TokenFile: tokenPath,
+		TLSCert:   certPath,
+		TLSKey:    keyPath,
+	}}
+
+	httpSrv, err := c.newHTTPServer(srv, log.Nop())
+	is.NoErr(err)
+	is.True(httpSrv.IdleTimeout > 0)
+	is.Equal(httpSrv.IdleTimeout, idleTimeout)
+	// WriteTimeout must stay unset (0): a blanket write deadline would sever
+	// a legitimately long-lived streamable-HTTP response mid-stream.
+	is.Equal(httpSrv.WriteTimeout, time.Duration(0))
+}
+
+// TestNewHTTPServer_WarnsOnNonLoopbackBind is the H-4 hardening regression
+// test: newHTTPServer (the real Execute call site, not just the helper)
+// warns when --http resolves to a non-loopback address, and stays silent for
+// a loopback-restricted one.
+func TestNewHTTPServer_WarnsOnNonLoopbackBind(t *testing.T) {
+	cases := []struct {
+		name     string
+		addr     string
+		wantWarn bool
+	}{
+		{"loopback bind: no warning", "127.0.0.1:0", false},
+		{"all-interfaces bind: warns", ":0", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+
+			tokenPath := writeTestToken(t, "s3cr3t-token")
+			certPath, keyPath := writeTestCert(t)
+
+			var buf bytes.Buffer
+			logger := log.New(zerolog.New(&buf).Level(zerolog.WarnLevel))
+
+			srv := mcpengine.NewServer(mcpengine.Config{})
+			c := &MCPCommand{flags: MCPFlags{
+				HTTP:      tc.addr,
+				TokenFile: tokenPath,
+				TLSCert:   certPath,
+				TLSKey:    keyPath,
+			}}
+
+			_, err := c.newHTTPServer(srv, logger)
+			is.NoErr(err)
+
+			gotWarning := strings.Contains(buf.String(), "non-loopback")
+			is.Equal(gotWarning, tc.wantWarn)
+		})
+	}
+}
+
+// TestWarnIfNonLoopback exercises the H-4 helper directly across the address
+// shapes an operator might pass to --http: loopback IPv4/IPv6, "localhost",
+// an explicit non-loopback IP, an unqualified hostname, and the
+// all-interfaces empty-host form.
+func TestWarnIfNonLoopback(t *testing.T) {
+	cases := []struct {
+		name     string
+		addr     string
+		wantWarn bool
+	}{
+		{"loopback IPv4 with port", "127.0.0.1:8443", false},
+		{"loopback IPv6 with port", "[::1]:8443", false},
+		{"localhost hostname", "localhost:8443", false},
+		{"all interfaces (empty host)", ":8443", true},
+		{"explicit non-loopback IP", "0.0.0.0:8443", true},
+		{"non-loopback hostname", "mcp.example.com:8443", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+
+			var buf bytes.Buffer
+			logger := log.New(zerolog.New(&buf).Level(zerolog.WarnLevel))
+
+			warnIfNonLoopback(logger, tc.addr)
+
+			is.Equal(buf.Len() > 0, tc.wantWarn)
+		})
+	}
 }
 
 // TestRequireBearerToken_AuthenticatesGoodRejectsBad is the AC-8 auth
@@ -118,7 +226,7 @@ func TestRequireBearerToken_AuthenticatesGoodRejectsBad(t *testing.T) {
 		reached = true
 		w.WriteHeader(http.StatusOK)
 	})
-	handler := requireBearerToken(token, next)
+	handler := requireBearerToken(token, next, log.Nop())
 
 	cases := []struct {
 		name       string
@@ -161,7 +269,7 @@ func TestNewMCPHTTPHandler_EndToEndAuth(t *testing.T) {
 
 	const token = "the-right-token"
 	srv := mcpengine.NewServer(mcpengine.Config{})
-	handler := newMCPHTTPHandler(srv, token)
+	handler := newMCPHTTPHandler(srv, token, log.Nop())
 
 	t.Run("missing token rejected before reaching the MCP handler", func(t *testing.T) {
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/", nil)
@@ -182,6 +290,245 @@ func TestNewMCPHTTPHandler_EndToEndAuth(t *testing.T) {
 		// the request through to the wrapped mcp.Server.
 		is.True(rec.Code != http.StatusUnauthorized)
 	})
+}
+
+// TestNewMCPHTTPHandler_ToolsListRequiresAuth is the AC-5 regression test,
+// made explicit per the design doc: an unauthenticated tools/list JSON-RPC
+// call is rejected 401 by the bearer middleware before it ever reaches the
+// MCP protocol handler — the caller learns nothing about the catalog, not
+// even an empty one, and gets no 200.
+func TestNewMCPHTTPHandler_ToolsListRequiresAuth(t *testing.T) {
+	is := is.New(t)
+
+	srv := mcpengine.NewServer(mcpengine.Config{})
+	handler := newMCPHTTPHandler(srv, "the-right-token", log.Nop())
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	is.Equal(rec.Code, http.StatusUnauthorized)
+	// Not a (even empty) JSON-RPC result: the middleware must reject before
+	// the request reaches tools/list handling at all.
+	is.True(!strings.Contains(rec.Body.String(), `"result"`))
+}
+
+// TestLoadBearerToken_RejectsEmptyOrWhitespace is the AC-6 regression test:
+// a --token-file that is empty, or whitespace-only after trimming, is
+// refused — an empty required token would make every empty Authorization
+// header a trivial constant-time "match".
+func TestLoadBearerToken_RejectsEmptyOrWhitespace(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"empty file", ""},
+		{"whitespace only", "   \n\t  \n"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+
+			path := filepath.Join(t.TempDir(), "token.txt")
+			is.NoErr(os.WriteFile(path, []byte(tc.content), 0o600))
+
+			_, err := loadBearerToken(path)
+			is.True(err != nil)
+		})
+	}
+}
+
+// TestHTTPCatalog_AllowMutationsGatesWriteTools is the AC-7 regression test:
+// --allow-mutations gates the write tools (apply, scaffold_connector,
+// scaffold_processor) identically over HTTP as it does over stdio — the
+// mutation gate is transport-independent (design doc "One tool catalog").
+// Drives a real MCP client over a real HTTP round-trip (initialize +
+// tools/list), not just an inspection of the *sdkmcp.Server's internal tool
+// registry, so the assertion covers the same path an agent actually uses.
+func TestHTTPCatalog_AllowMutationsGatesWriteTools(t *testing.T) {
+	cases := []struct {
+		name           string
+		allowMutations bool
+		wantApply      bool
+	}{
+		{"mutations disabled: apply absent over HTTP", false, false},
+		{"mutations enabled: apply present over HTTP", true, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+
+			const token = "the-right-token"
+			srv := mcpengine.NewServer(mcpengine.Config{AllowMutations: tc.allowMutations})
+			handler := newMCPHTTPHandler(srv, token, log.Nop())
+
+			httpServer := httptest.NewServer(handler)
+			defer httpServer.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			transport := &sdkmcp.StreamableClientTransport{
+				Endpoint:   httpServer.URL,
+				HTTPClient: &http.Client{Transport: bearerRoundTripper{token: token}},
+			}
+			client := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "test-client", Version: "0.0.0"}, nil)
+
+			session, err := client.Connect(ctx, transport, nil)
+			is.NoErr(err)
+			defer session.Close()
+
+			result, err := session.ListTools(ctx, nil)
+			is.NoErr(err)
+
+			hasApply := false
+			for _, tool := range result.Tools {
+				if tool.Name == mcpengine.ToolApply {
+					hasApply = true
+				}
+			}
+			is.Equal(hasApply, tc.wantApply)
+		})
+	}
+}
+
+// bearerRoundTripper adds "Authorization: Bearer <token>" to every outgoing
+// request — used by tests that drive a real *sdkmcp.Client against the
+// --http handler, since sdkmcp.StreamableClientTransport has no built-in
+// bearer-auth option (mirroring how an operator would configure their own
+// agent's HTTP client against conduit mcp --http).
+type bearerRoundTripper struct {
+	token string
+}
+
+func (t bearerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set("Authorization", "Bearer "+t.token)
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+// TestRequireBearerToken_RejectionsAreLoggedWithoutLeakingToken is the
+// AC-8/AC-10 pairing the design doc calls out as the security-regression
+// anchor: a 401 is observable (method/path/remote_addr/outcome logged) and
+// the log line — on rejection or success — never contains the configured
+// token or the (wrong) token the caller presented. This test must fail if
+// any future change logs either.
+func TestRequireBearerToken_RejectionsAreLoggedWithoutLeakingToken(t *testing.T) {
+	is := is.New(t)
+
+	const (
+		realToken  = "s3cr3t-real-token-value"
+		wrongToken = "guessed-wrong-token-value"
+	)
+
+	var buf bytes.Buffer
+	logger := log.New(zerolog.New(&buf).Level(zerolog.WarnLevel))
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := requireBearerToken(realToken, next, logger)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer "+wrongToken)
+	req.RemoteAddr = "203.0.113.7:54321"
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+	is.Equal(rec.Code, http.StatusUnauthorized)
+
+	logged := buf.String()
+
+	// AC-10: the rejection is observable — an operator can tell a 401
+	// happened, for what method/path, and from where.
+	is.True(strings.Contains(logged, "unauthorized"))
+	is.True(strings.Contains(logged, "POST"))
+	is.True(strings.Contains(logged, "/mcp"))
+	is.True(strings.Contains(logged, "203.0.113.7:54321"))
+
+	// AC-8: neither the configured token nor the (wrong) presented one ever
+	// appears in the log output — a 401 audit trail must not itself leak
+	// the secret it exists to protect.
+	is.True(!strings.Contains(logged, realToken))
+	is.True(!strings.Contains(logged, wrongToken))
+}
+
+// TestRequireBearerToken_SuccessIsNotLoggedAsRejection complements the
+// rejection-logging test: a request with the correct token must not produce
+// an "unauthorized" log line.
+func TestRequireBearerToken_SuccessIsNotLoggedAsRejection(t *testing.T) {
+	is := is.New(t)
+
+	const token = "the-right-token"
+
+	var buf bytes.Buffer
+	logger := log.New(zerolog.New(&buf).Level(zerolog.WarnLevel))
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := requireBearerToken(token, next, logger)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+	is.Equal(rec.Code, http.StatusOK)
+	is.True(!strings.Contains(buf.String(), "unauthorized"))
+}
+
+// TestHTTPServer_GracefulShutdownDrains is the AC-12 regression test: a real
+// bound --http listener, on context cancellation, drains via
+// http.Server.Shutdown (the same call Execute's errgroup makes) rather than
+// dropping in-flight connections, and returns cleanly.
+func TestHTTPServer_GracefulShutdownDrains(t *testing.T) {
+	is := is.New(t)
+
+	tokenPath := writeTestToken(t, "s3cr3t-token")
+	certPath, keyPath := writeTestCert(t)
+
+	srv := mcpengine.NewServer(mcpengine.Config{})
+	c := &MCPCommand{flags: MCPFlags{
+		HTTP:      "127.0.0.1:0",
+		TokenFile: tokenPath,
+		TLSCert:   certPath,
+		TLSKey:    keyPath,
+	}}
+
+	httpSrv, err := c.newHTTPServer(srv, log.Nop())
+	is.NoErr(err)
+
+	var lc net.ListenConfig
+	ln, err := lc.Listen(context.Background(), "tcp", httpSrv.Addr)
+	is.NoErr(err)
+
+	serveErrCh := make(chan error, 1)
+	go func() {
+		serveErrCh <- httpSrv.ServeTLS(ln, "", "")
+	}()
+
+	// Give the listener a moment to start accepting before shutting down —
+	// avoids a race where Shutdown runs before ServeTLS has registered the
+	// listener.
+	time.Sleep(50 * time.Millisecond)
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	is.NoErr(httpSrv.Shutdown(shutdownCtx))
+
+	select {
+	case err := <-serveErrCh:
+		// http.ErrServerClosed is Shutdown's documented clean-exit signal —
+		// exactly what Execute's own errgroup goroutine treats as success
+		// (mcp.go: "cerrors.Is(err, http.ErrServerClosed) { return nil }").
+		is.True(err != nil)
+		is.Equal(err, http.ErrServerClosed)
+	case <-time.After(5 * time.Second):
+		t.Fatal("ServeTLS did not return after Shutdown; a connection may not have drained")
+	}
 }
 
 func writeTestToken(t *testing.T, token string) string {

--- a/cmd/conduit/root/mcp/mcp.go
+++ b/cmd/conduit/root/mcp/mcp.go
@@ -31,8 +31,10 @@ import (
 	mcpengine "github.com/conduitio/conduit/cmd/conduit/internal/mcp"
 	"github.com/conduitio/conduit/pkg/conduit"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/ecdysis"
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -51,7 +53,12 @@ var (
 type MCPFlags struct {
 	conduit.Config
 
-	HTTP string `long:"http" usage:"also serve the streamable-HTTP transport on this address (in addition to stdio); requires --token-file and --tls-cert/--tls-key"`
+	// H-1 (design doc 20260712-mcp-http-transport.md, AC-11/SR-1): this usage
+	// string previously said HTTP is served "in addition to stdio" — false,
+	// since Execute serves HTTP-only in --http mode (a daemon has no
+	// attached stdin to also read stdio from). Keep this text in sync with
+	// Execute's actual branch.
+	HTTP string `long:"http" usage:"serve the streamable-HTTP transport on this address INSTEAD OF stdio (EXPERIMENTAL; see docs/operations/mcp-server.md); requires --token-file and --tls-cert/--tls-key"`
 	// AllowMutations is a startup/process flag, deliberately not a tool
 	// argument — see cmd/conduit/internal/mcp.Config.AllowMutations's doc.
 	AllowMutations bool   `long:"allow-mutations" usage:"register the write tools (apply, scaffold_connector, scaffold_processor); an operator/process-level switch, never agent-settable"`
@@ -87,9 +94,13 @@ filesystem. --allow-mutations is an operator/process-level flag, never something
 a tool argument.
 
 Serves stdio by default (the primary agent channel — no auth needed, since the agent owns the
-process). Pass --http <addr> to additionally serve the streamable-HTTP transport; --http requires
-both --token-file (a bearer token, compared constant-time) and --tls-cert/--tls-key — it refuses to
-start otherwise.
+process). Pass --http <addr> to serve the streamable-HTTP transport INSTEAD OF stdio — this is a
+network-daemon mode (systemd/container) with no attached stdin, so it does not also serve stdio;
+--http requires both --token-file (a bearer token, compared constant-time) and
+--tls-cert/--tls-key — it refuses to start with either missing (fail-closed: no plaintext, no
+unauthenticated HTTP). The HTTP transport is EXPERIMENTAL: no rate limiting, no per-agent tokens,
+and a single shared token with no rotation short of a restart — see
+docs/operations/mcp-server.md.
 
 The inspect tool requires a running Conduit: pass --api-address to point it at one.`,
 		Example: "conduit mcp\n" +
@@ -168,7 +179,7 @@ func (c *MCPCommand) Execute(ctx context.Context) error {
 		return srv.Run(ctx, &sdkmcp.StdioTransport{})
 	}
 
-	httpSrv, err := c.newHTTPServer(srv)
+	httpSrv, err := c.newHTTPServer(srv, c.httpLogger())
 	if err != nil {
 		return err
 	}
@@ -195,4 +206,25 @@ func (c *MCPCommand) Execute(ctx context.Context) error {
 	})
 
 	return grp.Wait()
+}
+
+// httpLogger builds the log.CtxLogger the --http path uses for its startup/
+// auth-event logging (design doc H-2/H-4). It mirrors
+// pkg/conduit/runtime.go's own newLogger construction (same log.level/
+// log.format config, same zerolog.ParseLevel/log.ParseFormat calls) rather
+// than importing it: MCPCommand does not build a conduit.Runtime, and
+// pulling in that dependency for two lines of zerolog setup would be a
+// heavier coupling than the duplication here. Malformed level/format values
+// fall back to zerolog's/log's zero values (InfoLevel, FormatCLI) rather
+// than failing --http startup over a logging config typo.
+func (c *MCPCommand) httpLogger() log.CtxLogger {
+	level, err := zerolog.ParseLevel(c.flags.Config.Log.Level)
+	if err != nil {
+		level = zerolog.InfoLevel
+	}
+	format, err := log.ParseFormat(c.flags.Config.Log.Format)
+	if err != nil {
+		format = log.FormatCLI
+	}
+	return log.InitLogger(level, format)
 }

--- a/cmd/conduit/root/mcp/mcp_test.go
+++ b/cmd/conduit/root/mcp/mcp_test.go
@@ -1,0 +1,92 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/matryer/is"
+)
+
+// TestDocs_HTTPHelpTextMatchesBehavior is the H-1/AC-11 regression test
+// (design doc 20260712-mcp-http-transport.md, SR-1): the --http usage string
+// and Docs().Long previously claimed HTTP is served "in addition to stdio",
+// which Execute's own behavior (HTTP-only in --http mode, see the comment
+// above the errgroup in Execute) contradicts. Guard against that mismatch
+// reappearing.
+func TestDocs_HTTPHelpTextMatchesBehavior(t *testing.T) {
+	is := is.New(t)
+
+	var c MCPCommand
+	docs := c.Docs()
+
+	// The stale claim must never come back.
+	is.True(!strings.Contains(docs.Long, "in addition to stdio"))
+
+	// The corrected behavior must be stated: --http replaces stdio, not
+	// co-serves it.
+	is.True(strings.Contains(docs.Long, "INSTEAD OF stdio"))
+
+	flags := ecdysisFlagUsage(t, &c, "http")
+	is.True(!strings.Contains(flags, "in addition to stdio"))
+	is.True(strings.Contains(flags, "INSTEAD OF stdio"))
+}
+
+// ecdysisFlagUsage returns the `usage` struct tag value ecdysis.BuildFlags
+// derives for the named long flag, by reading it directly off MCPFlags via
+// the same struct c.Flags() builds from — avoids depending on ecdysis'
+// internal flag representation for a simple text assertion.
+func ecdysisFlagUsage(t *testing.T, c *MCPCommand, long string) string {
+	t.Helper()
+	for _, f := range c.Flags() {
+		if f.Long == long {
+			return f.Usage
+		}
+	}
+	t.Fatalf("flag --%s not found", long)
+	return ""
+}
+
+// TestExecute_NoHTTPFlag_UsesStdioTransport is the AC-1 regression test: with
+// no --http flag, Execute must take the stdio path and never attempt to
+// construct an HTTP server. Proven by cancelling ctx before calling Execute:
+// the stdio path (srv.Run with a real transport) returns context.Canceled
+// promptly per sdkmcp.Server.Run's documented cancellation behavior, while
+// the HTTP path would instead fail validateHTTPConfig with a distinct
+// conduiterr (no --token-file/--tls-cert/--tls-key configured) — a
+// different, distinguishable error that this test would catch.
+func TestExecute_NoHTTPFlag_UsesStdioTransport(t *testing.T) {
+	is := is.New(t)
+
+	c := &MCPCommand{flags: MCPFlags{}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled: the stdio path must return promptly
+
+	done := make(chan error, 1)
+	go func() { done <- c.Execute(ctx) }()
+
+	select {
+	case err := <-done:
+		is.True(err != nil)
+		is.True(cerrors.Is(err, context.Canceled))
+	case <-time.After(10 * time.Second):
+		t.Fatal("Execute did not return promptly on the no-HTTP path; it may not be taking the stdio branch")
+	}
+}

--- a/docs/operations/mcp-server.md
+++ b/docs/operations/mcp-server.md
@@ -72,18 +72,27 @@ Badger-only structural gate and refuses outright to touch a running pipeline. Ei
 `--allow-mutations` above is the orthogonal gate deciding whether the `apply` tool is registered at
 all; it says nothing about which transport a registered `apply` tool uses.
 
-## HTTP transport
+## HTTP transport (EXPERIMENTAL)
 
-`--http <addr>` additionally serves the streamable-HTTP transport (in addition to stdio, not
-instead of it) — for a remote agent or a shared Conduit instance multiple agents connect to over
-the network.
+`--http <addr>` serves the streamable-HTTP transport **instead of** stdio — this is a
+network-daemon mode (systemd/container) with no attached stdin, so it does not also serve stdio.
+Use it for a remote agent, or a shared Conduit instance multiple agents connect to over the
+network.
+
+See [`docs/design-documents/20260712-mcp-http-transport.md`](../design-documents/20260712-mcp-http-transport.md)
+for the full threat model and hardening record. **This transport is experimental**: the
+fail-closed/auth/TLS fundamentals below are solid, but it is a single shared token with no
+rotation short of a restart, no per-agent identity, and no rate limiting — see "Not yet built"
+below before exposing it beyond a trusted network.
 
 HTTP refuses to start without **both**:
 
 - `--token-file <path>`: a file containing a bearer token. Every request's `Authorization: Bearer
   <token>` header is compared against it in constant time (`crypto/subtle.ConstantTimeCompare`).
+  The token is a **file path**, never an inline flag value — it never lands in `ps`/argv/shell
+  history. An empty (or whitespace-only) token file is refused at startup.
 - `--tls-cert <path>` / `--tls-key <path>`: a TLS certificate/key pair. HTTP is only ever served
-  over TLS — there is no plaintext HTTP path.
+  over TLS (`MinVersion: TLS1.2`) — there is no plaintext HTTP path.
 
 ```console
 $ conduit mcp --http :8443 \
@@ -93,7 +102,38 @@ $ conduit mcp --http :8443 \
 ```
 
 A request with a missing or incorrect bearer token is rejected with `401 Unauthorized` before it
-ever reaches the MCP protocol handler.
+ever reaches the MCP protocol handler — including `tools/list`, so an unauthenticated caller learns
+nothing about the catalog, not even whether `--allow-mutations` is on.
+
+### Operational behavior
+
+- **Startup log line:** on success, a structured `info` line names the bound address and auth mode
+  (`serving MCP over streamable HTTP`).
+- **Non-loopback bind warning:** if `--http` resolves to an address that is not restricted to
+  loopback (e.g. `:8443`, `0.0.0.0:8443`, or a public hostname), a `warn`-level log line calls out
+  the exposure at startup. TLS + the bearer token already make this safe; the warning exists so an
+  operator who meant `--http localhost:8443` notices if they typed (or defaulted to) something
+  wider.
+- **Auth-failure logging:** every rejected request logs `method`, `path`, `remote_addr`, and
+  `outcome=unauthorized` at `warn` level — so brute-force/probing attempts against the token are
+  observable. **The token itself, and whatever credential the caller presented, are never logged**
+  — only request metadata.
+- **Timeouts:** `ReadHeaderTimeout: 10s` (Slowloris guard) and `IdleTimeout: 120s` (bounds an idle
+  keep-alive connection). No blanket `WriteTimeout` — streamable HTTP can legitimately hold a
+  response open while streaming a tool result.
+- **Body cap:** requests are capped at 4 MiB (`http.MaxBytesReader`); an oversized body fails the
+  read instead of being buffered in full.
+- **Graceful shutdown:** on `SIGTERM`/context cancellation, in-flight requests drain via
+  `http.Server.Shutdown` within a 5s window before the process exits.
+
+### Not yet built (v0.18 candidates)
+
+- Rate limiting / lockout on repeated auth failures.
+- Per-agent tokens with revocation; optional mTLS (client-cert) auth.
+- Token hot-reload / rotation without a restart.
+- Cipher-suite pinning and a TLS 1.3 floor.
+
+Rotating the shared token today means restarting `conduit mcp` with a new `--token-file`.
 
 ## Known limitations (Wave 3)
 


### PR DESCRIPTION
## Summary

Implements the H-1..H-4 must-fix hardening items and the missing-coverage tests identified in
[`docs/design-documents/20260712-mcp-http-transport.md`](docs/design-documents/20260712-mcp-http-transport.md)
so the already-merged `conduit mcp --http` transport (#2591) can ship in v0.17 labeled
**experimental** per that doc's recommendation. This is a hardening pass on existing, already-tested
code (`cmd/conduit/root/mcp/http.go`, `mcp.go`) — no re-implementation, no new transport behavior,
no rate limiting/mTLS/per-agent tokens (explicitly deferred to v0.18 by the design doc).

Roadmap: Phase-1 execution plan §2, "HTTP transport security: authn (token) + TLS for the HTTP MCP
surface; documented."

### Must-fixes implemented

- **H-1 (AC-11 / SR-1):** `--http`'s usage string and `Docs().Long` claimed HTTP is served "in
  addition to stdio" — false; `Execute` serves HTTP-only in `--http` mode (a daemon has no attached
  stdin to co-serve stdio from). Text now says "INSTEAD OF stdio" and marks the transport
  **EXPERIMENTAL**, pointing at `docs/operations/mcp-server.md`.
- **H-2 (AC-10 / AC-8):** every rejected (`401`) HTTP MCP request now logs
  `method`/`path`/`remote_addr`/`outcome=unauthorized` at `warn`, and a startup line logs the bound
  address + auth mode at `info`. Verified by test and by a manual smoke run (see below) that neither
  the configured token nor the presented (wrong) one ever appears in log output.
- **H-3:** added `IdleTimeout: 120s` to the `--http` server. No `WriteTimeout` — streamable HTTP can
  legitimately hold a response open while streaming a tool result, so a blanket write deadline would
  be wrong.
- **H-4:** warn at startup (`warn`-level, non-blocking) when `--http` resolves to a non-loopback
  address (including the all-interfaces `:port` form). TLS + the bearer token already make this
  safe; the warning exists so a typo'd or defaulted-wide bind doesn't go unnoticed.

### Missing-coverage tests added (design doc's AC checklist)

- **AC-1** (`cmd/conduit/root/mcp/mcp_test.go`): no `--http` takes the stdio path and never
  constructs an `http.Server` — proven by cancelling `ctx` before `Execute` and asserting it returns
  `context.Canceled` promptly (the HTTP path would instead fail `validateHTTPConfig` with a distinct
  error).
- **AC-5:** an unauthenticated `tools/list` JSON-RPC call is `401`, not an empty (or any) catalog.
- **AC-6:** an empty or whitespace-only `--token-file` is refused.
- **AC-7:** `--allow-mutations` gates `apply`/etc. identically over HTTP as over stdio — driven
  end-to-end with a real `*sdkmcp.Client` over `httptest.NewServer`, not just an internal registry
  check.
- **AC-8 / AC-10:** auth rejections are logged and observable; the security-regression anchor test
  scans captured log output and fails if the real or presented token ever appears in it.
- **AC-12:** a real bound `--http` listener drains cleanly via `http.Server.Shutdown` on cancellation
  (same call `Execute`'s errgroup makes) and returns `http.ErrServerClosed`.
- Plus direct tests for the H-3 `IdleTimeout` and H-4 non-loopback-warning additions (both the
  `newHTTPServer` call site and the `warnIfNonLoopback` helper across loopback/IPv6/hostname/
  all-interfaces address shapes).

### Docs

`docs/operations/mcp-server.md`'s "HTTP transport" section rewritten: fixes the same
"in addition to stdio" claim, marks the transport **EXPERIMENTAL** with a link to the design doc,
documents the new startup/warning/auth-failure log lines and timeouts, and lists what's explicitly
**not** built yet (rate limiting, per-agent tokens, rotation, cipher pinning) so an operator isn't
surprised. `markdownlint-cli2` clean.

No `CHANGELOG.md` exists in this repo — changelog is generated from the conventional-commit title
per `docs/releases.md`.

## Risk tier

**Tier 2 (Features/CLI)** — this touches a command/transport surface, not the data path. It can
carry Tier-1 `apply` calls, but the three independent non-agent-passable gates protecting writes
(`--allow-mutations`, `--api.allow-live-restart-apply`, the diff-hash check) are unchanged; this PR
only adds logging/timeouts/text around the existing fail-closed auth gate, it does not touch
mutation authorization logic.

## Adversarial self-review

- **Auth path:** `requireBearerToken`'s constant-time compare and the 401-before-handler ordering
  are untouched — I only added a `logger.Warn(...)` call inside the existing `if !ok ||
  !constantTimeEqual(...)` branch, before the `401` is written. Verified the log call references only
  `r.Method`/`r.URL.Path`/`r.RemoteAddr` — never `presented` or `token`. Grepped the diff for both
  identifiers to confirm neither reaches a log call.
- **Fail-closed preserved:** `validateHTTPConfig`/`loadBearerToken`/`tls.LoadX509KeyPair` calls and
  their ordering in `newHTTPServer` are unchanged; I only added `warnIfNonLoopback` (a log call, no
  control flow effect) and the startup `logger.Info` call after those checks already passed. Manually
  verified `--http :0` with no `--token-file`/`--tls-cert`/`--tls-key` still refuses to start
  (`go run ./cmd/conduit mcp --http :0` → `--http requires both --token-file and
  --tls-cert/--tls-key; refusing to serve HTTP with no auth and no TLS`, exit 2) before opening this
  PR.
- **No token leakage in logs:** manually ran the built binary with `--http`, hit it with `curl`
  presenting no token and a wrong token, and inspected the captured log output directly — confirmed
  `rejected MCP HTTP request: missing or invalid bearer token` lines carry only
  `method`/`outcome`/`path`/`remote_addr`, never the token file's contents or the `Authorization`
  header value. `TestRequireBearerToken_RejectionsAreLoggedWithoutLeakingToken` encodes this as a
  standing regression test (scans captured log output for both the real and the wrong-guessed token
  string).
- **Logger construction (`httpLogger`) duplicates `pkg/conduit/runtime.go`'s `newLogger`** rather than
  importing it — `MCPCommand` doesn't build a `conduit.Runtime`, and the ecdysis config-parsing
  pipeline does not populate `Config.Log.NewLogger` (verified: `ecdysis.ParseConfig` unmarshals via
  viper from flag/env/file values, and `NewLogger` has no `long` struct tag, so it's never set on the
  parsed config — confirmed by reading `ecdysis@v0.6.0/config.go`'s `setDefaults`/`ParseConfig`).
  Duplicating two lines of `zerolog.ParseLevel`/`log.ParseFormat` was the smaller coupling; flagging
  this as a judgment call in case a reviewer prefers exporting `pkg/conduit.NewLoggerFromConfig` or
  similar instead.
- **AC-1's stdio test** exercises `Execute` with a real `sdkmcp.StdioTransport{}` and an
  already-cancelled `context.Context`, relying on `Server.Run`'s documented behavior ("blocks until
  ... the provided context is cancelled") to return promptly via the `ctx.Done()` select branch
  without needing to actually read from `os.Stdin`. The SDK's own cancellation test
  (`cmd_test.go:TestServerRunContextCancel`) uses in-memory transports instead of real stdio to avoid
  exactly this hazard; I judged the real-stdio version acceptable here because the test asserts a
  bounded 10s timeout (never hangs CI, worst case is a deterministic failure) and it passed
  repeatedly locally including under `-race`. Flagging this as the one test in the PR with a
  (low, bounded) environment-dependency risk.
- **Non-loopback warning is advisory only** (H-4 was explicitly specified as "warn", not "refuse") —
  it does not change the fail-closed gate; a misconfigured-but-token/TLS-complete `--http :8443` still
  starts, just with a warning. This matches the design doc's explicit scope (TLS+token already make
  it safe; the warning is about surprising the operator, not blocking a valid config).

## Verification

- `go build ./...` — clean.
- `go test -race -count=1 ./cmd/conduit/root/mcp/... ./cmd/conduit/internal/mcp/...` — all pass,
  including the new AC-1/5/6/7/8/10/12 tests and the H-3/H-4 tests.
- `golangci-lint run ./cmd/conduit/root/mcp/...` (v2.12.2, matching `tools/go.mod`) — 0 issues.
- `npx --yes markdownlint-cli2@0.18.1 docs/operations/mcp-server.md` — 0 errors.
- Manual smoke test: built binary, ran `conduit mcp --http :18443 --token-file ... --tls-cert ...
  --tls-key ...`, confirmed the non-loopback warning + startup log lines, then `curl`'d it
  unauthenticated and with a wrong token and confirmed `401` + the auth-failure log lines with no
  token leakage; confirmed `--http` with no token/TLS still refuses to start.

## Process-maturity note

Per CLAUDE.md's honesty rule: this PR's own review is the adversarial self-review pass above
(**live now**), not a second-session human review. Tier-2 review (one reviewer approval, CI green)
is the applicable bar. **Not merging this PR** — leaving it open for review.