### PR TITLE
feat(cli): conduit pipelines start/stop verbs + MCP tools (§3)

### DIFF
--- a/cmd/conduit/api/mock/pipeline_service.go
+++ b/cmd/conduit/api/mock/pipeline_service.go
@@ -141,3 +141,43 @@ func (mr *MockPipelineServiceMockRecorder) PlanPipeline(ctx, in any, opts ...any
 	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PlanPipeline", reflect.TypeOf((*MockPipelineService)(nil).PlanPipeline), varargs...)
 }
+
+// StartPipeline mocks base method.
+func (m *MockPipelineService) StartPipeline(ctx context.Context, in *apiv1.StartPipelineRequest, opts ...grpc.CallOption) (*apiv1.StartPipelineResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "StartPipeline", varargs...)
+	ret0, _ := ret[0].(*apiv1.StartPipelineResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StartPipeline indicates an expected call of StartPipeline.
+func (mr *MockPipelineServiceMockRecorder) StartPipeline(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartPipeline", reflect.TypeOf((*MockPipelineService)(nil).StartPipeline), varargs...)
+}
+
+// StopPipeline mocks base method.
+func (m *MockPipelineService) StopPipeline(ctx context.Context, in *apiv1.StopPipelineRequest, opts ...grpc.CallOption) (*apiv1.StopPipelineResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "StopPipeline", varargs...)
+	ret0, _ := ret[0].(*apiv1.StopPipelineResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StopPipeline indicates an expected call of StopPipeline.
+func (mr *MockPipelineServiceMockRecorder) StopPipeline(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopPipeline", reflect.TypeOf((*MockPipelineService)(nil).StopPipeline), varargs...)
+}

--- a/cmd/conduit/api/services.go
+++ b/cmd/conduit/api/services.go
@@ -39,6 +39,13 @@ type PipelineService interface {
 	GetDLQ(ctx context.Context, in *apiv1.GetDLQRequest, opts ...grpc.CallOption) (*apiv1.GetDLQResponse, error)
 	PlanPipeline(ctx context.Context, in *apiv1.PlanPipelineRequest, opts ...grpc.CallOption) (*apiv1.PlanPipelineResponse, error)
 	ApplyPipeline(ctx context.Context, in *apiv1.ApplyPipelineRequest, opts ...grpc.CallOption) (*apiv1.ApplyPipelineResponse, error)
+	// StartPipeline and StopPipeline back `conduit pipelines start|stop` (design
+	// doc 20260712-cli-pipeline-lifecycle-verbs.md): live lifecycle transitions
+	// against a running Conduit server, no offline/local-store path. The
+	// server-side RPCs, handlers, and lifecycle.Service.Start/Stop already
+	// shipped before this interface extension — this is CLI wiring only.
+	StartPipeline(ctx context.Context, in *apiv1.StartPipelineRequest, opts ...grpc.CallOption) (*apiv1.StartPipelineResponse, error)
+	StopPipeline(ctx context.Context, in *apiv1.StopPipelineRequest, opts ...grpc.CallOption) (*apiv1.StopPipelineResponse, error)
 }
 
 //go:generate mockgen -destination=mock/processor_service.go -package=mock . ProcessorService

--- a/cmd/conduit/internal/mcp/doc.go
+++ b/cmd/conduit/internal/mcp/doc.go
@@ -25,10 +25,12 @@
 // # Read/write separation
 //
 // Read tools (validate, lint, dry_run, doctor, deploy, inspect) are always
-// registered by NewServer. Write tools (apply, scaffold_connector,
-// scaffold_processor) are registered only when Config.AllowMutations is set
-// — an operator/process-level flag on `conduit mcp`, never a tool argument
-// an agent could pass. See NewServer's doc and the design doc §3.
+// registered by NewServer. Write tools (apply, start, stop,
+// scaffold_connector, scaffold_processor) are registered only when
+// Config.AllowMutations is set — an operator/process-level flag on
+// `conduit mcp`, never a tool argument an agent could pass. See NewServer's
+// doc, the design doc §3, and 20260712-cli-pipeline-lifecycle-verbs.md §4 for
+// start/stop specifically.
 //
 // # Content-in, never a server path
 //

--- a/cmd/conduit/internal/mcp/inspect.go
+++ b/cmd/conduit/internal/mcp/inspect.go
@@ -25,16 +25,25 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// inspectClient is the narrow surface the inspect tool needs from a running
-// Conduit's gRPC API — the same three calls
-// cmd/conduit/root/pipelines/inspect.go makes (GetPipeline, ListConnectors+
-// GetConnector per connector, GetDLQ). Declaring it here (rather than
-// depending on *api.Client concretely) lets the tool be unit-tested against
-// a fake, without a live gRPC server.
+// inspectClient is the narrow surface the inspect/start/stop tools need from
+// a running Conduit's gRPC API — the same calls
+// cmd/conduit/root/pipelines/{inspect,start,stop}.go make (GetPipeline,
+// ListConnectors+GetConnector per connector, GetDLQ, StartPipeline,
+// StopPipeline). Declaring it here (rather than depending on *api.Client
+// concretely) lets every tool built on this seam be unit-tested against a
+// fake, without a live gRPC server.
+//
+// StartPipeline/StopPipeline were added alongside the start/stop tools
+// (design doc 20260712-cli-pipeline-lifecycle-verbs.md §2: "the MCP server's
+// existing API client seam ... extended with the two lifecycle methods") —
+// the name predates them but the seam is now shared by every tool that needs
+// a live server, not just inspect.
 type inspectClient interface {
 	GetPipeline(ctx context.Context, id string) (*apiv1.Pipeline, error)
 	ListConnectors(ctx context.Context, pipelineID string) ([]*apiv1.Connector, error)
 	GetDLQ(ctx context.Context, id string) (*apiv1.Pipeline_DLQ, error)
+	StartPipeline(ctx context.Context, id string) error
+	StopPipeline(ctx context.Context, id string, force bool) error
 	Close() error
 }
 
@@ -83,7 +92,37 @@ func (a *apiInspectClient) GetDLQ(ctx context.Context, id string) (*apiv1.Pipeli
 	return resp.Dlq, nil
 }
 
+func (a *apiInspectClient) StartPipeline(ctx context.Context, id string) error {
+	_, err := a.c.PipelineServiceClient.StartPipeline(ctx, &apiv1.StartPipelineRequest{Id: id})
+	return err
+}
+
+func (a *apiInspectClient) StopPipeline(ctx context.Context, id string, force bool) error {
+	_, err := a.c.PipelineServiceClient.StopPipeline(ctx, &apiv1.StopPipelineRequest{Id: id, Force: force})
+	return err
+}
+
 func (a *apiInspectClient) Close() error { return a.c.Close() }
+
+// apiAddressSuggestion is the remediation every tool on the inspectClient
+// seam (inspect, start, stop) attaches when Config.APIAddress is unset — kept
+// as one string so the three call sites can't drift.
+const apiAddressSuggestion = "restart conduit mcp with --api-address <host:port> pointing at a running `conduit run` instance"
+
+// requireAPIAddress returns a common.unavailable error when apiAddress is
+// empty — the shared "no live server configured" failure mode for every tool
+// built on the inspectClient seam. tool names the calling tool in the
+// message only (e.g. "inspect", "start", "stop"). Returns nil when
+// apiAddress is set, i.e. "no error, proceed".
+func requireAPIAddress(apiAddress, tool string) error {
+	if apiAddress != "" {
+		return nil
+	}
+	ce := conduiterr.New(conduiterr.CodeUnavailable,
+		fmt.Sprintf("conduit mcp was not started with --api-address; %s requires the gRPC address of a running Conduit", tool))
+	ce.Suggestion = apiAddressSuggestion
+	return ce
+}
 
 // InspectArgs is the inspect tool's input.
 type InspectArgs struct {
@@ -108,10 +147,7 @@ func (s *server) inspect(ctx context.Context, _ *sdkmcp.CallToolRequest, in Insp
 		ce := conduiterr.New(conduiterr.CodeInvalidArgument, "pipelineId is required")
 		return toolErr[InspectResult](ce)
 	}
-	if s.cfg.APIAddress == "" {
-		ce := conduiterr.New(conduiterr.CodeUnavailable,
-			"conduit mcp was not started with --api-address; inspect requires the gRPC address of a running Conduit")
-		ce.Suggestion = "restart conduit mcp with --api-address <host:port> pointing at a running `conduit run` instance"
+	if ce := requireAPIAddress(s.cfg.APIAddress, "inspect"); ce != nil {
 		return toolErr[InspectResult](ce)
 	}
 

--- a/cmd/conduit/internal/mcp/inspect_test.go
+++ b/cmd/conduit/internal/mcp/inspect_test.go
@@ -25,13 +25,25 @@ import (
 )
 
 // fakeInspectClient is an inspectClient test double: canned
-// responses/errors, no gRPC dial.
+// responses/errors, no gRPC dial. Shared by the inspect and start/stop tool
+// tests, since they all go through the same client seam (inspect.go's doc).
 type fakeInspectClient struct {
 	pipeline   *apiv1.Pipeline
 	connectors []*apiv1.Connector
 	dlq        *apiv1.Pipeline_DLQ
 	err        error
 	closed     bool
+
+	// startErr/stopErr let start/stop tool tests exercise a transition
+	// failure independently of err (which also drives GetPipeline/
+	// ListConnectors/GetDLQ) — e.g. a successful StopPipeline whose read-back
+	// GetPipeline then fails.
+	startErr error
+	stopErr  error
+
+	startCalled bool
+	stopCalled  bool
+	stopForce   bool
 }
 
 func (f *fakeInspectClient) GetPipeline(context.Context, string) (*apiv1.Pipeline, error) {
@@ -53,6 +65,17 @@ func (f *fakeInspectClient) GetDLQ(context.Context, string) (*apiv1.Pipeline_DLQ
 		return nil, f.err
 	}
 	return f.dlq, nil
+}
+
+func (f *fakeInspectClient) StartPipeline(context.Context, string) error {
+	f.startCalled = true
+	return f.startErr
+}
+
+func (f *fakeInspectClient) StopPipeline(_ context.Context, _ string, force bool) error {
+	f.stopCalled = true
+	f.stopForce = force
+	return f.stopErr
 }
 
 func (f *fakeInspectClient) Close() error {

--- a/cmd/conduit/internal/mcp/server.go
+++ b/cmd/conduit/internal/mcp/server.go
@@ -34,6 +34,8 @@ const (
 	ToolDeploy            = "deploy"
 	ToolInspect           = "inspect"
 	ToolApply             = "apply"
+	ToolStart             = "start"
+	ToolStop              = "stop"
 	ToolScaffoldConnector = "scaffold_connector"
 	ToolScaffoldProcessor = "scaffold_processor"
 )
@@ -95,8 +97,10 @@ type server struct {
 // registered; none of them mutate anything (deploy computes a Diff/hash but
 // never executes it; see deploy.go).
 //
-// Write tools — apply, scaffold_connector, scaffold_processor — are
-// registered only when cfg.AllowMutations is set (design doc §3, AC-2/AC-3).
+// Write tools — apply, start, stop, scaffold_connector, scaffold_processor —
+// are registered only when cfg.AllowMutations is set (design doc §3,
+// AC-2/AC-3; start/stop added by 20260712-cli-pipeline-lifecycle-verbs.md
+// §4).
 //
 // Every tool is a thin handler over the exact engine the matching CLI verb
 // calls (cmd/conduit/internal/validate, pkg/conduit/check via doctorcheck,
@@ -117,9 +121,11 @@ func NewServer(cfg Config) *sdkmcp.Server {
 			"configuration offline (content-in: pass the pipeline YAML as `config`, never a server file path). " +
 			"doctor checks whether the local machine/configuration is ready for `conduit run`. inspect reads a " +
 			"running pipeline's live status (requires the server to have been started with --api-address). If " +
-			"present, apply/scaffold_connector/scaffold_processor mutate the local pipeline store or filesystem " +
-			"— apply requires the hash from a prior deploy call and is refused on a stale hash or a running " +
-			"pipeline; these three tools only appear when the operator started conduit mcp with --allow-mutations.",
+			"present, apply/start/stop/scaffold_connector/scaffold_processor mutate the local pipeline store, a " +
+			"running pipeline, or the filesystem — apply requires the hash from a prior deploy call and is " +
+			"refused on a stale hash or a running pipeline; start/stop require --api-address like inspect and " +
+			"are refused on an invalid transition (already running / not running); these tools only appear when " +
+			"the operator started conduit mcp with --allow-mutations.",
 	})
 
 	sdkmcp.AddTool(srv, &sdkmcp.Tool{
@@ -161,6 +167,19 @@ func NewServer(cfg Config) *sdkmcp.Server {
 				"recomputed plan (a stale hash is refused, nothing mutated). Refuses to mutate a currently " +
 				"-running pipeline. Same engine as `conduit pipelines apply`.",
 		}, s.apply)
+		sdkmcp.AddTool(srv, &sdkmcp.Tool{
+			Name: ToolStart,
+			Description: "Starts a pipeline registered in a running Conduit (transitions to Running). " +
+				"Requires --api-address, like inspect; no offline fallback. Refused if the pipeline is " +
+				"already running (pipeline.running). Same engine as `conduit pipelines start`.",
+		}, s.start)
+		sdkmcp.AddTool(srv, &sdkmcp.Tool{
+			Name: ToolStop,
+			Description: "Stops a running pipeline registered in a running Conduit — graceful drain by " +
+				"default, or immediate with force:true. Requires --api-address, like inspect; no offline " +
+				"fallback. Refused if the pipeline isn't running (pipeline.not_running). Same engine as " +
+				"`conduit pipelines stop`.",
+		}, s.stop)
 		sdkmcp.AddTool(srv, &sdkmcp.Tool{
 			Name:        ToolScaffoldConnector,
 			Description: "Scaffolds a new Go connector plugin repository (source and/or destination). Same engine as `conduit connector new`.",

--- a/cmd/conduit/internal/mcp/server_test.go
+++ b/cmd/conduit/internal/mcp/server_test.go
@@ -28,7 +28,7 @@ import (
 
 var readToolNames = []string{ToolValidate, ToolLint, ToolDryRun, ToolDoctor, ToolDeploy, ToolInspect}
 
-var writeToolNames = []string{ToolApply, ToolScaffoldConnector, ToolScaffoldProcessor}
+var writeToolNames = []string{ToolApply, ToolStart, ToolStop, ToolScaffoldConnector, ToolScaffoldProcessor}
 
 // TestNewServer_ReadToolsAlwaysRegistered is AC-1's catalog half: every read
 // tool is present regardless of AllowMutations.
@@ -94,6 +94,31 @@ func TestNewServer_WriteToolsGatedByAllowMutations(t *testing.T) {
 		_, err := cs.CallTool(context.Background(), &sdkmcp.CallToolParams{
 			Name:      ToolApply,
 			Arguments: map[string]any{"config": validPipelineYAML, "hash": "deadbeef"},
+		})
+		is.True(err != nil)
+	})
+
+	// AC-12: the same belt-and-suspenders assertion for start/stop
+	// specifically — the design doc calls this out as "the gate assertion"
+	// for the lifecycle tools, parity with apply above.
+	t.Run("calling start directly without allow-mutations fails at tool lookup, not tool execution", func(t *testing.T) {
+		srv := NewServer(Config{AllowMutations: false})
+		cs := connectTestClient(t, srv)
+
+		_, err := cs.CallTool(context.Background(), &sdkmcp.CallToolParams{
+			Name:      ToolStart,
+			Arguments: map[string]any{"pipelineId": "orders"},
+		})
+		is.True(err != nil)
+	})
+
+	t.Run("calling stop directly without allow-mutations fails at tool lookup, not tool execution", func(t *testing.T) {
+		srv := NewServer(Config{AllowMutations: false})
+		cs := connectTestClient(t, srv)
+
+		_, err := cs.CallTool(context.Background(), &sdkmcp.CallToolParams{
+			Name:      ToolStop,
+			Arguments: map[string]any{"pipelineId": "orders"},
 		})
 		is.True(err != nil)
 	})

--- a/cmd/conduit/internal/mcp/tools_lifecycle.go
+++ b/cmd/conduit/internal/mcp/tools_lifecycle.go
@@ -1,0 +1,180 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	apiv1 "github.com/conduitio/conduit/proto/api/v1"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Lifecycle action names — mirrors
+// cmd/conduit/root/pipelines.actionStart/actionStop.
+const (
+	actionStart = "start"
+	actionStop  = "stop"
+)
+
+// The 5-value status vocabulary pkg/pipeline.Status exposes internally,
+// rendered by pipelineStatusLabel — mirrors
+// cmd/conduit/root/pipelines.statusRunning et al.
+const (
+	statusRunning     = "Running"
+	statusStopped     = "Stopped"
+	statusUserStopped = "UserStopped"
+	statusDegraded    = "Degraded"
+	statusRecovering  = "Recovering"
+)
+
+// LifecycleResult mirrors cmd/conduit/root/pipelines.LifecycleResult's
+// fields exactly — the same shape the CLI start/stop commands return, so an
+// agent and a human get identical result data for the identical RPC (design
+// doc 20260712-cli-pipeline-lifecycle-verbs.md §2: "same verbs the CLI
+// uses").
+type LifecycleResult struct {
+	PipelineID string `json:"pipeline_id"`
+	Action     string `json:"action"` // "start" | "stop"
+	Force      bool   `json:"force,omitempty"`
+	Status     string `json:"status"`
+}
+
+// StartArgs is the start tool's input.
+type StartArgs struct {
+	PipelineID string `json:"pipelineId" jsonschema:"the ID of a pipeline registered in a running Conduit to start"`
+}
+
+// start implements the start (write) tool: transitions a stopped pipeline to
+// Running via the live server's StartPipeline RPC — the same engine
+// `conduit pipelines start` calls, through the same client seam `inspect`
+// uses (inspectClient). Only registered when the server was started with
+// --allow-mutations (design doc §4). Like inspect, it requires
+// Config.APIAddress and has no offline/local-store fallback: starting a
+// pipeline only has meaning against a process that stays up (design doc §3).
+func (s *server) start(ctx context.Context, _ *sdkmcp.CallToolRequest, in StartArgs) (*sdkmcp.CallToolResult, Result[LifecycleResult], error) {
+	if in.PipelineID == "" {
+		ce := conduiterr.New(conduiterr.CodeInvalidArgument, "pipelineId is required")
+		return toolErr[LifecycleResult](ce)
+	}
+	if ce := requireAPIAddress(s.cfg.APIAddress, ToolStart); ce != nil {
+		return toolErr[LifecycleResult](ce)
+	}
+
+	client, err := s.cfg.newAPIClient(ctx, s.cfg.APIAddress)
+	if err != nil {
+		return toolErr[LifecycleResult](mapGRPCErr(err))
+	}
+	defer client.Close() // best-effort cleanup; nothing left to report to if this fails
+
+	if err := client.StartPipeline(ctx, in.PipelineID); err != nil {
+		return toolErr[LifecycleResult](mapGRPCErr(fmt.Errorf("failed to start pipeline %q: %w", in.PipelineID, err)))
+	}
+
+	result, err := readLifecycleStatus(ctx, client, in.PipelineID, actionStart, false)
+	if err != nil {
+		return toolErr[LifecycleResult](mapGRPCErr(err))
+	}
+	return toolOK(true, result, nil)
+}
+
+// StopArgs is the stop tool's input. Force mirrors the CLI's --force flag —
+// see StopFlags' doc in cmd/conduit/root/pipelines/stop.go for why a forced
+// stop is safe (not a data-loss escape hatch) despite skipping the graceful
+// drain.
+type StopArgs struct {
+	PipelineID string `json:"pipelineId" jsonschema:"the ID of a pipeline registered in a running Conduit to stop"`
+	Force      bool   `json:"force,omitempty" jsonschema:"skip graceful drain and stop immediately; may leave in-flight records un-drained (safe: positions are crash-safe and delivery is at-least-once, so this behaves like a crash, not data loss)"`
+}
+
+// stop implements the stop (write) tool: transitions a running pipeline to
+// UserStopped via the live server's StopPipeline RPC — graceful drain by
+// default, or immediate with force:true. Same engine, client seam, and
+// --allow-mutations/--api-address gating as start.
+func (s *server) stop(ctx context.Context, _ *sdkmcp.CallToolRequest, in StopArgs) (*sdkmcp.CallToolResult, Result[LifecycleResult], error) {
+	if in.PipelineID == "" {
+		ce := conduiterr.New(conduiterr.CodeInvalidArgument, "pipelineId is required")
+		return toolErr[LifecycleResult](ce)
+	}
+	if ce := requireAPIAddress(s.cfg.APIAddress, ToolStop); ce != nil {
+		return toolErr[LifecycleResult](ce)
+	}
+
+	client, err := s.cfg.newAPIClient(ctx, s.cfg.APIAddress)
+	if err != nil {
+		return toolErr[LifecycleResult](mapGRPCErr(err))
+	}
+	defer client.Close() // best-effort cleanup; nothing left to report to if this fails
+
+	if err := client.StopPipeline(ctx, in.PipelineID, in.Force); err != nil {
+		return toolErr[LifecycleResult](mapGRPCErr(fmt.Errorf("failed to stop pipeline %q: %w", in.PipelineID, err)))
+	}
+
+	result, err := readLifecycleStatus(ctx, client, in.PipelineID, actionStop, in.Force)
+	if err != nil {
+		return toolErr[LifecycleResult](mapGRPCErr(err))
+	}
+	return toolOK(true, result, nil)
+}
+
+// readLifecycleStatus reads a pipeline's status back via GetPipeline after a
+// successful start/stop transition RPC and labels it with the 5-value status
+// vocabulary pkg/pipeline.Status exposes internally — mirrors
+// cmd/conduit/root/pipelines.readLifecycleResult exactly (see
+// pipelineStatusLabel's doc below for why this is safe to call, not a race).
+// A read-back failure is its own error, not a silently-swallowed one: the
+// transition already took effect, so a false success here would tell the
+// agent nothing happened when it did.
+func readLifecycleStatus(ctx context.Context, client inspectClient, id, action string, force bool) (LifecycleResult, error) {
+	pipeline, err := client.GetPipeline(ctx, id)
+	if err != nil {
+		return LifecycleResult{}, fmt.Errorf("%s succeeded but reading back pipeline %q status failed: %w", action, id, err)
+	}
+	return LifecycleResult{
+		PipelineID: id,
+		Action:     action,
+		Force:      force,
+		Status:     pipelineStatusLabel(action, pipeline.GetState().GetStatus()),
+	}, nil
+}
+
+// pipelineStatusLabel mirrors
+// cmd/conduit/root/pipelines.pipelineStatusLabel exactly — duplicated, not
+// imported, because cmd/conduit/internal/mcp cannot depend on
+// cmd/conduit/root/pipelines (root packages wire commands together and sit
+// above the engine packages in the dependency graph; see doc.go). Keep any
+// change to one in sync with the other; see that function's doc for the full
+// rationale on why a "stop" action's collapsed STATUS_STOPPED read-back is
+// unambiguously "UserStopped".
+func pipelineStatusLabel(action string, status apiv1.Pipeline_Status) string {
+	switch status {
+	case apiv1.Pipeline_STATUS_RUNNING:
+		return statusRunning
+	case apiv1.Pipeline_STATUS_STOPPED:
+		if action == actionStop {
+			return statusUserStopped
+		}
+		return statusStopped
+	case apiv1.Pipeline_STATUS_DEGRADED:
+		return statusDegraded
+	case apiv1.Pipeline_STATUS_RECOVERING:
+		return statusRecovering
+	case apiv1.Pipeline_STATUS_UNSPECIFIED:
+		fallthrough
+	default:
+		return status.String()
+	}
+}

--- a/cmd/conduit/internal/mcp/tools_lifecycle_test.go
+++ b/cmd/conduit/internal/mcp/tools_lifecycle_test.go
@@ -1,0 +1,285 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/pipeline"
+	apiv1 "github.com/conduitio/conduit/proto/api/v1"
+	"github.com/matryer/is"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func newServerWithFakeInspectClient(fake *fakeInspectClient, allowMutations bool) *sdkmcp.Server {
+	return NewServer(Config{
+		AllowMutations: allowMutations,
+		APIAddress:     "localhost:0",
+		newAPIClient: func(context.Context, string) (inspectClient, error) {
+			return fake, nil
+		},
+	})
+}
+
+// TestStart_NoAPIAddress_RefusesWithSuggestion mirrors
+// TestInspect_NoAPIAddress_RefusesWithSuggestion: start/stop require a live
+// server just like inspect (design doc §3), so the same "no --api-address"
+// failure mode applies.
+func TestStart_NoAPIAddress_RefusesWithSuggestion(t *testing.T) {
+	is := is.New(t)
+
+	srv := NewServer(Config{AllowMutations: true}) // APIAddress left empty
+	cs := connectTestClient(t, srv)
+
+	res, err := cs.CallTool(context.Background(), &sdkmcp.CallToolParams{
+		Name:      ToolStart,
+		Arguments: map[string]any{"pipelineId": "orders"},
+	})
+	is.NoErr(err)
+	is.True(res.IsError)
+
+	env := decodeStructuredContent[Result[LifecycleResult]](t, res)
+	is.True(env.Error != nil)
+	is.Equal(env.Error.Code, conduiterr.CodeUnavailable.Reason())
+	is.True(env.Error.Suggestion != "")
+}
+
+func TestStop_NoAPIAddress_RefusesWithSuggestion(t *testing.T) {
+	is := is.New(t)
+
+	srv := NewServer(Config{AllowMutations: true}) // APIAddress left empty
+	cs := connectTestClient(t, srv)
+
+	res, err := cs.CallTool(context.Background(), &sdkmcp.CallToolParams{
+		Name:      ToolStop,
+		Arguments: map[string]any{"pipelineId": "orders"},
+	})
+	is.NoErr(err)
+	is.True(res.IsError)
+
+	env := decodeStructuredContent[Result[LifecycleResult]](t, res)
+	is.True(env.Error != nil)
+	is.Equal(env.Error.Code, conduiterr.CodeUnavailable.Reason())
+	is.True(env.Error.Suggestion != "")
+}
+
+// TestStart_EmptyPipelineID_RejectedBeforeCallingRPC is AC-14: an empty
+// pipelineId is refused before any RPC — the fake's StartPipeline must never
+// be called.
+func TestStart_EmptyPipelineID_RejectedBeforeCallingRPC(t *testing.T) {
+	is := is.New(t)
+
+	fake := &fakeInspectClient{}
+	srv := newServerWithFakeInspectClient(fake, true)
+	cs := connectTestClient(t, srv)
+
+	res, err := cs.CallTool(context.Background(), &sdkmcp.CallToolParams{
+		Name:      ToolStart,
+		Arguments: map[string]any{"pipelineId": ""},
+	})
+	is.NoErr(err)
+	is.True(res.IsError)
+	is.True(!fake.startCalled)
+
+	env := decodeStructuredContent[Result[LifecycleResult]](t, res)
+	is.True(env.Error != nil)
+	is.Equal(env.Error.Code, conduiterr.CodeInvalidArgument.Reason())
+}
+
+func TestStop_EmptyPipelineID_RejectedBeforeCallingRPC(t *testing.T) {
+	is := is.New(t)
+
+	fake := &fakeInspectClient{}
+	srv := newServerWithFakeInspectClient(fake, true)
+	cs := connectTestClient(t, srv)
+
+	res, err := cs.CallTool(context.Background(), &sdkmcp.CallToolParams{
+		Name:      ToolStop,
+		Arguments: map[string]any{"pipelineId": ""},
+	})
+	is.NoErr(err)
+	is.True(res.IsError)
+	is.True(!fake.stopCalled)
+
+	env := decodeStructuredContent[Result[LifecycleResult]](t, res)
+	is.True(env.Error != nil)
+	is.Equal(env.Error.Code, conduiterr.CodeInvalidArgument.Reason())
+}
+
+// TestStart_TransitionsStoppedPipelineToRunning is AC-11: a successful call
+// starts the pipeline and returns a structured result matching the CLI's
+// LifecycleResult fields, with an empty error.
+func TestStart_TransitionsStoppedPipelineToRunning(t *testing.T) {
+	is := is.New(t)
+
+	fake := &fakeInspectClient{
+		pipeline: &apiv1.Pipeline{Id: "orders", State: &apiv1.Pipeline_State{Status: apiv1.Pipeline_STATUS_RUNNING}},
+	}
+	srv := newServerWithFakeInspectClient(fake, true)
+	cs := connectTestClient(t, srv)
+
+	res, err := cs.CallTool(context.Background(), &sdkmcp.CallToolParams{
+		Name:      ToolStart,
+		Arguments: map[string]any{"pipelineId": "orders"},
+	})
+	is.NoErr(err)
+	is.True(!res.IsError)
+	is.True(fake.startCalled)
+	is.True(fake.closed) // the client is always closed, even on success
+
+	env := decodeStructuredContent[Result[LifecycleResult]](t, res)
+	is.True(env.OK)
+	is.True(env.Error == nil)
+	is.Equal(env.Result.PipelineID, "orders")
+	is.Equal(env.Result.Action, "start")
+	is.Equal(env.Result.Force, false)
+	is.Equal(env.Result.Status, "Running")
+}
+
+// TestStop_ForceTrue_CallsRPCWithForce is AC-13: force:true is passed through
+// to the StopPipeline call unmodified.
+func TestStop_ForceTrue_CallsRPCWithForce(t *testing.T) {
+	is := is.New(t)
+
+	fake := &fakeInspectClient{
+		pipeline: &apiv1.Pipeline{Id: "orders", State: &apiv1.Pipeline_State{Status: apiv1.Pipeline_STATUS_STOPPED}},
+	}
+	srv := newServerWithFakeInspectClient(fake, true)
+	cs := connectTestClient(t, srv)
+
+	res, err := cs.CallTool(context.Background(), &sdkmcp.CallToolParams{
+		Name:      ToolStop,
+		Arguments: map[string]any{"pipelineId": "orders", "force": true},
+	})
+	is.NoErr(err)
+	is.True(!res.IsError)
+	is.True(fake.stopCalled)
+	is.True(fake.stopForce)
+
+	env := decodeStructuredContent[Result[LifecycleResult]](t, res)
+	is.True(env.OK)
+	is.Equal(env.Result.Force, true)
+	is.Equal(env.Result.Status, "UserStopped")
+}
+
+// TestStop_Graceful_DefaultsForceFalse covers the default (no force key at
+// all) path: force=false reaches the RPC and the result omits it from the
+// struct's zero value.
+func TestStop_Graceful_DefaultsForceFalse(t *testing.T) {
+	is := is.New(t)
+
+	fake := &fakeInspectClient{
+		pipeline: &apiv1.Pipeline{Id: "orders", State: &apiv1.Pipeline_State{Status: apiv1.Pipeline_STATUS_STOPPED}},
+	}
+	srv := newServerWithFakeInspectClient(fake, true)
+	cs := connectTestClient(t, srv)
+
+	res, err := cs.CallTool(context.Background(), &sdkmcp.CallToolParams{
+		Name:      ToolStop,
+		Arguments: map[string]any{"pipelineId": "orders"},
+	})
+	is.NoErr(err)
+	is.True(!res.IsError)
+	is.True(fake.stopCalled)
+	is.True(!fake.stopForce)
+
+	env := decodeStructuredContent[Result[LifecycleResult]](t, res)
+	is.Equal(env.Result.Force, false)
+}
+
+// TestStart_AlreadyRunning_ReturnsCodedErrorSameAsCLI is AC-13: the same
+// pipeline.running code the CLI surfaces (see
+// cmd/conduit/root/pipelines/start_test.go's equivalent) comes back through
+// the MCP envelope, since both go through the same RPC — no divergent logic.
+func TestStart_AlreadyRunning_ReturnsCodedErrorSameAsCLI(t *testing.T) {
+	is := is.New(t)
+
+	wantErr := conduiterr.Wrap(pipeline.CodePipelineRunning, "can't start pipeline orders: already running", pipeline.ErrPipelineRunning)
+	fake := &fakeInspectClient{startErr: wantErr}
+	srv := newServerWithFakeInspectClient(fake, true)
+	cs := connectTestClient(t, srv)
+
+	res, err := cs.CallTool(context.Background(), &sdkmcp.CallToolParams{
+		Name:      ToolStart,
+		Arguments: map[string]any{"pipelineId": "orders"},
+	})
+	is.NoErr(err)
+	is.True(res.IsError)
+	is.True(fake.closed)
+
+	env := decodeStructuredContent[Result[LifecycleResult]](t, res)
+	is.True(env.Error != nil)
+	is.Equal(env.Error.Code, pipeline.CodePipelineRunning.Reason())
+}
+
+// TestStop_NotRunning_ReturnsCodedErrorSameAsCLI is the stop-side twin of the
+// above, for pipeline.not_running.
+func TestStop_NotRunning_ReturnsCodedErrorSameAsCLI(t *testing.T) {
+	is := is.New(t)
+
+	wantErr := conduiterr.Wrap(pipeline.CodePipelineNotRunning, "pipeline orders is not running", pipeline.ErrPipelineNotRunning)
+	fake := &fakeInspectClient{stopErr: wantErr}
+	srv := newServerWithFakeInspectClient(fake, true)
+	cs := connectTestClient(t, srv)
+
+	res, err := cs.CallTool(context.Background(), &sdkmcp.CallToolParams{
+		Name:      ToolStop,
+		Arguments: map[string]any{"pipelineId": "orders"},
+	})
+	is.NoErr(err)
+	is.True(res.IsError)
+	is.True(fake.closed)
+
+	env := decodeStructuredContent[Result[LifecycleResult]](t, res)
+	is.True(env.Error != nil)
+	is.Equal(env.Error.Code, pipeline.CodePipelineNotRunning.Reason())
+}
+
+// TestStart_ReadBackFailure_SurfacesAsError: a successful transition whose
+// read-back GetPipeline fails must not be reported as a silent success.
+func TestStart_ReadBackFailure_SurfacesAsError(t *testing.T) {
+	is := is.New(t)
+
+	fake := &fakeInspectClient{err: context.DeadlineExceeded}
+	srv := newServerWithFakeInspectClient(fake, true)
+	cs := connectTestClient(t, srv)
+
+	res, err := cs.CallTool(context.Background(), &sdkmcp.CallToolParams{
+		Name:      ToolStart,
+		Arguments: map[string]any{"pipelineId": "orders"},
+	})
+	is.NoErr(err)
+	is.True(res.IsError)
+	is.True(fake.startCalled)
+
+	env := decodeStructuredContent[Result[LifecycleResult]](t, res)
+	is.True(env.Error != nil)
+}
+
+// TestPipelineStatusLabel_MCP pins the same mapping the CLI's version does
+// (lifecycle_test.go in cmd/conduit/root/pipelines) — kept in sync manually
+// since the mcp package can't import the root command package (see
+// pipelineStatusLabel's doc).
+func TestPipelineStatusLabel_MCP(t *testing.T) {
+	is := is.New(t)
+
+	is.Equal(pipelineStatusLabel("start", apiv1.Pipeline_STATUS_RUNNING), "Running")
+	is.Equal(pipelineStatusLabel("stop", apiv1.Pipeline_STATUS_STOPPED), "UserStopped")
+	is.Equal(pipelineStatusLabel("start", apiv1.Pipeline_STATUS_STOPPED), "Stopped")
+	is.Equal(pipelineStatusLabel("start", apiv1.Pipeline_STATUS_DEGRADED), "Degraded")
+	is.Equal(pipelineStatusLabel("stop", apiv1.Pipeline_STATUS_RECOVERING), "Recovering")
+}

--- a/cmd/conduit/internal/testutils/mock_helpers.go
+++ b/cmd/conduit/internal/testutils/mock_helpers.go
@@ -55,6 +55,46 @@ func MockGetPipelines(mockService *mock.MockPipelineService, pipelines []*apiv1.
 	}, nil).Times(1)
 }
 
+// MockGetPipelineWithStatus is like MockGetPipeline but lets the caller pick
+// the read-back status — used by the start/stop lifecycle command tests,
+// which need a Pipeline_State distinct from MockGetPipeline's hardcoded
+// STATUS_RUNNING (e.g. STATUS_STOPPED after a successful stop).
+func MockGetPipelineWithStatus(mockService *mock.MockPipelineService, pipelineID string, status apiv1.Pipeline_Status) {
+	mockService.EXPECT().GetPipeline(gomock.Any(), &apiv1.GetPipelineRequest{
+		Id: pipelineID,
+	}).Return(&apiv1.GetPipelineResponse{
+		Pipeline: &apiv1.Pipeline{
+			Id:    pipelineID,
+			State: &apiv1.Pipeline_State{Status: status},
+		},
+	}, nil).Times(1)
+}
+
+// MockStartPipeline sets up a StartPipeline expectation returning err (nil on
+// success).
+func MockStartPipeline(mockService *mock.MockPipelineService, pipelineID string, err error) {
+	var resp *apiv1.StartPipelineResponse
+	if err == nil {
+		resp = &apiv1.StartPipelineResponse{}
+	}
+	mockService.EXPECT().StartPipeline(gomock.Any(), &apiv1.StartPipelineRequest{
+		Id: pipelineID,
+	}).Return(resp, err).Times(1)
+}
+
+// MockStopPipeline sets up a StopPipeline expectation for the given force
+// value, returning err (nil on success).
+func MockStopPipeline(mockService *mock.MockPipelineService, pipelineID string, force bool, err error) {
+	var resp *apiv1.StopPipelineResponse
+	if err == nil {
+		resp = &apiv1.StopPipelineResponse{}
+	}
+	mockService.EXPECT().StopPipeline(gomock.Any(), &apiv1.StopPipelineRequest{
+		Id:    pipelineID,
+		Force: force,
+	}).Return(resp, err).Times(1)
+}
+
 // ProcessorService --------------------------------------------
 
 func MockGetProcessor(

--- a/cmd/conduit/root/mcp/mcp.go
+++ b/cmd/conduit/root/mcp/mcp.go
@@ -61,11 +61,11 @@ type MCPFlags struct {
 	HTTP string `long:"http" usage:"serve the streamable-HTTP transport on this address INSTEAD OF stdio (EXPERIMENTAL; see docs/operations/mcp-server.md); requires --token-file and --tls-cert/--tls-key"`
 	// AllowMutations is a startup/process flag, deliberately not a tool
 	// argument — see cmd/conduit/internal/mcp.Config.AllowMutations's doc.
-	AllowMutations bool   `long:"allow-mutations" usage:"register the write tools (apply, scaffold_connector, scaffold_processor); an operator/process-level switch, never agent-settable"`
+	AllowMutations bool   `long:"allow-mutations" usage:"register the write tools (apply, start, stop, scaffold_connector, scaffold_processor); an operator/process-level switch, never agent-settable"`
 	TokenFile      string `long:"token-file" usage:"path to a file containing the bearer token --http requires (compared constant-time)"`
 	TLSCert        string `long:"tls-cert" usage:"TLS certificate file for --http"`
 	TLSKey         string `long:"tls-key" usage:"TLS key file for --http"`
-	APIAddress     string `long:"api-address" usage:"gRPC address of a running Conduit, dialed by the inspect tool"`
+	APIAddress     string `long:"api-address" usage:"gRPC address of a running Conduit, dialed by the inspect/start/stop tools"`
 }
 
 // MCPCommand implements `conduit mcp`: a long-running server, like `conduit
@@ -88,10 +88,10 @@ func (c *MCPCommand) Docs() ecdysis.Docs {
 		Short: "Run Conduit's MCP server, exposing pipeline operations to AI agents",
 		Long: `Registers Conduit's operations as MCP tools that are 1:1 with the CLI verbs and call the
 exact same engines — validate/lint/dry_run/deploy/doctor/inspect are always available (deploy only
-computes a diff + hash, never mutates); apply/scaffold_connector/scaffold_processor are additionally
-registered only when --allow-mutations is set, since those tools mutate the local pipeline store or
-filesystem. --allow-mutations is an operator/process-level flag, never something an agent can pass as
-a tool argument.
+computes a diff + hash, never mutates); apply/start/stop/scaffold_connector/scaffold_processor are
+additionally registered only when --allow-mutations is set, since those tools mutate the local
+pipeline store, a running pipeline, or the filesystem. --allow-mutations is an operator/process-level
+flag, never something an agent can pass as a tool argument.
 
 Serves stdio by default (the primary agent channel — no auth needed, since the agent owns the
 process). Pass --http <addr> to serve the streamable-HTTP transport INSTEAD OF stdio — this is a
@@ -102,7 +102,9 @@ unauthenticated HTTP). The HTTP transport is EXPERIMENTAL: no rate limiting, no 
 and a single shared token with no rotation short of a restart — see
 docs/operations/mcp-server.md.
 
-The inspect tool requires a running Conduit: pass --api-address to point it at one.`,
+The inspect, start, and stop tools all require a running Conduit: pass --api-address to point them at
+one. start/stop have no offline fallback the way apply does — starting or stopping a pipeline only
+has meaning against a live server.`,
 		Example: "conduit mcp\n" +
 			"conduit mcp --api-address localhost:8084\n" +
 			"conduit mcp --allow-mutations\n" +

--- a/cmd/conduit/root/pipelines/lifecycle.go
+++ b/cmd/conduit/root/pipelines/lifecycle.go
@@ -1,0 +1,142 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelines
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/conduitio/conduit/cmd/conduit/api"
+	"github.com/conduitio/conduit/cmd/conduit/internal/display"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	apiv1 "github.com/conduitio/conduit/proto/api/v1"
+)
+
+// Lifecycle action names — the values readLifecycleResult's action parameter
+// takes, and LifecycleResult.Action's two possible values.
+const (
+	actionStart = "start"
+	actionStop  = "stop"
+)
+
+// The 5-value status vocabulary pkg/pipeline.Status exposes internally,
+// rendered by pipelineStatusLabel. See that function's doc.
+const (
+	statusRunning     = "Running"
+	statusStopped     = "Stopped"
+	statusUserStopped = "UserStopped"
+	statusDegraded    = "Degraded"
+	statusRecovering  = "Recovering"
+)
+
+// LifecycleResult is the shared result shape StartCommand and StopCommand
+// return: the pipeline transitioned, which action ran, and its resulting
+// status, read back from the server after the transition RPC returns. See
+// docs/design-documents/20260712-cli-pipeline-lifecycle-verbs.md §1.
+//
+// Force is only meaningful for "stop" and is omitted from JSON when false, so
+// a "start" result never carries a stray "force":false.
+type LifecycleResult struct {
+	PipelineID string `json:"pipeline_id"`
+	Action     string `json:"action"` // "start" | "stop"
+	Force      bool   `json:"force,omitempty"`
+	Status     string `json:"status"`
+
+	// protoStatus is the raw read-back status Render uses to match the
+	// existing inspect-style lowercase text vocabulary
+	// (display.PrintStatusFromProtoString). Unexported: never marshaled, so
+	// --json only ever carries the Status field above.
+	protoStatus apiv1.Pipeline_Status
+}
+
+// readLifecycleResult reads a pipeline's status back via GetPipeline after a
+// successful start/stop transition RPC and builds the LifecycleResult both
+// commands render. Called only after the transition RPC itself has already
+// succeeded — a failure here means the transition took effect but the
+// read-back didn't, which is reported as its own error rather than silently
+// swallowed (an agent or script must not see a false success).
+func readLifecycleResult(ctx context.Context, client *api.Client, id, action string, force bool) (*LifecycleResult, error) {
+	resp, err := client.PipelineServiceClient.GetPipeline(ctx, &apiv1.GetPipelineRequest{Id: id})
+	if err != nil {
+		return nil, cerrors.Errorf("%s succeeded but reading back pipeline %q status failed: %w", action, id, err)
+	}
+
+	status := resp.GetPipeline().GetState().GetStatus()
+	return &LifecycleResult{
+		PipelineID:  id,
+		Action:      action,
+		Force:       force,
+		Status:      pipelineStatusLabel(action, status),
+		protoStatus: status,
+	}, nil
+}
+
+// pipelineStatusLabel renders a lifecycle transition's resulting status using
+// the 5-value vocabulary pkg/pipeline.Status exposes internally (Running,
+// SystemStopped, UserStopped, Degraded, Recovering) — see
+// docs/design-documents/20260704-phase-1-execution-plan.md §3: "the UI can't
+// collapse System/UserStopped into one 'Stopped' while the CLI keeps them
+// distinct."
+//
+// The wire protocol collapses StatusUserStopped/StatusSystemStopped into a
+// single Pipeline_STATUS_STOPPED (pkg/http/api/toproto/pipeline.go
+// PipelineStatus) — GetPipeline's read-back alone cannot tell them apart. But
+// a successful "stop" action's read-back can only ever be StatusUserStopped:
+// StatusSystemStopped is set exclusively during server-startup reconciliation
+// of pipelines that were running before a restart
+// (pkg/pipeline/service.go:74-79), never by an explicit StopPipeline RPC
+// succeeding. So a STATUS_STOPPED read-back immediately after this command's
+// own successful stop call is unambiguously "UserStopped", not a guess.
+//
+// Mirrored (not shared via import) in
+// cmd/conduit/internal/mcp/tools_lifecycle.go, since the mcp package cannot
+// depend on this root command package — keep any change to one in sync with
+// the other.
+func pipelineStatusLabel(action string, status apiv1.Pipeline_Status) string {
+	switch status {
+	case apiv1.Pipeline_STATUS_RUNNING:
+		return statusRunning
+	case apiv1.Pipeline_STATUS_STOPPED:
+		if action == actionStop {
+			return statusUserStopped
+		}
+		return statusStopped
+	case apiv1.Pipeline_STATUS_DEGRADED:
+		return statusDegraded
+	case apiv1.Pipeline_STATUS_RECOVERING:
+		return statusRecovering
+	case apiv1.Pipeline_STATUS_UNSPECIFIED:
+		fallthrough
+	default:
+		return display.PrintStatusFromProtoString(status.String())
+	}
+}
+
+// renderLifecycleResult renders the text (non-JSON) form of a LifecycleResult
+// as a single human line naming the pipeline and its resulting status,
+// through the same display.PrintStatusFromProtoString helper `inspect` uses
+// (AC-5) — so the human-readable status vocabulary matches across CLI verbs,
+// even though the --json Status field above uses the richer 5-value label.
+func renderLifecycleResult(result any) string {
+	res, ok := result.(*LifecycleResult)
+	if !ok {
+		return ""
+	}
+
+	buf := new(bytes.Buffer)
+	fmt.Fprintf(buf, "Pipeline %s  [%s]\n", res.PipelineID, display.PrintStatusFromProtoString(res.protoStatus.String()))
+	return buf.String()
+}

--- a/cmd/conduit/root/pipelines/lifecycle_test.go
+++ b/cmd/conduit/root/pipelines/lifecycle_test.go
@@ -1,0 +1,79 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelines
+
+import (
+	"testing"
+
+	apiv1 "github.com/conduitio/conduit/proto/api/v1"
+	json "github.com/goccy/go-json"
+	"github.com/matryer/is"
+)
+
+// TestPipelineStatusLabel pins the 5-value status vocabulary mapping,
+// including the collapsed-STOPPED disambiguation described on
+// pipelineStatusLabel's doc: a "stop" action's STATUS_STOPPED read-back is
+// always "UserStopped", never "SystemStopped" (which this RPC path can never
+// produce).
+func TestPipelineStatusLabel(t *testing.T) {
+	is := is.New(t)
+
+	tests := []struct {
+		name   string
+		action string
+		status apiv1.Pipeline_Status
+		want   string
+	}{
+		{"start running", "start", apiv1.Pipeline_STATUS_RUNNING, "Running"},
+		{"stop stopped", "stop", apiv1.Pipeline_STATUS_STOPPED, "UserStopped"},
+		{"start unexpectedly stopped", "start", apiv1.Pipeline_STATUS_STOPPED, "Stopped"},
+		{"degraded", "start", apiv1.Pipeline_STATUS_DEGRADED, "Degraded"},
+		{"recovering", "stop", apiv1.Pipeline_STATUS_RECOVERING, "Recovering"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			is.Equal(pipelineStatusLabel(tt.action, tt.status), tt.want)
+		})
+	}
+}
+
+// TestLifecycleResult_JSON pins AC-2/AC-4's literal --json shapes: no stray
+// "force" key on a start result, and force:true present on a forced stop.
+func TestLifecycleResult_JSON(t *testing.T) {
+	is := is.New(t)
+
+	start := &LifecycleResult{PipelineID: "orders", Action: "start", Status: "Running"}
+	b, err := json.Marshal(start)
+	is.NoErr(err)
+	is.Equal(string(b), `{"pipeline_id":"orders","action":"start","status":"Running"}`)
+
+	stop := &LifecycleResult{PipelineID: "orders", Action: "stop", Status: "UserStopped"}
+	b, err = json.Marshal(stop)
+	is.NoErr(err)
+	is.Equal(string(b), `{"pipeline_id":"orders","action":"stop","status":"UserStopped"}`)
+
+	forced := &LifecycleResult{PipelineID: "orders", Action: "stop", Force: true, Status: "UserStopped"}
+	b, err = json.Marshal(forced)
+	is.NoErr(err)
+	is.Equal(string(b), `{"pipeline_id":"orders","action":"stop","force":true,"status":"UserStopped"}`)
+}
+
+// TestRenderLifecycleResult_WrongType asserts Render never panics on an
+// unexpected result type (defensive: the decorator always passes back
+// whatever ExecuteWithClientResult returned, but Render's signature is `any`).
+func TestRenderLifecycleResult_WrongType(t *testing.T) {
+	is := is.New(t)
+	is.Equal(renderLifecycleResult("not a LifecycleResult"), "")
+}

--- a/cmd/conduit/root/pipelines/pipelines.go
+++ b/cmd/conduit/root/pipelines/pipelines.go
@@ -39,6 +39,8 @@ func (c *PipelinesCommand) SubCommands() []ecdysis.Command {
 		&DryRunCommand{},
 		&DeployCommand{},
 		&ApplyCommand{},
+		&StartCommand{},
+		&StopCommand{},
 	}
 }
 

--- a/cmd/conduit/root/pipelines/start.go
+++ b/cmd/conduit/root/pipelines/start.go
@@ -1,0 +1,101 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelines
+
+import (
+	"context"
+
+	"github.com/conduitio/conduit/cmd/conduit/api"
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	apiv1 "github.com/conduitio/conduit/proto/api/v1"
+	"github.com/conduitio/ecdysis"
+)
+
+var (
+	_ cecdysis.CommandWithExecuteWithClientResult = (*StartCommand)(nil)
+	_ ecdysis.CommandWithDocs                     = (*StartCommand)(nil)
+	_ ecdysis.CommandWithArgs                     = (*StartCommand)(nil)
+)
+
+// StartArgs holds StartCommand's positional argument.
+type StartArgs struct {
+	PipelineID string
+}
+
+// StartCommand implements `conduit pipelines start PIPELINE_ID`: transitions
+// a stopped pipeline registered in a running Conduit to Running, via the
+// StartPipeline RPC (server-side: pkg/lifecycle.Service.Start — already
+// shipped; this command is CLI wiring only). Mirrors InspectCommand's shape:
+// one required positional ID, a live gRPC client, --json for free via the
+// client-result decorator.
+//
+// Unlike deploy/apply, start has no offline/local-store fallback: starting a
+// pipeline means running its goroutines inside a live process, which only has
+// meaning against a process that stays up (a `conduit run` server) — a
+// one-shot CLI invocation that started the pipeline would have it die the
+// moment the process exited. See
+// docs/design-documents/20260712-cli-pipeline-lifecycle-verbs.md §3.
+type StartCommand struct {
+	args StartArgs
+}
+
+func (c *StartCommand) Usage() string { return "start PIPELINE_ID" }
+
+func (c *StartCommand) Docs() ecdysis.Docs {
+	return ecdysis.Docs{
+		Short: "Start a pipeline registered in a running Conduit",
+		Long: `Transitions a stopped pipeline to Running against a live Conduit server. Requires a
+reachable server (conduit run) at the configured gRPC address — there is deliberately no
+offline/local-store fallback, since a started pipeline's goroutines only stay alive inside a
+long-running process; see 'conduit pipelines apply' for the offline pipeline-config path.
+
+Starting an already-running pipeline is refused with pipeline.running (exit 2); nothing is
+mutated — use 'conduit pipelines stop' first if you need to restart it.`,
+		Example: "conduit pipelines start orders\n" +
+			"conduit pipelines start orders --json",
+	}
+}
+
+func (c *StartCommand) Args(args []string) error {
+	if len(args) == 0 {
+		return cerrors.Errorf("requires a pipeline ID")
+	}
+	if len(args) > 1 {
+		return cerrors.Errorf("too many arguments")
+	}
+	c.args.PipelineID = args[0]
+	return nil
+}
+
+// ExecuteWithClientResult calls StartPipeline, then reads the pipeline's
+// resulting status back via GetPipeline (AC-1/AC-2). A failure here — not
+// found, already running, or the server being unreachable — is returned
+// as-is: the client-result decorator maps its gRPC status to the process
+// exit code (NotFound/FailedPrecondition -> 2, Unavailable -> 3) and the
+// coded conduiterr the server attached survives unchanged (AC-6/8/10).
+func (c *StartCommand) ExecuteWithClientResult(ctx context.Context, client *api.Client) (any, error) {
+	if _, err := client.PipelineServiceClient.StartPipeline(ctx, &apiv1.StartPipelineRequest{
+		Id: c.args.PipelineID,
+	}); err != nil {
+		return nil, cerrors.Errorf("failed to start pipeline %q: %w", c.args.PipelineID, err)
+	}
+
+	return readLifecycleResult(ctx, client, c.args.PipelineID, actionStart, false)
+}
+
+func (c *StartCommand) Render(result any) string {
+	return renderLifecycleResult(result)
+}

--- a/cmd/conduit/root/pipelines/start_test.go
+++ b/cmd/conduit/root/pipelines/start_test.go
@@ -1,0 +1,120 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelines
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/matryer/is"
+	"go.uber.org/mock/gomock"
+
+	"github.com/conduitio/conduit/cmd/conduit/api"
+	"github.com/conduitio/conduit/cmd/conduit/api/mock"
+	"github.com/conduitio/conduit/cmd/conduit/internal/testutils"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/pipeline"
+	apiv1 "github.com/conduitio/conduit/proto/api/v1"
+)
+
+func TestStartExecutionArgs(t *testing.T) {
+	is := is.New(t)
+
+	is.Equal((&StartCommand{}).Args([]string{}).Error(), "requires a pipeline ID")
+	is.Equal((&StartCommand{}).Args([]string{"a", "b"}).Error(), "too many arguments")
+
+	c := &StartCommand{}
+	is.NoErr(c.Args([]string{"orders"}))
+	is.Equal(c.args.PipelineID, "orders")
+}
+
+// AC-1/AC-2: start on a stopped pipeline calls StartPipeline, reads the
+// resulting status back via GetPipeline, and renders both the --json shape
+// (via LifecycleResult) and the human text line.
+func TestStartCommandExecuteWithClient(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	cmd := &StartCommand{args: StartArgs{PipelineID: "orders"}}
+
+	mockPipeline := mock.NewMockPipelineService(ctrl)
+	testutils.MockStartPipeline(mockPipeline, "orders", nil)
+	testutils.MockGetPipelineWithStatus(mockPipeline, "orders", apiv1.Pipeline_STATUS_RUNNING)
+
+	client := &api.Client{PipelineServiceClient: mockPipeline}
+
+	result, err := cmd.ExecuteWithClientResult(ctx, client)
+	is.NoErr(err)
+
+	lr, ok := result.(*LifecycleResult)
+	is.True(ok)
+	is.Equal(lr.PipelineID, "orders")
+	is.Equal(lr.Action, "start")
+	is.Equal(lr.Force, false)
+	is.Equal(lr.Status, "Running")
+
+	out := cmd.Render(result)
+	is.True(strings.Contains(out, "Pipeline orders  [running]"))
+}
+
+// AC-6: starting an already-running pipeline surfaces the server's
+// pipeline.running error unchanged, and GetPipeline is never called (nothing
+// mutated, no further RPCs attempted after the failure).
+func TestStartCommandExecuteWithClient_AlreadyRunning(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	cmd := &StartCommand{args: StartArgs{PipelineID: "orders"}}
+
+	wantErr := conduiterr.Wrap(pipeline.CodePipelineRunning, "can't start pipeline orders: already running", pipeline.ErrPipelineRunning)
+	mockPipeline := mock.NewMockPipelineService(ctrl)
+	mockPipeline.EXPECT().StartPipeline(gomock.Any(), &apiv1.StartPipelineRequest{Id: "orders"}).
+		Return(nil, wantErr).Times(1)
+	// No GetPipeline expectation: the gomock controller fails the test if the
+	// command calls it after StartPipeline already failed.
+
+	client := &api.Client{PipelineServiceClient: mockPipeline}
+
+	_, err := cmd.ExecuteWithClientResult(ctx, client)
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code, pipeline.CodePipelineRunning)
+}
+
+// AC-8: an unknown pipeline ID surfaces pipeline.instance_not_found unchanged.
+func TestStartCommandExecuteWithClient_NotFound(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	cmd := &StartCommand{args: StartArgs{PipelineID: "nope"}}
+
+	wantErr := conduiterr.Wrap(pipeline.CodePipelineNotFound, "pipeline nope not found", pipeline.ErrInstanceNotFound)
+	mockPipeline := mock.NewMockPipelineService(ctrl)
+	mockPipeline.EXPECT().StartPipeline(gomock.Any(), &apiv1.StartPipelineRequest{Id: "nope"}).
+		Return(nil, wantErr).Times(1)
+
+	client := &api.Client{PipelineServiceClient: mockPipeline}
+
+	_, err := cmd.ExecuteWithClientResult(ctx, client)
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code, pipeline.CodePipelineNotFound)
+}

--- a/cmd/conduit/root/pipelines/stop.go
+++ b/cmd/conduit/root/pipelines/stop.go
@@ -1,0 +1,122 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelines
+
+import (
+	"context"
+
+	"github.com/conduitio/conduit/cmd/conduit/api"
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	apiv1 "github.com/conduitio/conduit/proto/api/v1"
+	"github.com/conduitio/ecdysis"
+)
+
+var (
+	_ cecdysis.CommandWithExecuteWithClientResult = (*StopCommand)(nil)
+	_ ecdysis.CommandWithDocs                     = (*StopCommand)(nil)
+	_ ecdysis.CommandWithFlags                    = (*StopCommand)(nil)
+	_ ecdysis.CommandWithArgs                     = (*StopCommand)(nil)
+)
+
+// StopArgs holds StopCommand's positional argument.
+type StopArgs struct {
+	PipelineID string
+}
+
+// StopFlags holds StopCommand's flags.
+type StopFlags struct {
+	// Force skips the graceful drain (stopGraceful) and stops immediately
+	// (stopForceful) via StopPipelineRequest.force. This may leave in-flight
+	// records un-drained, but it is not a data-loss escape hatch: positions
+	// are crash-safe (invariant 2) and delivery is at-least-once (invariant
+	// 3), so a forced stop behaves like a crash — recoverable on the next
+	// start, not lossy.
+	Force bool `long:"force" usage:"skip graceful drain and stop immediately; may leave in-flight records un-drained (safe: positions are crash-safe and delivery is at-least-once, so this behaves like a crash, not data loss)"`
+}
+
+// StopCommand implements `conduit pipelines stop PIPELINE_ID [--force]`:
+// transitions a running pipeline registered in a running Conduit to
+// UserStopped, via the StopPipeline RPC (server-side:
+// pkg/lifecycle.Service.Stop — already shipped; this command is CLI wiring
+// only). Like StartCommand it requires a live server and has no
+// offline/local-store fallback — see
+// docs/design-documents/20260712-cli-pipeline-lifecycle-verbs.md §3.
+//
+// StopPipeline returns once stopGraceful has asked the pub nodes to stop; the
+// drain then completes asynchronously. This command does not block/poll for
+// the drain to fully settle — it reports whatever GetPipeline's read-back
+// says once the transition RPC returns, so neither a human nor an agent
+// should assume "stop" returning means the drain is 100% complete (a --wait
+// flag is a deferred follow-up, not implemented here).
+type StopCommand struct {
+	args  StopArgs
+	flags StopFlags
+}
+
+func (c *StopCommand) Usage() string { return "stop PIPELINE_ID" }
+
+func (c *StopCommand) Docs() ecdysis.Docs {
+	return ecdysis.Docs{
+		Short: "Stop a pipeline registered in a running Conduit",
+		Long: `Transitions a running pipeline to UserStopped against a live Conduit server: gracefully
+by default (drains in-flight records before returning), or immediately with --force. Requires a
+reachable server (conduit run) at the configured gRPC address — there is deliberately no
+offline/local-store fallback, since there is nothing running to stop without a live process.
+
+This command does not wait for a graceful drain to fully settle before returning — it reports the
+pipeline's status immediately after the transition RPC returns, which may still be transitional.
+
+Stopping an already-stopped pipeline is refused with pipeline.not_running (exit 2); nothing is
+mutated — use 'conduit pipelines start' first.`,
+		Example: "conduit pipelines stop orders\n" +
+			"conduit pipelines stop orders --force\n" +
+			"conduit pipelines stop orders --json",
+	}
+}
+
+func (c *StopCommand) Flags() []ecdysis.Flag { return ecdysis.BuildFlags(&c.flags) }
+
+func (c *StopCommand) Args(args []string) error {
+	if len(args) == 0 {
+		return cerrors.Errorf("requires a pipeline ID")
+	}
+	if len(args) > 1 {
+		return cerrors.Errorf("too many arguments")
+	}
+	c.args.PipelineID = args[0]
+	return nil
+}
+
+// ExecuteWithClientResult calls StopPipeline with the --force flag, then
+// reads the pipeline's resulting status back via GetPipeline (AC-3/AC-4). A
+// failure here — not found, not running, or the server being unreachable —
+// is returned as-is: the client-result decorator maps its gRPC status to the
+// process exit code and the coded conduiterr the server attached survives
+// unchanged (AC-6/8/10).
+func (c *StopCommand) ExecuteWithClientResult(ctx context.Context, client *api.Client) (any, error) {
+	if _, err := client.PipelineServiceClient.StopPipeline(ctx, &apiv1.StopPipelineRequest{
+		Id:    c.args.PipelineID,
+		Force: c.flags.Force,
+	}); err != nil {
+		return nil, cerrors.Errorf("failed to stop pipeline %q: %w", c.args.PipelineID, err)
+	}
+
+	return readLifecycleResult(ctx, client, c.args.PipelineID, actionStop, c.flags.Force)
+}
+
+func (c *StopCommand) Render(result any) string {
+	return renderLifecycleResult(result)
+}

--- a/cmd/conduit/root/pipelines/stop_test.go
+++ b/cmd/conduit/root/pipelines/stop_test.go
@@ -1,0 +1,142 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelines
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/matryer/is"
+	"go.uber.org/mock/gomock"
+
+	"github.com/conduitio/conduit/cmd/conduit/api"
+	"github.com/conduitio/conduit/cmd/conduit/api/mock"
+	"github.com/conduitio/conduit/cmd/conduit/internal/testutils"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/pipeline"
+	apiv1 "github.com/conduitio/conduit/proto/api/v1"
+)
+
+func TestStopExecutionArgs(t *testing.T) {
+	is := is.New(t)
+
+	is.Equal((&StopCommand{}).Args([]string{}).Error(), "requires a pipeline ID")
+	is.Equal((&StopCommand{}).Args([]string{"a", "b"}).Error(), "too many arguments")
+
+	c := &StopCommand{}
+	is.NoErr(c.Args([]string{"orders"}))
+	is.Equal(c.args.PipelineID, "orders")
+	is.Equal(c.flags.Force, false) // default: graceful
+}
+
+// AC-3: stop on a running pipeline calls StopPipeline with force=false (the
+// graceful path), reads the status back, and the result carries no stray
+// "force" (Force is the Go zero value, JSON-omitted).
+func TestStopCommandExecuteWithClient_Graceful(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	cmd := &StopCommand{args: StopArgs{PipelineID: "orders"}}
+
+	mockPipeline := mock.NewMockPipelineService(ctrl)
+	testutils.MockStopPipeline(mockPipeline, "orders", false, nil)
+	testutils.MockGetPipelineWithStatus(mockPipeline, "orders", apiv1.Pipeline_STATUS_STOPPED)
+
+	client := &api.Client{PipelineServiceClient: mockPipeline}
+
+	result, err := cmd.ExecuteWithClientResult(ctx, client)
+	is.NoErr(err)
+
+	lr, ok := result.(*LifecycleResult)
+	is.True(ok)
+	is.Equal(lr.PipelineID, "orders")
+	is.Equal(lr.Action, "stop")
+	is.Equal(lr.Force, false)
+	is.Equal(lr.Status, "UserStopped")
+
+	out := cmd.Render(result)
+	is.True(strings.Contains(out, "Pipeline orders  [stopped]"))
+}
+
+// AC-4: --force calls StopPipeline with force=true and the result carries
+// Force:true.
+func TestStopCommandExecuteWithClient_Force(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	cmd := &StopCommand{args: StopArgs{PipelineID: "orders"}, flags: StopFlags{Force: true}}
+
+	mockPipeline := mock.NewMockPipelineService(ctrl)
+	testutils.MockStopPipeline(mockPipeline, "orders", true, nil)
+	testutils.MockGetPipelineWithStatus(mockPipeline, "orders", apiv1.Pipeline_STATUS_STOPPED)
+
+	client := &api.Client{PipelineServiceClient: mockPipeline}
+
+	result, err := cmd.ExecuteWithClientResult(ctx, client)
+	is.NoErr(err)
+
+	lr, ok := result.(*LifecycleResult)
+	is.True(ok)
+	is.Equal(lr.Force, true)
+	is.Equal(lr.Status, "UserStopped")
+}
+
+// AC-7: stopping an already-stopped pipeline surfaces pipeline.not_running
+// unchanged, and GetPipeline is never called.
+func TestStopCommandExecuteWithClient_NotRunning(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	cmd := &StopCommand{args: StopArgs{PipelineID: "orders"}}
+
+	wantErr := conduiterr.Wrap(pipeline.CodePipelineNotRunning, `can't stop pipeline with status "UserStopped"`, pipeline.ErrPipelineNotRunning)
+	mockPipeline := mock.NewMockPipelineService(ctrl)
+	mockPipeline.EXPECT().StopPipeline(gomock.Any(), &apiv1.StopPipelineRequest{Id: "orders", Force: false}).
+		Return(nil, wantErr).Times(1)
+
+	client := &api.Client{PipelineServiceClient: mockPipeline}
+
+	_, err := cmd.ExecuteWithClientResult(ctx, client)
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code, pipeline.CodePipelineNotRunning)
+}
+
+// AC-8: an unknown pipeline ID surfaces pipeline.instance_not_found unchanged.
+func TestStopCommandExecuteWithClient_NotFound(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	cmd := &StopCommand{args: StopArgs{PipelineID: "nope"}}
+
+	wantErr := conduiterr.Wrap(pipeline.CodePipelineNotFound, "pipeline nope not found", pipeline.ErrInstanceNotFound)
+	mockPipeline := mock.NewMockPipelineService(ctrl)
+	mockPipeline.EXPECT().StopPipeline(gomock.Any(), &apiv1.StopPipelineRequest{Id: "nope", Force: false}).
+		Return(nil, wantErr).Times(1)
+
+	client := &api.Client{PipelineServiceClient: mockPipeline}
+
+	_, err := cmd.ExecuteWithClientResult(ctx, client)
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code, pipeline.CodePipelineNotFound)
+}

--- a/docs/operations/mcp-server.md
+++ b/docs/operations/mcp-server.md
@@ -33,6 +33,8 @@ conduit mcp --api-address localhost:8084
 | `deploy` | no (preview only) | no | `conduit pipelines deploy` |
 | `inspect` | no | no | `conduit pipelines inspect` (requires `--api-address`) |
 | `apply` | yes | **yes** | `conduit pipelines apply` |
+| `start` | yes (running pipeline) | **yes** | `conduit pipelines start` (requires `--api-address`) |
+| `stop` | yes (running pipeline) | **yes** | `conduit pipelines stop` (requires `--api-address`) |
 | `scaffold_connector` | yes (filesystem) | **yes** | `conduit connector new` |
 | `scaffold_processor` | yes (filesystem) | **yes** | `conduit processor new` |
 
@@ -71,6 +73,17 @@ operator gate that requires). Without a reachable server, they fall back to the 
 Badger-only structural gate and refuses outright to touch a running pipeline. Either way,
 `--allow-mutations` above is the orthogonal gate deciding whether the `apply` tool is registered at
 all; it says nothing about which transport a registered `apply` tool uses.
+
+ `start`/`stop` transition a pipeline by ID against a running Conduit server's `StartPipeline`/
+`StopPipeline` RPCs — the same engine `conduit pipelines start`/`stop` call. Unlike `deploy`/`apply`
+they have **no standalone fallback**: starting a pipeline means running its goroutines inside a live
+process, which only has meaning against a process that stays up, and stopping is meaningless with no
+server to stop anything on. Both tools refuse with `common.unavailable` if `--api-address` wasn't
+set at `conduit mcp` startup, exactly like `inspect`. `stop`'s `force` argument mirrors the CLI's
+`--force`: it skips the graceful drain (immediate stop) rather than waiting for in-flight records to
+finish, but is not a data-loss escape hatch — positions are crash-safe and delivery is at-least-once,
+so a forced stop behaves like a crash (recoverable), not silent loss. See
+[`docs/design-documents/20260712-cli-pipeline-lifecycle-verbs.md`](../design-documents/20260712-cli-pipeline-lifecycle-verbs.md).
 
 ## HTTP transport (EXPERIMENTAL)
 


### PR DESCRIPTION
## What
`conduit pipelines start` / `conduit pipelines stop` CLI verbs + `start`/`stop` MCP tools, wiring the CLI and agent surfaces to the `StartPipeline`/`StopPipeline` RPCs that already ship server-side. Advances execution-plan **§3 (CLI verb parity)**. Design: `docs/design-documents/20260712-cli-pipeline-lifecycle-verbs.md` (merged #2602). Risk tier 2.

## Design decisions
- **Require a live server** (mirror `inspect`; no Badger-only local fallback — a standalone "start" would run in a process that immediately exits).
- **`--allow-mutations` gate:** start/stop MCP tools registered only inside that block, like `apply` — operator/process-level, never a tool argument.
- **`--json`** via a Result type; reuse existing `CodePipelineRunning`/`CodePipelineNotRunning` codes (none added).
- **`pause` deferred:** no Paused state in the 5-value enum, no engine primitive; faking it as stop+start changes delivery semantics — separate design.

## Verification
`go build ./...` clean; `go test -race` green on `root/pipelines`, `internal/mcp`, `api`; `golangci-lint` 0 issues; mock regenerated with pinned mockgen; `mcp-server.md` markdown clean (pinned 0.38.0).

## Process note
Authored by a subagent; finalized (lint/build/test/commit) by the main session after the agent stalled at the finish line (infra flake). **Pending a thorough fresh-context review before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3cLokwNJYLLBpdyt3cgGr