### PR TITLE
docs(readme): bump install examples to v0.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Download the right `.deb` file for your machine architecture from the
 [latest release](https://github.com/conduitio/conduit/releases/latest), then run:
 
 ```sh
-dpkg -i conduit_0.15.0_Linux_x86_64.deb
+dpkg -i conduit_0.17.0_Linux_x86_64.deb
 ```
 
 ### RPM
@@ -103,7 +103,7 @@ Download the right `.rpm` file for your machine architecture from the
 [latest release](https://github.com/conduitio/conduit/releases/latest), then run:
 
 ```sh
-rpm -i conduit_0.15.0_Linux_x86_64.rpm
+rpm -i conduit_0.17.0_Linux_x86_64.rpm
 ```
 
 ### Build from source


### PR DESCRIPTION
Release prep for v0.17.0 (ROADMAP §2–§4 CLI/agent surface). The README Debian/RPM install examples referenced the stale `conduit_0.15.0_*` package name (they were not bumped for the 0.16 line); update them to `0.17.0`.

Tier 3 (docs). No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3cLokwNJYLLBpdyt3cgGr