### PR TITLE
docs(design): v0.18 UI & extensibility epic — built-in UI + connector registry

### DIFF
--- a/docs/design-documents/20260713-connector-registry-mvp.md
+++ b/docs/design-documents/20260713-connector-registry-mvp.md
@@ -1,0 +1,366 @@
+# Connector registry MVP: `conduit connectors install`
+
+## Summary
+
+The second half of the v0.18 "UI & extensibility" epic: a **connector registry** so a user (or an
+agent) can go from "I need the Postgres connector" to a running, **signature-verified**,
+version-compatible connector in one command:
+
+```sh
+conduit connectors install postgres          # latest compatible
+conduit connectors install postgres@v0.14.0   # pinned
+```
+
+MVP shape, chosen for a small team and for GitOps-friendliness:
+
+- **A static, git-backed index** (connector metadata: names, versions, per-OS/arch artifacts, min
+  Conduit + protocol version, publisher, signature reference) served from a well-known URL —
+  **no hosted service to run.**
+- **Artifacts on GitHub Releases** of each connector repo (where they already live), fetched
+  through the existing Scarf download gateway for stats.
+- **Keyless signing (Sigstore/cosign)** at publish time via a reusable GitHub Action; `install`
+  **verifies the signature and provenance before the artifact is ever made runnable**, refusing
+  unsigned/unverifiable artifacts unless the user passes an explicit, loud `--allow-unsigned`.
+- **Compatibility gate:** the index records each version's min Conduit + connector-protocol
+  version; `install` refuses an incompatible artifact with an actionable error instead of
+  installing something that will fail at pipeline start.
+- **A static registry web UI** (search, verified badges, download stats) built from the same
+  index, sharing the React component library with the built-in UI.
+
+"Install" means: place the verified standalone-connector artifact into the configured
+`--connectors.path` directory (default `<basePath>/connectors`) and cache it — the exact
+directory Conduit already loads standalone connectors from. No new runtime loading path.
+
+## Context
+
+### What exists
+
+- **Two connector kinds:** built-in (compiled into the `conduit` binary) and **standalone**
+  (separate processes, gRPC over the connector protocol), loaded from `--connectors.path`
+  (`pkg/conduit/config.go`). The registry targets standalone artifacts — the extensibility story.
+- **Distribution today is manual:** each `conduit-connector-*` repo publishes GitHub Releases;
+  the user downloads the right artifact for their OS/arch and drops it in the connectors dir
+  themselves. No discovery, no one-command install, no signature/trust, no compatibility check.
+- **`conduit connectors`** has `list`, `describe`, `new` — no `install`.
+- **Download stats already flow through Scarf** (`conduit.gateway.scarf.sh`, see `.goreleaser.yml`);
+  the registry reuses this rather than building a stats service.
+- **No signing infra exists yet** (no cosign/sigstore/SLSA in `.github/`) — this is greenfield and
+  is the single largest piece of the MVP.
+
+### Why now / why this matters
+
+Kafka Connect's ecosystem (Confluent Hub) is a real competitive point: "where do I get connectors
+and how do I trust them." Conduit's answer must be at least as easy **and** safer by default
+(signed, provenance-checked, no click-through-EULA hub). It also directly serves the agent-native
+bet: an agent should be able to `install` a connector as a bounded, verifiable step, not "go find
+a binary on the internet."
+
+## Goals / Non-goals
+
+### Goals
+
+- `conduit connectors install <name>[@<version>]` — resolve from the index, fetch the artifact for
+  the host OS/arch, **verify signature + provenance**, **check Conduit/protocol compatibility**,
+  install into `--connectors.path`, and cache. `--json` output + stable error codes.
+- **Refuse-by-default trust, pinned to identity.** An artifact installs only if its signature +
+  provenance validate against the **identity registered for that connector name** (§ Decision 1).
+  A valid signature by the _wrong_ identity refuses (`ERR_IDENTITY_MISMATCH`), distinct from
+  `ERR_UNSIGNED`. `--allow-unsigned` is the only escape hatch and is gated (§ Failure modes) —
+  never a plain flag an agent or script can flip.
+- **A tamper-evident index (§ Decision 2).** The index that _stores_ the sha256 and the expected
+  identity is itself signed and freeze-protected; `install` verifies it before trusting any field.
+- **Actionable compatibility refusal:** incompatible min-version → a `ConduitError` naming the
+  required vs running versions and the fix, not a silent install that breaks at pipeline start.
+- **Publishing flow:** a **reusable GitHub Action** any connector repo drops in to build → sign
+  (keyless) → emit SLSA provenance → open an index PR. "Verified" derives from identity + provenance
+  (§ Decision 1), never a manual blessing; **first registration of a name is human-reviewed**.
+- **Post-install revocation checking:** `conduit connectors audit` re-checks installed connectors
+  against the current signed index + revocation list and flags any version that has since been
+  yanked or whose publisher identity was revoked — the mechanism that protects _already-installed_
+  systems, which install-time refusal alone does not.
+- **Offline / air-gapped install:** a documented path to pre-fetch an artifact + its signature/
+  provenance bundle and install from local disk, and a local cache so repeats don't re-download.
+- **Static registry web UI:** search, per-connector page, verified badge, version list,
+  compatibility, download stats — built from the index, sharing the built-in UI's design tokens.
+- **`conduit connectors uninstall <name>` and `list --installed`** to round-trip the lifecycle.
+
+### Non-goals (MVP)
+
+- **No hosted dynamic registry API/service.** The index is static (git/CDN). A hosted service with
+  live search/auth is a later option if the static index outgrows itself.
+- **No private/paid registries, no auth-gated connectors.** (And per the one-way ratchet, the
+  registry core is never paywalled.)
+- **No auto-update / background upgrade.** Install is explicit; upgrade is `install @<newer>`.
+- **No inter-connector dependency resolution** — standalone connectors are self-contained.
+- **No WASM-connector distribution yet** — WASM connectors are a v0.19 go/no-go item; the index
+  schema reserves an artifact `kind` field so WASM slots in later without a breaking change.
+- **Not a general artifact store** — only Conduit connectors (later: processors, templates, reusing
+  the same index shape).
+
+## Decision
+
+### 1. Trust root and identity registration (the security foundation)
+
+This is the first-class decision the rest of the design hangs on, and getting it wrong makes every
+signature check theater. Keyless cosign proves _who_ signed an artifact (an OIDC issuer + a
+workflow-identity SAN) — it does **not** prove that _who_ is the entity allowed to publish the name
+`postgres`. Without pinning, anyone who forks the publish Action into their own repo can produce a
+perfectly valid, Rekor-logged signature for a connector named `postgres` and earn a green "verified"
+badge. So:
+
+- **Per-name identity pinning.** The index records, **per connector name**,
+  `publisher.expectedOIDCIssuer` and `publisher.expectedIdentityPattern` (repo + workflow path,
+  pinned to a ref/tag pattern). `install` verifies with cosign's `--certificate-oidc-issuer` and
+  `--certificate-identity` set to those pinned values — **a valid signature by any _other_ identity
+  refuses** (`ERR_IDENTITY_MISMATCH`), distinct from `ERR_UNSIGNED`.
+- **`verified` is derived, never asserted.** A version is "verified" iff its signature +
+  SLSA provenance validate against the name's pinned identity. It is never a hand-set field.
+- **Registration is a human act; version bumps are not.** The trust axis is _establishes trust_ vs
+  _exercises established trust_, not _community_ vs _first-party_:
+  - **First registration of a name** (and any later change to its pinned identity — an org move,
+    a workflow rename) requires a **human-reviewed** PR to the index and is **never auto-merged**,
+    first-party included. This is the actual root-of-trust decision.
+  - **A new version of an already-registered name, signed by its already-pinned identity,** may be
+    low-touch/auto-merged once index-CI re-verification (below) passes.
+
+### 2. Index format + integrity (a signed, tamper-evident trust store)
+
+The `install`-time checks read the expected sha256 _and_ the expected identity _from the index_, so
+**the index is itself a trust root** — an unsigned static JSON served over TLS has integrity against
+network attackers but none against a compromised origin/CDN or a bad merged PR. TLS is not enough.
+The MVP adopts "TUF-lite" (four properties below) rather than full
+[TUF](https://theupdateframework.io/) (see Alternatives for why, and TUF as the v2 escalation):
+
+1. **The built index is signed** with a **registry root key distinct from any connector's signing
+   identity**, held in a GitHub Environment gated by required reviewers. `install` verifies this
+   signature **before trusting any field in the index**, independent of TLS/CDN.
+2. **Freeze/rollback protection:** the signed index carries a monotonically increasing version + a
+   signed timestamp; `install` refuses an index older than the newest it has seen or past a
+   max-staleness window (distinct error from "index unreachable"), defeating a CDN that replays a
+   stale index still listing a since-yanked version as good.
+3. **Index-CI re-verification:** before _any_ merge (including auto-merged first-party version
+   bumps), index-repo CI independently re-fetches the artifact at the claimed `url`, recomputes
+   `sha256`, and re-runs `cosign verify` against the name's pinned identity — the index never
+   records an assertion it has not itself checked.
+4. **Branch protection + required signed commits** on the index repo (necessary, not sufficient
+   on its own — it gates _who pushes_, not _whether the JSON is true_).
+
+Per-connector, per-version entry fields: `artifacts[] { os, arch, kind: "standalone", url
+(Scarf-gatewayed), sha256, size }`, `minConduitVersion`, `minProtocolVersion`, `signature` (cosign
+bundle / Rekor inclusion reference), `slsaProvenance` (attestation reference), `deprecated?`,
+`yanked? { reason }`. A top-level `schemaVersion` lets `install` refuse a too-new index with
+"upgrade Conduit" rather than mis-parse it (announce → warn → remove, matching config/protocol
+policy). A signed **revocation list** (per-version yanks and a publisher-level
+`publisher.revoked { reason }` that invalidates _all_ versions under a compromised identity) is part
+of the integrity-checked bundle, not a bolt-on unsigned field. `kind` reserves room for WASM
+(v0.19) without a breaking change.
+
+### 3. `install` pipeline (verification is the authorization gate, not sha256)
+
+1. Fetch + **verify the signed index** (§2) before trusting any field.
+2. Resolve `<name>[@version]` **exact-match only** (no fuzzy/nearest-match — a typo'd name is a hard
+   `ERR_NOT_FOUND`, never an auto-installed lookalike); if `@version` omitted, pick the newest
+   version whose `minConduitVersion`/`minProtocolVersion` the running Conduit satisfies, so "latest"
+   never means "latest-incompatible". Refuse a yanked/revoked selection with its reason.
+3. Select the host-OS/arch artifact; **none → refuse**, listing available platforms.
+4. Download (following any Scarf redirect) into a **per-install, `0700`, uniquely-named staging dir
+   owned by the invoking user** — never a shared/predictable path.
+5. Compute the digest **from the actual received bytes** and: (a) check it against the index's
+   `sha256` — this is **corruption detection**, integrity against a bad download, _not_ a trust
+   boundary; (b) run the **authorization gate** — `cosign verify` of the signature over the
+   artifact's own digest **and** the SLSA attestation `subject` digest, against the name's **pinned
+   identity** (§1) + Rekor inclusion. Any failure → delete staging, refuse. `--allow-unsigned`
+   (§ Failure modes) skips only (b), keeps (a), and is gated as described there.
+6. Only on full success: verify + rename via the same resolved file descriptor with `O_NOFOLLOW`
+   (no symlink substitution between check and use); a **per-target lock** serializes concurrent
+   installs so two can't interleave the rename + manifest write. The move is atomic (temp + rename)
+   so a crash mid-install leaves either the old artifact or nothing, never a partial. Update the
+   install manifest and cache only after the rename succeeds. Emit a structured audit event
+   (connector, version, resolved digest, whether signed, operator, timestamp).
+
+Once §2 index-signing lands, the index's `sha256` becomes trustworthy too and (a)/(b) converge on
+the same fact — belt-and-suspenders, deliberately.
+
+### 4. Publishing (reusable Action, keyless, SLSA)
+
+A `conduitio/connector-publish-action` a connector repo's release workflow calls: build the OS/arch
+matrix, sign each artifact with **cosign keyless** (GitHub OIDC — no long-lived keys to custody or
+leak), emit **SLSA provenance** (target **Build L3**: GitHub-hosted ephemeral runners,
+non-falsifiable provenance; L2 floor if a self-hosted runner is ever unavoidable) whose `subject`
+digest and `builder.id`/`configSource.uri` bind to the artifact and the pinned identity, and open an
+index PR. **New-name registration goes to human review (§1); a version bump from the pinned identity
+can auto-merge once index-CI re-verification (§2.3) passes.**
+
+### 5. Web UI (static, shares the component library)
+
+A static site generated from the index: searchable connector list, per-connector page (versions,
+compatibility matrix, verified badge, install command, Scarf-sourced download stats). No backend.
+Uses the **shared React component library / design tokens** from the built-in-UI doc so the two
+v0.18 React surfaces are one visual language.
+
+## Alternatives considered
+
+- **Hosted registry service (API + DB + auth), Confluent-Hub-style.** More capable (live search,
+  richer stats, private registries) but a real always-on service to build, run, secure, and pay
+  for — disproportionate for the MVP and for a small team, and it centralizes trust. The static
+  index gets 90% of the value at near-zero operational cost and is GitOps-native. Revisit only if
+  the static index demonstrably can't scale.
+- **Long-lived signing keys instead of keyless.** Rejected: key custody/rotation is exactly the
+  kind of standing liability a small team should avoid. Sigstore keyless ties trust to the CI
+  identity + transparency log with nothing to leak.
+- **Trust-on-first-use / checksum-only (no signatures).** Rejected as the default: a checksum
+  proves integrity, not provenance — it doesn't stop a malicious artifact that matches its own
+  hash. Signature + provenance is the default; checksum-only survives as the explicit
+  `--allow-unsigned` escape hatch.
+- **Bundle everything as built-in connectors instead of a registry.** Doesn't scale, bloats the
+  binary, and defeats the any-language / community-authored extensibility bet.
+- **Full [TUF](https://theupdateframework.io/) (The Update Framework) for the MVP.** TUF's
+  root/targets/snapshot/timestamp roles with threshold signing are the gold standard for exactly
+  this problem (compromise-resilient, freeze/rollback-proof software distribution). We adopt its
+  _properties_ (§ Decision 2: a signed index, freeze/rollback protection, CI re-verification) but
+  not its full role/ceremony for the MVP — the operational cost (key ceremonies, threshold signer
+  coordination) is disproportionate for a small team and a static index. **Full TUF is the named
+  v2 escalation** if the static index outgrows ad-hoc signing; the index schema and signing seam
+  are designed so that migration is not a rewrite.
+
+## Failure modes (the 80%)
+
+- **Wrong-identity signature (the impersonation attack)** → a valid, Rekor-logged signature by an
+  identity _other_ than the name's pinned one → refuse `ERR_IDENTITY_MISMATCH`. This is the attack
+  keyless-without-pinning would wave through.
+- **Unsigned / verification fails** → refuse `ERR_UNSIGNED`, delete staging. Never install.
+- **Tampered index** (a field — `url`, `sha256`, `expectedIdentityPattern` — altered without a
+  valid index signature) → `install` refuses `ERR_INDEX_INTEGRITY` before trusting any field.
+- **Stale / frozen index** (a compromised CDN replays an old index still listing a since-yanked
+  version) → refuse/warn distinctly from "unreachable" via the signed monotonic version + timestamp
+  max-staleness check.
+- **`--allow-unsigned` misuse** → gated, not a bare flag (see below).
+- **Incompatible min-version** → refuse with required-vs-running versions + fix; resolution prefers
+  a compatible version, so this only fires on an explicit incompatible `@`-pin.
+- **No artifact for host OS/arch** → refuse, list available platforms.
+- **Corrupt/truncated download** → sha256 (corruption check) mismatch → refuse + retry; staging
+  cleaned up. (Trust still comes from the signature over the artifact's own digest, § Decision 3.)
+- **Scarf gateway compromised/misbehaving** → the digest is recomputed from the _actual received
+  bytes_ after following redirects, so a gateway can only cause a failed verification (denial of
+  service), **never** a successful install of the wrong artifact — the gateway is outside the trust
+  boundary. A direct-to-GitHub-Releases fallback covers a Scarf _outage_ (availability, not
+  security).
+- **Network down / air-gapped** → cache hit serves without network; documented offline install from
+  a locally-provided artifact + signature/provenance bundle.
+- **Yanked version or revoked publisher** → refuse with reason at install; **and** `conduit
+  connectors audit` flags it on already-installed systems (revocation isn't only an install-time
+  concern).
+- **Index too new (`schemaVersion` ahead)** → "upgrade Conduit," never a mis-parse.
+- **Typosquat / name confusion** → **exact-name resolution only** (no fuzzy nearest-match); `install`
+  prints the resolved publisher identity before completing; a typo is `ERR_NOT_FOUND`.
+- **Concurrent installs** → a per-target lock serializes the rename + manifest write; two
+  simultaneous installs can't interleave.
+- **Staging TOCTOU** → per-install `0700` uniquely-named staging owned by the invoking user;
+  verify + rename on the same resolved fd with `O_NOFOLLOW` (no symlink substitution between check
+  and use).
+- **Crash mid-install** → atomic temp-write + rename; the connectors dir never holds a partial; the
+  manifest updates only after the rename succeeds.
+- **Disk full during staging/move** → fail before touching the live connectors dir.
+
+### `--allow-unsigned` is a gated control, not a warning
+
+A loud warning does not stop a rushed human or a prompt-injected agent. So:
+
+- **TTY:** require a typed confirmation (re-type the connector name), not `y/N`.
+- **Non-interactive (no TTY, `CI=true`, or invoked via MCP):** **hard-refuse** unless a _separate_,
+  harder-to-reach env escape hatch is also set (e.g. `CONDUIT_ALLOW_UNSIGNED_INSTALL=I_UNDERSTAND`),
+  so a CLI flag alone in a script/agent prompt cannot enable it.
+- **Operator policy wins:** a site config (`install.allowUnsigned: false`) hard-disables the path
+  regardless of any flag or env — the actual defense for the agent scenario, since the MCP tool
+  shares the CLI code path and must not expose unsigned-install as a flippable tool parameter.
+- **Audit:** every unsigned install emits a durable structured audit event (connector, version,
+  resolved digest, operator, timestamp).
+
+## Testing
+
+The verification + integrity suite is the security warranty and the highest-leverage part of the
+epic. Negative tests carry the weight — each attack refuses with its _distinct_ error code:
+
+- **Identity/signature (the trust core):** a valid signed artifact by the pinned identity installs;
+  an **unsigned** (`ERR_UNSIGNED`), a **tampered** artifact (digest mismatch), and a
+  **valid-signature-by-a-different-identity** (`ERR_IDENTITY_MISMATCH`) all refuse. `--allow-unsigned`
+  installs the unsigned one only through its gate (below).
+- **Index integrity:** mutating a served index field (`url`/`sha256`/`expectedIdentityPattern`)
+  without a valid index signature → `install` refuses `ERR_INDEX_INTEGRITY`. A **stale/replayed**
+  index (older monotonic version / past max-staleness) refuses distinctly from "unreachable."
+- **Index-repo CI:** an index PR whose claimed artifact fails re-fetch + sha256 + `cosign verify`
+  against the pinned identity is rejected before merge (including for first-party version bumps).
+- **`--allow-unsigned` gating:** refuses in a non-TTY/`CI`/MCP context absent the separate env
+  escape hatch; an operator `install.allowUnsigned: false` overrides the flag; an unsigned install
+  emits the audit event.
+- **Revocation/audit:** `conduit connectors audit` flags an installed version later yanked or whose
+  publisher was revoked.
+- **Compatibility resolution:** newest-compatible selection; explicit incompatible `@`-pin refuses;
+  no-platform-artifact refuses; **exact-name only** — a typo'd name is `ERR_NOT_FOUND`, never a
+  fuzzy auto-install.
+- **Concurrency + atomicity:** concurrent `install <name>` don't corrupt the manifest or race the
+  target path; kill mid-install → connectors dir has the old artifact or nothing, never a partial.
+- **Scarf untrusted:** a gateway redirected to a wrong artifact still fails verification (digest
+  recomputed from received bytes); a Scarf outage falls back to direct GitHub Releases.
+- **Offline/cache:** second install is cache-served; the documented offline path works with no
+  network.
+- **Publish-action E2E (north-star):** author a connector → publish (keyless sign + SLSA
+  provenance) → a fresh `install` verifies against the pinned identity → run, all signed.
+
+## Upgrade / rollback
+
+- **Index `schemaVersion`** is the compatibility contract; additive fields are backward-compatible,
+  a major bump follows announce → warn → remove.
+- **`install` is reversible:** `uninstall` removes the artifact + manifest entry; nothing in the
+  engine's serialized state changes (a connector artifact is a file in a directory).
+- **The `artifact.kind` field** reserves room for WASM (v0.19) with no breaking index change.
+- Rolling back the feature = the `install`/`uninstall` commands and the Action; no data migration.
+
+## Epic / PR plan and acceptance criteria
+
+The trust model — **deciding and recording, per connector name, which identity may sign it, in a
+tamper-evident index** — is the hard part and the critical path, not "wire up `cosign verify`."
+Sequenced so that trust lands before anything trusts it:
+
+1. **Freeze the index schema + trust model** (`schemaVersion`; per-name `publisher.expectedOIDCIssuer`
+   / `expectedIdentityPattern`; `sha256`/compat/`signature`/`slsaProvenance` per artifact; the
+   signed revocation list + `publisher.revoked`; the index-signing + freeze/rollback design). _AC:
+   schema documented + a sample index validates; identity-registration-vs-version-bump review paths
+   specified; too-new `schemaVersion` refusal specified._ **Unblocker for parallel work — but the
+   trust-model fields must be frozen here, not retrofitted.**
+2. **`install` core: verified-index fetch → exact-match resolve → platform-select → download →
+   sha256 (corruption) → per-target-locked atomic install (`O_NOFOLLOW`, `0700` staging) →
+   manifest + audit event**, with the compatibility gate. _AC: newest-compatible resolution;
+   incompatible/no-platform/yanked/typo refuse with distinct coded errors; concurrent installs
+   don't race; crash-mid-install leaves no partial; `--json`._
+3. **Trust core: index-signature verification + per-name identity-pinned `cosign verify` + SLSA
+   provenance** (subject digest + `builder.id`/`configSource.uri` bound to the pinned identity +
+   Rekor inclusion), wired as the gate before step-2's atomic move; the **gated** `--allow-unsigned`.
+   _AC (the security warranty — see Testing): `ERR_UNSIGNED`, `ERR_IDENTITY_MISMATCH`,
+   `ERR_INDEX_INTEGRITY`, stale-index, and `--allow-unsigned`-in-non-interactive all refuse/gate as
+   specified; operator policy overrides the flag; the verify suite is green._ **Tier-1-adjacent
+   (supply-chain) — highest review bar; do not let 4/6 gate it.**
+4. **Publishing Action** (`conduitio/connector-publish-action`): build matrix → keyless sign → SLSA
+   (target L3) provenance → index PR. **New-name registration is human-reviewed; a pinned-identity
+   version bump auto-merges only after index-CI re-verification.** _AC: an author repo publishes a
+   connector a fresh `install` verifies E2E; `verified` derives from identity; index-CI rejects a
+   PR whose artifact fails re-fetch/verify._
+5. **`uninstall`, `list --installed`, `audit`** + the local cache/offline path. _AC: round-trip
+   lifecycle; `audit` flags a since-yanked/revoked installed version; offline install tested._
+6. **Registry web UI** (static, shared design tokens): search, per-connector page, verified badge,
+   compatibility, Scarf stats. _AC: generated from the index; shares the built-in UI's tokens; no
+   backend._
+
+**Parallelization:** once step 1 (schema + trust model) is frozen, step 2 (install plumbing), step 4
+(publishing Action), and step 6 (web UI) proceed in parallel. **Step 3 (trust core) is the critical
+path and highest risk — it gates any real install, and 2/4/6 must not be allowed to gate _it_.**
+Step 5 follows step 2. Findings 1–2 from the security review (identity pinning + a signed index) are
+merge-blockers for step 3: do not ship verification that treats "signed by anyone" as "verified."
+
+## Related
+
+- Phase 1 Execution Plan (v2): `docs/design-documents/20260704-phase-1-execution-plan.md` (§7).
+- Built-in UI (shares the React component library): `docs/design-documents/20260713-greenfield-built-in-ui.md`.
+- Connector/processor scaffolding (`conduit connector new`, the authoring side of extensibility):
+  `docs/design-documents/20260707-connector-processor-scaffolding.md`.
+- Connector protocol (compatibility metadata source): `ConduitIO/conduit-connector-protocol`.

--- a/docs/design-documents/20260713-greenfield-built-in-ui.md
+++ b/docs/design-documents/20260713-greenfield-built-in-ui.md
@@ -1,0 +1,353 @@
+# Greenfield built-in UI: observe + operate (`conduit-ui`)
+
+## Summary
+
+v0.18's headline is a new built-in web UI — a **greenfield React app in a new `conduit-ui` repo**,
+embedded into the `conduit` binary and served by `conduit run`. Its scope is **observe + operate**,
+not authoring:
+
+- **Observe:** live record flow (over the already-built Inspect streaming RPCs), per-stage
+  inspection with **before/after diffs**, a pipeline graph, and throughput/lag/health.
+- **Operate (v0.18 core):** **start / stop** an existing pipeline — these map to the existing
+  `StartPipeline`/`StopPipeline` RPCs.
+
+The UI is **not** an authoring surface: pipelines are created/edited as config (YAML →
+`deploy`/`apply`, MCP, or the library), which stays the single source of truth. This is the line
+that keeps Conduit config-as-code and agent-native rather than a second, drifting source of truth
+(the Airbyte/Fivetran model — see Alternatives).
+
+**Honesty note (this revision).** An earlier draft claimed `pause`, `repair`, and server-side
+sampling were existing verbs the UI would just call, and mis-stated the pipeline status enum. Two
+independent reviews verified against the code: those were wrong. `pause`, a pipeline-scoped
+`repair`, DLQ-record inspection, Inspect drop-metrics, and configurable CORS are **prerequisite
+Tier-2 work on `conduit`** (§ Prerequisite API work), each its own PR — not UI wiring. The UI epic
+does not start against a verb until its API prerequisite has landed.
+
+## Context
+
+### What exists (verified against the tree) — and what does not
+
+- **No UI in the tree.** No `ui/`, no submodule, no `conduit-ui` in `go.mod` — only the retired
+  external Ember UI's `http://localhost:4200` CORS fingerprint. Greenfield; no parity obligation.
+- **The Inspect streaming RPCs exist and are unused.** `InspectConnector`,
+  `InspectProcessorIn`, `InspectProcessorOut` (`proto/api/v1/api.proto`), grpc-gateway-forwarded
+  and websocket-proxied (`pkg/foundation/grpcutil/websocket.go`, wired in
+  `pkg/conduit/runtime.go`). No client consumes them today. The UI consumes them; it builds no new
+  streaming primitive. **Correction from the earlier draft:** the proxy lives under
+  `pkg/foundation/grpcutil`, not `pkg/web/api/grpcutil`.
+- **But the Inspector has no sampling or drop-visibility.** `pkg/inspector/inspector.go` fans out
+  with `select { case s.C <- rec: default: /* log a warning */ }` against a fixed 1000-record
+  buffer — **uncontrolled drop-on-full, no rate control, drop counts not exposed** (only a log
+  line). So "the hard server half already exists" is true for _transport_ but **not** for the
+  backpressure story: honest drop-reporting is server work (§ Prerequisite API work).
+- **The pipeline status enum has 4 wire-visible values, not 5.** Internally there are five states
+  (`pkg/pipeline/instance.go`: `StatusRunning`, `StatusSystemStopped`, `StatusUserStopped`,
+  `StatusDegraded`, `StatusRecovering`), but `toproto.PipelineStatus`
+  (`pkg/http/api/toproto/pipeline.go`) **collapses** `SystemStopped`/`UserStopped` into one
+  `Pipeline_STATUS_STOPPED`. Over the wire the UI (like `conduit pipelines list`) sees exactly
+  **running / stopped / degraded / recovering**. There is no "created/provisioned" state — a fresh
+  instance initializes to `StatusUserStopped`. Consequence: the UI cannot distinguish "an operator
+  stopped this" from "the engine restarted and this hasn't been resumed yet" — those are opposite
+  answers to "should I worry," and closing the gap needs an additive API change (§ Prerequisite).
+- **`start`/`stop` exist as RPCs** (`StartPipeline`/`StopPipeline`, behind
+  `conduit pipelines start`/`stop`). These are the real operate verbs for v0.18.
+- **`repair` is NOT pipeline-scoped and has no RPC.** `cmd/conduit/internal/repair` operates on
+  **YAML text** (a file path / an MCP `Config string`); `repair.Apply` "edits the config file only
+  — it never touches the pipeline store or a running pipeline." Making repair a UI operate action
+  needs new server work (§ Prerequisite), not a call to an existing verb.
+- **CORS is a single hardcoded origin.** `pkg/conduit/runtime.go` calls
+  `allowCORS(gwmux, "http://localhost:4200")` and reflects `Access-Control-Allow-Origin` only for
+  an exact match. "Runs against a remote engine" and dev-mode (a Vite dev server on another port)
+  can't work in a browser until this is configurable (§ Prerequisite).
+- **`/openapi/`, `/v1/*`, `/healthz`, `/readyz`, metrics are already-claimed routes.** The SPA's
+  route must be registered so these still match first.
+- **Observability primitives (v0.16):** `/healthz`, `/readyz`, Prometheus metrics, structured
+  `ConduitError` (code/path/suggestion). **Config-as-code authoring:**
+  `conduit run --pipelines <dir>` imports YAML at startup; `deploy`/`apply` gate changes behind a
+  reviewed plan+hash — the discipline the UI must not undercut with a blind write path.
+
+### Why now
+
+A running pipeline is a black box unless you scrape logs or wire Prometheus. The Inspect streams —
+already paid for — turn that into a first-class visual: watch records move, see where they stall,
+diff a record before/after a processor, stop a runaway. That is the "visual wow" the Phase 1 plan
+scheduled for v0.18, and it is _mostly_ a client-side build once the prerequisite API gaps close.
+
+## Goals / Non-goals
+
+### Goals
+
+- **React** app consuming **only documented HTTP APIs** + metrics/health, with a **TypeScript
+  client generated from the served OpenAPI schema** (`proto/api/v1/api.swagger.json`) and
+  contract-tested — provably "just another API client," runnable against a remote engine.
+- **Observe:** health-first fleet view; per-pipeline graph; live record flow with **freeze** and
+  **per-stage before/after diffs**; throughput + destination lag; honest drop-rate display.
+- **Operate:** **start / stop** an existing pipeline (existing RPCs), with confirmation on stop,
+  optimistic-but-authoritative feedback, and fast reversibility.
+- **Errors render identically to the CLI** (`code`/`path`/`suggestion`) and are actionable.
+- **Accessible + resilient:** keyboard nav, WCAG AA, reduced-motion; a live table that does not
+  spam a screen reader; a keyboard/SR-navigable linear equivalent of the graph; a defined
+  reconnect/loading spec; works against a read-only or unreachable engine.
+- **Embedded + served by `conduit`** (`go:embed`), gated by config; observe on by default, operate
+  guarded (§ Decision 7).
+
+### Non-goals (v0.18 — deliberate scoping lines)
+
+- **No pipeline authoring in the UI.** No create/edit/delete of pipelines/connectors; no drag-drop
+  DAG editor; no schema-driven config forms; no in-browser secrets. Authoring is CLI/MCP/YAML;
+  config stays the single source of truth. (A future _config-first_ authoring flow — UI composes
+  YAML → `apply` plan-review → export to git — is v0.19+, demand-gated, and explicitly **not** the
+  Airbyte "UI is the source of truth" model.)
+- **No UI-owned state.** The UI holds no pipeline definition the config import doesn't already own.
+- **`pause`, pipeline-scoped `repair`, DLQ inspection are not committed to v0.18's UI** until their
+  API prerequisites land (§ Prerequisite). If a prerequisite slips, its UI slice descopes with it.
+- **No bulk operate** in v0.18 (would be N sequential calls to the per-pipeline verb — deferred;
+  stated so it's a decision, not an omission).
+- **Not a metrics/tracing replacement** — Prometheus stays the long-horizon system of record.
+
+## Prerequisite API work on `conduit` (each its own Tier-2 PR, gates the matching UI slice)
+
+These are the "already exists" claims that did not survive review. The UI epic depends on them;
+they ship first, with `--json` + error codes, and (where they touch a public contract) a versioning
+note.
+
+1. **Inspect drop-metric.** Expose a per-stream dropped-record count/rate (a field on the Inspect
+   stream or a companion metric) so the UI can honestly show "N records/sec dropped" instead of
+   pretending sampling exists. _Precondition for the live-flow drop indicator._
+2. **Configurable CORS allowlist** (replace the single hardcoded `localhost:4200`). _Precondition
+   for remote-engine use and dev-mode._
+3. **Stop-reason on pipeline state** (additive — a `stopReason`/`stopped_by` field alongside the
+   existing `Error`, not a renumbered enum) so the fleet view can distinguish operator-stopped from
+   engine-stopped-pending-resume. _Precondition for the fleet view's "should I worry" accuracy._
+   Breaking-change discipline: additive field, documented, no enum renumber.
+4. **Pause — its own design doc first.** `pause` is a data-path decision (invariant 7 / ack-safety):
+   define quiesce semantics (graceful source-quiesce + drain in-flight + checkpoint, resumable via
+   start with no loss) and whether it is a distinct status or `UserStopped` + a resumable flag,
+   _before_ any verb or UI. Not committed to v0.18 unless that doc lands.
+5. **Pipeline-scoped `repair` API + `Pipeline`→`PipelineDocument` export.** A server surface that
+   exports a running pipeline's config as the YAML shape `repair.Collect` consumes, runs
+   `repair.Collect`/`Apply`, and routes the result back through `PlanPipeline`/`ApplyPipeline` (so a
+   repair is a reviewed apply, consistent with plan+hash). Its own design doc — it changes a public
+   contract. Not committed to v0.18's UI unless it lands.
+6. **DLQ-record inspection.** DLQ connectors are not persisted or listed
+   (`pkg/connector/service.go` deletes persisted DLQ connectors on startup; `ProvisionTypeDLQ` is
+   excluded from the normal lifecycle), so there is no ID to `InspectConnector` and no
+   list-DLQ'd-records RPC. Either scope a "last-N DLQ'd records + cause" read API, or **explicitly
+   descope DLQ visibility from v0.18** and say so. _Precondition for the degraded-path DLQ view._
+7. **List pagination (only if needed).** `ListPipelines` has a name filter but no
+   `page_size`/`page_token`. Client-side virtualization covers hundreds; if unfiltered
+   `ListPipelines` p95 at 500+ pipelines is unacceptable, file the pagination gap rather than
+   discover it in production.
+
+## Decision
+
+### 1. New `conduit-ui` repo, generated + contract-tested client
+
+React + TypeScript. The client is **generated from the served OpenAPI schema** and contract-tested
+in CI (drift → red), so the UI can never depend on an undocumented endpoint. **The 3 Inspect
+endpoints are excluded from generation** — grpc-gateway emits them as `{result: Record}` with
+"(streaming responses)", which a generator would mis-model as a single object; they are consumed by
+a small hand-written websocket wrapper, and covered by a schema-shape assertion that the `result`
+wrapper hasn't drifted.
+
+### 2. Two zoom levels, not one surface
+
+- **Fleet view (landing): health-first.** Not an alphabetical table (the CLI already wins at that).
+  Degraded + recovering pinned to the top, always above the fold, with the error's first line
+  inline; running collapsed into a light strip; stopped de-emphasized. A persistent header count
+  ("12 running · 1 degraded · 2 recovering"). Top user task = "is anything wrong?" answered in zero
+  clicks.
+- **Pipeline detail (DAG) view.** One pipeline's source→processors→destination graph; node =
+  connector/processor with per-node status + live throughput; this is where record flow and
+  per-stage inspection live. Fleet and detail are **separate views**, not one component.
+
+### 3. Observe over the existing Inspect streams — honestly
+
+Subscribe via the existing websocket proxy. Because the Inspector drops-on-full with no rate
+control, the UI shows the **drop rate** (from prerequisite #1) as "N records/sec dropped," never a
+false "sampled at N/sec." Per-stage inspection opens at most _stage-count_ inspect connections for
+the _currently-viewed_ pipeline only, all torn down on unmount; it never opens streams for
+pipelines not in view.
+
+### 4. Live record flow: freeze-first, with per-stage diffs
+
+The signature feature, specified at the UX level, not just transport:
+
+- **Freeze-by-default-usable.** A bounded ring buffer (~last 50–100 records) updating in place
+  (highlight-flash, not append-scroll); a **Live/Freeze** toggle (Live on, one key to Freeze) that
+  stops _rendering_ new rows without dropping the stream. Without freeze, inspecting a record on a
+  busy pipeline is impossible.
+- **Click a record → side drawer** (not a context-stealing modal): key/payload/metadata/position,
+  syntax-highlighted, large payloads capped with an explicit "show full record."
+- **Per-stage before/after diff — the differentiating feature.** For a record's position, show it
+  at each stage (source Inspect → each processor In/Out → destination Inspect) as a **field-level
+  diff**: exactly which fields a processor added/changed/dropped. This is the thing Kafka Connect
+  cannot give you; it must ship as a real diff, not four raw-JSON tabs compared by eye.
+- **Filtering:** by key (exact/prefix) and an "errors-only" toggle (per-record processing
+  errors/nacks, not just DLQ'd). Finding record X matters more than seeing everything.
+- **Sampling-policy transparency:** state and show whether the visible slice is representative
+  (uniform vs per-key), so "I don't see key X" is interpretable.
+
+### 4b. Degraded / error path
+
+- **Show _when_ and _how long_,** not just current status: render "degraded since HH:MM (Xm ago)"
+  from the state's `UpdatedAt`. (The engine's `Instance.Error` holds only the latest error — no
+  history; flapping-detection is an explicit stretch/descope, not a silent absence.)
+- **`Recovering` gets its own affordance:** stop/repair during automatic recovery is risk-flagged
+  or disabled with a tooltip, not silently raced.
+- **`repair` shows the config diff before apply** (contingent on prerequisite #5): the `Fix`
+  (`ConfigPath`/`Op`/`Value`) renders as "set `/connectors/1/config/servers`: `localhost:9092` →
+  `kafka:9092`"; the commit click is on the diff, never a blind "Repair" button — consistent with
+  the plan+hash discipline the same class of change gets everywhere else.
+- **DLQ view** contingent on prerequisite #6 (last-N DLQ'd records + cause), else descoped.
+
+### 5. Content states — enumerated, each designed
+
+| State | Design |
+|---|---|
+| Zero pipelines | Not a blank table: name the authoring path (`conduit pipelines deploy` / `--pipelines <dir>`), pre-empting a hunt for a nonexistent "create" button. |
+| All stopped, fresh boot, none resumed | Needs prerequisite #3 (`stopReason`) or a "server just started, N pending resume" banner from reconciliation; else indistinguishable from "operator stopped all." |
+| Engine unreachable at first load | Connection-attempt state naming the target URL — not an infinite skeleton. |
+| Stream dropped mid-session | Freeze + "reconnecting" banner + last-known timestamp; **never clear** rows (clearing reads as a false "no records"). |
+| Huge graph (100s of nodes) | Collapsed-by-default beyond ~20 nodes, grouped/searchable, **degraded/recovering nodes force-expanded** regardless of collapse — a problem is never hidden in a folded group. |
+| Healthy-but-idle vs stalled | Surface lag/backpressure **at the node**, so genuine idle ≠ stalled. |
+| Partial availability (observe up, mutate down) | "Read-only" here means the mutate path is unavailable (not the future-auth case): operate disables with a reason, observe continues. |
+
+### 6. Operate safety
+
+- **Stop confirms; pause (when it exists) does not.** Stop uses a lightweight inline "Stop — click
+  again to confirm," not a modal. (This asymmetry is a stated decision so components don't diverge.)
+- **Fast reversibility, not undo:** after Stop, a one-click "Start again" appears where the action
+  was taken.
+- **Bounded optimistic window:** show "stopping…" immediately; replace with the authoritative
+  status only on the API response; if it takes >~2s, keep "stopping…" — never silently revert.
+- **Multi-actor reconciliation:** status reflects changes from _any_ actor (this tab, another tab,
+  the CLI, MCP, another operator) via poll/stream, not just this tab's own in-flight response.
+
+### 7. Embedding, routing, auth exposure
+
+- **`go:embed` the built SPA**, served at `/` by the existing HTTP server, **mux-ordered so
+  `/v1/*`, `/openapi/*`, `/healthz`, `/readyz`, metrics match first** (a route-collision test
+  asserts their content-type/status is unchanged).
+- **Disable mechanism + binary-size are an explicit choice:** either route-disable (assets stay in
+  the binary, config gates the route — the `swagger-ui` precedent) or a build tag that drops them;
+  the epic picks one and states the acceptable binary-size delta (release-engineering impact, not
+  just a flag).
+- **Observe default-on; operate guarded.** The HTTP API has no auth today (bind-to-localhost /
+  front with a proxy — same as the API's own posture). Because "operate" lets anyone reaching the
+  port stop pipelines, either operate is behind an explicit opt-in flag, or the UI shows a
+  persistent "no auth configured — anyone who can reach this can stop pipelines" banner whenever the
+  API is unauthenticated. Auth itself is a tracked dependency, not solved here.
+
+### 8. Shared visual language with the registry UI — tokens, not a package (v0.18)
+
+The registry web UI is a static site; this is an embedded SPA — two deployment models. For v0.18,
+share **design tokens (CSS variables) + a small set of duplicated primitives**, _not_ a published
+component package (which, with two consumers and one maintainer, is speculative machinery — CLAUDE.md
+YAGNI). Real package extraction is a v0.19+ decision with its own repo/version-pinning plan.
+
+## Alternatives considered
+
+- **Airbyte/Fivetran click-to-create (UI as source of truth).** Rejected: a second source of truth
+  `conduit run --pipelines <dir>` can't reconcile (restart re-imports the dir — UI-only pipelines
+  orphan/conflict); fights agent-native + config-as-code; a full CRUD builder is the largest
+  never-finished surface for a small team whose moat is the engine, not a click-ops catalog.
+- **Pure read-only (no operate).** Rejected: start/stop are safe existing verbs; an operator who
+  can _see_ a runaway but must switch to a terminal to stop it is worse for no safety gain (the UI
+  grants nothing the API didn't).
+- **Revive/parity the Ember UI.** Not executable — not in the tree.
+- **Separate-deploy SPA.** Rejected as the v0.18 default (built-in means `conduit run` serves it);
+  the generated client makes a remote dashboard a trivial _later_ option.
+- **A shared component _package_ now.** Rejected for v0.18 (YAGNI, two deployment models) — tokens +
+  duplicated primitives instead.
+
+## Failure modes (the 80%)
+
+- **Stream drop (WS/SSE):** backoff reconnect, visible "reconnecting," re-subscribe with no
+  double-count; prolonged loss → last-known snapshot + staleness banner, rows never cleared.
+- **Render backpressure:** ring-buffer + in-place update; virtualize/collapse large tables/graphs so
+  the DOM never unbounded-grows; show the server drop rate.
+- **Pipeline backpressure (the operational signal):** surface destination lag/queue depth (feeds
+  `/readyz`) at the node, so a slow destination reads as lag, not "fewer records."
+- **Engine unreachable / partial availability:** operate disables with a reason; observe degrades to
+  last-known; no crash.
+- **Operate races / multi-actor:** authoritative status reconciliation from any actor (Decision 6).
+- **Per-stage fan-out cost:** bounded to the viewed pipeline's stage count; torn down on unmount.
+- **CORS / route collision:** configurable origin (prerequisite #2); SPA mux-ordered last with a
+  collision test.
+- **Contract drift:** generated-client contract test fails CI on schema/client divergence.
+- **Scale:** fleet virtualized for 500+ pipelines; graph collapses >~20 nodes with forced-expand of
+  problem nodes.
+
+## Testing
+
+- **Contract test** the generated client against the served OpenAPI (drift → red); the 3 Inspect
+  endpoints excluded from generation but covered by a `result`-wrapper schema-shape assertion.
+- **Run against a remote engine** in CI (proves "just another API client," and exercises the
+  configurable-CORS prerequisite).
+- **Accessibility:** axe/WCAG AA + keyboard-nav + reduced-motion, **plus** a scripted screen-reader
+  pass over the live record table (no per-record `aria-live` spam) and the graph's linear
+  equivalent.
+- **Reconnect/backpressure/scale:** simulate drop (reconnect, no dup/miss, "reconnecting" ≠ "no
+  data"), a firehose (drop-rate shown, bounded DOM), 500+ pipelines, a 200+-node graph.
+- **Operate:** start/stop reflect authoritative status; delayed-response test proves the optimistic
+  window holds "stopping…" and never silently reverts; multi-actor status change is reflected.
+
+## Upgrade / rollback
+
+Additive and reversible. The UI is served behind a config flag; disabling removes the surface with
+no data-format impact. No serialized-format changes. The UI↔API contract is the OpenAPI schema; the
+contract test is the compatibility gate. `conduit-ui` versions independently but its embedded build
+is pinned per `conduit` release (a build-time asset). The one additive engine change that touches a
+public contract — `stopReason` (prerequisite #3) — is a documented, non-renumbering field addition.
+
+## Epic / PR plan and acceptance criteria
+
+Prerequisite API PRs on `conduit` (each Tier-2, `--json` + error codes, land before the matching UI
+slice): (P1) Inspect drop-metric · (P2) configurable CORS · (P3) `stopReason` · (P4) pause design
+doc _then_ verb · (P5) pipeline-scoped repair API + Pipeline→YAML export design doc · (P6) DLQ-record
+read API _or_ explicit descope. P4–P6 are gated on their own design docs and are **not** on the
+v0.18 UI critical path — the UI ships observe + start/stop without them.
+
+UI epic (`conduit-ui` + embed in `conduit`), with **user-testable** ACs:
+
+1. **Bootstrap.** Repo, React+TS, CI, generated client + contract test (Inspect endpoints excluded
+   from generation, their `result`-wrapper shape-asserted instead), design tokens shared with the
+   registry UI. _AC: `make` builds a static bundle; the generated client round-trips every
+   non-streaming schema path in CI._
+2. **Fleet view (health-first).** _AC: every non-`running` pipeline with an error (degraded,
+   recovering) is above the fold with zero scroll for fleets ≤50; a persistent status count header;
+   a degraded pipeline's `code`/`configPath`/`suggestion` is reachable in **≤2 clicks**; the
+   zero-pipelines state names the authoring command (copy-reviewed)._
+3. **Pipeline detail + graph.** _AC: node states render the 4 wire values 1:1 (no invented 5th); a
+   200+-node graph stays interactive and never hides a degraded/recovering node in a collapsed group
+   by default; a keyboard/SR-navigable linear equivalent covers every node and edge._
+4. **Live record flow + per-stage diff.** _AC: a record can be frozen, opened, and fully inspected
+   without dropping the stream or losing records on un-freeze; the per-stage diff highlights exactly
+   the fields a field-mutating test processor added/changed/removed; reconnect after a simulated
+   drop shows no dup/miss and a "reconnecting" state distinct from "no data"; the server drop rate is
+   displayed under a firehose._
+5. **Metrics + node-level lag/backpressure.** _AC: a healthy-idle pipeline is visually
+   distinguishable from a stalled one via node-level lag._
+6. **Operate: start/stop.** _AC: stop requires a confirming second action and start does not; the
+   optimistic "stopping…" holds until the authoritative response (tested with a delayed response)
+   and never silently reverts; a status change from another actor is reflected; a "no auth" banner
+   shows when the API is unauthenticated (or operate is behind an opt-in flag)._
+7. **Embed + serve + a11y pass.** _AC: `conduit run` serves the SPA at `/`; a route-collision test
+   asserts `/v1/*`, `/openapi/*`, `/healthz`, `/readyz`, metrics are unchanged; disabled cleanly by
+   config; WCAG AA + the live-table/graph screen-reader ACs from §Testing pass; the chosen
+   disable-mechanism and binary-size delta are documented._
+
+Degraded-path richness (transition timestamp, `Recovering` affordance) rides with #2/#3; **repair
+diff-apply (#4b) and DLQ view are gated on prerequisites P5/P6** and descope cleanly if those slip.
+
+## Related
+
+- Phase 1 Execution Plan (v2): `docs/design-documents/20260704-phase-1-execution-plan.md` (§6, §7).
+- Connector registry MVP (shares design tokens): `docs/design-documents/20260713-connector-registry-mvp.md`.
+- Hot-reload / `--dev`: `docs/design-documents/20260712-pipeline-dev-hot-reload.md`.
+- Deploy/apply (the authoring path the UI deliberately doesn't duplicate):
+  `docs/design-documents/20260708-cli-pipeline-deploy-apply.md`.
+- Structured errors the UI renders:
+  `docs/design-documents/20260705-conduit-error-and-structured-output.md`.
+- `repair` (today: YAML-text, not pipeline-scoped): `docs/design-documents/20260712-repair-command.md`.


### PR DESCRIPTION
Design docs for the two v0.18 headline items (Phase 1 Execution Plan §6/§7): a greenfield **built-in UI** (observe + operate, not authoring) and a **connector registry MVP** (signed static index, no hosted service).

Both were hardened by independent review before this PR:
- **UI doc** — technical + UI/UX review. Caught real factual errors (verified against the code): the status enum is **4 wire-visible values, not 5**; `pause`, pipeline-scoped `repair`, Inspect **sampling**, DLQ-record listing, and configurable **CORS** are **prerequisite API work on `conduit`**, not existing verbs. Each is now its own gated Tier-2 PR; the UI ships observe + start/stop without the gated ones. Added: health-first fleet IA, freeze-first record flow with per-stage diffs, enumerated empty/loading/scale states, operate safety, live-table/graph accessibility, and user-testable ACs.
- **Registry doc** — supply-chain security review. Added a **trust-root** section: per-name identity pinning (`cosign verify` against a registered identity, `ERR_IDENTITY_MISMATCH`), a **signed, freeze-protected index** (TUF-lite — the index is itself a trust root), gated `--allow-unsigned` (hard-refuse in CI/MCP), and post-install `conduit connectors audit` for revocation — without which a green "verified" badge is earnable by any attacker.

Tier 3 (docs). Populates the previously-empty v0.18.0 milestone (epic issues filed separately). markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3cLokwNJYLLBpdyt3cgGr