### PR TITLE
feat(inspector): meter dropped records (per-session count + metric)

### DIFF
--- a/pkg/foundation/metrics/measure/measure.go
+++ b/pkg/foundation/metrics/measure/measure.go
@@ -57,8 +57,11 @@ var (
 		"Number of inspector sessions by ID of pipeline component (connector or processor)",
 		[]string{"component_id"},
 	)
+	// _total suffix per Prometheus counter convention; this is a new metric with
+	// no consumer yet, so the name is fixed correctly now rather than matching the
+	// repo's older, suffix-less counters.
 	InspectorDroppedRecordsCounter = metrics.NewLabeledCounter(
-		"conduit_inspector_dropped_records",
+		"conduit_inspector_dropped_records_total",
 		"Number of records dropped by inspector sessions because the session buffer was full, "+
 			"by ID of pipeline component (summed across all sessions on that component).",
 		[]string{"component_id"},

--- a/pkg/foundation/metrics/measure/measure.go
+++ b/pkg/foundation/metrics/measure/measure.go
@@ -57,6 +57,12 @@ var (
 		"Number of inspector sessions by ID of pipeline component (connector or processor)",
 		[]string{"component_id"},
 	)
+	InspectorDroppedRecordsCounter = metrics.NewLabeledCounter(
+		"conduit_inspector_dropped_records",
+		"Number of records dropped by inspector sessions because the session buffer was full, "+
+			"by ID of pipeline component (summed across all sessions on that component).",
+		[]string{"component_id"},
+	)
 
 	ConnectorBytesHistogram = metrics.NewLabeledHistogram("conduit_connector_bytes",
 		"Number of bytes a connector processed by pipeline name, plugin and type (source, destination).",

--- a/pkg/inspector/inspector.go
+++ b/pkg/inspector/inspector.go
@@ -35,6 +35,17 @@ type Session struct {
 
 	id          string
 	componentID string
+	// droppedRecords counts records dropped for this session because C was full.
+	// Written by Inspector.Send under the Inspector lock; read lock-free by
+	// Dropped(), so it must be atomic.
+	droppedRecords atomic.Int64
+}
+
+// Dropped returns the number of records dropped for this session because its
+// buffer C was full. It is a monotonic per-session count (the process-wide,
+// component-aggregated view is the conduit_inspector_dropped_records metric).
+func (s *Session) Dropped() int64 {
+	return s.droppedRecords.Load()
 }
 
 // Inspector is attached to an inspectable pipeline component
@@ -106,6 +117,13 @@ func (i *Inspector) Send(ctx context.Context, batch []opencdc.Record) {
 			select {
 			case s.C <- rClone:
 			default:
+				// The session's consumer is too slow; drop the record (the
+				// inspector is a side-channel, so this never affects pipeline
+				// delivery). Meter it per-session (Dropped()) and per-component
+				// (the metric) so a slow inspection is observable instead of
+				// silent — see the conduit_inspector_dropped_records metric.
+				s.droppedRecords.Add(1)
+				measure.InspectorDroppedRecordsCounter.WithValues(s.componentID).Inc()
 				i.logger.
 					Warn(ctx).
 					Str(log.InspectorSessionID, s.id).

--- a/pkg/inspector/inspector_test.go
+++ b/pkg/inspector/inspector_test.go
@@ -144,6 +144,49 @@ func TestInspector_Send_SlowConsumer(t *testing.T) {
 	_, got, err := cchan.ChanOut[opencdc.Record](s.C).RecvTimeout(context.Background(), 100*time.Millisecond)
 	is.True(cerrors.Is(err, context.DeadlineExceeded))
 	is.True(!got)
+
+	is.Equal(s.Dropped(), int64(1)) // exactly the one record past the buffer was dropped
+}
+
+// TestInspector_Dropped_PerSession proves drops are counted per session, not per
+// Send: with two sessions on the same inspector, only the never-drained session
+// drops records; the one drained after every Send never fills, so it drops
+// nothing. Draining synchronously (not via a background goroutine) keeps the test
+// deterministic — no scheduling race that could make the "fast" session drop.
+func TestInspector_Dropped_PerSession(t *testing.T) {
+	is := is.New(t)
+
+	bufferSize := 5
+	underTest := New(log.Nop(), bufferSize)
+	slow := underTest.NewSession(context.Background(), "test-id") // never drained
+	fast := underTest.NewSession(context.Background(), "test-id") // drained each Send
+
+	const sent = 20 // well past bufferSize
+	for i := 0; i < sent; i++ {
+		underTest.Send(context.Background(), []opencdc.Record{
+			{Position: opencdc.Position(fmt.Sprintf("test-pos-%v", i))},
+		})
+		<-fast.C // keep fast empty so it never drops
+	}
+
+	is.Equal(slow.Dropped(), int64(sent-bufferSize)) // slow kept only bufferSize, dropped the rest
+	is.Equal(fast.Dropped(), int64(0))               // fast was drained, dropped nothing
+}
+
+// TestInspector_Dropped_NoDropWhenRoom proves a session with buffer room drops
+// nothing.
+func TestInspector_Dropped_NoDropWhenRoom(t *testing.T) {
+	is := is.New(t)
+
+	underTest := New(log.Nop(), 10)
+	s := underTest.NewSession(context.Background(), "test-id")
+
+	for i := 0; i < 5; i++ { // fewer than the buffer size
+		underTest.Send(context.Background(), []opencdc.Record{
+			{Position: opencdc.Position(fmt.Sprintf("test-pos-%v", i))},
+		})
+	}
+	is.Equal(s.Dropped(), int64(0))
 }
 
 func assertGotRecord(is *is.I, s *Session, recWant opencdc.Record) {


### PR DESCRIPTION
v0.18 built-in-UI **prerequisite P1** (#2624). The inspector drops records when a session's buffer is full (a side-channel — never affects pipeline delivery), but the loss was unmetered. Meters it so the UI can honestly show a drop rate instead of pretending sampling exists.

## What changed
- New metric `conduit_inspector_dropped_records{component_id}`, incremented on each drop (labeled to match `conduit_inspector_sessions` — bounded cardinality, no proto change).
- New `Session.Dropped()` — atomic per-session count, for testability + a future per-stream field.

## Known limitation (deliberate)
The metric aggregates drops across **all sessions on a component** — "drops for the component being watched," not "for my specific stream." Accurate per-stream accounting needs a field on the Inspect stream (a proto change) — a noted follow-up; `Session.Dropped()` already tracks the per-session number for it.

## Log left unchanged (deliberate)
The per-record drop `Warn` is untouched. Trace would hide drops from default operation (level is `info`); a per-Inspector aggregate ticker would proliferate goroutines (2 per connector + 2 per processor). The pre-existing per-record-Warn spam under a firehose is a separate follow-up (ideal: one global periodic aggregate log).

## Failure-mode analysis
- **Not the data path.** The inspector is a side-channel; dropping an inspected copy never affects ack/position/checkpoint/delivery. No invariant touched. No proto/serialized-format change.
- **Concurrency:** `droppedRecords` is written under the Inspector lock in `Send` and read lock-free by `Dropped()` → `atomic.Int64` (necessary, not redundant). Race-clean.
- **Rollback:** revert; drop the metric/accessor. No migration.

## Testing note (honest scoping)
No `measure.*` metric value is unit-tested anywhere in the repo (the globals wire to a registry only at runtime, no test helper). So unit tests assert the **drop logic via `Session.Dropped()`**; the metric `.Inc()` is a trivial adjacent line, and its value / `/metrics` rendering is integration/manual — not claimed as a unit-tested AC.

Tests: `Dropped()==1` in the slow-consumer case; **per-session isolation** (a drained session drops nothing while an undrained one drops the overflow, deterministic — synchronous drain); no-drop-when-room. Race-clean (3×).

## Adversarial self-review
Re-read the diff: the atomic write is under the lock, the lock-free read is atomic; the metric label matches the sibling gauge; purely additive; the per-session test drains synchronously to avoid a scheduling-race flake.

Risk tier: **2** (observability, additive). Plan independently reviewed before implementation; findings folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3cLokwNJYLLBpdyt3cgGr