### PR TITLE
feat(metrics): add component_id label to connector/processor throughput+latency metrics (P7)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -24,16 +24,32 @@ locally, you can get metrics if you run `curl localhost:8080/metrics`.
     | `conduit_pipelines`                            | Gauge     | Number of pipelines by status.                                                                                 |
     | `conduit_connectors`                           | Gauge     | Number of connectors by type (source, destination).                                                            |
     | `conduit_processors`                           | Gauge     | Number of processors by name and type.                                                                         |
-    | `conduit_connector_bytes`                      | Histogram | Number of bytes* a connector processed by pipeline name, plugin and type (source, destination).                |
+    | `conduit_connector_bytes`                      | Histogram | Number of bytes* a connector processed by pipeline name, plugin, type (source, destination) and component ID.  |
     | `conduit_dlq_bytes`                            | Histogram | Number of bytes* a DLQ connector processed per pipeline and plugin.                                            |
     | `conduit_pipeline_execution_duration_seconds`  | Histogram | Amount of time records spent in a pipeline.                                                                    |
-    | `conduit_connector_execution_duration_seconds` | Histogram | Amount of time spent reading or writing records per pipeline, plugin and connector type (source, destination). |
-    | `conduit_processor_execution_duration_seconds` | Histogram | Amount of time spent on processing records per pipeline and processor.                                         |
+    | `conduit_connector_execution_duration_seconds` | Histogram | Amount of time spent reading or writing records per pipeline, plugin, connector type (source, destination) and component ID. |
+    | `conduit_processor_execution_duration_seconds` | Histogram | Amount of time spent on processing records per pipeline, processor and component ID.                           |
     | `conduit_dlq_execution_duration_seconds`       | Histogram | Amount of time spent writing records to DLQ connector per pipeline and plugin.                                 |
     | `conduit_inspector_sessions`                   | Gauge     | Number of inspector sessions by ID of pipeline component (connector or processor)                              |
 
   *We calculate bytes based on the JSON representation of the record payload
   and key.
+
+  **`component_id` label (added in P7):** `conduit_connector_bytes`,
+  `conduit_connector_execution_duration_seconds` and
+  `conduit_processor_execution_duration_seconds` carry a `component_id` label
+  holding the connector or processor **instance ID** — the same ID space used
+  by the topology nodes and by `conduit_inspector_sessions` /
+  `conduit_inspector_dropped_records_total`. This is an additive change: no
+  existing label was removed, so dashboards/queries that only aggregate on the
+  pre-existing labels (`pipeline_name`, `plugin`, `type`/`processor`) keep
+  working unchanged. Per-node attribution (e.g. a fleet UI's per-node
+  throughput view) is opt-in — group or filter by `component_id` to get it.
+  Because a new label starts a new Prometheus series, upgrading Conduit resets
+  the counters/histograms these three metrics contribute to (the old series
+  stop being written, new ones carrying `component_id` start from zero); this
+  does not affect any other metric and has no effect on pipeline state or
+  data.
 
 - **Go runtime metrics**: The default metrics exposed by Prometheus' official Go
   package, [client_golang](https://pkg.go.dev/github.com/prometheus/client_golang).

--- a/pkg/foundation/metrics/measure/measure.go
+++ b/pkg/foundation/metrics/measure/measure.go
@@ -25,6 +25,13 @@ const (
 	labelPipelineName = "pipeline_name"
 	labelType         = "type"
 	labelPlugin       = "plugin"
+	// labelComponentID is the ID of the pipeline component (connector or
+	// processor) a metric belongs to. It uses the same ID space as the
+	// topology nodes and as the existing conduit_inspector_sessions /
+	// conduit_inspector_dropped_records_total metrics (see
+	// pkg/inspector.Inspector.NewSession), so per-node dashboards can join
+	// across all of these metrics on this label.
+	labelComponentID = "component_id"
 )
 
 // Any changes in metrics defined below should also be reflected in the metrics documentation.
@@ -55,7 +62,7 @@ var (
 	InspectorsGauge = metrics.NewLabeledGauge(
 		"conduit_inspector_sessions",
 		"Number of inspector sessions by ID of pipeline component (connector or processor)",
-		[]string{"component_id"},
+		[]string{labelComponentID},
 	)
 	// _total suffix per Prometheus counter convention; this is a new metric with
 	// no consumer yet, so the name is fixed correctly now rather than matching the
@@ -64,12 +71,19 @@ var (
 		"conduit_inspector_dropped_records_total",
 		"Number of records dropped by inspector sessions because the session buffer was full, "+
 			"by ID of pipeline component (summed across all sessions on that component).",
-		[]string{"component_id"},
+		[]string{labelComponentID},
 	)
 
+	// ConnectorBytesHistogram carries a component_id label in addition to the
+	// original pipeline_name/plugin/type labels (added for P7, additive: no
+	// existing label was removed). component_id is the connector's instance
+	// ID, letting the UI attribute throughput to a specific node. Scraping
+	// dashboards that only key on the original three labels keep working
+	// unchanged (Prometheus aggregates across component_id values unless a
+	// query explicitly groups by it); per-node granularity is opt-in.
 	ConnectorBytesHistogram = metrics.NewLabeledHistogram("conduit_connector_bytes",
-		"Number of bytes a connector processed by pipeline name, plugin and type (source, destination).",
-		[]string{labelPipelineName, labelPlugin, labelType},
+		"Number of bytes a connector processed by pipeline name, plugin, type (source, destination) and component ID.",
+		[]string{labelPipelineName, labelPlugin, labelType, labelComponentID},
 		// buckets from 1KiB to 2MiB
 		prometheus.HistogramOpts{Buckets: []float64{1024, 1024 << 1, 1024 << 2, 1024 << 3, 1024 << 4, 1024 << 5, 1024 << 6, 1024 << 7, 1024 << 8, 1024 << 9, 1024 << 10, 1024 << 11}},
 	)
@@ -84,14 +98,17 @@ var (
 		[]string{labelPipelineName},
 		prometheus.HistogramOpts{Buckets: []float64{.001, .0025, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5}},
 	)
+	// ConnectorExecutionDurationTimer carries a component_id label in addition
+	// to the original labels, see the comment on ConnectorBytesHistogram for
+	// the additive-contract rationale (same for both metrics below).
 	ConnectorExecutionDurationTimer = metrics.NewLabeledTimer("conduit_connector_execution_duration_seconds",
-		"Amount of time spent reading or writing records per pipeline, plugin and connector type (source, destination).",
-		[]string{labelPipelineName, labelPlugin, labelType},
+		"Amount of time spent reading or writing records per pipeline, plugin, connector type (source, destination) and component ID.",
+		[]string{labelPipelineName, labelPlugin, labelType, labelComponentID},
 		prometheus.HistogramOpts{Buckets: []float64{.001, .0025, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5}},
 	)
 	ProcessorExecutionDurationTimer = metrics.NewLabeledTimer("conduit_processor_execution_duration_seconds",
-		"Amount of time spent on processing records per pipeline and processor.",
-		[]string{labelPipelineName, "processor"},
+		"Amount of time spent on processing records per pipeline, processor and component ID.",
+		[]string{labelPipelineName, "processor", labelComponentID},
 		prometheus.HistogramOpts{Buckets: []float64{.001, .0025, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5}},
 	)
 	DLQExecutionDurationTimer = metrics.NewLabeledTimer("conduit_dlq_execution_duration_seconds",

--- a/pkg/foundation/metrics/measure/measure_test.go
+++ b/pkg/foundation/metrics/measure/measure_test.go
@@ -1,0 +1,176 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package measure_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit/pkg/foundation/metrics"
+	"github.com/conduitio/conduit/pkg/foundation/metrics/measure"
+	condprom "github.com/conduitio/conduit/pkg/foundation/metrics/prometheus"
+	"github.com/matryer/is"
+	promclient "github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// registerFreshBackend registers a fresh conduit metrics.Registry against the
+// global measure.go specs (mirroring what pkg/conduit/runtime.go does at
+// startup) and returns a throwaway prometheus.Registry that scrapes only that
+// backend. It must be called BEFORE any WithValues(...) call under test:
+// WithValues fans out over the registries attached at call time, so a
+// registry registered afterwards would not observe those values. Every test
+// gets its own backing registry, so tests don't interfere with each other
+// even though measure.go's metric variables are package-level globals shared
+// across the test binary.
+func registerFreshBackend(is *is.I) *promclient.Registry {
+	reg := condprom.NewRegistry(nil)
+	metrics.Register(reg)
+
+	promReg := promclient.NewRegistry()
+	is.NoErr(promReg.Register(reg))
+	return promReg
+}
+
+// findMetric returns the *dto.Metric in family with the given labels
+// (name -> value), or nil if no metric matches.
+func findMetric(family *dto.MetricFamily, labels map[string]string) *dto.Metric {
+	for _, m := range family.GetMetric() {
+		got := make(map[string]string, len(m.GetLabel()))
+		for _, l := range m.GetLabel() {
+			got[l.GetName()] = l.GetValue()
+		}
+		match := len(got) == len(labels)
+		if match {
+			for k, v := range labels {
+				if got[k] != v {
+					match = false
+					break
+				}
+			}
+		}
+		if match {
+			return m
+		}
+	}
+	return nil
+}
+
+func findFamily(families []*dto.MetricFamily, name string) *dto.MetricFamily {
+	for _, f := range families {
+		if f.GetName() == name {
+			return f
+		}
+	}
+	return nil
+}
+
+// TestConnectorBytesHistogram_ComponentIDLabel asserts that
+// conduit_connector_bytes (P7) carries a component_id label set to the
+// connector instance ID, alongside all pre-existing labels (additive change,
+// nothing removed).
+func TestConnectorBytesHistogram_ComponentIDLabel(t *testing.T) {
+	is := is.New(t)
+
+	const (
+		pipelineName = "test-pipeline-connector-bytes"
+		plugin       = "test-plugin"
+		connType     = "source"
+		componentID  = "test-connector-instance-id"
+	)
+
+	promReg := registerFreshBackend(is)
+
+	h := measure.ConnectorBytesHistogram.WithValues(pipelineName, plugin, connType, componentID)
+	h.Observe(1024)
+
+	families, err := promReg.Gather()
+	is.NoErr(err)
+	family := findFamily(families, "conduit_connector_bytes")
+	is.True(family != nil) // conduit_connector_bytes family must be present
+
+	m := findMetric(family, map[string]string{
+		"pipeline_name": pipelineName,
+		"plugin":        plugin,
+		"type":          connType,
+		"component_id":  componentID,
+	})
+	is.True(m != nil) // expected a conduit_connector_bytes series with all 4 labels, including component_id
+	is.Equal(m.GetHistogram().GetSampleCount(), uint64(1))
+}
+
+// TestConnectorExecutionDurationTimer_ComponentIDLabel asserts that
+// conduit_connector_execution_duration_seconds (P7) carries a component_id
+// label set to the connector instance ID, alongside all pre-existing labels.
+func TestConnectorExecutionDurationTimer_ComponentIDLabel(t *testing.T) {
+	is := is.New(t)
+
+	const (
+		pipelineName = "test-pipeline-connector-duration"
+		plugin       = "test-plugin"
+		connType     = "destination"
+		componentID  = "test-connector-instance-id-2"
+	)
+
+	promReg := registerFreshBackend(is)
+
+	timer := measure.ConnectorExecutionDurationTimer.WithValues(pipelineName, plugin, connType, componentID)
+	timer.Update(10 * time.Millisecond)
+
+	families, err := promReg.Gather()
+	is.NoErr(err)
+	family := findFamily(families, "conduit_connector_execution_duration_seconds")
+	is.True(family != nil) // conduit_connector_execution_duration_seconds family must be present
+
+	m := findMetric(family, map[string]string{
+		"pipeline_name": pipelineName,
+		"plugin":        plugin,
+		"type":          connType,
+		"component_id":  componentID,
+	})
+	is.True(m != nil) // expected a conduit_connector_execution_duration_seconds series with all 4 labels, including component_id
+	is.Equal(m.GetHistogram().GetSampleCount(), uint64(1))
+}
+
+// TestProcessorExecutionDurationTimer_ComponentIDLabel asserts that
+// conduit_processor_execution_duration_seconds (P7) carries a component_id
+// label set to the processor instance ID, alongside all pre-existing labels.
+func TestProcessorExecutionDurationTimer_ComponentIDLabel(t *testing.T) {
+	is := is.New(t)
+
+	const (
+		pipelineName = "test-pipeline-processor-duration"
+		plugin       = "test-processor-plugin"
+		componentID  = "test-processor-instance-id"
+	)
+
+	promReg := registerFreshBackend(is)
+
+	timer := measure.ProcessorExecutionDurationTimer.WithValues(pipelineName, plugin, componentID)
+	timer.Update(5 * time.Millisecond)
+
+	families, err := promReg.Gather()
+	is.NoErr(err)
+	family := findFamily(families, "conduit_processor_execution_duration_seconds")
+	is.True(family != nil) // conduit_processor_execution_duration_seconds family must be present
+
+	m := findMetric(family, map[string]string{
+		"pipeline_name": pipelineName,
+		"processor":     plugin,
+		"component_id":  componentID,
+	})
+	is.True(m != nil) // expected a conduit_processor_execution_duration_seconds series with all 3 labels, including component_id
+	is.Equal(m.GetHistogram().GetSampleCount(), uint64(1))
+}

--- a/pkg/lifecycle-poc/funnel/connector_metrics.go
+++ b/pkg/lifecycle-poc/funnel/connector_metrics.go
@@ -37,17 +37,24 @@ type ConnectorMetricsImpl struct {
 	histogram metrics.RecordBytesHistogram
 }
 
-func NewConnectorMetrics(pipelineName, pluginName string, connType connector.Type) ConnectorMetricsImpl {
+// NewConnectorMetrics builds the shared connector throughput/latency metrics
+// for one connector instance. componentID is the connector's instance ID
+// (same ID space as the topology nodes and the conduit_inspector_* metrics),
+// recorded via the component_id label so per-node dashboards can attribute
+// throughput to a specific connector instance.
+func NewConnectorMetrics(pipelineName, pluginName string, connType connector.Type, componentID string) ConnectorMetricsImpl {
 	timer := measure.ConnectorExecutionDurationTimer.WithValues(
 		pipelineName,
 		pluginName,
 		strings.ToLower(connType.String()),
+		componentID,
 	)
 
 	histogram := measure.ConnectorBytesHistogram.WithValues(
 		pipelineName,
 		pluginName,
 		strings.ToLower(connType.String()),
+		componentID,
 	)
 
 	return ConnectorMetricsImpl{

--- a/pkg/lifecycle-poc/funnel/processor_metrics.go
+++ b/pkg/lifecycle-poc/funnel/processor_metrics.go
@@ -42,8 +42,13 @@ func (m ProcessorMetricsImpl) Observe(recordsNum int, start time.Time) {
 	}()
 }
 
-func NewProcessorMetrics(pipelineName, plugin string) ProcessorMetricsImpl {
+// NewProcessorMetrics builds the shared processor latency metric for one
+// processor instance. componentID is the processor's instance ID (same ID
+// space as the topology nodes and the conduit_inspector_* metrics), recorded
+// via the component_id label so per-node dashboards can attribute latency to
+// a specific processor instance.
+func NewProcessorMetrics(pipelineName, plugin, componentID string) ProcessorMetricsImpl {
 	return ProcessorMetricsImpl{
-		timer: measure.ProcessorExecutionDurationTimer.WithValues(pipelineName, plugin),
+		timer: measure.ProcessorExecutionDurationTimer.WithValues(pipelineName, plugin, componentID),
 	}
 }

--- a/pkg/lifecycle-poc/service.go
+++ b/pkg/lifecycle-poc/service.go
@@ -590,7 +590,7 @@ func (s *Service) buildProcessorTasks(
 				instance.ID,
 				runnableProc,
 				logger,
-				s.newProcessorMetrics(pl.Config.Name, instance.Plugin),
+				s.newProcessorMetrics(pl.Config.Name, instance.Plugin, instance.ID),
 			),
 		)
 	}
@@ -812,15 +812,16 @@ func (s *Service) newConnectorMetrics(pipelineName string, instance *connector.I
 		pipelineName,
 		instance.Plugin,
 		instance.Type,
+		instance.ID,
 	)
 }
 
-func (s *Service) newProcessorMetrics(pipelineName, plugin string) funnel.ProcessorMetrics {
+func (s *Service) newProcessorMetrics(pipelineName, plugin, componentID string) funnel.ProcessorMetrics {
 	if s.metricsDisabled {
 		return &funnel.NoOpProcessorMetrics{}
 	}
 
-	return funnel.NewProcessorMetrics(pipelineName, plugin)
+	return funnel.NewProcessorMetrics(pipelineName, plugin, componentID)
 }
 
 func (s *Service) newDLQMetrics(pipelineName string, plugin string) funnel.ConnectorMetrics {

--- a/pkg/lifecycle/service.go
+++ b/pkg/lifecycle/service.go
@@ -611,7 +611,7 @@ func (s *Service) buildProcessorNode(
 	return &stream.ProcessorNode{
 		Name:           proc.ID,
 		Processor:      proc,
-		ProcessorTimer: measure.ProcessorExecutionDurationTimer.WithValues(pl.Config.Name, proc.Plugin),
+		ProcessorTimer: measure.ProcessorExecutionDurationTimer.WithValues(pl.Config.Name, proc.Plugin, proc.ID),
 	}
 }
 
@@ -737,6 +737,7 @@ func (s *Service) buildMetricsNode(
 				pl.Config.Name,
 				conn.Plugin,
 				strings.ToLower(conn.Type.String()),
+				conn.ID,
 			),
 		),
 	}
@@ -781,6 +782,7 @@ func (s *Service) buildDestinationNodes(
 				pl.Config.Name,
 				instance.Plugin,
 				strings.ToLower(instance.Type.String()),
+				instance.ID,
 			),
 		}
 		metricsNode := s.buildMetricsNode(pl, instance)


### PR DESCRIPTION
## Summary

Tier 2. P7 from the UI & extensibility epic: add a `component_id` label (the connector/processor **instance ID**) to three existing metrics, so per-node dashboards (UI-5, in progress in parallel) can attribute throughput and latency to a specific pipeline component instead of only aggregating per pipeline/plugin/type.

Metrics changed:
- `conduit_connector_bytes` (Histogram)
- `conduit_connector_execution_duration_seconds` (Histogram)
- `conduit_processor_execution_duration_seconds` (Histogram)

`component_id` uses the same ID space as the topology nodes and as the existing `conduit_inspector_sessions` / `conduit_inspector_dropped_records_total` metrics (`connector.Instance.ID` / `processor.Instance.ID`, the same value passed to `Inspector.NewSession`).

## Contract impact (semi-public — dashboards key on label sets)

**Additive only.** No existing label (`pipeline_name`, `plugin`, `type` / `processor`) was removed. Adding a label does start a new Prometheus time series, so:

- Existing dashboards/queries that only reference the original labels keep working unchanged — Prometheus aggregates across `component_id` values unless a query explicitly groups by it.
- Per-node granularity is opt-in: group or filter by `component_id` to get it.
- On upgrade, the counters/histograms these three metrics contribute to reset (old series stop being written, new ones carrying `component_id` start from zero). No other metric is affected; no effect on pipeline state or data.

`docs/metrics.md` updated with the new label and this migration note.

## Feasibility check (before implementing)

Verified the instance ID is available at all six `WithValues(...)` call sites without any refactor — connector/processor instances are already in scope when these curried metrics are constructed at pipeline-build time:

- `pkg/lifecycle/service.go`: `buildMetricsNode` (`conn.ID`), `buildDestinationNodes` (`instance.ID`), `buildProcessorNode` (`proc.ID`).
- `pkg/lifecycle-poc/service.go` / `pkg/lifecycle-poc/funnel/*`: the `--dev` hot-reload engine shares the same three `measure.go` metric definitions, so its `NewConnectorMetrics`/`NewProcessorMetrics` call sites also needed the ID threaded through (`instance.ID` was already in scope in both `buildSourceTasks`/`buildDestinationTasks` and `buildProcessorTasks`).

No invasive plumbing was needed in either engine.

## What did NOT change

- **Timing of observation.** Only the `WithValues(...)` construction call (at pipeline-build time) was touched — `Observe`/`Update` call sites in `pkg/lifecycle/stream/{metrics,destination,source}.go` are untouched. `conduit_connector_bytes` is still observed on ack (Invariant 1 enforcement site) with no change to ack ordering or timing.
- No labels removed from any metric.
- `conduit_dlq_bytes` / `conduit_dlq_execution_duration_seconds` are untouched (out of scope per the task).

## Self-review findings

- Confirmed via `git diff` that only the six `WithValues(...)` call sites and the `measure.go` definitions changed — no emit-site (`Observe`/`Update`) diffs.
- Cardinality: `component_id` is bounded per pipeline (one value per connector/processor instance), same order of magnitude as the existing inspector metrics — no blowup risk.
- Empty/nil-ID: `conn.ID` / `instance.ID` / `proc.ID` are plain Go strings, not pointers — an empty string is a valid (if degenerate) label value, not a panic. `WithLabelValues` in `client_golang` only panics on a label-count mismatch, which is why every existing call site of the three changed metrics (`pkg/lifecycle` **and** `pkg/lifecycle-poc/funnel`) had to be updated in this PR — a missed call site would panic at runtime, not fail to compile (`WithValues` is variadic). Verified by grepping for all three metric names' `WithValues` call sites after the change.
- Verified `-race` is clean on both engines, including the poc/dev engine, since it wasn't explicitly named in the task but shares the same label contract.

## Test plan

- [x] Added `pkg/foundation/metrics/measure/measure_test.go`: for each of the three metrics, registers a fresh backing registry, observes through `WithValues(...)`, scrapes via a real `prometheus.Registry`, and asserts a series exists carrying `component_id` with the expected value alongside all pre-existing labels.
- [x] `make build` — clean.
- [x] `make lint` (golangci-lint) — 0 issues.
- [x] `go test -race ./pkg/foundation/metrics/... ./pkg/lifecycle/...` — all green.
- [x] `go test -race ./pkg/lifecycle-poc/...` — all green (extra: the `--dev` engine shares these metrics).
- [x] `make markdown-lint` — clean.

## Roadmap

Unblocks per-node metrics for UI-5 (fleet console per-node throughput/latency view), part of the v0.18 UI & extensibility epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)