### PR TITLE
test(dev): fix -count>1 panic in dev events_test (flake-hunt failure)

### DIFF
--- a/pkg/conduit/dev/events_test.go
+++ b/pkg/conduit/dev/events_test.go
@@ -112,10 +112,19 @@ func TestReporter_JSON_RoundTrips(t *testing.T) {
 	is.Equal(strings.Count(buf.String(), "\n"), 1)
 }
 
+// devExampleTestCode is registered once at package-init, not inside the test
+// body. conduiterr.Register panics on a duplicate reason and MUST be called
+// only from a package-level var initializer (see its godoc); registering inside
+// the test re-ran it on every `-count>1` iteration, panicking with
+// "duplicate code reason dev_test.example" on the second run and crashing the
+// whole package's test binary. That is exactly the process-global-state flake
+// the scheduled `-count=3` flake-hunt job catches. Match the pattern the other
+// exitcode_test.go files already use.
+var devExampleTestCode = conduiterr.Register("dev_test.example", 0)
+
 func TestErrorInfoFromErr_ConduitError_PreservesFields(t *testing.T) {
 	is := is.New(t)
-	code := conduiterr.Register("dev_test.example", 0)
-	ce := conduiterr.New(code, "boom")
+	ce := conduiterr.New(devExampleTestCode, "boom")
 	ce.ConfigPath = "/pipelines/0/id"
 	ce.Suggestion = "fix it"
 


### PR DESCRIPTION
**Tier 3 (test-only).** Fixes the `flake hunt` CI failure on `main`.

## Root cause
`TestErrorInfoFromErr_ConduitError_PreservesFields` (`pkg/conduit/dev/events_test.go`, new with the `--dev` watcher in #2616) called `conduiterr.Register("dev_test.example", 0)` **inside the test body**. `conduiterr.Register` writes a process-global registry and **panics on a duplicate reason** (its godoc says it must be called only from a package-level var initializer). The flake-hunt runs `-count=3`, so the second iteration re-registered the same reason → panic → the whole `pkg/conduit/dev` test binary crashed.

It's actually **deterministic** under `-count>=2`; it read as "flaky" only because the flake-hunt is the sole job running `-count>1`. The PR-gating `test` job uses `-count=1`, so **main's normal CI was always green** — this only ever failed the flake-hunt path. Not a regression from any recent merge.

## Fix
Move the registration to a package-level `var` (matches the `exitcode_test.go` convention), so it runs once at init regardless of `-count`. Test-only, one file, no production change.

## Verification
`-count=3` passes; `-race -count=20 -shuffle=on` × 4 consecutive runs (~80 iterations) all green. Pre-fix the same command panicked reproducibly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)