### PR TITLE
fix(api): redact connector/DLQ Settings values in API responses (#2640)

### DIFF
--- a/pkg/http/api/connector_v1_test.go
+++ b/pkg/http/api/connector_v1_test.go
@@ -67,7 +67,7 @@ func TestConnectorAPIv1_ListConnectors(t *testing.T) {
 				},
 				Config: &apiv1.Connector_Config{
 					Name:     source.Config.Name,
-					Settings: source.Config.Settings,
+					Settings: wantRedactedSettings(source.Config.Settings),
 				},
 				Type:         apiv1.Connector_Type(source.Type),
 				Plugin:       source.Plugin,
@@ -86,7 +86,7 @@ func TestConnectorAPIv1_ListConnectors(t *testing.T) {
 				},
 				Config: &apiv1.Connector_Config{
 					Name:     destination.Config.Name,
-					Settings: destination.Config.Settings,
+					Settings: wantRedactedSettings(destination.Config.Settings),
 				},
 				Type:         apiv1.Connector_Type(destination.Type),
 				Plugin:       destination.Plugin,
@@ -141,7 +141,7 @@ func TestConnectorAPIv1_ListConnectorsByPipeline(t *testing.T) {
 				},
 				Config: &apiv1.Connector_Config{
 					Name:     source.Config.Name,
-					Settings: source.Config.Settings,
+					Settings: wantRedactedSettings(source.Config.Settings),
 				},
 				Type:         apiv1.Connector_Type(source.Type),
 				Plugin:       source.Plugin,
@@ -180,6 +180,14 @@ func TestConnectorAPIv1_CreateConnector(t *testing.T) {
 
 	csMock.EXPECT().Create(ctx, source.Type, source.Plugin, source.PipelineID, source.Config).Return(source, nil).Times(1)
 
+	// reqConfig is the unredacted config the client sends in the request; the
+	// API never redacts inbound Config, only what it hands back (see want,
+	// below).
+	reqConfig := &apiv1.Connector_Config{
+		Name:     source.Config.Name,
+		Settings: source.Config.Settings,
+	}
+
 	now := time.Now()
 	want := &apiv1.CreateConnectorResponse{Connector: &apiv1.Connector{
 		Id: source.ID,
@@ -188,7 +196,7 @@ func TestConnectorAPIv1_CreateConnector(t *testing.T) {
 		},
 		Config: &apiv1.Connector_Config{
 			Name:     source.Config.Name,
-			Settings: source.Config.Settings,
+			Settings: wantRedactedSettings(source.Config.Settings),
 		},
 		Type:         apiv1.Connector_Type(source.Type),
 		Plugin:       source.Plugin,
@@ -204,7 +212,7 @@ func TestConnectorAPIv1_CreateConnector(t *testing.T) {
 			Type:       want.Connector.Type,
 			Plugin:     want.Connector.Plugin,
 			PipelineId: want.Connector.PipelineId,
-			Config:     want.Connector.Config,
+			Config:     reqConfig,
 		},
 	)
 
@@ -364,7 +372,7 @@ func TestConnectorAPIv1_GetConnector(t *testing.T) {
 		},
 		Config: &apiv1.Connector_Config{
 			Name:     source.Config.Name,
-			Settings: source.Config.Settings,
+			Settings: wantRedactedSettings(source.Config.Settings),
 		},
 		Type:         apiv1.Connector_Type(source.Type),
 		Plugin:       source.Plugin,
@@ -410,6 +418,14 @@ func TestConnectorAPIv1_UpdateConnector(t *testing.T) {
 
 	csMock.EXPECT().Update(ctx, before.ID, after.Plugin, after.Config).Return(after, nil).Times(1)
 
+	// reqConfig is the unredacted config the client sends in the request; the
+	// API never redacts inbound Config, only what it hands back (see want,
+	// below).
+	reqConfig := &apiv1.Connector_Config{
+		Name:     after.Config.Name,
+		Settings: after.Config.Settings,
+	}
+
 	now := time.Now()
 	want := &apiv1.UpdateConnectorResponse{Connector: &apiv1.Connector{
 		Id: after.ID,
@@ -418,7 +434,7 @@ func TestConnectorAPIv1_UpdateConnector(t *testing.T) {
 		},
 		Config: &apiv1.Connector_Config{
 			Name:     after.Config.Name,
-			Settings: after.Config.Settings,
+			Settings: wantRedactedSettings(after.Config.Settings),
 		},
 		Type:         apiv1.Connector_Type(after.Type),
 		Plugin:       after.Plugin,
@@ -432,7 +448,7 @@ func TestConnectorAPIv1_UpdateConnector(t *testing.T) {
 		ctx,
 		&apiv1.UpdateConnectorRequest{
 			Id:     want.Connector.Id,
-			Config: want.Connector.Config,
+			Config: reqConfig,
 			Plugin: want.Connector.Plugin,
 		},
 	)

--- a/pkg/http/api/pipeline_v1_test.go
+++ b/pkg/http/api/pipeline_v1_test.go
@@ -258,3 +258,77 @@ func TestPipelineAPIv1_ApplyPipeline_GateDenied_SurfacesCodedError(t *testing.T)
 	is.True(ok)
 	is.Equal(st.Code(), codes.FailedPrecondition)
 }
+
+// dlqSecretSentinel is planted in a DLQ's Settings across the tests below
+// (#2640, the exact leak site this issue was filed against — PipelineDLQ
+// returned pl.Settings unredacted). If it ever shows up in a GetDLQ/UpdateDLQ
+// response, the redaction at toproto.PipelineDLQ regressed.
+const dlqSecretSentinel = "SENTINEL_dlq_aws_secret_9f3a"
+
+// TestPipelineAPIv1_GetDLQ_RedactsSettings is the regression test for #2640:
+// GetDLQ must never echo back a DLQ Settings value, only "***", while Plugin
+// and the window fields stay untouched.
+func TestPipelineAPIv1_GetDLQ_RedactsSettings(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	psMock := mock.NewPipelineOrchestrator(ctrl)
+	provMock := mock.NewProvisioner(ctrl)
+	api := NewPipelineAPIv1(psMock, provMock, false)
+
+	pl := &pipeline.Instance{
+		ID: "p1",
+		DLQ: pipeline.DLQ{
+			Plugin:              "builtin:s3",
+			Settings:            map[string]string{"aws.secretAccessKey": dlqSecretSentinel},
+			WindowSize:          10,
+			WindowNackThreshold: 5,
+		},
+	}
+	psMock.EXPECT().Get(ctx, "p1").Return(pl, nil).Times(1)
+
+	got, err := api.GetDLQ(ctx, &apiv1.GetDLQRequest{Id: "p1"})
+	is.NoErr(err)
+
+	is.Equal(got.Dlq.Plugin, "builtin:s3") // structural field must be untouched
+	is.Equal(got.Dlq.WindowSize, uint64(10))
+	is.Equal(got.Dlq.WindowNackThreshold, uint64(5))
+	is.Equal(len(got.Dlq.Settings), 1)
+	is.True(got.Dlq.Settings["aws.secretAccessKey"] != dlqSecretSentinel) // secret leaked
+	is.Equal(got.Dlq.Settings["aws.secretAccessKey"], "***")
+}
+
+// TestPipelineAPIv1_UpdateDLQ_RedactsSettings is the same regression as
+// GetDLQ's, but for the UpdateDLQ response: the updated DLQ's Settings must
+// come back redacted even though the *request* carried the real value (the
+// API redacts what it hands back, never what a config-as-code/API client
+// sends it).
+func TestPipelineAPIv1_UpdateDLQ_RedactsSettings(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	psMock := mock.NewPipelineOrchestrator(ctrl)
+	provMock := mock.NewProvisioner(ctrl)
+	api := NewPipelineAPIv1(psMock, provMock, false)
+
+	reqDLQ := pipeline.DLQ{
+		Plugin:   "builtin:s3",
+		Settings: map[string]string{"aws.secretAccessKey": dlqSecretSentinel},
+	}
+	updated := &pipeline.Instance{ID: "p1", DLQ: reqDLQ}
+	psMock.EXPECT().UpdateDLQ(ctx, "p1", reqDLQ).Return(updated, nil).Times(1)
+
+	got, err := api.UpdateDLQ(ctx, &apiv1.UpdateDLQRequest{
+		Id: "p1",
+		Dlq: &apiv1.Pipeline_DLQ{
+			Plugin:   reqDLQ.Plugin,
+			Settings: reqDLQ.Settings,
+		},
+	})
+	is.NoErr(err)
+
+	is.Equal(got.Dlq.Plugin, "builtin:s3")
+	is.Equal(len(got.Dlq.Settings), 1)
+	is.True(got.Dlq.Settings["aws.secretAccessKey"] != dlqSecretSentinel) // secret leaked
+	is.Equal(got.Dlq.Settings["aws.secretAccessKey"], "***")
+}

--- a/pkg/http/api/processor_v1_test.go
+++ b/pkg/http/api/processor_v1_test.go
@@ -87,7 +87,7 @@ func TestProcessorAPIv1_ListProcessors(t *testing.T) {
 				Id:     prs[0].ID,
 				Plugin: prs[0].Plugin,
 				Config: &apiv1.Processor_Config{
-					Settings: prs[0].Config.Settings,
+					Settings: wantRedactedSettings(prs[0].Config.Settings),
 				},
 				Parent: &apiv1.Processor_Parent{
 					Id:   prs[0].Parent.ID,
@@ -101,7 +101,7 @@ func TestProcessorAPIv1_ListProcessors(t *testing.T) {
 				Id:     prs[1].ID,
 				Plugin: prs[1].Plugin,
 				Config: &apiv1.Processor_Config{
-					Settings: prs[1].Config.Settings,
+					Settings: wantRedactedSettings(prs[1].Config.Settings),
 				},
 				Parent: &apiv1.Processor_Parent{
 					Id:   prs[1].Parent.ID,
@@ -195,7 +195,7 @@ func TestProcessorAPIv1_ListProcessorsByParents(t *testing.T) {
 				Id:     prs[0].ID,
 				Plugin: prs[0].Plugin,
 				Config: &apiv1.Processor_Config{
-					Settings: prs[0].Config.Settings,
+					Settings: wantRedactedSettings(prs[0].Config.Settings),
 				},
 				Parent: &apiv1.Processor_Parent{
 					Id:   prs[0].Parent.ID,
@@ -209,7 +209,7 @@ func TestProcessorAPIv1_ListProcessorsByParents(t *testing.T) {
 				Id:     prs[2].ID,
 				Plugin: prs[2].Plugin,
 				Config: &apiv1.Processor_Config{
-					Settings: prs[2].Config.Settings,
+					Settings: wantRedactedSettings(prs[2].Config.Settings),
 				},
 				Parent: &apiv1.Processor_Parent{
 					Id:   prs[2].Parent.ID,
@@ -222,7 +222,7 @@ func TestProcessorAPIv1_ListProcessorsByParents(t *testing.T) {
 				Id:     prs[3].ID,
 				Plugin: prs[3].Plugin,
 				Config: &apiv1.Processor_Config{
-					Settings: prs[3].Config.Settings,
+					Settings: wantRedactedSettings(prs[3].Config.Settings),
 				},
 				Parent: &apiv1.Processor_Parent{
 					Id:   prs[3].Parent.ID,
@@ -269,11 +269,18 @@ func TestProcessorAPIv1_CreateProcessor(t *testing.T) {
 	}
 	psMock.EXPECT().Create(ctx, pr.Plugin, pr.Parent, config, pr.Condition).Return(pr, nil).Times(1)
 
+	// reqConfig is the unredacted config the client sends in the request; the
+	// API never redacts inbound Config, only what it hands back (see want,
+	// below).
+	reqConfig := &apiv1.Processor_Config{
+		Settings: pr.Config.Settings,
+	}
+
 	want := &apiv1.CreateProcessorResponse{Processor: &apiv1.Processor{
 		Id:     pr.ID,
 		Plugin: pr.Plugin,
 		Config: &apiv1.Processor_Config{
-			Settings: pr.Config.Settings,
+			Settings: wantRedactedSettings(pr.Config.Settings),
 		},
 		Parent: &apiv1.Processor_Parent{
 			Id:   pr.Parent.ID,
@@ -289,7 +296,7 @@ func TestProcessorAPIv1_CreateProcessor(t *testing.T) {
 		&apiv1.CreateProcessorRequest{
 			Plugin:    want.Processor.Plugin,
 			Parent:    want.Processor.Parent,
-			Config:    want.Processor.Config,
+			Config:    reqConfig,
 			Condition: want.Processor.Condition,
 		},
 	)
@@ -327,7 +334,7 @@ func TestProcessorAPIv1_GetProcessor(t *testing.T) {
 		Id:     pr.ID,
 		Plugin: pr.Plugin,
 		Config: &apiv1.Processor_Config{
-			Settings: pr.Config.Settings,
+			Settings: wantRedactedSettings(pr.Config.Settings),
 		},
 		Parent: &apiv1.Processor_Parent{
 			Id:   pr.Parent.ID,
@@ -374,11 +381,18 @@ func TestProcessorAPIv1_UpdateProcessor(t *testing.T) {
 	}
 	psMock.EXPECT().Update(ctx, pr.ID, pr.Plugin, config).Return(pr, nil).Times(1)
 
+	// reqConfig is the unredacted config the client sends in the request; the
+	// API never redacts inbound Config, only what it hands back (see want,
+	// below).
+	reqConfig := &apiv1.Processor_Config{
+		Settings: pr.Config.Settings,
+	}
+
 	want := &apiv1.UpdateProcessorResponse{Processor: &apiv1.Processor{
 		Id:     pr.ID,
 		Plugin: pr.Plugin,
 		Config: &apiv1.Processor_Config{
-			Settings: pr.Config.Settings,
+			Settings: wantRedactedSettings(pr.Config.Settings),
 		},
 		Parent: &apiv1.Processor_Parent{
 			Id:   pr.Parent.ID,
@@ -393,7 +407,7 @@ func TestProcessorAPIv1_UpdateProcessor(t *testing.T) {
 		&apiv1.UpdateProcessorRequest{
 			Id:     want.Processor.Id,
 			Plugin: want.Processor.Plugin,
-			Config: want.Processor.Config,
+			Config: reqConfig,
 		},
 	)
 

--- a/pkg/http/api/redact_helpers_test.go
+++ b/pkg/http/api/redact_helpers_test.go
@@ -1,0 +1,36 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+// wantRedactedSettings is the shared test expectation for what an outbound
+// Connector/Processor/DLQ Settings map looks like once it has crossed the API
+// boundary (#2640): every value replaced with "***", every key preserved.
+//
+// It is a separate, hand-rolled implementation rather than a call into
+// toproto's own (unexported) redaction helper on purpose — asserting against
+// the production implementation would make the test tautological (it would
+// pass even if that implementation regressed to a no-op). Keep this in sync
+// with the "***" constant (github.com/conduitio/conduit/pkg/foundation/log.Redacted)
+// if that ever changes.
+func wantRedactedSettings(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k := range in {
+		out[k] = "***"
+	}
+	return out
+}

--- a/pkg/http/api/toproto/connector.go
+++ b/pkg/http/api/toproto/connector.go
@@ -49,10 +49,17 @@ func Connector(in *connector.Instance) *apiv1.Connector {
 	return apiConnector
 }
 
+// ConnectorConfig converts a connector.Config to its wire representation.
+//
+// Invariant (secret redaction): Settings routinely contains credentials
+// (DB passwords, SASL creds, access keys). Since conduit-commons has no
+// per-parameter secret marker yet, every value is redacted to "***"
+// (deny-by-default) — see redactSettings for the full rationale. Keys stay
+// visible; only values are masked.
 func ConnectorConfig(in connector.Config) *apiv1.Connector_Config {
 	return &apiv1.Connector_Config{
 		Name:     in.Name,
-		Settings: in.Settings,
+		Settings: redactSettings(in.Settings),
 	}
 }
 

--- a/pkg/http/api/toproto/pipeline.go
+++ b/pkg/http/api/toproto/pipeline.go
@@ -79,10 +79,17 @@ func PipelineStoppedReason(in pipeline.Status) apiv1.Pipeline_State_StoppedReaso
 	}
 }
 
+// PipelineDLQ converts a pipeline.DLQ to its wire representation.
+//
+// Invariant (secret redaction): Settings routinely contains credentials for
+// the DLQ destination plugin. Since conduit-commons has no per-parameter
+// secret marker yet, every value is redacted to "***" (deny-by-default) —
+// see redactSettings for the full rationale. Keys stay visible; only values
+// are masked.
 func PipelineDLQ(in pipeline.DLQ) *apiv1.Pipeline_DLQ {
 	return &apiv1.Pipeline_DLQ{
 		Plugin:   in.Plugin,
-		Settings: in.Settings,
+		Settings: redactSettings(in.Settings),
 		//nolint:gosec // no risk of overflow, existing pipeline that's already been validated
 		WindowSize: uint64(in.WindowSize),
 		//nolint:gosec // no risk of overflow, existing pipeline that's already been validated

--- a/pkg/http/api/toproto/processor.go
+++ b/pkg/http/api/toproto/processor.go
@@ -39,9 +39,17 @@ func Processor(in *processor.Instance) *apiv1.Processor {
 	}
 }
 
+// ProcessorConfig converts a processor.Config to its wire representation.
+//
+// Invariant (secret redaction): Settings can contain credentials (e.g. an
+// HTTP processor's Authorization header, an API key for a third-party
+// enrichment call). Since conduit-commons has no per-parameter secret marker
+// yet, every value is redacted to "***" (deny-by-default) — see
+// redactSettings for the full rationale. Keys stay visible; only values are
+// masked.
 func ProcessorConfig(in processor.Config) *apiv1.Processor_Config {
 	return &apiv1.Processor_Config{
-		Settings: in.Settings,
+		Settings: redactSettings(in.Settings),
 		Workers:  int32(in.Workers), //nolint:gosec // no risk of overflow
 	}
 }

--- a/pkg/http/api/toproto/redact.go
+++ b/pkg/http/api/toproto/redact.go
@@ -1,0 +1,54 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toproto
+
+import "github.com/conduitio/conduit/pkg/foundation/log"
+
+// redactSettings returns a copy of in with every value replaced by
+// log.Redacted ("***"); keys are preserved so callers can still see which
+// settings exist. It never mutates in.
+//
+// Security: connector, processor and DLQ Settings/Config maps routinely
+// contain credentials — database passwords, SASL/SCRAM secrets, cloud access
+// keys — entered by users via config-as-code or the API's own Create/Update
+// RPCs. conduit-commons' config.Parameter has no field marking a parameter as
+// secret yet (tracked upstream as conduit-commons#2566), so there is no
+// reliable way to identify *which* keys in a given map are sensitive from
+// this package. Rather than guess with a key-name heuristic (which leaks
+// exactly the key it fails to match), every outbound Settings/Config value is
+// redacted: deny-by-default. This mirrors the log-output redaction already
+// done for connector settings (see pkg/foundation/log/redact.go) — that path
+// covers what gets written to logs, this one covers what the HTTP/gRPC API
+// hands back to a caller. The API is unauthenticated by default, so this is
+// the last line of defense against a secret leaking to anyone who can reach
+// it.
+//
+// This must be called at every toproto conversion that embeds a
+// Settings/Config map in a response (see ConnectorConfig, ProcessorConfig,
+// PipelineDLQ) — a single missed call site reintroduces the leak. It must
+// NOT be called anywhere on the inbound (fromproto) path: Create/Update
+// requests need the real values to configure the connector/processor, and
+// config-as-code provisioning parses YAML directly, never through this
+// package.
+func redactSettings(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k := range in {
+		out[k] = log.Redacted
+	}
+	return out
+}

--- a/pkg/http/api/toproto/redact_test.go
+++ b/pkg/http/api/toproto/redact_test.go
@@ -1,0 +1,126 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toproto_test
+
+import (
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/connector"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/http/api/toproto"
+	"github.com/conduitio/conduit/pkg/pipeline"
+	"github.com/conduitio/conduit/pkg/processor"
+	"github.com/matryer/is"
+)
+
+// Sentinel secret values planted in Settings across this file's tests
+// (#2640). If any of these ever shows up in a toproto-built API response,
+// a redaction site regressed.
+const (
+	redactTestDBPasswordSentinel = "SENTINEL_db_pw_9f3a2c"
+	redactTestSASLSentinel       = "SENTINEL_sasl_7b1e4d"
+	redactTestAccessKeySentinel  = "SENTINEL_access_key_44ff"
+)
+
+// TestConnectorConfig_RedactsSettings is the regression test for the #2640
+// connector leak site (pkg/http/api/toproto/connector.go): ConnectorConfig
+// must never echo back a Settings value, only "***", while keeping every key
+// visible and leaving Name untouched.
+func TestConnectorConfig_RedactsSettings(t *testing.T) {
+	is := is.New(t)
+
+	in := connector.Config{
+		Name: "my-postgres-source",
+		Settings: map[string]string{
+			"url":           redactTestDBPasswordSentinel,
+			"sasl.password": redactTestSASLSentinel,
+		},
+	}
+
+	got := toproto.ConnectorConfig(in)
+
+	is.Equal(got.Name, "my-postgres-source") // structural field must be untouched
+	is.Equal(len(got.Settings), 2)
+	for _, v := range got.Settings {
+		is.True(v != redactTestDBPasswordSentinel) // secret leaked
+		is.True(v != redactTestSASLSentinel)       // secret leaked
+		is.Equal(v, log.Redacted)
+	}
+	_, hasURL := got.Settings["url"]
+	_, hasSASL := got.Settings["sasl.password"]
+	is.True(hasURL)  // key must stay visible
+	is.True(hasSASL) // key must stay visible
+
+	// input must not be mutated by the conversion
+	is.Equal(in.Settings["url"], redactTestDBPasswordSentinel)
+	is.Equal(in.Settings["sasl.password"], redactTestSASLSentinel)
+}
+
+func TestConnectorConfig_NilSettings(t *testing.T) {
+	is := is.New(t)
+
+	got := toproto.ConnectorConfig(connector.Config{Name: "no-settings"})
+	is.Equal(got.Name, "no-settings")
+	is.Equal(got.Settings, nil)
+}
+
+// TestProcessorConfig_RedactsSettings is the regression test for the #2640
+// processor leak site (pkg/http/api/toproto/processor.go): ProcessorConfig
+// must never echo back a Settings value (e.g. an HTTP processor's API key),
+// only "***", while leaving Workers untouched.
+func TestProcessorConfig_RedactsSettings(t *testing.T) {
+	is := is.New(t)
+
+	in := processor.Config{
+		Settings: map[string]string{
+			"request.headers.Authorization": redactTestAccessKeySentinel,
+		},
+		Workers: 4,
+	}
+
+	got := toproto.ProcessorConfig(in)
+
+	is.Equal(got.Workers, int32(4)) // structural field must be untouched
+	is.Equal(len(got.Settings), 1)
+	is.Equal(got.Settings["request.headers.Authorization"], log.Redacted)
+	is.True(got.Settings["request.headers.Authorization"] != redactTestAccessKeySentinel)
+}
+
+// TestPipelineDLQ_RedactsSettings is the regression test for the #2640 DLQ
+// leak site (pkg/http/api/toproto/pipeline.go PipelineDLQ, the exact site
+// filed in the issue): the DLQ destination's Settings must never be echoed
+// back, only "***", while Plugin/WindowSize/WindowNackThreshold stay
+// untouched.
+func TestPipelineDLQ_RedactsSettings(t *testing.T) {
+	is := is.New(t)
+
+	in := pipeline.DLQ{
+		Plugin: "builtin:s3",
+		Settings: map[string]string{
+			"aws.secretAccessKey": redactTestAccessKeySentinel,
+		},
+		WindowSize:          10,
+		WindowNackThreshold: 5,
+	}
+
+	got := toproto.PipelineDLQ(in)
+
+	is.Equal(got.Plugin, "builtin:s3") // structural field must be untouched
+	is.Equal(got.WindowSize, uint64(10))
+	is.Equal(got.WindowNackThreshold, uint64(5))
+	is.Equal(len(got.Settings), 1)
+	is.Equal(got.Settings["aws.secretAccessKey"], log.Redacted)
+	is.True(got.Settings["aws.secretAccessKey"] != redactTestAccessKeySentinel)
+}


### PR DESCRIPTION
## Vulnerability

Connector, processor, and pipeline-DLQ `Settings`/`Config` maps (`map[string]string`) routinely
contain credentials — database passwords, SASL/SCRAM secrets, cloud access keys — and were
returned **in plaintext** by the HTTP/gRPC API, which is unauthenticated by default. Anyone who
can reach a running Conduit instance's API could read every connector's secrets via
`GetConnector`/`ListConnectors`/`GetDLQ`/`UpdateDLQ`/etc.

Filed site: `pkg/http/api/toproto/pipeline.go` `PipelineDLQ` returning `Settings: in.Settings`
unredacted. Verified during this fix that the same bug existed in `pkg/http/api/toproto/connector.go`
`ConnectorConfig` (Get/List/Create/Update connectors) and `pkg/http/api/toproto/processor.go`
`ProcessorConfig` (Get/List/Create/Update processors, e.g. an HTTP processor's `Authorization`
header or a third-party API key).

## Why deny-by-default (redact everything, not just known secret keys)

`conduit-commons`' `config.Parameter` has no field marking a parameter as secret yet (tracked
upstream as conduit-commons#2566). Without that metadata, there is no reliable way to know which
keys in a given `Settings` map are sensitive from this package. A key-name heuristic (e.g. regex
on `password`/`secret`/`key`) would leak exactly the key it fails to match — a false sense of
security. So every outbound Settings/Config **value** is redacted to `"***"`; **keys stay
visible** so operators can still see what's configured.

## Fix

Added one helper, `redactSettings(map[string]string) map[string]string`
(`pkg/http/api/toproto/redact.go`), reusing the `"***"` constant already defined for log-output
redaction (`pkg/foundation/log.Redacted`). Applied it at the three toproto conversions that embed
a Settings/Config map in an API response:

- `pkg/http/api/toproto/connector.go` — `ConnectorConfig`
- `pkg/http/api/toproto/pipeline.go` — `PipelineDLQ`
- `pkg/http/api/toproto/processor.go` — `ProcessorConfig`

## Enumeration — how I confirmed every wire site is covered

1. Grepped `pkg/http/` for every `Settings:`/`Config:` literal — the only 3 outbound sites are the
   ones above; `pkg/http/api/fromproto/*` (inbound: Create/Update requests) is untouched by design.
2. Grepped the whole repo for direct construction of `apiv1.Connector_Config{`,
   `apiv1.Processor_Config{`, `apiv1.Pipeline_DLQ{` — the *only* real construction sites are the
   three `toproto` functions above; every hit outside `toproto` is a test helper
   (`cmd/conduit/internal/testutils/mock_helpers.go`), never a server code path. Confirmed every
   `ConnectorService`/`ProcessorService`/`PipelineService` RPC handler (List/Get/Create/Update)
   funnels through these three functions — there's no parallel construction path.
3. The REST endpoints are a grpc-gateway transcode of the same proto messages (no separate JSON
   marshaling path in `pkg/http`), so fixing the proto-message builders covers REST too.
4. The MCP server's `inspect` tool (`cmd/conduit/internal/mcp/inspect.go`) and the CLI's
   `describe`/`display.DisplayConnectorConfig` consume the same gRPC API responses (`apiv1.Connector`,
   `apiv1.Pipeline_DLQ`) — downstream of the fix, no separate leak site.
5. `apiv1.PipelineDocument` (the `PlanPipeline`/`ApplyPipeline` request shape) is inbound-only —
   there is no `toproto.PipelineDocument`, confirming it's never echoed back. `provisioning.Diff`
   (Plan/Apply's response) was *already* designed to omit values (see its doc comment: "carries no
   From/To value pairs... since connector Settings routinely contain credentials"), and its hash is
   a one-way SHA-256 digest — nothing to fix there.
6. **Export path**: `pkg/provisioning/export.go`'s `Service.Export` builds a `config.Pipeline`
   with real Settings, but it's used *only* internally for diffing (`Import`, `Plan`, `Delete`) —
   never serialized to a file or returned over the API. There is no `conduit pipelines export`
   CLI command in this codebase (checked `cmd/conduit/root/pipelines/`); the closest command is
   `describe`, which reads from the (now-redacted) API. Nothing to fix here, but worth flagging:
   if an export-to-file command is added later, it must NOT reuse `provisioning.Export` output
   directly for an untrusted-facing file without redaction, or reintroduce this class of bug.

## Contract change / migration

This is an intentional, security-motivated breaking change to API response bodies:
`GetConnector`/`ListConnectors`/`GetProcessor`/`ListProcessors`/`GetDLQ`/`UpdateDLQ` (and their
REST equivalents) now return `"***"` for every Settings/Config value instead of the real value.
Keys are unchanged. **Clients needing config values must read the source YAML or use `${ENV}`
refs — the API no longer returns secret values.** Config-as-code provisioning (which parses YAML
directly via `os.ExpandEnv`, never through this API) and the value actually passed to a connector
at start are untouched — confirmed by inspecting `pkg/http/api/fromproto/*` (inbound path) and
`pkg/provisioning/*` (config-as-code path), neither of which calls `redactSettings`.

## Tests

- `pkg/http/api/toproto/redact_test.go` — sentinel-secret regression tests for all three
  conversions (`ConnectorConfig`, `ProcessorConfig`, `PipelineDLQ`): plants a sentinel value,
  asserts it never appears in the output, asserts the value is `"***"`, keys stay visible, and
  structural fields (`Name`, `Plugin`, `Workers`, `WindowSize`) are untouched. Also asserts the
  input map isn't mutated, and a nil Settings map stays nil.
- `pkg/http/api/pipeline_v1_test.go` — added `TestPipelineAPIv1_GetDLQ_RedactsSettings` and
  `TestPipelineAPIv1_UpdateDLQ_RedactsSettings` (the exact filed site had no prior test coverage
  at the API-handler level).
- Updated 5 existing API-handler tests (`connector_v1_test.go` ×3, `processor_v1_test.go` ×2) that
  asserted the old (unredacted) contract — split each into a real `reqConfig` (what the client
  sends) vs. a redacted `want` (what the API now returns), so Create/Update requests still carry
  real values while responses assert `"***"`.
- **Verified the regression tests actually catch the bug**: temporarily reverted the
  `redactSettings(...)` calls back to `in.Settings` and reran — all 5 new tests failed as
  expected (sentinel values / raw settings observed in the response); restored the fix and
  reran — all green.

## Failure-mode analysis

- **What could this break**: any client relying on reading real Settings values back from the API
  (e.g. a UI settings-edit form that pre-fills from `GetConnector`). This is the intended breaking
  change — the alternative (status quo) is the vulnerability. Config-as-code and connector
  runtime configuration are unaffected (verified above).
- **Which metric/alert would show it**: none automated today (no such alert exists); a support
  report of "connector edit form shows *** instead of the value" would be the practical signal.
  The CLI's `describe`/`DisplayConnectorConfig` will now print `***` for every setting — expected,
  not a bug.
- **Rollback**: revert this commit; `toproto.ConnectorConfig`/`ProcessorConfig`/`PipelineDLQ`
  return to echoing raw values (reintroducing the vulnerability) — acceptable only as a stopgap,
  not a real rollback option given this is a security fix.

## Process notes

- Risk tier: **Tier 2** (API/CLI-facing behavior change, not a data-path/ack/position/checkpoint/
  protocol change — connectors read real config from provisioning/fromproto exactly as before).
  Flagging as security-sensitive per the requester's explicit ask for independent review before
  merge.
- Gates run and green: `make build`, `make lint` (0 issues), `go test -race ./pkg/http/...
  ./pkg/foundation/... ./cmd/...` (all green), `make generate` (no diff — no proto/mock/paramgen
  changes needed).
- Adversarial self-review: see the Enumeration section above — that *is* the self-review pass,
  performed by grepping for every construction site and every RPC handler rather than trusting
  the three sites named in the task description.

References #2640.

Do not merge — requester will review independently (security-sensitive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)