### PR TITLE
feat(registry): conduit connectors install core — fail-closed by construction (PR-1)

### DIFF
--- a/cmd/conduit/root/connectors/connectors.go
+++ b/cmd/conduit/root/connectors/connectors.go
@@ -33,6 +33,7 @@ func (c *ConnectorsCommand) SubCommands() []ecdysis.Command {
 		&ListCommand{},
 		&DescribeCommand{},
 		newNewCommand(),
+		&InstallCommand{},
 	}
 }
 

--- a/cmd/conduit/root/connectors/install.go
+++ b/cmd/conduit/root/connectors/install.go
@@ -1,0 +1,238 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectors
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/pkg/conduit"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/registry"
+	"github.com/conduitio/ecdysis"
+)
+
+var (
+	_ ecdysis.CommandWithFlags   = (*InstallCommand)(nil)
+	_ ecdysis.CommandWithConfig  = (*InstallCommand)(nil)
+	_ ecdysis.CommandWithArgs    = (*InstallCommand)(nil)
+	_ ecdysis.CommandWithDocs    = (*InstallCommand)(nil)
+	_ cecdysis.CommandWithResult = (*InstallCommand)(nil)
+)
+
+// InstallFlags embeds conduit.Config so `conduit connectors install`
+// resolves --connectors.path the same way (flags, CONDUIT_ env vars, and
+// the config file) as `conduit run`/`conduit doctor` — install writes into
+// that same directory, so it must agree with the rest of the CLI on where
+// it is. The remaining fields are install-specific.
+type InstallFlags struct {
+	conduit.Config
+
+	IndexURL    string        `long:"index-url" usage:"registry index URL"`
+	IndexFile   string        `long:"index-file" usage:"read the index from a local file instead of --index-url (offline mode)"`
+	LockTimeout time.Duration `long:"lock-timeout" usage:"max time to wait to acquire the per-connector install lock"`
+	DryRun      bool          `long:"dry-run" usage:"resolve and select a platform artifact; report what would be installed without downloading or writing anything"`
+}
+
+// InstallArgs holds InstallCommand's parsed positional argument.
+type InstallArgs struct {
+	Name    string
+	Version string // "" = newest compatible
+}
+
+// InstallCommand implements `conduit connectors install <name>[@version]`.
+// It is an OFFLINE command (mirrors doctor/repair, not list/describe): it
+// does not dial the running Conduit API — it drives
+// pkg/registry.Install directly against --connectors.path on disk.
+//
+// # Fail-closed by construction
+//
+// This is the one production call site for pkg/registry.Install. It passes
+// registry.FailClosedVerifier{} for BOTH IndexVerifier and ArtifactVerifier
+// — explicitly and visibly, per plan-v2 §2.2 — so every real invocation of
+// this command refuses with registry.CodeVerificationUnavailable
+// ("registry.verification_unavailable") until PR-2 wires in the real trust
+// core. There is no flag, no config value, and no environment variable that
+// changes this in this build.
+type InstallCommand struct {
+	flags InstallFlags
+	args  InstallArgs
+	Cfg   conduit.Config
+}
+
+func (c *InstallCommand) Usage() string { return "install <name>[@version]" }
+
+func (c *InstallCommand) Docs() ecdysis.Docs {
+	return ecdysis.Docs{
+		Short: "Install a standalone connector from the registry index",
+		Long: `install resolves <name>[@version] against the registry index (exact-match name lookup,
+newest-compatible version selection when @version is omitted), downloads the artifact for this
+host's platform, checks its integrity, and — pending the trust core landing in a future
+release — refuses at the verification step: this build has no code path that installs an
+unverified connector artifact.
+
+Exit codes (via the ConduitError's registered category):
+  0  success
+  1  Runtime    — internal bug, archive-shape violation, verification not yet available
+  2  Validation — connector/version not found, incompatible version, yanked/revoked, no platform artifact
+  3  Environment — index unreachable, download failed, corrupt download, install lock contended`,
+		Example: "conduit connectors install postgres\n" +
+			"conduit connectors install postgres@0.14.1\n" +
+			"conduit connectors install postgres --dry-run\n" +
+			"conduit connectors install postgres --json",
+	}
+}
+
+func (c *InstallCommand) Flags() []ecdysis.Flag {
+	flags := ecdysis.BuildFlags(&c.flags)
+
+	currentPath, err := os.Getwd()
+	if err != nil {
+		panic(cerrors.Errorf("failed to get current working directory: %w", err))
+	}
+	// Assigning c.Cfg here (not just building a local default), mirroring
+	// doctor.DoctorCommand.Flags(): ParseConfig's viper.Unmarshal only
+	// overwrites fields it has flag/env/file data for, so c.Cfg must start
+	// non-zero for --connectors.path's default to survive into
+	// ExecuteWithResult.
+	c.Cfg = conduit.DefaultConfigWithBasePath(currentPath)
+	flags.SetDefault("config.path", c.Cfg.ConduitCfg.Path)
+	flags.SetDefault("connectors.path", c.Cfg.Connectors.Path)
+	flags.SetDefault("index-url", registry.DefaultIndexURL)
+	flags.SetDefault("lock-timeout", registry.DefaultLockTimeout)
+
+	return flags
+}
+
+func (c *InstallCommand) Config() ecdysis.Config {
+	path := filepath.Dir(c.flags.ConduitCfg.Path)
+	return ecdysis.Config{
+		EnvPrefix:     "CONDUIT",
+		Parsed:        &c.Cfg,
+		Path:          c.flags.ConduitCfg.Path,
+		DefaultValues: conduit.DefaultConfigWithBasePath(path),
+	}
+}
+
+// Args parses "<name>[@version]" — split on the FIRST "@" only, so a
+// version constraint is never mistaken for part of the name.
+func (c *InstallCommand) Args(args []string) error {
+	if len(args) == 0 {
+		return cerrors.Errorf("requires a connector name, optionally with @version (e.g. postgres or postgres@0.14.1)")
+	}
+	if len(args) > 1 {
+		return cerrors.Errorf("too many arguments")
+	}
+
+	name, version, _ := strings.Cut(args[0], "@")
+	if name == "" {
+		return cerrors.Errorf("connector name must not be empty")
+	}
+	c.args.Name = name
+	c.args.Version = version
+	return nil
+}
+
+func (c *InstallCommand) ResultCommand() string { return "connectors.install" }
+
+func (c *InstallCommand) ExecuteWithResult(ctx context.Context) (cecdysis.Outcome, error) {
+	opts := registry.InstallOptions{
+		Name:           c.args.Name,
+		Version:        c.args.Version,
+		ConnectorsPath: c.Cfg.Connectors.Path,
+
+		IndexURL:  c.flags.IndexURL,
+		IndexFile: c.flags.IndexFile,
+
+		// The one production wiring: BOTH verifiers are FailClosedVerifier
+		// until PR-2 lands (see InstallCommand's doc). No flag or config
+		// value anywhere in this file can change this.
+		IndexVerifier:    registry.FailClosedVerifier{},
+		ArtifactVerifier: registry.FailClosedVerifier{},
+
+		RunningConduitVersion:  conduit.Version(false),
+		RunningProtocolVersion: runningProtocolVersion(),
+
+		InstalledBy: installedByUser(),
+		LockTimeout: c.flags.LockTimeout,
+		DryRun:      c.flags.DryRun,
+	}
+
+	result, err := registry.Install(ctx, opts)
+	if err != nil {
+		return cecdysis.Outcome{}, err
+	}
+
+	return cecdysis.Outcome{OK: true, Result: result}, nil
+}
+
+func (c *InstallCommand) Render(outcome cecdysis.Outcome) string {
+	res, ok := outcome.Result.(*registry.InstallResult)
+	if !ok || res == nil {
+		return ""
+	}
+
+	var b strings.Builder
+	switch {
+	case res.DryRun:
+		fmt.Fprintf(&b, "Would install %s@%s (%s/%s) from %s\n", res.Name, res.Version, res.OS, res.Arch, res.ArtifactURL)
+	case res.AlreadyInstalled:
+		fmt.Fprintf(&b, "%s@%s is already installed (%s)\n", res.Name, res.Version, res.ArtifactFile)
+	default:
+		fmt.Fprintf(&b, "Installed %s@%s (%s/%s) as %s\n", res.Name, res.Version, res.OS, res.Arch, res.ArtifactFile)
+	}
+	if res.Deprecated {
+		fmt.Fprintf(&b, "warning: %s@%s is deprecated\n", res.Name, res.Version)
+	}
+	return b.String()
+}
+
+// runningProtocolVersion reports the conduit-connector-protocol module
+// version this binary was built against, via Go's embedded build info —
+// avoiding a hand-maintained constant that could drift from go.mod. Falls
+// back to "development" (treated by resolve.go's compatibility check as
+// satisfying every minProtocolVersion) when build info isn't available,
+// e.g. `go run`.
+func runningProtocolVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "development"
+	}
+	const protocolModule = "github.com/conduitio/conduit-connector-protocol"
+	for _, dep := range info.Deps {
+		if dep.Path == protocolModule {
+			return dep.Version
+		}
+	}
+	return "development"
+}
+
+// installedByUser returns the current OS user's username, best-effort, for
+// the manifest entry's InstalledBy/audit event's Operator fields. An empty
+// string (never an error) if it cannot be determined.
+func installedByUser() string {
+	u, err := user.Current()
+	if err != nil {
+		return ""
+	}
+	return u.Username
+}

--- a/cmd/conduit/root/connectors/install_test.go
+++ b/cmd/conduit/root/connectors/install_test.go
@@ -1,0 +1,294 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// These are full-stack integration tests for `conduit connectors install`:
+// they build the real cobra command (via ecdysis, exactly like cmd/conduit/cli
+// does) and drive it through cmd.ExecuteC(), mirroring
+// cmd/conduit/root/doctor/doctor_test.go's own pattern for a
+// cecdysis.CommandWithResult command. The point of these tests is to prove
+// the ONE production call site (this file's ExecuteWithResult) actually
+// wires registry.FailClosedVerifier for both verifiers, and that --json
+// carries the resulting registry.verification_unavailable code end to end
+// — not just that pkg/registry.Install itself behaves (that is
+// pkg/registry/install_test.go's job).
+package connectors_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	json "github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/cmd/conduit/root/connectors"
+	"github.com/conduitio/conduit/pkg/registry/index"
+	"github.com/conduitio/ecdysis"
+	"github.com/spf13/cobra"
+)
+
+func buildInstallCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	e := ecdysis.New(ecdysis.WithDecorators(cecdysis.CommandWithResultDecorator{}))
+	return e.MustBuildCobraCommand(&connectors.InstallCommand{})
+}
+
+func runInstall(t *testing.T, args ...string) (output string, err error) {
+	t.Helper()
+	cmd := buildInstallCmd(t)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+
+	_, err = cmd.ExecuteC()
+	return out.String(), err
+}
+
+// buildFixtureArchive returns a valid tar.gz containing a single root-level
+// regular file, for the fixture artifact server below.
+func buildFixtureArchive(t *testing.T, name string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	content := []byte("binary-content-for-" + name)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "conduit-connector-" + name, Mode: 0o755, Size: int64(len(content)),
+	}))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+	return buf.Bytes()
+}
+
+func hexEncode(d [32]byte) string {
+	const hextable = "0123456789abcdef"
+	out := make([]byte, 64)
+	for i, b := range d {
+		out[i*2] = hextable[b>>4]
+		out[i*2+1] = hextable[b&0x0f]
+	}
+	return string(out)
+}
+
+// newFixtureIndexFile serves a real artifact (over a local httptest server,
+// closed via t.Cleanup) and writes a schema-valid, unsigned index file to
+// disk (offline --index-file mode) referencing it — so a CLI-level install
+// attempt runs the FULL pipeline (resolve, platform select, download,
+// corruption check) and only then reaches the verification gate, exactly
+// like a real, reachable registry would.
+func newFixtureIndexFile(t *testing.T, name, version string) (indexPath string) {
+	t.Helper()
+	archiveBytes := buildFixtureArchive(t, name)
+	digest := sha256.Sum256(archiveBytes)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(archiveBytes)
+	}))
+	t.Cleanup(srv.Close)
+
+	payload := index.Payload{
+		SchemaVersion: 1,
+		Index:         index.IndexMeta{Version: 1, Timestamp: time.Now()},
+		Connectors: []index.Connector{
+			{
+				Name: name,
+				Publisher: index.Publisher{
+					ExpectedOIDCIssuer:      "https://token.actions.githubusercontent.com",
+					ExpectedIdentityPattern: `^https://github\.com/example/` + name + `/.*$`,
+				},
+				Versions: []index.ConnectorVersion{
+					{
+						Version: version, MinConduitVersion: "0.1.0", MinProtocolVersion: "0.1.0",
+						Artifacts: []index.Artifact{
+							{
+								OS: runtime.GOOS, Arch: runtime.GOARCH, Kind: "standalone",
+								URL:    srv.URL,
+								SHA256: hexEncode(digest),
+								Size:   int64(len(archiveBytes)),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	envelope := map[string]any{"payload": payload, "signatures": []any{}}
+	data, err := json.Marshal(envelope)
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "index.json")
+	require.NoError(t, os.WriteFile(path, data, 0o644))
+	return path
+}
+
+func TestInstallArgs_MissingName(t *testing.T) {
+	_, err := runInstall(t, "--json")
+	require.Error(t, err)
+}
+
+func TestInstallArgs_TooManyArgs(t *testing.T) {
+	_, err := runInstall(t, "widget", "extra", "--json")
+	require.Error(t, err)
+}
+
+func TestInstall_SplitsNameAndVersion(t *testing.T) {
+	indexPath := newFixtureIndexFile(t, "widget", "2.0.0")
+	connectorsPath := t.TempDir()
+
+	out, err := runInstall(t,
+		"widget@2.0.0",
+		"--connectors.path="+connectorsPath,
+		"--index-file="+indexPath,
+		"--json",
+	)
+	require.Error(t, err) // fail-closed: FailClosedVerifier always refuses
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	require.NotNil(t, res.Error)
+	// If the name/version split were wrong ("widget@2.0.0" treated as one
+	// literal name), resolution would fail with connector_not_found
+	// instead — asserting verification_unavailable proves resolution
+	// (and download/corruption-check) succeeded first, i.e. the split
+	// worked and the pipeline actually ran end to end up to the gate.
+	assert.Equal(t, "registry.verification_unavailable", res.Error.Code)
+}
+
+// TestInstall_FailClosedByConstruction_JSON is the CLI-level version of
+// pkg/registry/install_test.go's AC-6 test: the real command, with no flag
+// or config value able to change its verifier wiring, must refuse via
+// --json with the stable registry.verification_unavailable code, after
+// actually resolving, downloading, and integrity-checking the artifact —
+// and must install nothing.
+func TestInstall_FailClosedByConstruction_JSON(t *testing.T) {
+	indexPath := newFixtureIndexFile(t, "widget", "1.0.0")
+	connectorsPath := t.TempDir()
+
+	out, err := runInstall(t,
+		"widget",
+		"--connectors.path="+connectorsPath,
+		"--index-file="+indexPath,
+		"--json",
+	)
+	require.Error(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	assert.Equal(t, "connectors.install", res.Command)
+	assert.False(t, res.OK)
+	require.NotNil(t, res.Error)
+	assert.Equal(t, "registry.verification_unavailable", res.Error.Code)
+
+	entries, rerr := os.ReadDir(connectorsPath)
+	require.NoError(t, rerr)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), "conduit-connector-")
+	}
+}
+
+// TestInstall_DryRun_JSON proves --dry-run resolves and reports without
+// ever reaching the (fail-closed) verification gate at all — no download
+// even happens, so this uses a deliberately unreachable artifact URL to
+// prove that.
+func TestInstall_DryRun_JSON(t *testing.T) {
+	payload := index.Payload{
+		SchemaVersion: 1,
+		Index:         index.IndexMeta{Version: 1, Timestamp: time.Now()},
+		Connectors: []index.Connector{
+			{
+				Name: "widget",
+				Publisher: index.Publisher{
+					ExpectedOIDCIssuer:      "https://token.actions.githubusercontent.com",
+					ExpectedIdentityPattern: `^https://github\.com/example/widget/.*$`,
+				},
+				Versions: []index.ConnectorVersion{
+					{
+						Version: "1.0.0", MinConduitVersion: "0.1.0", MinProtocolVersion: "0.1.0",
+						Artifacts: []index.Artifact{
+							{
+								OS: runtime.GOOS, Arch: runtime.GOARCH, Kind: "standalone",
+								URL:    "https://example.invalid/widget.tar.gz",
+								SHA256: "d34db33fd34db33fd34db33fd34db33fd34db33fd34db33fd34db33fd34db33",
+								Size:   1024,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	envelope := map[string]any{"payload": payload, "signatures": []any{}}
+	data, err := json.Marshal(envelope)
+	require.NoError(t, err)
+	indexPath := filepath.Join(t.TempDir(), "index.json")
+	require.NoError(t, os.WriteFile(indexPath, data, 0o644))
+
+	connectorsPath := t.TempDir()
+
+	out, err := runInstall(t,
+		"widget",
+		"--connectors.path="+connectorsPath,
+		"--index-file="+indexPath,
+		"--dry-run",
+		"--json",
+	)
+	require.NoError(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	assert.True(t, res.OK)
+	assert.Nil(t, res.Error)
+
+	result, ok := res.Result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "widget", result["name"])
+	assert.Equal(t, "1.0.0", result["version"])
+	assert.Equal(t, true, result["dryRun"])
+	assert.Equal(t, "https://example.invalid/widget.tar.gz", result["artifactUrl"])
+
+	entries, rerr := os.ReadDir(connectorsPath)
+	require.NoError(t, rerr)
+	assert.Empty(t, entries)
+}
+
+func TestInstall_UnknownConnector_JSON(t *testing.T) {
+	indexPath := newFixtureIndexFile(t, "widget", "1.0.0")
+	connectorsPath := t.TempDir()
+
+	out, err := runInstall(t,
+		"nonexistent",
+		"--connectors.path="+connectorsPath,
+		"--index-file="+indexPath,
+		"--json",
+	)
+	require.Error(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	require.NotNil(t, res.Error)
+	assert.Equal(t, "registry.connector_not_found", res.Error.Code)
+}

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gammazero/deque v1.2.1
 	github.com/goccy/go-json v0.10.6
+	github.com/gofrs/flock v0.12.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
@@ -152,7 +153,6 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
-	github.com/gofrs/flock v0.12.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/golangci/dupl v0.0.0-20250308024227-f665c8d69b32 // indirect

--- a/pkg/registry/audit.go
+++ b/pkg/registry/audit.go
@@ -1,0 +1,78 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"os"
+	"time"
+
+	json "github.com/goccy/go-json"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+)
+
+// AuditEvent is one append-only entry in <connectors.path>/.registry/audit.jsonl.
+//
+// Signed/VerifiedIdentity/AllowUnsigned mirror ManifestEntry's own fields:
+// present now (PR-0/PR-1) even though every event this build can produce has
+// Signed: false, VerifiedIdentity: "", AllowUnsigned: false (see
+// manifest.go's ManifestEntry doc — the same reasoning applies here).
+type AuditEvent struct {
+	Event            string    `json:"event"` // "connector_install" in this PR; more added by later PRs
+	Connector        string    `json:"connector"`
+	Version          string    `json:"version"`
+	Digest           string    `json:"digest"` // "sha256:<hex>"
+	Operator         string    `json:"operator,omitempty"`
+	Timestamp        time.Time `json:"timestamp"`
+	Signed           bool      `json:"signed"`
+	VerifiedIdentity string    `json:"verifiedIdentity"`
+	AllowUnsigned    bool      `json:"allowUnsigned"`
+}
+
+// AppendAuditEvent appends ev as one JSON line to path, creating the file
+// (and its parent directory) if needed.
+//
+// Invariant: callers must only append an audit event AFTER the install it
+// describes has already durably completed (binary renamed into place,
+// manifest written) — install.go's call site does this last, deliberately,
+// so the audit trail never claims an install happened before it actually
+// did.
+//
+// A single O_APPEND write of this size is atomic at the OS level — no
+// temp-file-plus-rename dance is needed the way manifest.go's SaveManifest
+// needs one for a whole-file rewrite — but Sync is still called explicitly
+// to force the append to durable storage before Install reports success to
+// its caller.
+func AppendAuditEvent(path string, ev AuditEvent) error {
+	line, err := json.Marshal(ev)
+	if err != nil {
+		return cerrors.Errorf("could not marshal audit event: %w", err)
+	}
+	line = append(line, '\n')
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return cerrors.Errorf("could not open audit log %q: %w", path, err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(line); err != nil {
+		return cerrors.Errorf("could not append to audit log %q: %w", path, err)
+	}
+	if err := f.Sync(); err != nil {
+		return cerrors.Errorf("could not sync audit log %q: %w", path, err)
+	}
+	return nil
+}

--- a/pkg/registry/audit_test.go
+++ b/pkg/registry/audit_test.go
@@ -1,0 +1,51 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry_test
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/registry"
+)
+
+func TestAppendAuditEvent_AppendsJSONLines(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+
+	ev1 := registry.AuditEvent{Event: "connector_install", Connector: "postgres", Version: "0.14.1", Timestamp: time.Now().UTC()}
+	ev2 := registry.AuditEvent{Event: "connector_install", Connector: "kafka", Version: "1.0.0", Timestamp: time.Now().UTC()}
+
+	require.NoError(t, registry.AppendAuditEvent(path, ev1))
+	require.NoError(t, registry.AppendAuditEvent(path, ev2))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	lines := 0
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		if len(scanner.Bytes()) > 0 {
+			lines++
+		}
+	}
+	assert.Equal(t, 2, lines)
+}

--- a/pkg/registry/chaos.go
+++ b/pkg/registry/chaos.go
@@ -1,0 +1,41 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+// chaosHook, when non-nil, is called at named points inside Install
+// (chaosPointDownloadComplete, chaosPointExtractComplete,
+// chaosPointPrerenameFDOpened, chaosPointPostRenamePreManifest) — a
+// test-only crash-injection mechanism. Production code (including
+// cmd/conduit/root/connectors/install.go) never sets this; only
+// install_test.go's chaos subprocess test binary does, via an
+// environment-variable-selected point, immediately calling os.Exit(137)
+// (SIGKILL's conventional exit status) to simulate a kill -9 at that exact
+// point in the pipeline. See install_test.go's TestInstall_ChaosKill for
+// the harness and docs/test-cases-style chaos test conventions (CLAUDE.md:
+// chaos tests use SIGKILL, not SIGTERM).
+var chaosHook func(point string)
+
+const (
+	chaosPointDownloadComplete      = "download-complete"
+	chaosPointExtractComplete       = "extract-complete"
+	chaosPointPrerenameFDOpened     = "prerename-fd-opened"
+	chaosPointPostRenamePreManifest = "post-rename-pre-manifest"
+)
+
+func fireChaos(point string) {
+	if chaosHook != nil {
+		chaosHook(point)
+	}
+}

--- a/pkg/registry/corruption.go
+++ b/pkg/registry/corruption.go
@@ -1,0 +1,52 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+)
+
+// CheckCorruption compares the digest computed from the ACTUALLY RECEIVED
+// bytes (got, from Download's incremental hash) against the index's
+// declared sha256 (want, an optionally "sha256:"-prefixed 64-character hex
+// string).
+//
+// This is integrity, not trust: a byte-for-byte match here detects
+// transport-level corruption (a bit-flip, a truncated transfer, a
+// compromised CDN edge serving different bytes) but says nothing about WHO
+// produced those bytes — proving that is ArtifactVerifier.VerifyArtifact's
+// job (the actual authorization/trust boundary), run separately and always
+// AFTER this check, never in place of it.
+func CheckCorruption(got [32]byte, want string) error {
+	want = strings.TrimPrefix(want, "sha256:")
+	wantBytes, err := hex.DecodeString(want)
+	if err != nil || len(wantBytes) != len(got) {
+		return conduiterr.New(CodeCorruptDownload, fmt.Sprintf(
+			"index sha256 %q is not a valid 64-character hex digest", want))
+	}
+	for i := range got {
+		if got[i] != wantBytes[i] {
+			return conduiterr.New(CodeCorruptDownload, fmt.Sprintf(
+				"downloaded artifact's sha256 (%x) does not match the index's declared sha256 (%s) — "+
+					"the download may have been corrupted or tampered with in transit; retrying is a fresh "+
+					"download attempt, not a recovery of the same lost bytes", got, want))
+		}
+	}
+	return nil
+}

--- a/pkg/registry/corruption_test.go
+++ b/pkg/registry/corruption_test.go
@@ -1,0 +1,62 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry_test
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry"
+)
+
+func TestCheckCorruption_Match(t *testing.T) {
+	digest := sha256.Sum256([]byte("hello world"))
+	want := hexDigest(digest)
+	assert.NoError(t, registry.CheckCorruption(digest, want))
+	assert.NoError(t, registry.CheckCorruption(digest, "sha256:"+want))
+}
+
+func TestCheckCorruption_Mismatch(t *testing.T) {
+	digest := sha256.Sum256([]byte("hello world"))
+	other := sha256.Sum256([]byte("goodbye world"))
+	err := registry.CheckCorruption(digest, hexDigest(other))
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeCorruptDownload, ce.Code)
+}
+
+func TestCheckCorruption_InvalidWant(t *testing.T) {
+	digest := sha256.Sum256([]byte("hello world"))
+	err := registry.CheckCorruption(digest, "not-hex")
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeCorruptDownload, ce.Code)
+}
+
+func hexDigest(d [32]byte) string {
+	const hextable = "0123456789abcdef"
+	out := make([]byte, 64)
+	for i, b := range d {
+		out[i*2] = hextable[b>>4]
+		out[i*2+1] = hextable[b&0x0f]
+	}
+	return string(out)
+}

--- a/pkg/registry/download.go
+++ b/pkg/registry/download.go
@@ -1,0 +1,115 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+)
+
+// maxRedirects bounds a download's redirect chain (e.g. following a Scarf
+// gateway to the underlying GitHub Releases asset) so a redirect loop fails
+// fast with CodeDownloadFailed instead of hanging or looping forever.
+const maxRedirects = 10
+
+// newDownloadClient returns an http.Client whose CheckRedirect refuses past
+// maxRedirects hops.
+func newDownloadClient() *http.Client {
+	return &http.Client{
+		CheckRedirect: func(_ *http.Request, via []*http.Request) error {
+			if len(via) >= maxRedirects {
+				return fmt.Errorf("stopped after %d redirects", maxRedirects)
+			}
+			return nil
+		},
+	}
+}
+
+// DownloadResult is what Download reports: the digest computed from the
+// bytes actually received (input to CheckCorruption, and later
+// ArtifactRef.Digest — never re-read from disk after the fact) and the
+// exact byte count written.
+type DownloadResult struct {
+	Path   string
+	Digest [32]byte
+	Size   int64
+}
+
+// Download streams url's response body into destPath (created exclusively,
+// 0600 — refuses if destPath already exists, since every staging path is
+// meant to be freshly created by the caller), computing a sha256 digest
+// incrementally over the same bytes as they are written — never buffering
+// the whole artifact in memory. The write is capped at maxBytes+1: reading
+// exactly maxBytes+1 bytes back (rather than hitting EOF at or before
+// maxBytes) proves the real payload exceeds the index's declared size
+// rather than happening to land exactly on it (the same technique
+// pkg/registry/boundedfetch uses for the index and bundle fetches — applied
+// here directly, rather than via that package, because an artifact is
+// streamed to disk rather than buffered into a []byte).
+//
+// Download does not compare the digest to any expected value — that is
+// CheckCorruption's job, deliberately kept separate so the "this is
+// integrity, not trust" distinction (Decision §3 step 5a) stays visible at
+// the call site instead of being buried inside this function.
+func Download(ctx context.Context, client *http.Client, url, destPath string, maxBytes int64) (DownloadResult, error) {
+	if client == nil {
+		client = newDownloadClient()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return DownloadResult{}, conduiterr.Wrap(CodeDownloadFailed, "could not build download request", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return DownloadResult{}, conduiterr.Wrap(CodeDownloadFailed, fmt.Sprintf("could not download %q", url), err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return DownloadResult{}, conduiterr.New(CodeDownloadFailed, fmt.Sprintf(
+			"downloading %q returned unexpected status %d", url, resp.StatusCode))
+	}
+
+	f, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return DownloadResult{}, conduiterr.Wrap(CodeDownloadFailed, fmt.Sprintf("could not create staging file %q", destPath), err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	limited := io.LimitReader(resp.Body, maxBytes+1)
+	n, err := io.Copy(f, io.TeeReader(limited, h))
+	if err != nil {
+		return DownloadResult{}, conduiterr.Wrap(CodeDownloadFailed, fmt.Sprintf("could not write staged download %q", destPath), err)
+	}
+	if n > maxBytes {
+		return DownloadResult{}, conduiterr.New(CodeDownloadFailed, fmt.Sprintf(
+			"downloaded artifact exceeds the declared size of %d bytes", maxBytes))
+	}
+	if err := f.Sync(); err != nil {
+		return DownloadResult{}, conduiterr.Wrap(CodeDownloadFailed, "could not sync staged download to disk", err)
+	}
+
+	var digest [32]byte
+	copy(digest[:], h.Sum(nil))
+	return DownloadResult{Path: destPath, Digest: digest, Size: n}, nil
+}

--- a/pkg/registry/download_test.go
+++ b/pkg/registry/download_test.go
@@ -1,0 +1,112 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry"
+)
+
+func TestDownload_Succeeds(t *testing.T) {
+	body := []byte("connector-archive-bytes")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "artifact.tar.gz")
+	res, err := registry.Download(context.Background(), nil, srv.URL, dest, int64(len(body)))
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(body)), res.Size)
+	assert.Equal(t, sha256.Sum256(body), res.Digest)
+
+	got, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	assert.Equal(t, body, got)
+}
+
+func TestDownload_FollowsRedirect(t *testing.T) {
+	body := []byte("redirected-bytes")
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer target.Close()
+
+	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer gateway.Close()
+
+	dest := filepath.Join(t.TempDir(), "artifact.tar.gz")
+	res, err := registry.Download(context.Background(), nil, gateway.URL, dest, int64(len(body)))
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(body)), res.Size)
+}
+
+func TestDownload_RedirectLoopFails(t *testing.T) {
+	var loopURL string
+	loop := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, loopURL, http.StatusFound)
+	}))
+	defer loop.Close()
+	loopURL = loop.URL
+
+	dest := filepath.Join(t.TempDir(), "artifact.tar.gz")
+	_, err := registry.Download(context.Background(), nil, loop.URL, dest, 1024)
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeDownloadFailed, ce.Code)
+}
+
+func TestDownload_ExceedsDeclaredSizeFails(t *testing.T) {
+	body := make([]byte, 100)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "artifact.tar.gz")
+	_, err := registry.Download(context.Background(), nil, srv.URL, dest, 10) // declared size far below actual
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeDownloadFailed, ce.Code)
+}
+
+func TestDownload_NonSuccessStatusFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "artifact.tar.gz")
+	_, err := registry.Download(context.Background(), nil, srv.URL, dest, 1024)
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeDownloadFailed, ce.Code)
+}

--- a/pkg/registry/export_test.go
+++ b/pkg/registry/export_test.go
@@ -1,0 +1,34 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+// This file exists ONLY to give the external registry_test package (in
+// install_test.go) a seam into the unexported chaos-injection hook (see
+// chaos.go) for the SIGKILL-simulation chaos tests. Being a _test.go file,
+// none of this is compiled into a production build.
+
+// SetChaosHookForTest installs a test-only crash-injection hook.
+func SetChaosHookForTest(fn func(point string)) {
+	chaosHook = fn
+}
+
+// Exported aliases of the unexported chaos point names, for the external
+// test package to reference without duplicating the literal strings.
+const (
+	ChaosPointDownloadComplete      = chaosPointDownloadComplete
+	ChaosPointExtractComplete       = chaosPointExtractComplete
+	ChaosPointPrerenameFDOpened     = chaosPointPrerenameFDOpened
+	ChaosPointPostRenamePreManifest = chaosPointPostRenamePreManifest
+)

--- a/pkg/registry/extract.go
+++ b/pkg/registry/extract.go
@@ -1,0 +1,132 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+)
+
+// maxExtractedBytes bounds the TOTAL decompressed size ExtractBinary will
+// write, independent of the (already size-capped, per the index's declared
+// Artifact.Size) compressed input — a decompression-bomb guard: a small
+// compressed file can still expand to an enormous one.
+const maxExtractedBytes = 1 << 30 // 1 GiB
+
+// ExtractBinary opens the tar.gz archive at archivePath and extracts the
+// single root-level regular file it must contain into destDir, returning
+// its path. It refuses, with CodeArchiveInvalid, rather than guesses, on
+// every one of the following:
+//
+//   - A path-traversal entry: an absolute path, or a relative path that
+//     escapes destDir once cleaned (e.g. "../../etc/passwd").
+//   - A symlink or hardlink entry: a malicious archive must not be able to
+//     point extraction at an arbitrary target via a link.
+//   - Zero or more than one candidate root-level regular file: this
+//     pipeline installs exactly one connector binary per artifact, so an
+//     ambiguous archive is refused, not guessed at. Non-root-level regular
+//     files (e.g. a LICENSE nested in a subdirectory) are extracted-and-
+//     ignored as far as "candidate" status goes, so an archive that
+//     legitimately bundles extra files alongside the binary at the root
+//     still resolves unambiguously.
+//   - An archive that expands past maxExtractedBytes.
+func ExtractBinary(archivePath, destDir string) (string, error) {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return "", conduiterr.Wrap(CodeArchiveInvalid, "could not open downloaded archive", err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return "", conduiterr.Wrap(CodeArchiveInvalid, "downloaded archive is not valid gzip", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+
+	var candidate string
+	var extractedTotal int64
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", conduiterr.Wrap(CodeArchiveInvalid, "downloaded archive is corrupt", err)
+		}
+
+		cleanName := filepath.Clean(hdr.Name)
+		if filepath.IsAbs(cleanName) || cleanName == ".." || strings.HasPrefix(cleanName, ".."+string(filepath.Separator)) {
+			return "", conduiterr.New(CodeArchiveInvalid, fmt.Sprintf(
+				"archive entry %q attempts to escape the extraction directory", hdr.Name))
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			continue // directory entries carry nothing to extract themselves
+		case tar.TypeSymlink, tar.TypeLink:
+			return "", conduiterr.New(CodeArchiveInvalid, fmt.Sprintf(
+				"archive entry %q is a symlink/hardlink, which is not permitted", hdr.Name))
+		case tar.TypeReg:
+			isRoot := !strings.Contains(cleanName, string(filepath.Separator))
+
+			destPath := filepath.Join(destDir, cleanName)
+			if err := os.MkdirAll(filepath.Dir(destPath), 0o700); err != nil {
+				return "", conduiterr.Wrap(CodeArchiveInvalid, "could not create extraction directory", err)
+			}
+			out, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o755)
+			if err != nil {
+				return "", conduiterr.Wrap(CodeArchiveInvalid, "could not create extracted file", err)
+			}
+			n, copyErr := io.Copy(out, io.LimitReader(tr, maxExtractedBytes-extractedTotal+1))
+			closeErr := out.Close()
+			if copyErr != nil {
+				return "", conduiterr.Wrap(CodeArchiveInvalid, "could not extract archive entry", copyErr)
+			}
+			if closeErr != nil {
+				return "", conduiterr.Wrap(CodeArchiveInvalid, "could not finalize extracted file", closeErr)
+			}
+			extractedTotal += n
+			if extractedTotal > maxExtractedBytes {
+				return "", conduiterr.New(CodeArchiveInvalid, "archive expands past the maximum allowed decompressed size")
+			}
+
+			if !isRoot {
+				continue // extracted (for completeness) but not a binary candidate
+			}
+			if candidate != "" {
+				return "", conduiterr.New(CodeArchiveInvalid, fmt.Sprintf(
+					"archive has more than one candidate binary at its root (%q and %q)", candidate, cleanName))
+			}
+			candidate = cleanName
+		default:
+			continue // ignore other entry types (e.g. pax extended headers) rather than refusing outright
+		}
+	}
+
+	if candidate == "" {
+		return "", conduiterr.New(CodeArchiveInvalid, "archive contains no root-level regular file to install")
+	}
+	return filepath.Join(destDir, candidate), nil
+}

--- a/pkg/registry/extract_test.go
+++ b/pkg/registry/extract_test.go
@@ -1,0 +1,154 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry"
+)
+
+// tarEntry is one entry to write into a test fixture archive.
+type tarEntry struct {
+	name     string
+	typeflag byte
+	linkname string
+	content  string
+}
+
+func buildArchive(t *testing.T, entries []tarEntry) string {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for _, e := range entries {
+		typeflag := e.typeflag
+		if typeflag == 0 {
+			typeflag = tar.TypeReg
+		}
+		hdr := &tar.Header{
+			Name:     e.name,
+			Typeflag: typeflag,
+			Mode:     0o755,
+			Size:     int64(len(e.content)),
+			Linkname: e.linkname,
+		}
+		require.NoError(t, tw.WriteHeader(hdr))
+		if len(e.content) > 0 {
+			_, err := tw.Write([]byte(e.content))
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "archive.tar.gz")
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o644))
+	return path
+}
+
+func TestExtractBinary_SingleFileSucceeds(t *testing.T) {
+	archivePath := buildArchive(t, []tarEntry{{name: "conduit-connector-postgres", content: "binary-bytes"}})
+	destDir := t.TempDir()
+
+	binPath, err := registry.ExtractBinary(archivePath, destDir)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(destDir, "conduit-connector-postgres"), binPath)
+
+	data, err := os.ReadFile(binPath)
+	require.NoError(t, err)
+	assert.Equal(t, "binary-bytes", string(data))
+}
+
+func TestExtractBinary_ZeroCandidatesRefuses(t *testing.T) {
+	// Only a nested file (not root-level) and a bare directory entry — no
+	// root-level regular file exists to be the candidate binary.
+	archivePath := buildArchive(t, []tarEntry{
+		{name: "docs", typeflag: tar.TypeDir},
+		{name: "docs/README.md", content: "hi"},
+	})
+	_, err := registry.ExtractBinary(archivePath, t.TempDir())
+	require.Error(t, err)
+	assertArchiveInvalid(t, err)
+}
+
+func TestExtractBinary_MultipleCandidatesRefuses(t *testing.T) {
+	archivePath := buildArchive(t, []tarEntry{
+		{name: "conduit-connector-a", content: "a"},
+		{name: "conduit-connector-b", content: "b"},
+	})
+	_, err := registry.ExtractBinary(archivePath, t.TempDir())
+	require.Error(t, err)
+	assertArchiveInvalid(t, err)
+}
+
+func TestExtractBinary_NestedFileIsNotACandidate(t *testing.T) {
+	archivePath := buildArchive(t, []tarEntry{
+		{name: "conduit-connector-postgres", content: "binary-bytes"},
+		{name: "docs/README.md", content: "hi"},
+	})
+	binPath, err := registry.ExtractBinary(archivePath, t.TempDir())
+	require.NoError(t, err)
+	assert.Contains(t, binPath, "conduit-connector-postgres")
+}
+
+func TestExtractBinary_PathTraversalRefuses(t *testing.T) {
+	archivePath := buildArchive(t, []tarEntry{{name: "../../etc/passwd", content: "evil"}})
+	_, err := registry.ExtractBinary(archivePath, t.TempDir())
+	require.Error(t, err)
+	assertArchiveInvalid(t, err)
+}
+
+func TestExtractBinary_AbsolutePathRefuses(t *testing.T) {
+	archivePath := buildArchive(t, []tarEntry{{name: "/etc/passwd", content: "evil"}})
+	_, err := registry.ExtractBinary(archivePath, t.TempDir())
+	require.Error(t, err)
+	assertArchiveInvalid(t, err)
+}
+
+func TestExtractBinary_SymlinkEntryRefuses(t *testing.T) {
+	archivePath := buildArchive(t, []tarEntry{
+		{name: "conduit-connector-postgres", typeflag: tar.TypeSymlink, linkname: "/etc/passwd"},
+	})
+	_, err := registry.ExtractBinary(archivePath, t.TempDir())
+	require.Error(t, err)
+	assertArchiveInvalid(t, err)
+}
+
+func TestExtractBinary_HardlinkEntryRefuses(t *testing.T) {
+	archivePath := buildArchive(t, []tarEntry{
+		{name: "conduit-connector-postgres", typeflag: tar.TypeLink, linkname: "somewhere"},
+	})
+	_, err := registry.ExtractBinary(archivePath, t.TempDir())
+	require.Error(t, err)
+	assertArchiveInvalid(t, err)
+}
+
+func assertArchiveInvalid(t *testing.T, err error) {
+	t.Helper()
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeArchiveInvalid, ce.Code)
+}

--- a/pkg/registry/install.go
+++ b/pkg/registry/install.go
@@ -1,0 +1,554 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry/boundedfetch"
+	"github.com/conduitio/conduit/pkg/registry/index"
+	"github.com/conduitio/conduit/pkg/registry/trust"
+)
+
+// DefaultIndexURL is the well-known registry index URL Install fetches from
+// when the caller does not set InstallOptions.IndexFile (plan-v2 §8: the
+// same GitHub Pages deployment that serves the human-facing site).
+const DefaultIndexURL = "https://registry.conduit.io/index.json"
+
+// MaxBundleBytes caps a fetched signature/provenance bundle fetch (P0-2
+// item 1, plan-v2 §2.4): a Sigstore bundle with a cert chain and Rekor
+// inclusion proof is normally a few KB; 1 MiB is generous headroom.
+const MaxBundleBytes int64 = 1 * 1024 * 1024
+
+// InstallSourceIndex is the only InstallOptions/ManifestEntry Source value
+// this PR produces. "offline-bundle" is PR-4's scope (offline/air-gapped
+// installs from a locally bundled index snapshot).
+const InstallSourceIndex = "index"
+
+// InstallOptions is Install's full configuration.
+//
+// IndexVerifier and ArtifactVerifier are REQUIRED, no-default constructor-
+// style arguments (plan-v2 §2.2): the one production call site
+// (cmd/conduit/root/connectors/install.go) passes FailClosedVerifier{} for
+// both, explicitly and visibly, until PR-2 lands. Nothing in this package
+// supplies a default — a nil verifier is a caller bug, not a "verification
+// skipped" default, and Install.validate refuses it outright.
+type InstallOptions struct {
+	// Name is the connector name to install (exact match only).
+	Name string
+	// Version is an optional version constraint ("0.14.1" or "v0.14.1").
+	// Empty selects the newest version compatible with
+	// RunningConduitVersion/RunningProtocolVersion.
+	Version string
+
+	// ConnectorsPath is the standalone connectors directory
+	// (--connectors.path) the binary is installed into, and under which
+	// .registry/ bookkeeping lives.
+	ConnectorsPath string
+
+	// IndexURL is the index to fetch over HTTP(S). Ignored if IndexFile is
+	// set.
+	IndexURL string
+	// IndexFile reads the index from a local path instead (offline mode);
+	// takes priority over IndexURL when both are set.
+	IndexFile string
+
+	IndexVerifier    IndexVerifier
+	ArtifactVerifier ArtifactVerifier
+
+	// RunningConduitVersion/RunningProtocolVersion are this build's own
+	// versions, compared against each candidate version's
+	// minConduitVersion/minProtocolVersion (see resolve.go).
+	RunningConduitVersion  string
+	RunningProtocolVersion string
+
+	// InstalledBy identifies the operator for the manifest entry and audit
+	// event (best-effort; e.g. the OS user running the command).
+	InstalledBy string
+
+	// LockTimeout bounds how long Install waits to acquire the per-target
+	// and manifest locks. Zero uses DefaultLockTimeout.
+	LockTimeout time.Duration
+
+	// DryRun performs resolution and platform selection only — no
+	// download, no filesystem write under ConnectorsPath.
+	DryRun bool
+
+	// HTTPClient overrides the download/bundle-fetch client. nil uses a
+	// redirect-bounded default (newDownloadClient). Primarily a test seam.
+	HTTPClient *http.Client
+
+	// GOOS/GOArch override runtime.GOOS/runtime.GOARCH for platform
+	// selection — a test seam only, never a user-facing flag (installing
+	// for a different host than the one running `install` is out of
+	// scope).
+	GOOS, GOArch string
+}
+
+func (o *InstallOptions) validate() error {
+	if o.Name == "" {
+		return conduiterr.New(conduiterr.CodeInvalidArgument, "connector name is required")
+	}
+	if o.ConnectorsPath == "" {
+		return conduiterr.New(conduiterr.CodeInvalidArgument, "--connectors.path is required")
+	}
+	if o.IndexURL == "" && o.IndexFile == "" {
+		return conduiterr.New(conduiterr.CodeInvalidArgument, "one of --index-url or --index-file is required")
+	}
+	if o.IndexVerifier == nil || o.ArtifactVerifier == nil {
+		// Should never happen from cmd/conduit (its one call site always
+		// passes FailClosedVerifier{} at minimum) — a nil verifier here is
+		// a programming error, not a user-input problem, but it must still
+		// fail closed rather than nil-pointer-panic deeper in the pipeline.
+		return conduiterr.New(CodeVerificationUnavailable, "no verifier configured for this install")
+	}
+	return nil
+}
+
+func (o *InstallOptions) goos() string {
+	if o.GOOS != "" {
+		return o.GOOS
+	}
+	return runtime.GOOS
+}
+
+func (o *InstallOptions) goarch() string {
+	if o.GOArch != "" {
+		return o.GOArch
+	}
+	return runtime.GOARCH
+}
+
+func (o *InstallOptions) lockTimeout() time.Duration {
+	if o.LockTimeout > 0 {
+		return o.LockTimeout
+	}
+	return DefaultLockTimeout
+}
+
+func (o *InstallOptions) httpClient() *http.Client {
+	if o.HTTPClient != nil {
+		return o.HTTPClient
+	}
+	return newDownloadClient()
+}
+
+// InstallResult is Install's success-path result, also used (with DryRun or
+// AlreadyInstalled set) for the two non-error early-exit paths.
+type InstallResult struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	OS      string `json:"os"`
+	Arch    string `json:"arch"`
+
+	// Deprecated mirrors the resolved version's index.ConnectorVersion.Deprecated
+	// flag — informational only; it never causes a refusal (see resolve.go).
+	Deprecated bool `json:"deprecated,omitempty"`
+
+	DryRun      bool   `json:"dryRun,omitempty"`
+	ArtifactURL string `json:"artifactUrl,omitempty"`
+	Size        int64  `json:"size,omitempty"`
+
+	AlreadyInstalled bool `json:"alreadyInstalled,omitempty"`
+
+	ArtifactFile       string `json:"artifactFile,omitempty"`
+	Digest             string `json:"digest,omitempty"`
+	SourceIndexVersion int64  `json:"sourceIndexVersion,omitempty"`
+}
+
+// Install runs the full non-crypto install pipeline: fetch+shape-check the
+// index, resolve name/version, select a host platform artifact, download it
+// into a private per-install staging directory, check byte-for-byte
+// integrity, run the verification gate, then — only past every one of
+// those — atomically install the binary and record the manifest/audit
+// entries.
+//
+// # Fail-closed by construction
+//
+// Step 6 below (ArtifactVerifier.VerifyArtifact) is the ONLY authorization
+// gate between an integrity-checked download and an installed, runnable
+// binary. With the production FailClosedVerifier (verify.go), this call
+// ALWAYS returns ErrVerificationNotConfigured — so no code path in this
+// function can reach extraction, the final rename, or a manifest write in a
+// normal build. This is verified directly by install_test.go's
+// TestInstall_FailClosedByConstruction (using FailClosedVerifier, the exact
+// production wiring cmd/conduit/root/connectors/install.go uses) alongside
+// TestInstall_FullPipeline (using a test-only pass-through verifier
+// injected via this same InstallOptions field — never a separate code
+// path — to exercise resolve/download/stage/sha256/manifest end to end).
+func Install(ctx context.Context, opts InstallOptions) (*InstallResult, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+
+	// 1-3: fetch + shape-check the index, resolve name/version, select a
+	// host platform artifact.
+	verified, resolved, artifact, err := resolveInstall(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.DryRun {
+		return &InstallResult{
+			Name: resolved.Connector.Name, Version: resolved.Version.Version,
+			OS: artifact.OS, Arch: artifact.Arch,
+			Deprecated:  resolved.Version.Deprecated,
+			DryRun:      true,
+			ArtifactURL: artifact.URL,
+			Size:        artifact.Size,
+		}, nil
+	}
+
+	// 4-9: lock, download, verify, extract, atomically install, record.
+	return installResolved(ctx, opts, verified, resolved, artifact)
+}
+
+// resolveInstall runs steps 1-3: fetch+shape-check the index (via
+// IndexVerifier), resolve name/version, and select the host platform
+// artifact. No filesystem write under opts.ConnectorsPath happens here —
+// this is exactly what --dry-run stops after.
+func resolveInstall(ctx context.Context, opts InstallOptions) (*index.VerifiedIndex, *ResolvedVersion, *index.Artifact, error) {
+	raw, err := fetchIndexRaw(ctx, opts)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	verified, err := opts.IndexVerifier.VerifyIndex(ctx, raw)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	resolved, err := Resolve(verified.Payload, ResolveOptions{
+		Name:                   opts.Name,
+		Version:                opts.Version,
+		RunningConduitVersion:  opts.RunningConduitVersion,
+		RunningProtocolVersion: opts.RunningProtocolVersion,
+	})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	artifact, err := SelectArtifact(resolved.Connector.Name, resolved.Version, opts.goos(), opts.goarch())
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return verified, resolved, artifact, nil
+}
+
+// installResolved runs steps 4-9 of Install against an already-resolved
+// connector version and platform artifact: acquire the per-target lock,
+// short-circuit if already installed, download+verify+extract+atomically
+// install, then record the manifest entry and audit event.
+func installResolved(ctx context.Context, opts InstallOptions, verified *index.VerifiedIndex, resolved *ResolvedVersion, artifact *index.Artifact) (*InstallResult, error) {
+	key, err := ManifestKey(resolved.Connector.Name, resolved.Version.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	// 4. Per-target lock: serializes the ENTIRE remaining pipeline for two
+	// concurrent installs of the same connector name.
+	targetLock, err := AcquireTargetLock(opts.ConnectorsPath, resolved.Connector.Name, opts.lockTimeout())
+	if err != nil {
+		return nil, err
+	}
+	defer targetLock.Unlock() //nolint:errcheck // best-effort; flock also releases at process exit
+
+	// Re-check "already installed" AFTER acquiring the lock, not before —
+	// a concurrent install of the same name that started earlier may have
+	// just finished; reading the manifest before the lock could observe a
+	// write in flight and give a stale answer.
+	entry, alreadyInstalled, err := lookupManifestEntry(opts.ConnectorsPath, key)
+	if err != nil {
+		return nil, err
+	}
+	if alreadyInstalled {
+		return &InstallResult{
+			Name: entry.Name, Version: entry.Version, OS: entry.OS, Arch: entry.Arch,
+			AlreadyInstalled:   true,
+			ArtifactFile:       entry.ArtifactFile,
+			Digest:             entry.Digest,
+			SourceIndexVersion: entry.SourceIndexVersion,
+		}, nil
+	}
+
+	entry, err = downloadVerifyAndInstall(ctx, opts, verified, resolved, artifact)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := writeManifestEntry(opts.ConnectorsPath, key, entry, opts.lockTimeout()); err != nil {
+		return nil, err
+	}
+
+	// 9. Audit event — appended only AFTER the rename and manifest write
+	// above have both succeeded (see AppendAuditEvent's invariant comment).
+	if err := AppendAuditEvent(auditLogPath(opts.ConnectorsPath), AuditEvent{
+		Event: "connector_install", Connector: entry.Name, Version: entry.Version,
+		Digest: entry.Digest, Operator: opts.InstalledBy, Timestamp: entry.InstalledAt,
+		Signed: entry.Signed, VerifiedIdentity: entry.VerifiedIdentity, AllowUnsigned: entry.AllowUnsigned,
+	}); err != nil {
+		return nil, conduiterr.Wrap(conduiterr.CodeInternal, "connector installed but could not append the audit log entry", err)
+	}
+
+	return &InstallResult{
+		Name: entry.Name, Version: entry.Version, OS: entry.OS, Arch: entry.Arch,
+		Deprecated:         resolved.Version.Deprecated,
+		ArtifactFile:       entry.ArtifactFile,
+		Digest:             entry.Digest,
+		SourceIndexVersion: entry.SourceIndexVersion,
+	}, nil
+}
+
+// downloadVerifyAndInstall runs steps 5-8: stage, download, corruption
+// check, the verification gate, extract, and the atomic rename — returning
+// the ManifestEntry to record (steps 8-9's write/audit stay in
+// installResolved, since they're identical regardless of how the entry was
+// produced).
+func downloadVerifyAndInstall(ctx context.Context, opts InstallOptions, verified *index.VerifiedIndex, resolved *ResolvedVersion, artifact *index.Artifact) (ManifestEntry, error) {
+	// 5. Staging directory: a private (0700), uniquely-named SUBDIRECTORY
+	// of ConnectorsPath — never the OS temp dir. This is required, not
+	// just tidy, so the final os.Rename below is a same-filesystem,
+	// therefore atomic, rename: a temp directory on a different volume
+	// would make that rename a non-atomic copy and could fail outright
+	// with EXDEV.
+	stagingRoot := stagingRootPath(opts.ConnectorsPath)
+	if err := os.MkdirAll(stagingRoot, 0o700); err != nil {
+		return ManifestEntry{}, conduiterr.Wrap(CodeDownloadFailed, "could not create staging root directory", err)
+	}
+	stagingDir, err := os.MkdirTemp(stagingRoot, "install-*")
+	if err != nil {
+		return ManifestEntry{}, conduiterr.Wrap(CodeDownloadFailed, "could not create staging directory", err)
+	}
+	// Cleaned up on EVERY exit path: on success the binary has already
+	// been renamed OUT of stagingDir, leaving only an empty extracted/
+	// tree; on any failure, nothing under ConnectorsPath outside
+	// .registry/staging was ever touched, and this removes the evidence of
+	// the attempt so a stale staging directory never accumulates.
+	defer os.RemoveAll(stagingDir)
+	if err := os.Chmod(stagingDir, 0o700); err != nil {
+		// Defensive: os.MkdirTemp already creates 0700 before umask: this
+		// asserts that property rather than relying on it silently.
+		return ManifestEntry{}, conduiterr.Wrap(CodeDownloadFailed, "could not set staging directory permissions", err)
+	}
+
+	archivePath := filepath.Join(stagingDir, "artifact.tar.gz")
+	dl, err := Download(ctx, opts.httpClient(), artifact.URL, archivePath, artifact.Size)
+	if err != nil {
+		return ManifestEntry{}, err
+	}
+	fireChaos(chaosPointDownloadComplete)
+
+	// 6a. Corruption check — integrity, not trust (corruption.go). Run
+	// FIRST and SEPARATELY from the verification gate below.
+	if err := CheckCorruption(dl.Digest, artifact.SHA256); err != nil {
+		return ManifestEntry{}, err
+	}
+
+	verifyResult, err := runVerificationGate(ctx, opts, dl, resolved, artifact)
+	if err != nil {
+		return ManifestEntry{}, err
+	}
+
+	binaryPath, err := extractAndGuard(archivePath, stagingDir)
+	if err != nil {
+		return ManifestEntry{}, err
+	}
+
+	finalName := fmt.Sprintf("conduit-connector-%s_%s", resolved.Connector.Name, resolved.Version.Version)
+	finalPath := filepath.Join(opts.ConnectorsPath, finalName)
+
+	// Invariant 5 (atomic state/checkpoint writes): os.Rename within one
+	// filesystem is a single atomic syscall — there is no OS-observable
+	// "mid-rename" state. A crash before it returns leaves the OLD binary
+	// (if any) untouched at finalPath; a crash after leaves the NEW binary
+	// fully present. This is exactly why staging must share a filesystem
+	// with ConnectorsPath (see the MkdirTemp call above) — the guarantee
+	// does not hold across devices (EXDEV).
+	if err := os.Rename(binaryPath, finalPath); err != nil {
+		return ManifestEntry{}, conduiterr.Wrap(CodeArchiveInvalid, fmt.Sprintf("could not install %q", finalName), err)
+	}
+	if err := os.Chmod(finalPath, 0o755); err != nil {
+		return ManifestEntry{}, conduiterr.Wrap(CodeArchiveInvalid, "could not set installed binary permissions", err)
+	}
+	fireChaos(chaosPointPostRenamePreManifest)
+
+	now := time.Now().UTC()
+	digestHex := fmt.Sprintf("%x", dl.Digest)
+	return ManifestEntry{
+		Name: resolved.Connector.Name, Version: resolved.Version.Version,
+		Kind: StandaloneArtifactKind, OS: artifact.OS, Arch: artifact.Arch,
+		ArtifactFile: finalName, Digest: "sha256:" + digestHex, Size: dl.Size,
+		InstalledAt: now, InstalledBy: opts.InstalledBy,
+		SourceIndexVersion: verified.Payload.Index.Version, Source: InstallSourceIndex,
+		Signed: verifyResult.Signed, VerifiedIdentity: verifyResult.VerifiedIdentity, AllowUnsigned: false,
+	}, nil
+}
+
+// runVerificationGate is step 6b: fetch the signature/provenance bundles
+// (bounded, P0-2) and hand the corruption-checked, in-memory digest — never
+// a path — to ArtifactVerifier.
+//
+// Invariant (fail-closed by construction): with the production
+// FailClosedVerifier, VerifyArtifact ALWAYS returns
+// ErrVerificationNotConfigured — nothing past this function executes in a
+// normal build.
+func runVerificationGate(ctx context.Context, opts InstallOptions, dl DownloadResult, resolved *ResolvedVersion, artifact *index.Artifact) (VerifyResult, error) {
+	ref, err := fetchArtifactRef(ctx, opts, dl.Digest, resolved.Version, artifact)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+	identity := trust.PinnedIdentity{
+		OIDCIssuer:      resolved.Connector.Publisher.ExpectedOIDCIssuer,
+		IdentityPattern: resolved.Connector.Publisher.ExpectedIdentityPattern,
+	}
+
+	verifyResult, err := opts.ArtifactVerifier.VerifyArtifact(ctx, ref, identity)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+	// Second, structural belt-and-suspenders check (plan-v2 §2.2): this PR
+	// has no --allow-unsigned wiring at all (that lands in PR-2), so any
+	// non-error VerifyResult that isn't Signed would mean some future
+	// ArtifactVerifier implementation returned success without actually
+	// authorizing the artifact — refuse rather than silently install.
+	if !verifyResult.Signed {
+		return VerifyResult{}, conduiterr.New(CodeVerificationUnavailable,
+			"artifact verifier returned success without signing the artifact — refusing to install "+
+				"(no --allow-unsigned path exists in this build)")
+	}
+	return verifyResult, nil
+}
+
+// extractAndGuard is step 7: extract the single candidate binary, then
+// verify-via-O_NOFOLLOW-fd immediately before the caller's rename.
+//
+// Invariant: the O_NOFOLLOW-opened fd protects the FINAL RENAME (in the
+// caller) from a symlink swapped into extractDir's binary name between
+// ExtractBinary returning and os.Rename running. It does NOT re-verify the
+// artifact's trust or contents — that already happened in
+// runVerificationGate, over an in-memory digest computed from the
+// downloaded bytes directly, never re-read from a path. ExtractBinary
+// itself already refused any symlink/hardlink TAR ENTRY outright, and
+// extractDir is private (0700), uniquely named, and freshly created by this
+// call, so the realistic TOCTOU window here is narrow — but the check is
+// real: an O_NOFOLLOW open of a symlink fails with ELOOP (unix) rather than
+// silently following it.
+func extractAndGuard(archivePath, stagingDir string) (string, error) {
+	extractDir := filepath.Join(stagingDir, "extracted")
+	if err := os.MkdirAll(extractDir, 0o700); err != nil {
+		return "", conduiterr.Wrap(CodeArchiveInvalid, "could not create extraction directory", err)
+	}
+	binaryPath, err := ExtractBinary(archivePath, extractDir)
+	if err != nil {
+		return "", err
+	}
+	fireChaos(chaosPointExtractComplete)
+
+	guardFD, err := openRegularNoFollow(binaryPath)
+	if err != nil {
+		return "", err
+	}
+	fireChaos(chaosPointPrerenameFDOpened)
+	guardFD.Close()
+
+	return binaryPath, nil
+}
+
+func fetchIndexRaw(ctx context.Context, opts InstallOptions) ([]byte, error) {
+	if opts.IndexFile != "" {
+		return index.FetchFile(opts.IndexFile)
+	}
+	return index.Fetch(ctx, opts.IndexURL)
+}
+
+// fetchArtifactRef fetches the signature bundle (always expected) and the
+// applicable SLSA provenance bundle (version-level or artifact-level,
+// whichever is present) into an ArtifactRef, bounded per MaxBundleBytes —
+// this package never hands ArtifactVerifier a bare URL; it fetches the
+// bytes itself so the interface stays crypto-library-agnostic.
+func fetchArtifactRef(ctx context.Context, opts InstallOptions, digest [32]byte, v index.ConnectorVersion, a *index.Artifact) (ArtifactRef, error) {
+	ref := ArtifactRef{Digest: digest}
+
+	if a.Signature.BundleURL != "" {
+		sig, err := fetchBundle(ctx, a.Signature.BundleURL)
+		if err != nil {
+			return ArtifactRef{}, err
+		}
+		ref.SignatureBundle = sig
+	}
+
+	provRef := a.SLSAProvenance
+	if provRef == nil {
+		provRef = v.SLSAProvenance
+	}
+	if provRef != nil && provRef.BundleURL != "" {
+		prov, err := fetchBundle(ctx, provRef.BundleURL)
+		if err != nil {
+			return ArtifactRef{}, err
+		}
+		ref.ProvenanceBundle = prov
+	}
+
+	return ref, nil
+}
+
+func fetchBundle(ctx context.Context, url string) ([]byte, error) {
+	data, err := boundedfetch.Fetch(ctx, url, MaxBundleBytes)
+	if err != nil {
+		if cerrors.Is(err, boundedfetch.ErrTooLarge) {
+			return nil, conduiterr.Wrap(trust.CodeBundleTooLarge, "signature/provenance bundle exceeds the maximum allowed size", err)
+		}
+		return nil, conduiterr.Wrap(CodeDownloadFailed, fmt.Sprintf("could not fetch bundle %q", url), err)
+	}
+	return data, nil
+}
+
+func lookupManifestEntry(connectorsPath, key string) (ManifestEntry, bool, error) {
+	m, err := LoadManifest(manifestPath(connectorsPath))
+	if err != nil {
+		return ManifestEntry{}, false, conduiterr.Wrap(conduiterr.CodeInternal, "could not read install manifest", err)
+	}
+	entry, ok := m.Installs[key]
+	return entry, ok, nil
+}
+
+func writeManifestEntry(connectorsPath, key string, entry ManifestEntry, lockTimeout time.Duration) error {
+	lock, err := AcquireManifestLock(connectorsPath, lockTimeout)
+	if err != nil {
+		return err
+	}
+	defer lock.Unlock() //nolint:errcheck // best-effort; flock also releases at process exit
+
+	path := manifestPath(connectorsPath)
+	m, err := LoadManifest(path)
+	if err != nil {
+		return conduiterr.Wrap(conduiterr.CodeInternal, "could not read install manifest", err)
+	}
+	if m.Installs == nil {
+		m.Installs = map[string]ManifestEntry{}
+	}
+	m.Installs[key] = entry
+	if err := SaveManifest(path, m); err != nil {
+		return conduiterr.Wrap(conduiterr.CodeInternal, "could not write install manifest", err)
+	}
+	return nil
+}

--- a/pkg/registry/install_test.go
+++ b/pkg/registry/install_test.go
@@ -1,0 +1,487 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	json "github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry"
+	"github.com/conduitio/conduit/pkg/registry/index"
+	"github.com/conduitio/conduit/pkg/registry/trust"
+)
+
+// passThroughVerifier is a test-only IndexVerifier/ArtifactVerifier that
+// unconditionally treats every index/artifact as verified. It is the ONLY
+// way this test suite exercises the download/stage/sha256/extract/
+// rename/manifest steps end to end — it is never exported, never
+// referenced from cmd/conduit, and exists specifically to prove those steps
+// work while the real trust core (PR-2) does not exist yet. See
+// TestInstall_FailClosedByConstruction, in the same file, for the test that
+// proves the REAL production wiring (FailClosedVerifier) refuses instead.
+type passThroughVerifier struct{}
+
+func (passThroughVerifier) VerifyIndex(_ context.Context, raw []byte) (*index.VerifiedIndex, error) {
+	p, err := index.ParseUnverified(raw)
+	if err != nil {
+		return nil, err
+	}
+	return &index.VerifiedIndex{Payload: *p, Verified: true}, nil
+}
+
+func (passThroughVerifier) VerifyArtifact(_ context.Context, _ registry.ArtifactRef, identity trust.PinnedIdentity) (registry.VerifyResult, error) {
+	return registry.VerifyResult{Signed: true, VerifiedIdentity: "test:" + identity.OIDCIssuer}, nil
+}
+
+// buildInstallArchive returns a valid tar.gz containing a single root-level
+// regular file — a fixture connector "binary".
+func buildInstallArchive(t *testing.T, label string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	content := []byte("binary-content-for-" + label)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "conduit-connector-" + label, Mode: 0o755, Size: int64(len(content)),
+	}))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+	return buf.Bytes()
+}
+
+// newInstallTestServer serves a schema-valid (but unsigned — signatures[]
+// is empty, which is fine since every test here uses either
+// FailClosedVerifier, which never checks it, or passThroughVerifier, which
+// deliberately skips crypto by design) registry index for one connector at
+// one version, plus its artifact and (fake, uninspected by any code this PR
+// ships) signature/provenance bundles.
+func newInstallTestServer(t *testing.T, name, version string) (srv *httptest.Server, indexURL string, archiveBytes []byte) {
+	t.Helper()
+	archiveBytes = buildInstallArchive(t, name)
+	digest := sha256.Sum256(archiveBytes)
+
+	mux := http.NewServeMux()
+	srv = httptest.NewServer(mux)
+
+	payload := index.Payload{
+		SchemaVersion: 1,
+		Index:         index.IndexMeta{Version: 7, Timestamp: time.Now()},
+		Connectors: []index.Connector{
+			{
+				Name: name,
+				Publisher: index.Publisher{
+					ExpectedOIDCIssuer:      "https://token.actions.githubusercontent.com",
+					ExpectedIdentityPattern: `^https://github\.com/example/` + name + `/.*$`,
+				},
+				Versions: []index.ConnectorVersion{
+					{
+						Version: version, MinConduitVersion: "0.1.0", MinProtocolVersion: "0.1.0",
+						Artifacts: []index.Artifact{
+							{
+								OS: runtime.GOOS, Arch: runtime.GOARCH, Kind: registry.StandaloneArtifactKind,
+								URL:       srv.URL + "/artifact.tar.gz",
+								SHA256:    hexEncode(digest),
+								Size:      int64(len(archiveBytes)),
+								Signature: index.SignatureRef{BundleURL: srv.URL + "/sig.json"},
+							},
+						},
+						SLSAProvenance: &index.ProvenanceRef{BundleURL: srv.URL + "/prov.json", PredicateType: "https://slsa.dev/provenance/v1"},
+					},
+				},
+			},
+		},
+	}
+
+	envelope := map[string]any{"payload": payload, "signatures": []any{}}
+	indexBytes, err := json.Marshal(envelope)
+	require.NoError(t, err)
+
+	mux.HandleFunc("/index.json", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write(indexBytes) })
+	mux.HandleFunc("/artifact.tar.gz", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write(archiveBytes) })
+	mux.HandleFunc("/sig.json", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(`{"sig":"fake-test-bundle"}`)) })
+	mux.HandleFunc("/prov.json", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(`{"prov":"fake-test-bundle"}`)) })
+
+	return srv, srv.URL + "/index.json", archiveBytes
+}
+
+func hexEncode(d [32]byte) string {
+	const hextable = "0123456789abcdef"
+	out := make([]byte, 64)
+	for i, b := range d {
+		out[i*2] = hextable[b>>4]
+		out[i*2+1] = hextable[b&0x0f]
+	}
+	return string(out)
+}
+
+// TestInstall_FailClosedByConstruction is the AC-6 test: the REAL
+// production wiring (FailClosedVerifier for BOTH verifiers — exactly what
+// cmd/conduit/root/connectors/install.go passes, with no way to configure
+// anything else) must refuse every install attempt with
+// CodeVerificationUnavailable, and must leave NOTHING resembling an
+// installed connector binary under ConnectorsPath.
+func TestInstall_FailClosedByConstruction(t *testing.T) {
+	srv, indexURL, _ := newInstallTestServer(t, "widget", "1.0.0")
+	defer srv.Close()
+
+	connectorsPath := t.TempDir()
+
+	_, err := registry.Install(context.Background(), registry.InstallOptions{
+		Name: "widget", ConnectorsPath: connectorsPath, IndexURL: indexURL,
+		IndexVerifier:          registry.FailClosedVerifier{},
+		ArtifactVerifier:       registry.FailClosedVerifier{},
+		RunningConduitVersion:  "1.0.0",
+		RunningProtocolVersion: "1.0.0",
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeVerificationUnavailable, ce.Code)
+
+	assertNoInstalledBinary(t, connectorsPath)
+}
+
+func assertNoInstalledBinary(t *testing.T, connectorsPath string) {
+	t.Helper()
+	entries, err := os.ReadDir(connectorsPath)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), "conduit-connector-",
+			"no connector binary should ever be visible under --connectors.path in this PR's shipped configuration")
+	}
+}
+
+// TestInstall_FullPipeline exercises resolve -> platform select -> download
+// -> corruption check -> (test-only) verification -> extract -> atomic
+// rename -> manifest write -> audit, using passThroughVerifier injected via
+// the SAME InstallOptions field the real command uses for FailClosedVerifier
+// — proving the seam, not a separate code path.
+func TestInstall_FullPipeline(t *testing.T) {
+	srv, indexURL, archiveBytes := newInstallTestServer(t, "widget", "1.0.0")
+	defer srv.Close()
+
+	connectorsPath := t.TempDir()
+
+	res, err := registry.Install(context.Background(), registry.InstallOptions{
+		Name: "widget", ConnectorsPath: connectorsPath, IndexURL: indexURL,
+		IndexVerifier:          passThroughVerifier{},
+		ArtifactVerifier:       passThroughVerifier{},
+		RunningConduitVersion:  "1.0.0",
+		RunningProtocolVersion: "1.0.0",
+		InstalledBy:            "test-operator",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, "widget", res.Name)
+	assert.Equal(t, "1.0.0", res.Version)
+	assert.Equal(t, runtime.GOOS, res.OS)
+	assert.Equal(t, runtime.GOARCH, res.Arch)
+	assert.False(t, res.AlreadyInstalled)
+	assert.Equal(t, "conduit-connector-widget_1.0.0", res.ArtifactFile)
+
+	// The installed binary is present, complete, and executable.
+	installedPath := filepath.Join(connectorsPath, "conduit-connector-widget_1.0.0")
+	data, err := os.ReadFile(installedPath)
+	require.NoError(t, err)
+	assert.Equal(t, "binary-content-for-widget", string(data))
+	info, err := os.Stat(installedPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+
+	expectedDigest := "sha256:" + hexEncode(sha256.Sum256(archiveBytes))
+	assert.Equal(t, expectedDigest, res.Digest)
+
+	// Manifest entry present and correctly keyed.
+	m, err := registry.LoadManifest(filepath.Join(connectorsPath, ".registry", "manifest.json"))
+	require.NoError(t, err)
+	entry, ok := m.Installs["widget@1.0.0"]
+	require.True(t, ok)
+	assert.Equal(t, expectedDigest, entry.Digest)
+	assert.True(t, entry.Signed)
+	assert.Equal(t, "test-operator", entry.InstalledBy)
+
+	// Audit log has exactly one connector_install event.
+	auditData, err := os.ReadFile(filepath.Join(connectorsPath, ".registry", "audit.jsonl"))
+	require.NoError(t, err)
+	assert.Contains(t, string(auditData), `"event":"connector_install"`)
+	assert.Contains(t, string(auditData), `"connector":"widget"`)
+
+	// Staging is cleaned up; nothing but the manifest/lock/audit
+	// bookkeeping and the installed binary remain.
+	stagingEntries, err := os.ReadDir(filepath.Join(connectorsPath, ".registry", "staging"))
+	require.NoError(t, err)
+	assert.Empty(t, stagingEntries)
+}
+
+func TestInstall_AlreadyInstalled(t *testing.T) {
+	srv, indexURL, _ := newInstallTestServer(t, "widget", "1.0.0")
+	defer srv.Close()
+	connectorsPath := t.TempDir()
+
+	opts := registry.InstallOptions{
+		Name: "widget", ConnectorsPath: connectorsPath, IndexURL: indexURL,
+		IndexVerifier: passThroughVerifier{}, ArtifactVerifier: passThroughVerifier{},
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+	}
+
+	first, err := registry.Install(context.Background(), opts)
+	require.NoError(t, err)
+	require.False(t, first.AlreadyInstalled)
+
+	second, err := registry.Install(context.Background(), opts)
+	require.NoError(t, err)
+	assert.True(t, second.AlreadyInstalled)
+	assert.Equal(t, first.Digest, second.Digest)
+}
+
+func TestInstall_DryRun(t *testing.T) {
+	srv, indexURL, _ := newInstallTestServer(t, "widget", "1.0.0")
+	defer srv.Close()
+	connectorsPath := t.TempDir()
+
+	res, err := registry.Install(context.Background(), registry.InstallOptions{
+		Name: "widget", ConnectorsPath: connectorsPath, IndexURL: indexURL,
+		IndexVerifier: passThroughVerifier{}, ArtifactVerifier: passThroughVerifier{},
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+		DryRun: true,
+	})
+	require.NoError(t, err)
+	assert.True(t, res.DryRun)
+	assert.Equal(t, srv.URL+"/artifact.tar.gz", res.ArtifactURL)
+
+	// Nothing at all written under ConnectorsPath — not even .registry/.
+	entries, err := os.ReadDir(connectorsPath)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestInstall_ConcurrentSameName(t *testing.T) {
+	srv, indexURL, _ := newInstallTestServer(t, "widget", "1.0.0")
+	defer srv.Close()
+	connectorsPath := t.TempDir()
+
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := registry.Install(context.Background(), registry.InstallOptions{
+				Name: "widget", ConnectorsPath: connectorsPath, IndexURL: indexURL,
+				IndexVerifier: passThroughVerifier{}, ArtifactVerifier: passThroughVerifier{},
+				RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+				LockTimeout: 10 * time.Second,
+			})
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		assert.NoErrorf(t, err, "goroutine %d", i)
+	}
+
+	m, err := registry.LoadManifest(filepath.Join(connectorsPath, ".registry", "manifest.json"))
+	require.NoError(t, err)
+	assert.Len(t, m.Installs, 1)
+
+	installedPath := filepath.Join(connectorsPath, "conduit-connector-widget_1.0.0")
+	data, err := os.ReadFile(installedPath)
+	require.NoError(t, err)
+	assert.Equal(t, "binary-content-for-widget", string(data))
+}
+
+func TestInstall_ConcurrentDifferentNames(t *testing.T) {
+	srvA, indexURLA, _ := newInstallTestServer(t, "widget-a", "1.0.0")
+	defer srvA.Close()
+	srvB, indexURLB, _ := newInstallTestServer(t, "widget-b", "1.0.0")
+	defer srvB.Close()
+
+	connectorsPath := t.TempDir()
+
+	var wg sync.WaitGroup
+	var errA, errB error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, errA = registry.Install(context.Background(), registry.InstallOptions{
+			Name: "widget-a", ConnectorsPath: connectorsPath, IndexURL: indexURLA,
+			IndexVerifier: passThroughVerifier{}, ArtifactVerifier: passThroughVerifier{},
+			RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+			LockTimeout: 10 * time.Second,
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		_, errB = registry.Install(context.Background(), registry.InstallOptions{
+			Name: "widget-b", ConnectorsPath: connectorsPath, IndexURL: indexURLB,
+			IndexVerifier: passThroughVerifier{}, ArtifactVerifier: passThroughVerifier{},
+			RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+			LockTimeout: 10 * time.Second,
+		})
+	}()
+	wg.Wait()
+
+	require.NoError(t, errA)
+	require.NoError(t, errB)
+
+	m, err := registry.LoadManifest(filepath.Join(connectorsPath, ".registry", "manifest.json"))
+	require.NoError(t, err)
+	assert.Len(t, m.Installs, 2)
+	_, ok := m.Installs["widget-a@1.0.0"]
+	assert.True(t, ok)
+	_, ok = m.Installs["widget-b@1.0.0"]
+	assert.True(t, ok)
+}
+
+// TestChaosHelperProcess is the subprocess entry point TestInstall_ChaosKill
+// re-execs (via os.Args[0]) with a chaos point selected by environment
+// variable. It is a no-op (skipped) unless CONDUIT_CHAOS_HELPER=1, so it
+// never runs as part of a normal `go test` invocation.
+//
+// os.Exit at the injected chaos point emulates exactly the state a SIGKILL
+// would leave: no deferred cleanup runs (Go's os.Exit never runs defers,
+// matching a real kill -9's effect on this process), and death is
+// immediate. 137 (128+9) is used as the exit status by the same convention
+// shells report for a SIGKILL'd child, so a human reading `echo $?` sees
+// the familiar number — this test does not send a literal SIGKILL signal.
+func TestChaosHelperProcess(t *testing.T) {
+	if os.Getenv("CONDUIT_CHAOS_HELPER") != "1" {
+		t.Skip("only runs as TestInstall_ChaosKill's subprocess")
+	}
+
+	point := os.Getenv("CONDUIT_CHAOS_POINT")
+	registry.SetChaosHookForTest(func(p string) {
+		if p == point {
+			os.Exit(137)
+		}
+	})
+
+	_, err := registry.Install(context.Background(), registry.InstallOptions{
+		Name:                   os.Getenv("CONDUIT_CHAOS_NAME"),
+		Version:                os.Getenv("CONDUIT_CHAOS_VERSION"),
+		ConnectorsPath:         os.Getenv("CONDUIT_CHAOS_CONNECTORS_PATH"),
+		IndexURL:               os.Getenv("CONDUIT_CHAOS_INDEX_URL"),
+		IndexVerifier:          passThroughVerifier{},
+		ArtifactVerifier:       passThroughVerifier{},
+		RunningConduitVersion:  "1.0.0",
+		RunningProtocolVersion: "1.0.0",
+		InstalledBy:            "chaos-test",
+	})
+	if err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+// TestInstall_ChaosKill is the AC-9-style chaos test: kill the install
+// process (see TestChaosHelperProcess) at each of the four injection points
+// and assert the connectors directory is left in one of exactly two states
+// — no binary at all, or the fully-written new one — never truncated, and
+// that a subsequent install of the same target still succeeds (the killed
+// process's flock does not wedge it).
+func TestInstall_ChaosKill(t *testing.T) {
+	points := []string{
+		registry.ChaosPointDownloadComplete,
+		registry.ChaosPointExtractComplete,
+		registry.ChaosPointPrerenameFDOpened,
+		registry.ChaosPointPostRenamePreManifest,
+	}
+
+	for _, point := range points {
+		t.Run(point, func(t *testing.T) {
+			srv, indexURL, _ := newInstallTestServer(t, "widget", "1.0.0")
+			defer srv.Close()
+			connectorsPath := t.TempDir()
+
+			cmd := exec.CommandContext(context.Background(), os.Args[0], "-test.run=^TestChaosHelperProcess$", "-test.v")
+			cmd.Env = append(os.Environ(),
+				"CONDUIT_CHAOS_HELPER=1",
+				"CONDUIT_CHAOS_POINT="+point,
+				"CONDUIT_CHAOS_NAME=widget",
+				"CONDUIT_CHAOS_VERSION=1.0.0",
+				"CONDUIT_CHAOS_CONNECTORS_PATH="+connectorsPath,
+				"CONDUIT_CHAOS_INDEX_URL="+indexURL,
+			)
+			var out bytes.Buffer
+			cmd.Stdout = &out
+			cmd.Stderr = &out
+
+			runErr := cmd.Run()
+			var exitErr *exec.ExitError
+			require.ErrorAsf(t, runErr, &exitErr, "subprocess output:\n%s", out.String())
+			assert.Equalf(t, 137, exitErr.ExitCode(), "subprocess should have been killed at %q; output:\n%s", point, out.String())
+
+			// Invariant: never a truncated/partial binary — either nothing
+			// named conduit-connector-widget* exists yet, or it is fully
+			// present at its expected size.
+			entries, rerr := os.ReadDir(connectorsPath)
+			require.NoError(t, rerr)
+			var binaryPresent bool
+			for _, e := range entries {
+				if strings.HasPrefix(e.Name(), "conduit-connector-widget") {
+					binaryPresent = true
+					info, ierr := e.Info()
+					require.NoError(t, ierr)
+					assert.Equal(t, int64(len("binary-content-for-widget")), info.Size(),
+						"installed binary must never be a truncated/partial file")
+				}
+			}
+			if point == registry.ChaosPointPostRenamePreManifest {
+				assert.True(t, binaryPresent, "binary should already be fully renamed into place by this injection point")
+			}
+
+			// A subsequent install of the SAME target must still succeed:
+			// the killed process's flock must not wedge it (flock releases
+			// at process death), and re-running past a partially-completed
+			// attempt (e.g. binary renamed but manifest not yet written)
+			// must be idempotent, not an error.
+			res, ierr := registry.Install(context.Background(), registry.InstallOptions{
+				Name: "widget", Version: "1.0.0", ConnectorsPath: connectorsPath, IndexURL: indexURL,
+				IndexVerifier: passThroughVerifier{}, ArtifactVerifier: passThroughVerifier{},
+				RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+				LockTimeout: 5 * time.Second,
+			})
+			require.NoError(t, ierr)
+			assert.Equal(t, "widget", res.Name)
+
+			installedPath := filepath.Join(connectorsPath, "conduit-connector-widget_1.0.0")
+			data, rerr := os.ReadFile(installedPath)
+			require.NoError(t, rerr)
+			assert.Equal(t, "binary-content-for-widget", string(data))
+		})
+	}
+}

--- a/pkg/registry/lock.go
+++ b/pkg/registry/lock.go
@@ -1,0 +1,92 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gofrs/flock"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+)
+
+// DefaultLockTimeout bounds how long Install waits to acquire a lock before
+// refusing with CodeInstallLocked — never an indefinite hang.
+const DefaultLockTimeout = 30 * time.Second
+
+// lockPollInterval is how often TryLockContext polls for the lock while
+// waiting.
+const lockPollInterval = 50 * time.Millisecond
+
+// acquireLock creates (if needed) the lock file's parent directory and
+// blocks — polling every lockPollInterval — until it acquires an exclusive
+// flock, timeout elapses, or a lower-level error occurs, whichever comes
+// first.
+//
+// flock releases automatically at the OS level on process exit, including
+// SIGKILL — a killed holder never leaves a stale lock file that wedges a
+// subsequent attempt indefinitely; --lock-timeout only bounds the wait for
+// a lock genuinely still held by a live process. This property is exercised
+// directly, not just assumed, by install_test.go's chaos/concurrent-install
+// tests.
+func acquireLock(path string, timeout time.Duration) (*flock.Flock, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, conduiterr.Wrap(CodeInstallLocked, fmt.Sprintf("could not create lock directory for %q", path), err)
+	}
+
+	fl := flock.New(path)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	locked, err := fl.TryLockContext(ctx, lockPollInterval)
+	if err != nil || !locked {
+		return nil, conduiterr.New(CodeInstallLocked, fmt.Sprintf(
+			"could not acquire the install lock %q within %s", path, timeout))
+	}
+	return fl, nil
+}
+
+// TargetLockPath returns the per-connector-name lock file path.
+func TargetLockPath(connectorsPath, name string) string {
+	return filepath.Join(locksDirPath(connectorsPath), name+".lock")
+}
+
+// ManifestLockPath returns the short-held global lock file guarding
+// manifest.json's read-modify-write critical section.
+func ManifestLockPath(connectorsPath string) string {
+	return filepath.Join(locksDirPath(connectorsPath), ".manifest.lock")
+}
+
+// AcquireTargetLock acquires the per-connector-name install lock,
+// serializing the FULL pipeline (download through manifest write) for two
+// concurrent installs of the SAME connector name. Callers must Unlock the
+// returned lock on every exit path (defer immediately after a successful
+// call).
+func AcquireTargetLock(connectorsPath, name string, timeout time.Duration) (*flock.Flock, error) {
+	return acquireLock(TargetLockPath(connectorsPath, name), timeout)
+}
+
+// AcquireManifestLock acquires the short-held global manifest lock —
+// required IN ADDITION to the per-target lock, because two installs of
+// DIFFERENT connector names never contend on separate TargetLocks at all,
+// but still share one manifest.json. Hold this only around the
+// read-modify-write of manifest.json, never for the whole install pipeline.
+func AcquireManifestLock(connectorsPath string, timeout time.Duration) (*flock.Flock, error) {
+	return acquireLock(ManifestLockPath(connectorsPath), timeout)
+}

--- a/pkg/registry/lock_test.go
+++ b/pkg/registry/lock_test.go
@@ -1,0 +1,87 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry"
+)
+
+func TestAcquireTargetLock_SecondWaiterBlocksThenSucceeds(t *testing.T) {
+	dir := t.TempDir()
+
+	lock1, err := registry.AcquireTargetLock(dir, "postgres", time.Second)
+	require.NoError(t, err)
+
+	var mu sync.Mutex
+	acquired := false
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		lock2, err := registry.AcquireTargetLock(dir, "postgres", 2*time.Second)
+		require.NoError(t, err)
+		mu.Lock()
+		acquired = true
+		mu.Unlock()
+		_ = lock2.Unlock()
+	}()
+
+	// The second acquire must not have succeeded immediately.
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	assert.False(t, acquired, "second lock acquired before the first was released")
+	mu.Unlock()
+
+	require.NoError(t, lock1.Unlock())
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.True(t, acquired)
+}
+
+func TestAcquireTargetLock_TimesOut(t *testing.T) {
+	dir := t.TempDir()
+
+	lock1, err := registry.AcquireTargetLock(dir, "postgres", time.Second)
+	require.NoError(t, err)
+	defer func() { _ = lock1.Unlock() }()
+
+	_, err = registry.AcquireTargetLock(dir, "postgres", 100*time.Millisecond)
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeInstallLocked, ce.Code)
+}
+
+func TestAcquireTargetLock_DifferentNamesDoNotContend(t *testing.T) {
+	dir := t.TempDir()
+
+	lockA, err := registry.AcquireTargetLock(dir, "postgres", time.Second)
+	require.NoError(t, err)
+	defer func() { _ = lockA.Unlock() }()
+
+	lockB, err := registry.AcquireTargetLock(dir, "kafka", time.Second)
+	require.NoError(t, err)
+	defer func() { _ = lockB.Unlock() }()
+}

--- a/pkg/registry/nofollow_unix.go
+++ b/pkg/registry/nofollow_unix.go
@@ -1,0 +1,51 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unix
+
+package registry
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+)
+
+// openRegularNoFollow opens path with O_NOFOLLOW so a symlink present at
+// this name is refused (ELOOP) rather than silently followed, then confirms
+// via fstat on the resulting fd that the resolved file is an ordinary
+// regular file. See install.go's call site for exactly what risk this
+// closes (the final install rename) and what it does NOT claim to do
+// (re-verify the artifact's trust — that already happened, over an
+// in-memory digest, before extraction ever ran).
+//
+// The returned *os.File is open; the caller is responsible for closing it.
+func openRegularNoFollow(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, conduiterr.Wrap(CodeArchiveInvalid,
+			"could not safely open the extracted binary (possible symlink substitution)", err)
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, conduiterr.Wrap(CodeArchiveInvalid, "could not stat the extracted binary", err)
+	}
+	if !fi.Mode().IsRegular() {
+		f.Close()
+		return nil, conduiterr.New(CodeArchiveInvalid, "extracted binary is not a regular file")
+	}
+	return f, nil
+}

--- a/pkg/registry/nofollow_unix_test.go
+++ b/pkg/registry/nofollow_unix_test.go
@@ -1,0 +1,70 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unix
+
+// This is an internal (package registry, not registry_test) test file
+// specifically because openRegularNoFollow is unexported — it is install.go's
+// last line of defense right before the final install rename, and the
+// property under test (an actual symlink AT THE EXPECTED PATH is refused,
+// not just a symlink tar entry refused earlier by ExtractBinary) has no
+// other way to reach it from outside the package.
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+)
+
+func TestOpenRegularNoFollow_RegularFileSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "binary")
+	require.NoError(t, os.WriteFile(path, []byte("content"), 0o755))
+
+	f, err := openRegularNoFollow(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	data := make([]byte, len("content"))
+	n, err := f.Read(data)
+	require.NoError(t, err)
+	assert.Equal(t, "content", string(data[:n]))
+}
+
+// TestOpenRegularNoFollow_SymlinkRefused is the direct proof of the TOCTOU
+// guard install.go's rename call site relies on: if something (e.g. a
+// symlink substituted into the staging directory between extraction and
+// the final rename) replaces the expected binary path with a symlink,
+// openRegularNoFollow must refuse it (ELOOP), not silently follow it to
+// whatever it points at.
+func TestOpenRegularNoFollow_SymlinkRefused(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target-outside")
+	require.NoError(t, os.WriteFile(target, []byte("attacker-controlled"), 0o644))
+
+	link := filepath.Join(dir, "binary")
+	require.NoError(t, os.Symlink(target, link))
+
+	_, err := openRegularNoFollow(link)
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, CodeArchiveInvalid, ce.Code)
+}

--- a/pkg/registry/nofollow_windows.go
+++ b/pkg/registry/nofollow_windows.go
@@ -1,0 +1,58 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package registry
+
+import (
+	"os"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+)
+
+// openRegularNoFollow is the Windows fallback for the unix build's
+// O_NOFOLLOW-based guard: the stdlib exposes no direct O_NOFOLLOW
+// equivalent on this platform. An Lstat-then-Open sequence is used instead.
+//
+// KNOWN, DOCUMENTED GAP: there is a window between the Lstat and the Open
+// during which a symlink could be swapped into path — weaker than the unix
+// build's single O_NOFOLLOW open, and deliberately not papered over as
+// equivalent. Windows is a supported OS in the registry index schema, so
+// this gap is called out explicitly in this package's failure-mode analysis
+// (see the PR description), not left as a silent assumption.
+func openRegularNoFollow(path string) (*os.File, error) {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return nil, conduiterr.Wrap(CodeArchiveInvalid, "could not stat the extracted binary", err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return nil, conduiterr.New(CodeArchiveInvalid, "extracted binary is a symlink, which is not permitted")
+	}
+
+	f, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, conduiterr.Wrap(CodeArchiveInvalid, "could not open the extracted binary", err)
+	}
+	fi2, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, conduiterr.Wrap(CodeArchiveInvalid, "could not stat the extracted binary", err)
+	}
+	if !fi2.Mode().IsRegular() {
+		f.Close()
+		return nil, conduiterr.New(CodeArchiveInvalid, "extracted binary is not a regular file")
+	}
+	return f, nil
+}

--- a/pkg/registry/paths.go
+++ b/pkg/registry/paths.go
@@ -1,0 +1,53 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import "path/filepath"
+
+// registryDirName is the dot-prefixed subdirectory of --connectors.path that
+// holds every registry-owned file: manifest.json, locks/, staging/, and
+// audit.jsonl. Dot-prefixed so pkg/plugin/connector/standalone/registry.go's
+// directory scanner — which already skips every directory entry outright,
+// not just dot-prefixed ones, then attempts to dispense every remaining
+// entry as a connector plugin binary — never treats this bookkeeping as a
+// candidate connector.
+const registryDirName = ".registry"
+
+// registryDir returns <connectorsPath>/.registry.
+func registryDir(connectorsPath string) string {
+	return filepath.Join(connectorsPath, registryDirName)
+}
+
+// manifestPath returns <connectorsPath>/.registry/manifest.json.
+func manifestPath(connectorsPath string) string {
+	return filepath.Join(registryDir(connectorsPath), "manifest.json")
+}
+
+// auditLogPath returns <connectorsPath>/.registry/audit.jsonl.
+func auditLogPath(connectorsPath string) string {
+	return filepath.Join(registryDir(connectorsPath), "audit.jsonl")
+}
+
+// stagingRootPath returns <connectorsPath>/.registry/staging — the parent
+// of every per-install staging directory (install.go creates one temp
+// subdirectory per Install call via os.MkdirTemp under this root).
+func stagingRootPath(connectorsPath string) string {
+	return filepath.Join(registryDir(connectorsPath), "staging")
+}
+
+// locksDirPath returns <connectorsPath>/.registry/locks.
+func locksDirPath(connectorsPath string) string {
+	return filepath.Join(registryDir(connectorsPath), "locks")
+}

--- a/pkg/registry/platform.go
+++ b/pkg/registry/platform.go
@@ -1,0 +1,65 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry/index"
+)
+
+// StandaloneArtifactKind is the only artifact kind this install pipeline
+// knows how to install. A future kind (e.g. a WASM processor-shaped
+// artifact) is skipped, not treated as an error, by SelectArtifact — an
+// unrecognized kind refuses gracefully via "no matching artifact", never a
+// crash.
+const StandaloneArtifactKind = "standalone"
+
+// SelectArtifact finds the artifact in v matching the exact (goos, goarch)
+// pair among StandaloneArtifactKind entries. No match refuses with
+// CodeNoPlatformArtifact, listing the (os, arch) pairs that DO exist for
+// this version so the operator/agent knows what is actually available
+// rather than just "not found".
+func SelectArtifact(connName string, v index.ConnectorVersion, goos, goarch string) (*index.Artifact, error) {
+	for i := range v.Artifacts {
+		a := v.Artifacts[i]
+		if a.Kind != StandaloneArtifactKind {
+			continue
+		}
+		if a.OS == goos && a.Arch == goarch {
+			return &a, nil
+		}
+	}
+
+	var available []string
+	for _, a := range v.Artifacts {
+		if a.Kind == StandaloneArtifactKind {
+			available = append(available, a.OS+"/"+a.Arch)
+		}
+	}
+	sort.Strings(available)
+
+	err := conduiterr.New(CodeNoPlatformArtifact, fmt.Sprintf(
+		"connector %q version %s has no standalone artifact for %s/%s", connName, v.Version, goos, goarch))
+	if len(available) > 0 {
+		err.Suggestion = "available platforms for this version: " + strings.Join(available, ", ")
+	} else {
+		err.Suggestion = "this version has no standalone artifacts for any platform"
+	}
+	return nil, err
+}

--- a/pkg/registry/platform_test.go
+++ b/pkg/registry/platform_test.go
@@ -1,0 +1,69 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry"
+	"github.com/conduitio/conduit/pkg/registry/index"
+)
+
+func TestSelectArtifact_Match(t *testing.T) {
+	v := index.ConnectorVersion{
+		Version: "0.14.1",
+		Artifacts: []index.Artifact{
+			{OS: "linux", Arch: "amd64", Kind: "standalone", URL: "http://x/linux"},
+			{OS: "darwin", Arch: "arm64", Kind: "standalone", URL: "http://x/darwin"},
+		},
+	}
+	a, err := registry.SelectArtifact("postgres", v, "darwin", "arm64")
+	require.NoError(t, err)
+	assert.Equal(t, "http://x/darwin", a.URL)
+}
+
+func TestSelectArtifact_NoMatchListsAvailable(t *testing.T) {
+	v := index.ConnectorVersion{
+		Version: "0.14.1",
+		Artifacts: []index.Artifact{
+			{OS: "linux", Arch: "amd64", Kind: "standalone", URL: "http://x/linux"},
+		},
+	}
+	_, err := registry.SelectArtifact("postgres", v, "windows", "amd64")
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeNoPlatformArtifact, ce.Code)
+	assert.Contains(t, ce.Suggestion, "linux/amd64")
+}
+
+func TestSelectArtifact_UnrecognizedKindSkippedGracefully(t *testing.T) {
+	v := index.ConnectorVersion{
+		Version: "0.14.1",
+		Artifacts: []index.Artifact{
+			{OS: "linux", Arch: "amd64", Kind: "wasm", URL: "http://x/wasm"},
+		},
+	}
+	_, err := registry.SelectArtifact("postgres", v, "linux", "amd64")
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeNoPlatformArtifact, ce.Code)
+	assert.Contains(t, ce.Suggestion, "no standalone artifacts")
+}

--- a/pkg/registry/resolve.go
+++ b/pkg/registry/resolve.go
@@ -1,0 +1,215 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry/index"
+	"github.com/conduitio/conduit/pkg/registry/trust"
+)
+
+// ResolveOptions is Resolve's input: which connector, which version (or
+// none, for newest-compatible), and the running build's own versions to
+// check compatibility against.
+type ResolveOptions struct {
+	// Name is looked up by EXACT match only — plan-v2/the design doc's
+	// explicit anti-typosquat stance: a near-miss name (e.g. "postgress")
+	// is CodeConnectorNotFound, never a fuzzy suggestion toward "postgres".
+	Name string
+	// Version is a version constraint string ("0.14.1" or "v0.14.1",
+	// compared via NormalizeVersion — never raw string equality). Empty
+	// means "newest version compatible with RunningConduitVersion/
+	// RunningProtocolVersion".
+	Version string
+
+	// RunningConduitVersion/RunningProtocolVersion are compared against
+	// each candidate ConnectorVersion's MinConduitVersion/
+	// MinProtocolVersion. A value that does not parse as semver (e.g. Go's
+	// own "development" build-info fallback for a locally built binary) is
+	// treated as satisfying every compatibility check — a local dev build
+	// must not hard-refuse every install just because it has no embedded
+	// version.
+	RunningConduitVersion  string
+	RunningProtocolVersion string
+}
+
+// ResolvedVersion bundles what platform selection and the rest of the
+// install pipeline need together: the connector (for its Publisher identity
+// pin and Name) and the one ConnectorVersion that was selected.
+type ResolvedVersion struct {
+	Connector index.Connector
+	Version   index.ConnectorVersion
+}
+
+// Resolve finds the connector named opts.Name in payload and selects one of
+// its versions per opts.Version (exact match) or, if empty, the newest
+// version compatible with the running build. It refuses (with a specific,
+// coded reason) a connector whose publisher identity has been revoked, a
+// pinned version that has been yanked, and an explicit version pin that is
+// incompatible with the running Conduit/protocol version — but does NOT
+// refuse a deprecated version (deprecated is a soft, informational flag,
+// not a trust or safety state; see ResolvedVersion.Version.Deprecated,
+// surfaced by the caller in --json/output). This mirrors the frozen index
+// schema's own modeling: schemaVersion the parser is strict; deprecated is
+// documented as orthogonal to trust, and no error code exists in the
+// canonical table (plan-v2 §4) for refusing on it.
+//
+// Resolve never mutates payload and performs no I/O — it is a pure function
+// over an already-fetched (and, in a real build, already-verified) index.
+func Resolve(payload index.Payload, opts ResolveOptions) (*ResolvedVersion, error) {
+	conn, err := findConnector(payload, opts.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	if conn.Publisher.Revoked != nil {
+		err := conduiterr.New(trust.CodeIdentityRevoked, fmt.Sprintf(
+			"connector %q's publisher identity has been revoked: %s", opts.Name, conn.Publisher.Revoked.Reason))
+		err.Suggestion = "every version of this connector is refused regardless of individual yank status; see the registry security advisory referenced in the revocation reason"
+		return nil, err
+	}
+
+	if opts.Version != "" {
+		return resolveExact(conn, opts)
+	}
+	return resolveNewestCompatible(conn, opts)
+}
+
+// findConnector does the exact-match name lookup. No Levenshtein/fuzzy
+// suggestion is computed here, deliberately: a first registration is the
+// one place typosquatting has no cryptographic backstop (plan-v2 §10), so
+// this pipeline must never nudge a typo toward an existing name.
+func findConnector(payload index.Payload, name string) (*index.Connector, error) {
+	for i := range payload.Connectors {
+		if payload.Connectors[i].Name == name {
+			return &payload.Connectors[i], nil
+		}
+	}
+	err := conduiterr.New(CodeConnectorNotFound, fmt.Sprintf(
+		"connector %q not found in the registry index", name))
+	err.Suggestion = "check the exact spelling — this is an exact-match lookup with no fuzzy suggestion, by design"
+	return nil, err
+}
+
+func resolveExact(conn *index.Connector, opts ResolveOptions) (*ResolvedVersion, error) {
+	wantV, err := NormalizeVersion(opts.Version)
+	if err != nil {
+		return nil, conduiterr.Wrap(CodeVersionNotFound,
+			fmt.Sprintf("connector %q: %q is not a valid version", conn.Name, opts.Version), err)
+	}
+
+	for i := range conn.Versions {
+		v := conn.Versions[i]
+		gotV, err := NormalizeVersion(v.Version)
+		if err != nil {
+			continue // a malformed index entry; skip defensively rather than fail the whole resolution
+		}
+		if !gotV.Equal(wantV) {
+			continue
+		}
+
+		if v.Yanked != nil {
+			e := conduiterr.New(index.CodeVersionYanked, fmt.Sprintf(
+				"connector %q version %s was yanked: %s", conn.Name, v.Version, v.Yanked.Reason))
+			e.Suggestion = "install a different version, or omit @version to auto-select the newest non-yanked, compatible one"
+			return nil, e
+		}
+		if err := checkCompatible(conn.Name, v, opts); err != nil {
+			return nil, err
+		}
+		return &ResolvedVersion{Connector: *conn, Version: v}, nil
+	}
+
+	return nil, conduiterr.New(CodeVersionNotFound, fmt.Sprintf(
+		"connector %q has no version %q in the registry index", conn.Name, opts.Version))
+}
+
+func resolveNewestCompatible(conn *index.Connector, opts ResolveOptions) (*ResolvedVersion, error) {
+	versions := append([]index.ConnectorVersion(nil), conn.Versions...)
+	sort.Slice(versions, func(i, j int) bool {
+		vi, ei := NormalizeVersion(versions[i].Version)
+		vj, ej := NormalizeVersion(versions[j].Version)
+		if ei != nil || ej != nil {
+			return false // malformed entries: leave relative order alone rather than guess
+		}
+		return vi.GreaterThan(vj) // descending: newest first
+	})
+
+	for _, v := range versions {
+		if v.Yanked != nil {
+			continue // never auto-select a yanked version
+		}
+		if err := checkCompatible(conn.Name, v, opts); err != nil {
+			continue // not compatible with the running build; try the next-newest
+		}
+		return &ResolvedVersion{Connector: *conn, Version: v}, nil
+	}
+
+	err := conduiterr.New(CodeIncompatibleVersion, fmt.Sprintf(
+		"no version of %q is compatible with the running Conduit (conduit %s, protocol %s)",
+		conn.Name, opts.RunningConduitVersion, opts.RunningProtocolVersion))
+	err.Suggestion = "upgrade Conduit, or pin an older @version explicitly if you know one is compatible"
+	return nil, err
+}
+
+// checkCompatible refuses a candidate version whose MinConduitVersion or
+// MinProtocolVersion exceeds the running build's own versions.
+func checkCompatible(name string, v index.ConnectorVersion, opts ResolveOptions) error {
+	if err := checkMinVersion("minConduitVersion", v.MinConduitVersion, opts.RunningConduitVersion); err != nil {
+		return newIncompatibleError(name, v, opts)
+	}
+	if err := checkMinVersion("minProtocolVersion", v.MinProtocolVersion, opts.RunningProtocolVersion); err != nil {
+		return newIncompatibleError(name, v, opts)
+	}
+	return nil
+}
+
+// checkMinVersion reports whether running satisfies >= minVer. An
+// unparsable running version (e.g. "development") is treated as satisfying
+// every check — see ResolveOptions's doc for why.
+func checkMinVersion(label, minVer, running string) error {
+	minV, err := NormalizeVersion(minVer)
+	if err != nil {
+		return fmt.Errorf("index entry has an invalid %s %q: %w", label, minVer, err)
+	}
+	runV, err := NormalizeVersion(running)
+	if err != nil {
+		return nil // unparsable running version (dev build): treat as compatible
+	}
+	if runV.LessThan(minV) {
+		return fmt.Errorf("%s %s not satisfied by running %s", label, minVer, running)
+	}
+	return nil
+}
+
+// newIncompatibleError builds the actionable CodeIncompatibleVersion error:
+// required vs. running versions, plus a concrete fix suggestion — per the
+// CLAUDE.md "errors are API" convention (a stable code, the failing
+// config-shaped fact, and a suggested fix). Returns error (not the
+// concrete *conduiterr.ConduitError type) per this codebase's forbidigo
+// convention — the type is reached via New/Wrap, never named directly
+// outside the conduiterr package.
+func newIncompatibleError(name string, v index.ConnectorVersion, opts ResolveOptions) error {
+	err := conduiterr.New(CodeIncompatibleVersion, fmt.Sprintf(
+		"connector %q version %s requires Conduit >= %s and protocol >= %s; running Conduit %s, protocol %s",
+		name, v.Version, v.MinConduitVersion, v.MinProtocolVersion, opts.RunningConduitVersion, opts.RunningProtocolVersion))
+	err.Suggestion = fmt.Sprintf(
+		"upgrade Conduit to >= %s, or install an older %s version compatible with your running Conduit (omit @version to auto-select one)",
+		v.MinConduitVersion, name)
+	return err
+}

--- a/pkg/registry/resolve_test.go
+++ b/pkg/registry/resolve_test.go
@@ -1,0 +1,184 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry"
+	"github.com/conduitio/conduit/pkg/registry/index"
+	"github.com/conduitio/conduit/pkg/registry/trust"
+)
+
+func testPayload() index.Payload {
+	return index.Payload{
+		SchemaVersion: 1,
+		Index:         index.IndexMeta{Version: 42, Timestamp: time.Now()},
+		Connectors: []index.Connector{
+			{
+				Name: "postgres",
+				Publisher: index.Publisher{
+					ExpectedOIDCIssuer:      "https://token.actions.githubusercontent.com",
+					ExpectedIdentityPattern: "^https://github\\.com/ConduitIO/conduit-connector-postgres/.*$",
+				},
+				Versions: []index.ConnectorVersion{
+					{
+						Version: "0.14.0", MinConduitVersion: "0.14.0", MinProtocolVersion: "0.14.0",
+						Artifacts: []index.Artifact{{OS: "linux", Arch: "amd64", Kind: "standalone", URL: "http://example/pg-0.14.0.tar.gz", SHA256: "aa"}},
+						Yanked:    &index.YankReason{Reason: "regression drops the WAL replication slot"},
+					},
+					{
+						Version: "0.14.1", MinConduitVersion: "0.14.0", MinProtocolVersion: "0.14.0",
+						Artifacts: []index.Artifact{{OS: "linux", Arch: "amd64", Kind: "standalone", URL: "http://example/pg-0.14.1.tar.gz", SHA256: "bb"}},
+					},
+					{
+						Version: "0.15.0", MinConduitVersion: "99.0.0", MinProtocolVersion: "99.0.0", // future, incompatible
+						Artifacts: []index.Artifact{{OS: "linux", Arch: "amd64", Kind: "standalone", URL: "http://example/pg-0.15.0.tar.gz", SHA256: "cc"}},
+					},
+					{
+						Version: "0.13.0", MinConduitVersion: "0.13.0", MinProtocolVersion: "0.13.0",
+						Deprecated: true,
+						Artifacts:  []index.Artifact{{OS: "linux", Arch: "amd64", Kind: "standalone", URL: "http://example/pg-0.13.0.tar.gz", SHA256: "dd"}},
+					},
+				},
+			},
+			{
+				Name: "revoked-sink",
+				Publisher: index.Publisher{
+					ExpectedOIDCIssuer:      "https://token.actions.githubusercontent.com",
+					ExpectedIdentityPattern: "^https://github\\.com/example/revoked-sink/.*$",
+					Revoked:                 &index.Revocation{Reason: "leaked GITHUB_TOKEN"},
+				},
+				Versions: []index.ConnectorVersion{
+					{Version: "1.0.0", MinConduitVersion: "0.1.0", MinProtocolVersion: "0.1.0"},
+				},
+			},
+		},
+	}
+}
+
+func TestResolve_ExactMatchNoFuzzy(t *testing.T) {
+	_, err := registry.Resolve(testPayload(), registry.ResolveOptions{
+		Name: "postgrez", RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeConnectorNotFound, ce.Code)
+	// Never suggests the near-miss name "postgres" as a fix for the typo
+	// "postgrez" — the anti-typosquat stance (plan-v2 §10): a first
+	// registration is the one place a near-miss name has no cryptographic
+	// backstop, so this lookup must never nudge a typo toward an existing
+	// name.
+	assert.NotContains(t, ce.Suggestion, "postgres")
+}
+
+func TestResolve_NewestCompatible(t *testing.T) {
+	rv, err := registry.Resolve(testPayload(), registry.ResolveOptions{
+		Name: "postgres", RunningConduitVersion: "0.14.0", RunningProtocolVersion: "0.14.0",
+	})
+	require.NoError(t, err)
+	// 0.15.0 is newer but incompatible; 0.14.0 is newer than 0.13.0 but
+	// yanked — 0.14.1 is the newest that is both non-yanked and compatible.
+	assert.Equal(t, "0.14.1", rv.Version.Version)
+}
+
+func TestResolve_NeverAutoSelectsYanked(t *testing.T) {
+	// Even with a running version that would make 0.14.0 "newest", it must
+	// never be auto-selected because it is yanked.
+	rv, err := registry.Resolve(testPayload(), registry.ResolveOptions{
+		Name: "postgres", RunningConduitVersion: "0.14.0", RunningProtocolVersion: "0.14.0",
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, "0.14.0", rv.Version.Version)
+}
+
+func TestResolve_ExactYankedRefuses(t *testing.T) {
+	_, err := registry.Resolve(testPayload(), registry.ResolveOptions{
+		Name: "postgres", Version: "0.14.0", RunningConduitVersion: "0.14.0", RunningProtocolVersion: "0.14.0",
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, index.CodeVersionYanked, ce.Code)
+	assert.Contains(t, ce.Message, "WAL replication slot")
+}
+
+func TestResolve_ExactVersionNotFound(t *testing.T) {
+	_, err := registry.Resolve(testPayload(), registry.ResolveOptions{
+		Name: "postgres", Version: "9.9.9", RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeVersionNotFound, ce.Code)
+}
+
+func TestResolve_ExactIncompatiblePin(t *testing.T) {
+	_, err := registry.Resolve(testPayload(), registry.ResolveOptions{
+		Name: "postgres", Version: "0.15.0", RunningConduitVersion: "0.14.0", RunningProtocolVersion: "0.14.0",
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeIncompatibleVersion, ce.Code)
+	assert.Contains(t, ce.Message, "99.0.0")
+	assert.Contains(t, ce.Message, "0.14.0")
+}
+
+func TestResolve_LeadingVTolerant(t *testing.T) {
+	rv, err := registry.Resolve(testPayload(), registry.ResolveOptions{
+		Name: "postgres", Version: "v0.14.1", RunningConduitVersion: "0.14.0", RunningProtocolVersion: "0.14.0",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "0.14.1", rv.Version.Version)
+}
+
+func TestResolve_RevokedPublisherRefusesEveryVersion(t *testing.T) {
+	_, err := registry.Resolve(testPayload(), registry.ResolveOptions{
+		Name: "revoked-sink", RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, trust.CodeIdentityRevoked, ce.Code)
+	assert.Contains(t, ce.Message, "leaked GITHUB_TOKEN")
+}
+
+func TestResolve_DevBuildSkipsCompatibilityCheck(t *testing.T) {
+	// "development" (Go's own fallback for a locally built binary with no
+	// embedded semver) must not hard-refuse every install.
+	rv, err := registry.Resolve(testPayload(), registry.ResolveOptions{
+		Name: "postgres", Version: "0.15.0", RunningConduitVersion: "development", RunningProtocolVersion: "development",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "0.15.0", rv.Version.Version)
+}
+
+func TestResolve_DeprecatedIsNotRefused(t *testing.T) {
+	// Deprecated is a soft, informational flag (plan-v2 §7) — never a
+	// refusal reason, and no error code exists for it in the canonical
+	// table.
+	rv, err := registry.Resolve(testPayload(), registry.ResolveOptions{
+		Name: "postgres", Version: "0.13.0", RunningConduitVersion: "0.13.0", RunningProtocolVersion: "0.13.0",
+	})
+	require.NoError(t, err)
+	assert.True(t, rv.Version.Deprecated)
+}


### PR DESCRIPTION
## Summary

**Tier: 2** (Features) — ships no working signature verification and cannot, by
construction, install anything as trusted by default (see below). The *feature*
"verified connector install" is Tier-1-adjacent; that bar is met by PR-2 (trust
core), not here.

Implements PR-1 ("install core") of the connector-registry MVP
(`docs/design-documents/20260713-connector-registry-mvp.md`, plan-v2 §7/§14),
building on PR-0's shared foundations (#2652): index types, the
`IndexVerifier`/`ArtifactVerifier` seam + `FailClosedVerifier`, the
`name@version` manifest, the canonical error table, `NormalizeVersion`,
`boundedfetch`, and `policy.Decide`.

### The install pipeline (`pkg/registry/install.go`)

1. Fetch + shape-check the index (`IndexVerifier.VerifyIndex`) — real crypto
   lands in PR-2; `FailClosedVerifier` here does `ParseUnverified` only.
2. Resolve `<name>[@version]` (`resolve.go`): exact-match name lookup, no
   fuzzy/Levenshtein suggestion (anti-typosquat); newest-compatible version
   selection when `@version` is omitted, via `NormalizeVersion` throughout;
   refuses a revoked publisher (`trust.CodeIdentityRevoked`, reused from PR-0)
   and a yanked version (`index.CodeVersionYanked`, reused from PR-0) with the
   reason from the index; an incompatible explicit `@version` pin gets an
   actionable error naming required-vs-running versions plus a fix suggestion.
   **Deprecated is a soft flag, never a refusal** — no code exists for it in
   the canonical table, and plan-v2 §7 explicitly treats it as orthogonal to
   trust; flagged below as a deviation from this task's literal wording.
3. Select the host `(os, arch)` artifact (`platform.go`) — no match lists the
   platforms that do exist; an unrecognized future `kind` (e.g. wasm) is
   skipped gracefully, never a crash.
4. Download (`download.go`) into a per-install staging directory that is a
   **subdirectory of `--connectors.path`** (never the OS temp dir — required
   for the final `os.Rename` to be atomic and same-filesystem), streamed with
   an incremental sha256 and a bounded redirect chain.
5. sha256 corruption check (`corruption.go`) — integrity, explicitly not
   trust — run first and separately from the verification gate.
6. **The verification gate**: fetches the signature/provenance bundles
   (bounded, `boundedfetch`) and calls `ArtifactVerifier.VerifyArtifact` with
   the in-memory digest (never a path) and the connector's `PinnedIdentity`.
   With the production `FailClosedVerifier`, this **always** returns
   `ErrVerificationNotConfigured` — nothing below this line executes in a
   normal build.
7. Extract (`extract.go`: path-traversal/symlink/hardlink refused, exactly
   one root-level regular file required) → an `O_NOFOLLOW`-guarded open
   (`nofollow_unix.go`/`nofollow_windows.go`) → atomic `os.Rename`.
8. Manifest write (`name@version`-keyed, under a short-held global manifest
   lock) → append-only audit event — **both only after the rename succeeds**.

### CLI (`cmd/conduit/root/connectors/install.go`)

`conduit connectors install <name>[@version]`, an offline
`cecdysis.CommandWithResult` command (mirrors `doctor`/`repair`, not the
gRPC-client pattern), `--json` on every path, `--index-url`/`--index-file`
(offline mode)/`--lock-timeout`/`--dry-run`. This is the **one production
call site**: it passes `registry.FailClosedVerifier{}` for both
`IndexVerifier` and `ArtifactVerifier`, explicitly and visibly — no flag or
config value anywhere changes this.

## Fail-closed-by-construction property (the AC-6 test)

- `pkg/registry/install_test.go:TestInstall_FailClosedByConstruction` — the
  real production wiring (`FailClosedVerifier` for both verifiers) refuses
  every attempt with `registry.verification_unavailable`, and leaves nothing
  resembling a connector binary under `--connectors.path`.
- `cmd/conduit/root/connectors/install_test.go:TestInstall_FailClosedByConstruction_JSON`
  — the same property through the real cobra command + `--json` envelope,
  after actually resolving/downloading/corruption-checking a real fixture
  artifact (proving the pipeline runs end-to-end up to the gate, not that it
  short-circuits early).
- The full non-crypto pipeline (resolve → download → stage → sha256 →
  extract → rename → manifest → audit) is exercised by
  `TestInstall_FullPipeline` via a test-only `passThroughVerifier`, injected
  through the exact same `InstallOptions.IndexVerifier`/`ArtifactVerifier`
  fields the real command uses for `FailClosedVerifier` — never a separate
  code path.

## Chaos / concurrency tests

- `TestInstall_ChaosKill` (4 injection points: download-complete,
  extract-complete, prerename-fd-opened, post-rename-pre-manifest): a real
  subprocess (`os/exec`) re-execs the test binary, which calls `os.Exit(137)`
  at the selected point — no deferred cleanup runs, exactly like a real
  `kill -9`. After each kill: the installed binary is either absent or fully
  present at its expected size (never truncated), and a subsequent install of
  the same target still succeeds (the killed process's `flock` doesn't wedge
  it).
- `TestInstall_ConcurrentSameName` (`-race`, 8 goroutines, same name):
  manifest ends up with exactly one entry, no corrupted read, every goroutine
  either succeeds or gets `registry.install_locked`.
- `TestInstall_ConcurrentDifferentNames` (`-race`): two different names
  install independently and concurrently; manifest ends up with two distinct
  entries, never corrupted.
- `TestOpenRegularNoFollow_SymlinkRefused` (`pkg/registry`, internal test):
  direct proof the `O_NOFOLLOW` guard refuses an actual symlink at the
  expected binary path, not just a symlink *tar entry* (which `ExtractBinary`
  already refuses at a different, earlier layer).

## Adversarial self-review findings

1. **TOCTOU / the `O_NOFOLLOW` nit** (plan-v2 §13): the guard fd opened right
   before the final rename protects **that rename**, from a symlink swapped
   into the extraction directory's binary name between `ExtractBinary`
   returning and `os.Rename` running — it does **not** re-verify the
   artifact's trust or contents. That already happened over `dl.Digest`, an
   in-memory digest computed directly from the downloaded bytes, never
   re-read from a path — stated explicitly in `install.go`'s
   `runVerificationGate`/`extractAndGuard` doc comments, not left vague.
2. **Audit-append failure after a successful rename+manifest write** returns
   a hard error and discards the `InstallResult`, even though the connector
   *is* correctly installed and manifested at that point. This is a
   considered trade-off (fail loud on an audit-log write failure, since the
   audit trail becomes a security-relevant property from PR-2 onward) but is
   a real UX rough edge: a caller doesn't get the digest/artifact-file back
   on this rare path. Flagging rather than silently accepting.
3. **Disk-full during staging/rename** is handled at the code level (every
   write returns a wrapped, coded error — no panic, no silent corruption) but
   is **not exercised by an automated test** — there's no portable, non-flaky
   way to simulate `ENOSPC` in this CI. Documented as a known gap, not
   claimed as tested.
4. **Different-name concurrent installs and the unlocked manifest read**:
   `lookupManifestEntry`'s "already installed" check reads the manifest
   *without* the manifest lock. This is safe: `atomicfile`'s temp+rename
   write means a concurrent reader only ever observes a fully-old or
   fully-new file (never torn), and the per-target lock already serializes
   every reader/writer pair for the *one* key a given install cares about —
   a concurrent write for a *different* name never touches that key.
5. **Deviation from this task's literal instruction** ("refuse
   yanked/revoked/**deprecated**"): implemented deprecated as a soft,
   non-refusing flag instead, per plan-v2 §7's explicit framing ("deprecated
   … orthogonal, not a trust state") and because no error code exists for it
   in the closed canonical table (inventing one would violate plan-v2's own
   coherence-fix discipline). `InstallResult.Deprecated`/`--json` surface it
   for the caller. Flagging this explicitly for confirmation rather than
   silently picking a side.

## Scope boundary kept (per mid-task scope reinforcement)

- **No trust/verification/crypto logic implemented.** `pkg/registry/trust` is
  referenced only for: `trust.PinnedIdentity` (a plain struct populated from
  index fields and handed to the verifier interface — pure wiring), and two
  **already-registered PR-0 codes** reused verbatim
  (`trust.CodeIdentityRevoked` for the plain-field publisher-revocation
  check, `trust.CodeBundleTooLarge` for a fetch-size-cap error). No signature/
  provenance/identity-checking behavior is implemented anywhere in this PR.
- **Zero new `conduiterr.Register` calls.** Every code this PR raises
  (`CodeConnectorNotFound`, `CodeVersionNotFound`, `CodeIncompatibleVersion`,
  `CodeNoPlatformArtifact`, `CodeCorruptDownload`, `CodeInstallLocked`,
  `CodeArchiveInvalid`, `CodeVerificationUnavailable`, `CodeDownloadFailed`,
  plus the reused `index.CodeVersionYanked`/`trust.CodeIdentityRevoked`/
  `trust.CodeBundleTooLarge`) already existed in PR-0's canonical table
  (`pkg/registry/codes.go`, `pkg/registry/index/codes.go`,
  `pkg/registry/trust/codes.go`) — confirmed by grep before implementation.
- **New dependency:** `gofrs/flock` promoted from indirect to direct
  (`go.mod`) — already vendored transitively, plan-justified for the
  per-target + manifest locks.

## Gate results

- `make build` — green.
- `make lint` (whole repo, golangci-lint) — 0 issues.
- `go test -race ./pkg/registry/... ./cmd/conduit/root/connectors/...` — all
  green, including the chaos and concurrent-install tests under `-race`.
- `go test -race ./cmd/...` (broader sanity check for the shared
  `connectors.go` wiring change) — all green.
- `go vet ./...` — clean except one pre-existing, unrelated warning in
  `pkg/lifecycle-poc/funnel` (confirmed untouched by this diff).

## Plan ambiguity flagged for DeVaris

The deprecated-version handling above (§5 in self-review) is the one place
this PR's literal task instruction and plan-v2's own text point in different
directions. Implemented per plan-v2 (the documented source of truth); please
confirm.

Roadmap: Phase 1, connector registry MVP. References PR-0 (#2652).

🤖 Generated with [Claude Code](https://claude.com/claude-code)