### PR TITLE
feat(registry): connector lifecycle — uninstall/list/audit + offline bundle (PR-4)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,6 +56,13 @@ linters:
         PolicyBypass:
           files:
             - "!**/pkg/registry/install.go"
+            # bundle.go is the second (and, as of PR-4, only other)
+            # sanctioned call site: it calls policy.DecideStaleBundle for
+            # the --allow-stale-bundle gate (plan-v2/step5 §7 step 3,
+            # gated exactly like --allow-unsigned per DeVaris's
+            # ratification) the same way install.go calls policy.Decide for
+            # --allow-unsigned.
+            - "!**/pkg/registry/bundle.go"
             - "!**/pkg/registry/policy/**"
             # Test files may import policy to assert against its exported
             # Code*/Decision types (the "confirms wiring" test pattern,

--- a/cmd/conduit/root/connectors/audit.go
+++ b/cmd/conduit/root/connectors/audit.go
@@ -1,0 +1,218 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectors
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/pkg/conduit"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/registry"
+	"github.com/conduitio/ecdysis"
+)
+
+var (
+	_ ecdysis.CommandWithFlags           = (*AuditCommand)(nil)
+	_ ecdysis.CommandWithConfig          = (*AuditCommand)(nil)
+	_ ecdysis.CommandWithDocs            = (*AuditCommand)(nil)
+	_ cecdysis.CommandWithResult         = (*AuditCommand)(nil)
+	_ cecdysis.CommandWithResultExitCode = (*AuditCommand)(nil)
+)
+
+// AuditFlags embeds conduit.Config for --connectors.path, matching every
+// other registry command.
+type AuditFlags struct {
+	conduit.Config
+
+	IndexURL     string        `long:"index-url" usage:"registry index URL"`
+	IndexFile    string        `long:"index-file" usage:"read the index from a local file instead of --index-url (offline mode)"`
+	MaxStaleness time.Duration `long:"max-staleness" usage:"maximum age of a verified registry index before it is considered stale"`
+}
+
+// AuditCommand implements `conduit connectors audit`. Like InstallCommand,
+// this is an offline command that never dials the running Conduit API — it
+// re-fetches and re-verifies the registry index directly, via the exact
+// same registry.TrustedVerifier install.go wires in, then checks every
+// installed connector against it. See pkg/registry/connectoraudit.go's
+// package doc for the full rationale ("audit reuses PR-2's verification
+// exactly — no lower-trust shortcut").
+type AuditCommand struct {
+	flags AuditFlags
+	Cfg   conduit.Config
+}
+
+func (c *AuditCommand) Usage() string { return "audit" }
+
+func (c *AuditCommand) Docs() ecdysis.Docs {
+	return ecdysis.Docs{
+		Short: "Re-verify every installed connector against the current registry index",
+		Long: `audit protects ALREADY-installed connectors: install-time refusal only stops a new
+bad install, but a connector installed last month whose version is yanked next week, or whose
+publisher is revoked, keeps running silently until something re-checks it. audit is that
+re-check — it re-fetches and re-verifies the signed index (identical to install's own
+verification pipeline; there is no lower-trust "audit-only" fetch path) and reports, per
+installed connector: YANKED_VERSION or REVOKED_PUBLISHER (registry-trust findings, Fail),
+DELISTED or UNKNOWN_VERSION (Warn), and the independent local-integrity checks
+MISSING_ARTIFACT/DRIFTED (Warn).
+
+An index that cannot be fetched or cryptographically verified fails the WHOLE run — never a
+per-connector finding, since an audit result built on an unverified index can't be trusted at
+all. This is intentionally distinct from "all clean": check the reported error code.
+
+Exit codes (via the ConduitError's registered category, worst finding wins):
+  0  every installed connector passed
+  1  internal error, or an index-integrity/tampering failure
+  2  a Fail finding was a validation-class registry refusal (e.g. a yanked version)
+  3  the index was unreachable, or a Fail finding was an environment-class refusal (e.g. a revoked publisher)`,
+		Example: "conduit connectors audit\nconduit connectors audit --json",
+	}
+}
+
+func (c *AuditCommand) Flags() []ecdysis.Flag {
+	flags := ecdysis.BuildFlags(&c.flags)
+
+	currentPath, err := os.Getwd()
+	if err != nil {
+		panic(cerrors.Errorf("failed to get current working directory: %w", err))
+	}
+	c.Cfg = conduit.DefaultConfigWithBasePath(currentPath)
+	flags.SetDefault("config.path", c.Cfg.ConduitCfg.Path)
+	flags.SetDefault("connectors.path", c.Cfg.Connectors.Path)
+	flags.SetDefault("index-url", registry.DefaultIndexURL)
+	flags.SetDefault("max-staleness", c.Cfg.Install.MaxStaleness)
+
+	return flags
+}
+
+func (c *AuditCommand) Config() ecdysis.Config {
+	path := filepath.Dir(c.flags.ConduitCfg.Path)
+	return ecdysis.Config{
+		EnvPrefix:     envPrefix,
+		Parsed:        &c.Cfg,
+		Path:          c.flags.ConduitCfg.Path,
+		DefaultValues: conduit.DefaultConfigWithBasePath(path),
+	}
+}
+
+func (c *AuditCommand) ResultCommand() string { return "connectors.audit" }
+
+// auditResult is Outcome.Result's concrete shape (mirrors doctorResult's
+// pattern in cmd/conduit/root/doctor/doctor.go): both --json and ExitCode
+// see the same data Render does.
+type auditResult struct {
+	Findings []registry.AuditResultEntry `json:"findings"`
+}
+
+func (c *AuditCommand) ExecuteWithResult(ctx context.Context) (cecdysis.Outcome, error) {
+	maxStaleness := c.flags.MaxStaleness
+	if maxStaleness == 0 {
+		maxStaleness = c.Cfg.Install.MaxStaleness
+	}
+
+	verifier := &registry.TrustedVerifier{
+		Anchors:      defaultTrustAnchors,
+		StatePath:    registry.IndexStatePath(c.Cfg.Connectors.Path),
+		MaxStaleness: maxStaleness,
+	}
+
+	report, err := registry.RunAudit(ctx, registry.AuditOptions{
+		ConnectorsPath: c.Cfg.Connectors.Path,
+		IndexURL:       c.flags.IndexURL,
+		IndexFile:      c.flags.IndexFile,
+		IndexVerifier:  verifier,
+	})
+	if err != nil {
+		// A hard index-verification failure (unreachable, tampered, stale,
+		// rollback) — never folded into a per-connector finding. See
+		// RunAudit's doc comment.
+		return cecdysis.Outcome{}, err
+	}
+
+	ok := true
+	for _, f := range report.Findings {
+		if f.Status == registry.AuditStatusFail {
+			ok = false
+			break
+		}
+	}
+
+	summary := auditSummary{Checked: len(report.Findings)}
+	for _, f := range report.Findings {
+		switch f.Status {
+		case registry.AuditStatusPass:
+			summary.Pass++
+		case registry.AuditStatusWarn:
+			summary.Warn++
+		case registry.AuditStatusFail:
+			summary.Fail++
+		}
+	}
+
+	return cecdysis.Outcome{OK: ok, Summary: summary, Result: auditResult{Findings: report.Findings}}, nil
+}
+
+// auditSummary is the --json envelope's "summary" payload (plan-v2/step5
+// §4's shape).
+type auditSummary struct {
+	Checked int `json:"checked"`
+	Pass    int `json:"pass"`
+	Warn    int `json:"warn"`
+	Fail    int `json:"fail"`
+}
+
+// ExitCode re-derives registry.AuditReport.ExitCode() from Outcome.Result,
+// mirroring DoctorCommand.ExitCode's pattern exactly.
+func (c *AuditCommand) ExitCode(outcome cecdysis.Outcome) int {
+	res, ok := outcome.Result.(auditResult)
+	if !ok {
+		return 0
+	}
+	return registry.AuditReport{Findings: res.Findings}.ExitCode()
+}
+
+func (c *AuditCommand) Render(outcome cecdysis.Outcome) string {
+	res, ok := outcome.Result.(auditResult)
+	if !ok {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, f := range res.Findings {
+		status := strings.ToUpper(string(f.Status))
+		if f.Finding == registry.FindingNone {
+			fmt.Fprintf(&b, "%-4s %s@%s\n", status, f.Name, f.InstalledVersion)
+			continue
+		}
+		fmt.Fprintf(&b, "%-4s %s@%s: %s", status, f.Name, f.InstalledVersion, f.Finding)
+		if f.Reason != "" {
+			fmt.Fprintf(&b, " — %s", f.Reason)
+		}
+		b.WriteString("\n")
+		if f.Suggestion != "" {
+			fmt.Fprintf(&b, "     suggestion: %s\n", f.Suggestion)
+		}
+	}
+	summary, ok := outcome.Summary.(auditSummary)
+	if ok {
+		fmt.Fprintf(&b, "\nchecked %d: %d pass, %d warn, %d fail\n", summary.Checked, summary.Pass, summary.Warn, summary.Fail)
+	}
+	return b.String()
+}

--- a/cmd/conduit/root/connectors/audit_test.go
+++ b/cmd/conduit/root/connectors/audit_test.go
@@ -1,0 +1,161 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Full-stack CLI integration tests for `conduit connectors audit`, mirroring
+// install_test.go's pattern: build the real cobra command via ecdysis and
+// drive it through cmd.ExecuteC(), proving the CLI wires the REAL
+// registry.TrustedVerifier (via signTestIndex's test-only trust anchor —
+// see that helper's doc comment) rather than re-testing RunAudit's own
+// finding-table logic, which pkg/registry/connectoraudit_test.go already
+// covers exhaustively.
+package connectors_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	json "github.com/goccy/go-json"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/cmd/conduit/root/connectors"
+	"github.com/conduitio/conduit/pkg/registry/index"
+	"github.com/conduitio/ecdysis"
+)
+
+// runAudit drives the real cobra command through ExecuteC and returns its
+// output, the leaf command (for cecdysis.ResultExitCode — see doctor_test.go's
+// identical pattern: a domain finding's nonzero exit code rides on a cobra
+// Annotation, not RunE's returned error), and any HARD command failure.
+func runAudit(t *testing.T, args ...string) (output string, leaf *cobra.Command, err error) {
+	t.Helper()
+	e := ecdysis.New(ecdysis.WithDecorators(cecdysis.CommandWithResultDecorator{}))
+	cmd := e.MustBuildCobraCommand(&connectors.AuditCommand{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	leaf, err = cmd.ExecuteC()
+	return out.String(), leaf, err
+}
+
+// writeAuditManifestFixture writes a manifest.json entry directly to disk —
+// audit_test.go doesn't need a real install pipeline run, just a
+// pre-existing installed state (mirrors pkg/registry/uninstall_test.go's
+// installFixture helper, at the CLI-test layer instead).
+func writeAuditManifestFixture(t *testing.T, connectorsPath, name, version string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(connectorsPath, ".registry"), 0o755))
+	artifactFile := name + "_" + version
+	require.NoError(t, os.WriteFile(filepath.Join(connectorsPath, artifactFile), []byte("fixture-bytes"), 0o755))
+
+	manifest := map[string]any{
+		"schemaVersion": 1,
+		"installs": map[string]any{
+			name + "@" + version: map[string]any{
+				"name": name, "version": version, "kind": "standalone",
+				"os": "linux", "arch": "amd64", "artifactFile": artifactFile,
+				"digest":      "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+				"installedAt": time.Now().UTC().Format(time.RFC3339), "source": "index",
+				"signed": true,
+			},
+		},
+	}
+	data, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(connectorsPath, ".registry", "manifest.json"), data, 0o644))
+}
+
+func TestAudit_YankedVersion_FailsWithNonzeroExit(t *testing.T) {
+	connectorsPath := t.TempDir()
+	writeAuditManifestFixture(t, connectorsPath, "postgres", "0.14.0")
+
+	payload := index.Payload{
+		SchemaVersion: 1,
+		Index:         index.IndexMeta{Version: 1, Timestamp: time.Now()},
+		Connectors: []index.Connector{{
+			Name:      "postgres",
+			Publisher: index.Publisher{ExpectedOIDCIssuer: "https://token.actions.githubusercontent.com"},
+			Versions: []index.ConnectorVersion{
+				{Version: "0.14.0", Yanked: &index.YankReason{Reason: "data-loss bug"}},
+			},
+		}},
+	}
+	data := signTestIndex(t, payload)
+	indexPath := filepath.Join(t.TempDir(), "index.json")
+	require.NoError(t, os.WriteFile(indexPath, data, 0o644))
+
+	out, leaf, err := runAudit(t, "--connectors.path="+connectorsPath, "--index-file="+indexPath, "--json")
+	require.NoError(t, err) // a Fail FINDING is not a HARD command failure — see CommandWithResultExitCode's doc
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	assert.False(t, res.OK)
+	assert.Nil(t, res.Error) // a Fail FINDING, not a hard command failure
+
+	code, hasCode := cecdysis.ResultExitCode(leaf)
+	require.True(t, hasCode)
+	assert.NotZero(t, code)
+}
+
+func TestAudit_AllPass_ZeroExit(t *testing.T) {
+	connectorsPath := t.TempDir()
+	writeAuditManifestFixture(t, connectorsPath, "postgres", "0.14.1")
+
+	payload := index.Payload{
+		SchemaVersion: 1,
+		Index:         index.IndexMeta{Version: 1, Timestamp: time.Now()},
+		Connectors: []index.Connector{{
+			Name:      "postgres",
+			Publisher: index.Publisher{ExpectedOIDCIssuer: "https://token.actions.githubusercontent.com"},
+			Versions:  []index.ConnectorVersion{{Version: "0.14.1"}},
+		}},
+	}
+	data := signTestIndex(t, payload)
+	indexPath := filepath.Join(t.TempDir(), "index.json")
+	require.NoError(t, os.WriteFile(indexPath, data, 0o644))
+
+	out, leaf, err := runAudit(t, "--connectors.path="+connectorsPath, "--index-file="+indexPath, "--json")
+	require.NoError(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	assert.True(t, res.OK)
+
+	_, hasCode := cecdysis.ResultExitCode(leaf)
+	assert.False(t, hasCode, "an all-pass audit must not record a nonzero exit code annotation")
+}
+
+// TestAudit_IndexUnreachable_HardFailsDistinctly is AC8 at the CLI layer.
+func TestAudit_IndexUnreachable_HardFailsDistinctly(t *testing.T) {
+	connectorsPath := t.TempDir()
+	writeAuditManifestFixture(t, connectorsPath, "postgres", "0.14.1")
+
+	out, _, err := runAudit(t,
+		"--connectors.path="+connectorsPath,
+		"--index-file="+filepath.Join(t.TempDir(), "does-not-exist.json"),
+		"--json",
+	)
+	require.Error(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	require.NotNil(t, res.Error)
+	assert.Equal(t, "registry.index_unreachable", res.Error.Code)
+}

--- a/cmd/conduit/root/connectors/bundle.go
+++ b/cmd/conduit/root/connectors/bundle.go
@@ -1,0 +1,186 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectors
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/pkg/conduit"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/registry"
+	"github.com/conduitio/ecdysis"
+)
+
+var (
+	_ ecdysis.CommandWithFlags   = (*BundleCommand)(nil)
+	_ ecdysis.CommandWithConfig  = (*BundleCommand)(nil)
+	_ ecdysis.CommandWithArgs    = (*BundleCommand)(nil)
+	_ ecdysis.CommandWithDocs    = (*BundleCommand)(nil)
+	_ cecdysis.CommandWithResult = (*BundleCommand)(nil)
+)
+
+// BundleFlags embeds conduit.Config only for --config.path resolution
+// (matching every other registry command's flag conventions) — bundle prep
+// does not touch --connectors.path at all, since its output is a
+// standalone tarball, never an install into that directory.
+type BundleFlags struct {
+	conduit.Config
+
+	OS        string `long:"os" usage:"target operating system (defaults to this host's)"`
+	Arch      string `long:"arch" usage:"target architecture (defaults to this host's)"`
+	Output    string `long:"output" usage:"output bundle path (defaults to <name>-<version>-<os>-<arch>.bundle.tar.gz)"`
+	IndexURL  string `long:"index-url" usage:"registry index URL"`
+	IndexFile string `long:"index-file" usage:"read the index from a local file instead of --index-url"`
+}
+
+type BundleArgs struct {
+	Name    string
+	Version string
+}
+
+// BundleCommand implements `conduit connectors bundle <name>[@version]`
+// (plan-v2/step5 §7 Phase A): prepares a self-contained offline-install
+// tarball on a networked machine, running the SAME full verification a
+// normal `install` would, before ever writing the tarball — see
+// pkg/registry/bundle.go's package doc for the soundness argument. It
+// shares install.go's trust-core wiring (defaultTrustAnchors,
+// TrustedVerifier) rather than inventing a second, divergent one.
+type BundleCommand struct {
+	flags BundleFlags
+	args  BundleArgs
+	Cfg   conduit.Config
+}
+
+func (c *BundleCommand) Usage() string { return "bundle <name>[@version]" }
+
+func (c *BundleCommand) Docs() ecdysis.Docs {
+	return ecdysis.Docs{
+		Short: "Prepare an offline install bundle for a connector",
+		Long: `bundle resolves <name>[@version] against the registry index (same resolution as
+install), downloads and fully verifies the artifact (signature + SLSA provenance against the
+connector's pinned identity — the same checks a normal install performs, all while online),
+and packages the artifact, its signature/provenance bundles (in cosign --bundle form — embedded
+cert chain and Rekor inclusion proof, no live Sigstore query needed later), and the FULL signed
+index snapshot into a single tarball.
+
+The bundle is a carrier for an already-verified installation, replayed later on a machine with
+no network access at all: "conduit connectors install --bundle <path>" re-verifies everything
+from the bundle's own contents — it never trusts the bundle just because it exists.
+
+Exit codes (via the ConduitError's registered category):
+  0  success
+  2  connector/version not found, incompatible version, yanked/revoked, no platform artifact
+  3  index unreachable, download failed, corrupt download`,
+		Example: "conduit connectors bundle postgres@0.14.1 --os linux --arch amd64 --output postgres.bundle.tar.gz\n" +
+			"conduit connectors bundle postgres --json",
+	}
+}
+
+func (c *BundleCommand) Flags() []ecdysis.Flag {
+	flags := ecdysis.BuildFlags(&c.flags)
+
+	currentPath, err := os.Getwd()
+	if err != nil {
+		panic(cerrors.Errorf("failed to get current working directory: %w", err))
+	}
+	c.Cfg = conduit.DefaultConfigWithBasePath(currentPath)
+	flags.SetDefault("config.path", c.Cfg.ConduitCfg.Path)
+	flags.SetDefault("index-url", registry.DefaultIndexURL)
+
+	return flags
+}
+
+func (c *BundleCommand) Config() ecdysis.Config {
+	path := filepath.Dir(c.flags.ConduitCfg.Path)
+	return ecdysis.Config{
+		EnvPrefix:     envPrefix,
+		Parsed:        &c.Cfg,
+		Path:          c.flags.ConduitCfg.Path,
+		DefaultValues: conduit.DefaultConfigWithBasePath(path),
+	}
+}
+
+func (c *BundleCommand) Args(args []string) error {
+	if len(args) == 0 {
+		return cerrors.Errorf("requires a connector name, optionally with @version (e.g. postgres or postgres@0.14.1)")
+	}
+	if len(args) > 1 {
+		return cerrors.Errorf("too many arguments")
+	}
+	name, version, _ := strings.Cut(args[0], "@")
+	if name == "" {
+		return cerrors.Errorf("connector name must not be empty")
+	}
+	c.args.Name = name
+	c.args.Version = version
+	return nil
+}
+
+func (c *BundleCommand) ResultCommand() string { return "connectors.bundle" }
+
+func (c *BundleCommand) ExecuteWithResult(ctx context.Context) (cecdysis.Outcome, error) {
+	verifier := &registry.TrustedVerifier{
+		Anchors:           defaultTrustAnchors,
+		StatePath:         registry.IndexStatePath(c.Cfg.Connectors.Path),
+		MaxStaleness:      c.Cfg.Install.MaxStaleness,
+		RequireProvenance: true,
+	}
+
+	output := c.flags.Output
+	if output == "" {
+		output = fmt.Sprintf("%s-%s-%s-%s.bundle.tar.gz", c.args.Name, orLatest(c.args.Version), orHost(c.flags.OS), orHost(c.flags.Arch))
+	}
+
+	result, err := registry.Bundle(ctx, registry.BundleOptions{
+		Name: c.args.Name, Version: c.args.Version, OutputPath: output,
+		IndexURL: c.flags.IndexURL, IndexFile: c.flags.IndexFile,
+		GOOS: c.flags.OS, GOArch: c.flags.Arch,
+		IndexVerifier: verifier, ArtifactVerifier: verifier,
+		RunningConduitVersion:  conduit.Version(false),
+		RunningProtocolVersion: runningProtocolVersion(),
+	})
+	if err != nil {
+		return cecdysis.Outcome{}, err
+	}
+
+	return cecdysis.Outcome{OK: true, Result: result}, nil
+}
+
+func (c *BundleCommand) Render(outcome cecdysis.Outcome) string {
+	res, ok := outcome.Result.(*registry.BundleResult)
+	if !ok || res == nil {
+		return ""
+	}
+	return fmt.Sprintf("Bundled %s@%s (%s/%s) into %s\n", res.Name, res.Version, res.OS, res.Arch, res.OutputPath)
+}
+
+func orLatest(s string) string {
+	if s == "" {
+		return "latest"
+	}
+	return s
+}
+
+func orHost(s string) string {
+	if s == "" {
+		return "host"
+	}
+	return s
+}

--- a/cmd/conduit/root/connectors/bundle_test.go
+++ b/cmd/conduit/root/connectors/bundle_test.go
@@ -1,0 +1,102 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// CLI-layer tests for `conduit connectors bundle` and `install --bundle`
+// wiring. The deep verification behavior (offline re-verification, tamper
+// detection, yank-short-circuit, stale-bundle gating) is already covered
+// exhaustively at the pkg/registry level (bundle_test.go there) against the
+// real registry.TrustedVerifier — this file only proves the CLI plumbs
+// flags/args through correctly and surfaces the right hard-failure codes,
+// mirroring install_test.go's own "prove the wiring, not the crypto" scope.
+package connectors_test
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	json "github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/cmd/conduit/root/connectors"
+	"github.com/conduitio/ecdysis"
+)
+
+func runBundle(t *testing.T, args ...string) (output string, err error) {
+	t.Helper()
+	e := ecdysis.New(ecdysis.WithDecorators(cecdysis.CommandWithResultDecorator{}))
+	cmd := e.MustBuildCobraCommand(&connectors.BundleCommand{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	_, err = cmd.ExecuteC()
+	return out.String(), err
+}
+
+func TestBundleArgs_MissingName(t *testing.T) {
+	_, err := runBundle(t, "--json")
+	require.Error(t, err)
+}
+
+func TestBundleArgs_TooManyArgs(t *testing.T) {
+	_, err := runBundle(t, "widget", "extra", "--json")
+	require.Error(t, err)
+}
+
+// TestBundle_IndexUnreachable_HardError proves the CLI wires IndexFile
+// through and surfaces the resulting hard failure with the expected code —
+// the same "prove the plumbing" scope as TestInstall_SplitsNameAndVersion.
+func TestBundle_IndexUnreachable_HardError(t *testing.T) {
+	out, err := runBundle(t,
+		"widget",
+		"--index-file="+filepath.Join(t.TempDir(), "does-not-exist.json"),
+		"--output="+filepath.Join(t.TempDir(), "out.bundle.tar.gz"),
+		"--json",
+	)
+	require.Error(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	require.NotNil(t, res.Error)
+	assert.Equal(t, "registry.index_unreachable", res.Error.Code)
+}
+
+// TestInstall_BundleFlag_MissingFile proves `install --bundle` routes to
+// the offline path (never reaching --index-url/--index-file resolution at
+// all) and surfaces a clear hard failure for a bundle path that doesn't
+// exist.
+func TestInstall_BundleFlag_MissingFile(t *testing.T) {
+	connectorsPath := t.TempDir()
+	out, err := runInstall(t,
+		"--bundle="+filepath.Join(t.TempDir(), "does-not-exist.bundle.tar.gz"),
+		"--connectors.path="+connectorsPath,
+		"--json",
+	)
+	require.Error(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	require.NotNil(t, res.Error)
+	assert.Equal(t, "registry.archive_invalid", res.Error.Code)
+}
+
+// TestInstall_NoNameNoBundle_HardError proves the "requires a connector
+// name ... or --bundle" validation fires when neither is given.
+func TestInstall_NoNameNoBundle_HardError(t *testing.T) {
+	_, err := runInstall(t, "--json")
+	require.Error(t, err)
+}

--- a/cmd/conduit/root/connectors/connectors.go
+++ b/cmd/conduit/root/connectors/connectors.go
@@ -18,6 +18,12 @@ import (
 	"github.com/conduitio/ecdysis"
 )
 
+// envPrefix is the shared ecdysis.Config.EnvPrefix every command in this
+// package that reads conduit.Config uses (e.g. CONDUIT_CONNECTORS_PATH) —
+// pulled out once so goconst doesn't flag five separate string literals
+// across install.go/uninstall.go/audit.go/bundle.go/list.go.
+const envPrefix = "CONDUIT"
+
 var (
 	_ ecdysis.CommandWithDocs        = (*ConnectorsCommand)(nil)
 	_ ecdysis.CommandWithSubCommands = (*ConnectorsCommand)(nil)
@@ -34,6 +40,9 @@ func (c *ConnectorsCommand) SubCommands() []ecdysis.Command {
 		&DescribeCommand{},
 		newNewCommand(),
 		&InstallCommand{},
+		&UninstallCommand{},
+		&AuditCommand{},
+		&BundleCommand{},
 	}
 }
 

--- a/cmd/conduit/root/connectors/install.go
+++ b/cmd/conduit/root/connectors/install.go
@@ -76,6 +76,20 @@ type InstallFlags struct {
 	LockTimeout time.Duration `long:"lock-timeout" usage:"max time to wait to acquire the per-connector install lock"`
 	DryRun      bool          `long:"dry-run" usage:"resolve and select a platform artifact; report what would be installed without downloading or writing anything"`
 
+	// Bundle installs fully offline from a tarball produced by `conduit
+	// connectors bundle` (PR-4, plan-v2/step5 §7 Phase B) — NO network call
+	// of any kind is made when this is set; everything is re-verified from
+	// the bundle's own contents. When set, <name>[@version] positional args
+	// are ignored (the bundle already names its own connector/version).
+	Bundle string `long:"bundle" usage:"install fully offline from a bundle tarball produced by 'conduit connectors bundle' (ignores the positional <name>[@version] argument)"`
+	// AllowStaleBundle tolerates a bundled index snapshot older than
+	// --max-staleness — gated identically to --allow-unsigned (plan-v2/
+	// step5 §7 step 3, ratified by DeVaris): requires interactive
+	// confirmation or the non-interactive env var escape hatch, and may be
+	// hard-disabled entirely by operator policy (install.allow-stale-bundle).
+	// Only ever consulted with --bundle.
+	AllowStaleBundle bool `long:"allow-stale-bundle" usage:"tolerate a --bundle whose snapshot is older than --max-staleness — requires interactive confirmation or an explicit non-interactive escape hatch; may be disabled entirely by operator policy (install.allow-stale-bundle)"`
+
 	// AllowUnsigned requests skipping signature/provenance verification —
 	// the sha256 corruption check always still runs regardless. Has NO
 	// default value that could be silently true, and is not itself
@@ -175,7 +189,7 @@ func (c *InstallCommand) Flags() []ecdysis.Flag {
 func (c *InstallCommand) Config() ecdysis.Config {
 	path := filepath.Dir(c.flags.ConduitCfg.Path)
 	return ecdysis.Config{
-		EnvPrefix:     "CONDUIT",
+		EnvPrefix:     envPrefix,
 		Parsed:        &c.Cfg,
 		Path:          c.flags.ConduitCfg.Path,
 		DefaultValues: conduit.DefaultConfigWithBasePath(path),
@@ -183,13 +197,19 @@ func (c *InstallCommand) Config() ecdysis.Config {
 }
 
 // Args parses "<name>[@version]" — split on the FIRST "@" only, so a
-// version constraint is never mistaken for part of the name.
+// version constraint is never mistaken for part of the name. With --bundle
+// set, the positional argument is optional and ignored if given (the
+// bundle already names its own connector/version) — but Args runs before
+// Flags parsing order is guaranteed relative to it in every ecdysis
+// command, so the actual "was --bundle set" check happens defensively in
+// ExecuteWithResult instead of here; this method only accepts the
+// zero-or-one-argument shape unconditionally.
 func (c *InstallCommand) Args(args []string) error {
-	if len(args) == 0 {
-		return cerrors.Errorf("requires a connector name, optionally with @version (e.g. postgres or postgres@0.14.1)")
-	}
 	if len(args) > 1 {
 		return cerrors.Errorf("too many arguments")
+	}
+	if len(args) == 0 {
+		return nil // valid for --bundle; ExecuteWithResult rejects it otherwise
 	}
 
 	name, version, _ := strings.Cut(args[0], "@")
@@ -214,6 +234,13 @@ func (c *InstallCommand) ExecuteWithResult(ctx context.Context) (cecdysis.Outcom
 		// trust.CodeProvenanceInvalid rather than installing. See
 		// TrustedVerifier.RequireProvenance's doc comment.
 		RequireProvenance: true,
+	}
+
+	if c.flags.Bundle != "" {
+		return c.executeFromBundle(ctx, verifier)
+	}
+	if c.args.Name == "" {
+		return cecdysis.Outcome{}, cerrors.Errorf("requires a connector name, optionally with @version (e.g. postgres or postgres@0.14.1), or --bundle <path>")
 	}
 
 	tty := isInteractiveTTY()
@@ -279,6 +306,62 @@ func (c *InstallCommand) ExecuteWithResult(ctx context.Context) (cecdysis.Outcom
 	}
 
 	return cecdysis.Outcome{OK: true, Result: result}, nil
+}
+
+// executeFromBundle is `conduit connectors install --bundle <path>`
+// (plan-v2/step5 §7 Phase B): fully offline, no network call of any kind —
+// see pkg/registry/bundle.go's InstallFromBundle for the verification
+// details. Shares this file's own TrustedVerifier wiring (verifier) rather
+// than constructing a second, divergent one.
+func (c *InstallCommand) executeFromBundle(ctx context.Context, verifier *registry.TrustedVerifier) (cecdysis.Outcome, error) {
+	tty := isInteractiveTTY()
+	ciEnv := os.Getenv("CI") != ""
+	envVarSet := os.Getenv(registry.StaleBundleEnvVar) == "I_UNDERSTAND"
+
+	typedConfirmation := false
+	if c.flags.AllowStaleBundle && tty && !ciEnv {
+		var err error
+		typedConfirmation, err = confirmStaleBundle(os.Stdin, os.Stdout, c.flags.Bundle)
+		if err != nil {
+			return cecdysis.Outcome{}, cerrors.Errorf("could not read confirmation: %w", err)
+		}
+	}
+
+	result, err := registry.InstallFromBundle(ctx, registry.InstallBundleOptions{
+		BundlePath:     c.flags.Bundle,
+		ConnectorsPath: c.Cfg.Connectors.Path,
+		Verifier:       verifier,
+		InstalledBy:    installedByUser(),
+		LockTimeout:    c.flags.LockTimeout,
+
+		RunningConduitVersion:  conduit.Version(false),
+		RunningProtocolVersion: runningProtocolVersion(),
+
+		AllowStaleBundle:         c.flags.AllowStaleBundle,
+		TTY:                      tty,
+		CIEnv:                    ciEnv,
+		IsMCP:                    false,
+		EnvVarSet:                envVarSet,
+		TypedConfirmation:        typedConfirmation,
+		OperatorAllowStaleBundle: c.Cfg.Install.AllowStaleBundle,
+	})
+	if err != nil {
+		return cecdysis.Outcome{}, err
+	}
+	return cecdysis.Outcome{OK: true, Result: result}, nil
+}
+
+// confirmStaleBundle is the typed re-confirmation prompt for
+// --allow-stale-bundle, mirroring confirmUnsignedInstall's exact-match
+// (never y/N) convention.
+func confirmStaleBundle(in *os.File, out *os.File, bundlePath string) (bool, error) {
+	fmt.Fprintf(out, "Type the bundle path (%s) to confirm installing a STALE offline bundle — its index "+
+		"snapshot is older than the configured maximum staleness: ", bundlePath)
+	scanner := bufio.NewScanner(in)
+	if !scanner.Scan() {
+		return false, scanner.Err()
+	}
+	return strings.TrimSpace(scanner.Text()) == bundlePath, nil
 }
 
 // isInteractiveTTY reports whether BOTH stdin and stdout are attached to a

--- a/cmd/conduit/root/connectors/list.go
+++ b/cmd/conduit/root/connectors/list.go
@@ -16,13 +16,18 @@ package connectors
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/alexeyco/simpletable"
 	"github.com/conduitio/conduit/cmd/conduit/api"
 	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
 	"github.com/conduitio/conduit/cmd/conduit/internal/display"
+	"github.com/conduitio/conduit/pkg/conduit"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/registry"
 	apiv1 "github.com/conduitio/conduit/proto/api/v1"
 	"github.com/conduitio/ecdysis"
 )
@@ -32,26 +37,81 @@ var (
 	_ ecdysis.CommandWithAliases                  = (*ListCommand)(nil)
 	_ ecdysis.CommandWithDocs                     = (*ListCommand)(nil)
 	_ ecdysis.CommandWithFlags                    = (*ListCommand)(nil)
+	_ ecdysis.CommandWithConfig                   = (*ListCommand)(nil)
 )
 
 type ListFlags struct {
+	conduit.Config
+
 	PipelineID string `long:"pipeline-id" usage:"filter connectors by pipeline ID"`
+
+	// Installed switches this command to a COMPLETELY DIFFERENT data
+	// source (step5/plan-v2 §3): the local install manifest (installed
+	// plugin ARTIFACTS in --connectors.path) rather than the running
+	// engine's pipeline connector INSTANCES. Mutually exclusive with
+	// --pipeline-id.
+	//
+	// Known scope limitation of this implementation: ListCommand is wired
+	// through cecdysis.CommandWithExecuteWithClientResultDecorator, which
+	// unconditionally dials and health-checks the engine BEFORE calling
+	// this command at all — so, as shipped, `--installed` still requires a
+	// reachable engine even though its own data source (the manifest)
+	// does not. Making `--installed` truly engine-independent needs either
+	// a second decorator variant that skips the mandatory dial, or
+	// splitting this into a separate CommandWithResult-based command —
+	// either is a real (if small) change to shared cecdysis machinery or
+	// command wiring, deliberately deferred out of this PR to keep its
+	// blast radius to pkg/registry and this one file; flagged here and in
+	// the PR description rather than silently shipping the design doc's
+	// full "independent of whether the engine is running" aspiration.
+	IndexURL  string `long:"index-url" usage:"registry index URL (only consulted with --installed, for a best-effort 'latest available' column)"`
+	IndexFile string `long:"index-file" usage:"read the index from a local file instead of --index-url (only consulted with --installed)"`
+	Installed bool   `long:"installed" usage:"list installed connector PLUGIN ARTIFACTS from the local manifest instead of pipeline connector instances (mutually exclusive with --pipeline-id)"`
 }
 
 type ListCommand struct {
 	flags ListFlags
+	Cfg   conduit.Config
 }
 
 func (c *ListCommand) Flags() []ecdysis.Flag {
-	return ecdysis.BuildFlags(&c.flags)
+	flags := ecdysis.BuildFlags(&c.flags)
+
+	currentPath, err := os.Getwd()
+	if err != nil {
+		panic(cerrors.Errorf("failed to get current working directory: %w", err))
+	}
+	c.Cfg = conduit.DefaultConfigWithBasePath(currentPath)
+	flags.SetDefault("config.path", c.Cfg.ConduitCfg.Path)
+	flags.SetDefault("connectors.path", c.Cfg.Connectors.Path)
+	flags.SetDefault("index-url", registry.DefaultIndexURL)
+
+	return flags
+}
+
+func (c *ListCommand) Config() ecdysis.Config {
+	path := filepath.Dir(c.flags.ConduitCfg.Path)
+	return ecdysis.Config{
+		EnvPrefix:     envPrefix,
+		Parsed:        &c.Cfg,
+		Path:          c.flags.ConduitCfg.Path,
+		DefaultValues: conduit.DefaultConfigWithBasePath(path),
+	}
 }
 
 func (c *ListCommand) Docs() ecdysis.Docs {
 	return ecdysis.Docs{
 		Short: "List existing Conduit connectors",
-		Long: `This command requires Conduit to be already running since it will list all connectors registered 
-by Conduit.`,
-		Example: "conduit connectors list\nconduit connectors ls",
+		Long: `This command requires Conduit to be already running since it will list all connectors registered
+by Conduit.
+
+With --installed, this instead lists installed connector PLUGIN ARTIFACTS from the local
+install manifest (--connectors.path) — an entirely different thing from a pipeline connector
+instance. Its data source (the manifest) does not itself require the engine, but this command
+still dials the engine first, like every other 'connectors list' invocation; --installed does
+not yet skip that precondition (a known scope limitation — see ListFlags.Installed's doc
+comment). --pipeline-id and --installed are mutually exclusive.`,
+		Example: "conduit connectors list\nconduit connectors ls\nconduit connectors list --installed",
 	}
 }
 
@@ -59,7 +119,29 @@ func (c *ListCommand) Aliases() []string { return []string{"ls"} }
 
 func (c *ListCommand) Usage() string { return "list" }
 
+// ExecuteWithClientResult implements the framework's client-result contract.
+// With --installed, it ignores client entirely and instead lists the local
+// install manifest (registry.ListInstalled) — a completely different data
+// source from the default mode's pipeline connector instances (see
+// ListFlags.Installed's doc comment for this implementation's one known
+// scope limitation: the client is still dialed unconditionally by the
+// decorator before this method ever runs).
 func (c *ListCommand) ExecuteWithClientResult(ctx context.Context, client *api.Client) (any, error) {
+	if c.flags.Installed {
+		if c.flags.PipelineID != "" {
+			return nil, cerrors.Errorf("--pipeline-id and --installed are mutually exclusive")
+		}
+		res, err := registry.ListInstalled(ctx, registry.ListInstalledOptions{
+			ConnectorsPath: c.Cfg.Connectors.Path,
+			IndexURL:       c.flags.IndexURL,
+			IndexFile:      c.flags.IndexFile,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return res, nil
+	}
+
 	resp, err := client.ConnectorServiceClient.ListConnectors(ctx, &apiv1.ListConnectorsRequest{
 		PipelineId: c.flags.PipelineID,
 	})
@@ -74,14 +156,67 @@ func (c *ListCommand) ExecuteWithClientResult(ctx context.Context, client *api.C
 	return resp, nil
 }
 
-// Render returns the human-readable table. The framework renders --json itself
-// (protojson over the returned response).
+// Render returns the human-readable table. The framework renders --json
+// itself (protojson for *apiv1.ListConnectorsResponse, go-json for
+// *registry.ListInstalledResult — see cecdysis.marshalJSON). The two result
+// shapes render as VISIBLY DISTINCT tables (different columns, and the
+// installed-mode table names itself explicitly) so a user never confuses
+// "N connectors in my pipelines" with "N connector plugin artifacts
+// installed on disk" (step5 §3).
 func (c *ListCommand) Render(result any) string {
-	resp, ok := result.(*apiv1.ListConnectorsResponse)
-	if !ok {
+	switch v := result.(type) {
+	case *apiv1.ListConnectorsResponse:
+		return getConnectorsTable(v.Connectors) + "\n"
+	case *registry.ListInstalledResult:
+		return getInstalledConnectorsTable(v) + "\n"
+	default:
 		return ""
 	}
-	return getConnectorsTable(resp.Connectors) + "\n"
+}
+
+func getInstalledConnectorsTable(res *registry.ListInstalledResult) string {
+	if len(res.Installed) == 0 {
+		return "No installed connector plugin artifacts found under --connectors.path."
+	}
+
+	table := simpletable.New()
+	table.Header = &simpletable.Header{
+		Cells: []*simpletable.Cell{
+			{Align: simpletable.AlignCenter, Text: "NAME"},
+			{Align: simpletable.AlignCenter, Text: "INSTALLED"},
+			{Align: simpletable.AlignCenter, Text: "SIGNED"},
+			{Align: simpletable.AlignCenter, Text: "INSTALLED_AT"},
+			{Align: simpletable.AlignCenter, Text: "LATEST_AVAILABLE"},
+			{Align: simpletable.AlignCenter, Text: "STATUS"},
+		},
+	}
+
+	for _, row := range res.Installed {
+		signed := "no"
+		if row.Signed {
+			signed = "yes"
+		}
+		latest := row.LatestAvailable
+		if latest == "" {
+			latest = "—"
+		}
+		table.Body.Cells = append(table.Body.Cells, []*simpletable.Cell{
+			{Align: simpletable.AlignLeft, Text: row.Name},
+			{Align: simpletable.AlignLeft, Text: row.Version},
+			{Align: simpletable.AlignLeft, Text: signed},
+			{Align: simpletable.AlignLeft, Text: row.InstalledAt.UTC().Format("2006-01-02 15:04 MST")},
+			{Align: simpletable.AlignLeft, Text: latest},
+			{Align: simpletable.AlignLeft, Text: string(row.Status)},
+		})
+	}
+
+	var b strings.Builder
+	b.WriteString("Installed connector PLUGIN ARTIFACTS (--connectors.path) — distinct from pipeline connector instances above.\n")
+	if res.IndexUnreachable {
+		b.WriteString("note: the registry index was unreachable; LATEST_AVAILABLE/STATUS columns are informational-only for this run.\n")
+	}
+	b.WriteString(table.String())
+	return b.String()
 }
 
 func getConnectorsTable(connectors []*apiv1.Connector) string {

--- a/cmd/conduit/root/connectors/list_test.go
+++ b/cmd/conduit/root/connectors/list_test.go
@@ -16,12 +16,21 @@ package connectors
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	json "github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/conduitio/conduit/cmd/conduit/api"
 	"github.com/conduitio/conduit/cmd/conduit/api/mock"
 	"github.com/conduitio/conduit/cmd/conduit/internal/testutils"
+	"github.com/conduitio/conduit/pkg/conduit"
+	"github.com/conduitio/conduit/pkg/registry"
 	apiv1 "github.com/conduitio/conduit/proto/api/v1"
 	"github.com/conduitio/ecdysis"
 	"github.com/matryer/is"
@@ -172,4 +181,61 @@ func TestListCommandExecuteWithClient_EmptyResponse(t *testing.T) {
 
 	output := strings.TrimSpace(cmd.Render(result))
 	is.True(len(output) == 0)
+}
+
+// --- --installed mode (PR-4) ---
+
+func writeListInstalledManifestFixture(t *testing.T, connectorsPath, name, version string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(connectorsPath, ".registry"), 0o755))
+	artifactFile := name + "_" + version
+	require.NoError(t, os.WriteFile(filepath.Join(connectorsPath, artifactFile), []byte("bytes"), 0o755))
+
+	manifest := map[string]any{
+		"schemaVersion": 1,
+		"installs": map[string]any{
+			name + "@" + version: map[string]any{
+				"name": name, "version": version, "kind": "standalone",
+				"os": "linux", "arch": "amd64", "artifactFile": artifactFile,
+				"digest":      "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+				"installedAt": time.Now().UTC().Format(time.RFC3339), "source": "index", "signed": true,
+			},
+		},
+	}
+	data, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(connectorsPath, ".registry", "manifest.json"), data, 0o644))
+}
+
+func TestListCommand_Installed_ReturnsManifestRows(t *testing.T) {
+	connectorsPath := t.TempDir()
+	writeListInstalledManifestFixture(t, connectorsPath, "postgres", "0.14.1")
+
+	cfg := conduit.DefaultConfigWithBasePath(t.TempDir())
+	cfg.Connectors.Path = connectorsPath
+
+	cmd := &ListCommand{
+		flags: ListFlags{Installed: true, IndexFile: filepath.Join(t.TempDir(), "does-not-exist.json")},
+		Cfg:   cfg,
+	}
+
+	// client is nil and must never be touched by the --installed path.
+	result, err := cmd.ExecuteWithClientResult(context.Background(), nil)
+	require.NoError(t, err)
+
+	res, ok := result.(*registry.ListInstalledResult)
+	require.True(t, ok)
+	require.Len(t, res.Installed, 1)
+	assert.Equal(t, "postgres", res.Installed[0].Name)
+	assert.True(t, res.IndexUnreachable)
+
+	rendered := cmd.Render(result)
+	assert.Contains(t, rendered, "postgres")
+	assert.Contains(t, rendered, "PLUGIN ARTIFACTS")
+}
+
+func TestListCommand_Installed_MutuallyExclusiveWithPipelineID(t *testing.T) {
+	cmd := &ListCommand{flags: ListFlags{Installed: true, PipelineID: "pipe1"}}
+	_, err := cmd.ExecuteWithClientResult(context.Background(), nil)
+	require.Error(t, err)
 }

--- a/cmd/conduit/root/connectors/uninstall.go
+++ b/cmd/conduit/root/connectors/uninstall.go
@@ -1,0 +1,307 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectors
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/conduitio/conduit/cmd/conduit/api"
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/pkg/conduit"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/plugin"
+	"github.com/conduitio/conduit/pkg/provisioning/config"
+	"github.com/conduitio/conduit/pkg/provisioning/config/yaml"
+	"github.com/conduitio/conduit/pkg/registry"
+	apiv1 "github.com/conduitio/conduit/proto/api/v1"
+	"github.com/conduitio/ecdysis"
+)
+
+var (
+	_ ecdysis.CommandWithFlags   = (*UninstallCommand)(nil)
+	_ ecdysis.CommandWithConfig  = (*UninstallCommand)(nil)
+	_ ecdysis.CommandWithArgs    = (*UninstallCommand)(nil)
+	_ ecdysis.CommandWithDocs    = (*UninstallCommand)(nil)
+	_ cecdysis.CommandWithResult = (*UninstallCommand)(nil)
+)
+
+// uninstallInUseCheckTimeout bounds how long UninstallCommand waits to
+// determine whether the running engine is reachable before falling back to
+// the offline provisioned-config scan (step5 §2 step 2) — short, since this
+// is a local health probe, not a real operation.
+const uninstallInUseCheckTimeout = 2 * time.Second
+
+// UninstallFlags embeds conduit.Config for the same reason InstallFlags
+// does: --connectors.path (and --pipelines.path, for the offline in-use
+// fallback scan) must resolve identically to every other command that
+// touches these directories.
+type UninstallFlags struct {
+	conduit.Config
+
+	Force bool `long:"force" usage:"remove the artifact even if a pipeline still references it (the affected pipelines are still named in the result/warning)"`
+}
+
+type UninstallArgs struct {
+	Name    string
+	Version string // "" = auto-resolve if exactly one version is installed
+}
+
+// UninstallCommand implements `conduit connectors uninstall <name>[@version]`.
+// Like InstallCommand, this is an OFFLINE command in the sense that it never
+// requires the engine to be running — it drives pkg/registry.Uninstall
+// directly against --connectors.path on disk. It DOES opportunistically try
+// to reach a running engine (a short health-checked dial, never a hard
+// requirement) to build the in-use check's pipeline-connector-instance
+// list; if the engine isn't reachable, it falls back to scanning
+// provisioned pipeline configs directly off disk (pkg/provisioning/config),
+// since the in-use check only needs to know what pipelines WOULD run, not
+// what is currently running.
+type UninstallCommand struct {
+	flags UninstallFlags
+	args  UninstallArgs
+	Cfg   conduit.Config
+}
+
+func (c *UninstallCommand) Usage() string { return "uninstall <name>[@version]" }
+
+func (c *UninstallCommand) Docs() ecdysis.Docs {
+	return ecdysis.Docs{
+		Short: "Remove an installed standalone connector",
+		Long: `uninstall removes a connector artifact and its install-manifest entry. If more
+than one version of <name> is installed, an explicit @version is required — an ambiguous
+"uninstall <name>" refuses rather than guessing which one you meant.
+
+Before removing anything, uninstall checks whether any pipeline (running, or merely
+provisioned on disk) references the exact name@version being removed. By default this
+refuses with a list of the affected pipelines; --force proceeds anyway and the result
+carries a warning naming them.
+
+Exit codes (via the ConduitError's registered category):
+  0  success
+  1  Runtime    — internal bug
+  2  Validation — not installed, ambiguous uninstall (multiple versions, no @version given)
+  3  Environment — connector is in use by a pipeline and --force was not given`,
+		Example: "conduit connectors uninstall postgres\n" +
+			"conduit connectors uninstall postgres@0.14.1\n" +
+			"conduit connectors uninstall postgres --force\n" +
+			"conduit connectors uninstall postgres --json",
+	}
+}
+
+func (c *UninstallCommand) Flags() []ecdysis.Flag {
+	flags := ecdysis.BuildFlags(&c.flags)
+
+	currentPath, err := os.Getwd()
+	if err != nil {
+		panic(cerrors.Errorf("failed to get current working directory: %w", err))
+	}
+	c.Cfg = conduit.DefaultConfigWithBasePath(currentPath)
+	flags.SetDefault("config.path", c.Cfg.ConduitCfg.Path)
+	flags.SetDefault("connectors.path", c.Cfg.Connectors.Path)
+	flags.SetDefault("pipelines.path", c.Cfg.Pipelines.Path)
+	flags.SetDefault("api.grpc.address", c.Cfg.API.GRPC.Address)
+
+	return flags
+}
+
+func (c *UninstallCommand) Config() ecdysis.Config {
+	path := filepath.Dir(c.flags.ConduitCfg.Path)
+	return ecdysis.Config{
+		EnvPrefix:     envPrefix,
+		Parsed:        &c.Cfg,
+		Path:          c.flags.ConduitCfg.Path,
+		DefaultValues: conduit.DefaultConfigWithBasePath(path),
+	}
+}
+
+// Args parses "<name>[@version]" — same convention as InstallCommand.Args.
+func (c *UninstallCommand) Args(args []string) error {
+	if len(args) == 0 {
+		return cerrors.Errorf("requires a connector name, optionally with @version (e.g. postgres or postgres@0.14.1)")
+	}
+	if len(args) > 1 {
+		return cerrors.Errorf("too many arguments")
+	}
+
+	name, version, _ := strings.Cut(args[0], "@")
+	if name == "" {
+		return cerrors.Errorf("connector name must not be empty")
+	}
+	c.args.Name = name
+	c.args.Version = version
+	return nil
+}
+
+func (c *UninstallCommand) ResultCommand() string { return "connectors.uninstall" }
+
+func (c *UninstallCommand) ExecuteWithResult(ctx context.Context) (cecdysis.Outcome, error) {
+	refs, err := collectInUseRefs(ctx, c.Cfg, c.args.Name, c.args.Version)
+	if err != nil {
+		return cecdysis.Outcome{}, err
+	}
+
+	result, err := registry.Uninstall(registry.UninstallOptions{
+		Name: c.args.Name, Version: c.args.Version, ConnectorsPath: c.Cfg.Connectors.Path,
+		Force: c.flags.Force, InUseRefs: refs, InstalledBy: installedByUser(),
+	})
+	if err != nil {
+		return cecdysis.Outcome{}, err
+	}
+
+	return cecdysis.Outcome{OK: true, Result: result}, nil
+}
+
+func (c *UninstallCommand) Render(outcome cecdysis.Outcome) string {
+	res, ok := outcome.Result.(*registry.UninstallResult)
+	if !ok || res == nil {
+		return ""
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Uninstalled %s@%s\n", res.Name, res.Version)
+	for _, w := range res.Warnings {
+		fmt.Fprintf(&b, "warning: %s\n", w)
+	}
+	if res.DriftDetected {
+		fmt.Fprintln(&b, "note: the removed artifact's digest did not match the one recorded at install time")
+	}
+	if res.ArtifactAlreadyMissing {
+		fmt.Fprintln(&b, "note: the artifact file was already missing on disk; only the manifest entry was cleaned up")
+	}
+	return b.String()
+}
+
+// collectInUseRefs builds the in-use check's pipeline-connector-instance
+// list (step5 §2 step 2): if the exact name@version to uninstall is unknown
+// yet (Version == "", ambiguous or not, decided later by registry.Uninstall
+// itself), this still needs SOME concrete version to match against — an
+// empty Version here means "match any installed version of Name" is not
+// quite right either, since the manifest may have more than one. To keep
+// this simple and correct, the identity match below is by NAME only when
+// Version is empty (over-matching is safe here: it can only ADD warnings/
+// refusals, never silently miss one), and by the exact name@version
+// otherwise.
+func collectInUseRefs(ctx context.Context, cfg conduit.Config, name, version string) ([]registry.InUseRef, error) {
+	instances, err := listConnectorInstances(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	var refs []registry.InUseRef
+	for _, inst := range instances {
+		fn := plugin.FullName(inst.Plugin)
+		if fn.PluginType() != plugin.PluginTypeStandalone || fn.PluginName() != name {
+			continue
+		}
+		if version != "" && fn.PluginVersion() != version {
+			continue
+		}
+		refs = append(refs, registry.InUseRef{PipelineID: inst.PipelineID, ConnectorID: inst.ID})
+	}
+	return refs, nil
+}
+
+// connectorInstanceRef is the minimal shape collectInUseRefs needs from
+// either source (the live API or a provisioned-config scan).
+type connectorInstanceRef struct {
+	ID         string
+	PipelineID string
+	Plugin     string
+}
+
+// listConnectorInstances tries the running engine first (a short
+// health-checked dial — see uninstallInUseCheckTimeout) via the SAME
+// ConnectorServiceClient.ListConnectors call `connectors list` already
+// makes, with no PipelineId filter; if the engine isn't reachable, it falls
+// back to scanning provisioned pipeline configs directly off disk via
+// pkg/provisioning/config, since uninstall only touches files under
+// --connectors.path and must work whether or not the engine is running.
+func listConnectorInstances(ctx context.Context, cfg conduit.Config) ([]connectorInstanceRef, error) {
+	dialCtx, cancel := context.WithTimeout(ctx, uninstallInUseCheckTimeout)
+	defer cancel()
+
+	client, err := api.NewClient(dialCtx, cfg.API.GRPC.Address)
+	if err == nil {
+		defer client.Close()
+		return listConnectorInstancesViaAPI(ctx, client)
+	}
+
+	return listConnectorInstancesFromProvisionedConfig(ctx, cfg.Pipelines.Path)
+}
+
+func listConnectorInstancesViaAPI(ctx context.Context, client *api.Client) ([]connectorInstanceRef, error) {
+	resp, err := client.ConnectorServiceClient.ListConnectors(ctx, &apiv1.ListConnectorsRequest{})
+	if err != nil {
+		return nil, cerrors.Errorf("failed to list connectors from the running engine: %w", err)
+	}
+	refs := make([]connectorInstanceRef, 0, len(resp.Connectors))
+	for _, c := range resp.Connectors {
+		refs = append(refs, connectorInstanceRef{ID: c.Id, PipelineID: c.PipelineId, Plugin: c.Plugin})
+	}
+	return refs, nil
+}
+
+// listConnectorInstancesFromProvisionedConfig reads every provisioned
+// pipeline config under path (a file or a directory of them — see
+// config.ResolveFiles, the exact same resolution `pipelines validate`/
+// config-file provisioning at startup use) and returns every connector
+// entry's plugin reference. A missing/empty path is not an error: it
+// matches "no provisioned pipelines to check," not "in use."
+func listConnectorInstancesFromProvisionedConfig(ctx context.Context, path string) ([]connectorInstanceRef, error) {
+	if path == "" {
+		return nil, nil
+	}
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, cerrors.Errorf("could not stat pipelines path %q: %w", path, err)
+	}
+
+	files, err := config.ResolveFiles(path)
+	if err != nil {
+		return nil, cerrors.Errorf("could not resolve pipeline config files under %q: %w", path, err)
+	}
+
+	parser := yaml.NewParser(log.Nop())
+	var refs []connectorInstanceRef
+	for _, file := range files {
+		f, err := os.Open(file)
+		if err != nil {
+			return nil, cerrors.Errorf("could not open pipeline config %q: %w", file, err)
+		}
+		pipelines, perr := parser.Parse(ctx, f)
+		_ = f.Close()
+		if perr != nil {
+			// A malformed provisioned config is a real problem, but not one
+			// uninstall should fail over silently — surface it as a hard
+			// error so the operator fixes the config rather than getting a
+			// false "not in use" answer.
+			return nil, cerrors.Errorf("could not parse pipeline config %q: %w", file, perr)
+		}
+		for _, p := range pipelines {
+			for _, c := range p.Connectors {
+				refs = append(refs, connectorInstanceRef{ID: c.ID, PipelineID: p.ID, Plugin: c.Plugin})
+			}
+		}
+	}
+	return refs, nil
+}

--- a/cmd/conduit/root/connectors/uninstall_test.go
+++ b/cmd/conduit/root/connectors/uninstall_test.go
@@ -1,0 +1,171 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Full-stack CLI integration tests for `conduit connectors uninstall`. The
+// gRPC engine is never running in these tests, so every run exercises the
+// offline provisioned-pipeline-config fallback (uninstall.go's
+// listConnectorInstancesFromProvisionedConfig) for the in-use check — a
+// real, not mocked, proof that uninstall works without a running engine.
+package connectors_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	json "github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/cmd/conduit/root/connectors"
+	"github.com/conduitio/ecdysis"
+)
+
+func runUninstall(t *testing.T, args ...string) (output string, err error) {
+	t.Helper()
+	e := ecdysis.New(ecdysis.WithDecorators(cecdysis.CommandWithResultDecorator{}))
+	cmd := e.MustBuildCobraCommand(&connectors.UninstallCommand{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	_, err = cmd.ExecuteC()
+	return out.String(), err
+}
+
+func writeUninstallManifestFixture(t *testing.T, connectorsPath, name, version string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(connectorsPath, ".registry"), 0o755))
+	artifactFile := name + "_" + version
+	require.NoError(t, os.WriteFile(filepath.Join(connectorsPath, artifactFile), []byte("fixture-bytes"), 0o755))
+
+	manifest := map[string]any{
+		"schemaVersion": 1,
+		"installs": map[string]any{
+			name + "@" + version: map[string]any{
+				"name": name, "version": version, "kind": "standalone",
+				"os": "linux", "arch": "amd64", "artifactFile": artifactFile,
+				"digest":      "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+				"installedAt": time.Now().UTC().Format(time.RFC3339), "source": "index",
+			},
+		},
+	}
+	data, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(connectorsPath, ".registry", "manifest.json"), data, 0o644))
+}
+
+func TestUninstall_NoPipelinesProvisioned_Succeeds(t *testing.T) {
+	connectorsPath := t.TempDir()
+	pipelinesPath := t.TempDir() // empty: nothing provisioned, so not in use
+	writeUninstallManifestFixture(t, connectorsPath, "postgres", "0.14.1")
+
+	out, err := runUninstall(t,
+		"postgres@0.14.1",
+		"--connectors.path="+connectorsPath,
+		"--pipelines.path="+pipelinesPath,
+		"--json",
+	)
+	require.NoError(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	assert.True(t, res.OK)
+
+	_, statErr := os.Stat(filepath.Join(connectorsPath, "postgres_0.14.1"))
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestUninstall_NotInstalled_HardError(t *testing.T) {
+	connectorsPath := t.TempDir()
+	pipelinesPath := t.TempDir()
+
+	out, err := runUninstall(t,
+		"postgres",
+		"--connectors.path="+connectorsPath,
+		"--pipelines.path="+pipelinesPath,
+		"--json",
+	)
+	require.Error(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	require.NotNil(t, res.Error)
+	assert.Equal(t, "registry.connector_not_installed", res.Error.Code)
+}
+
+// TestUninstall_InUseViaProvisionedConfig_RefusesWithoutForce is the
+// offline in-use check's own AC (step5 §2): a pipeline config referencing
+// the exact plugin@version being uninstalled, found via the provisioned-
+// config fallback (no engine running in this test process at all), refuses
+// the uninstall by default and succeeds loudly with --force.
+func TestUninstall_InUseViaProvisionedConfig_RefusesWithoutForce(t *testing.T) {
+	connectorsPath := t.TempDir()
+	pipelinesPath := t.TempDir()
+	writeUninstallManifestFixture(t, connectorsPath, "postgres", "0.14.1")
+
+	pipelineYAML := `
+version: "2.2"
+pipelines:
+  - id: pipe1
+    status: running
+    connectors:
+      - id: conn1
+        type: source
+        plugin: "standalone:postgres@0.14.1"
+        settings:
+          foo: bar
+`
+	require.NoError(t, os.WriteFile(filepath.Join(pipelinesPath, "pipeline1.yaml"), []byte(pipelineYAML), 0o644))
+
+	out, err := runUninstall(t,
+		"postgres@0.14.1",
+		"--connectors.path="+connectorsPath,
+		"--pipelines.path="+pipelinesPath,
+		"--json",
+	)
+	require.Error(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	require.NotNil(t, res.Error)
+	assert.Equal(t, "registry.connector_in_use", res.Error.Code)
+	assert.Contains(t, res.Error.Message, "pipe1")
+
+	// Nothing removed.
+	_, statErr := os.Stat(filepath.Join(connectorsPath, "postgres_0.14.1"))
+	assert.NoError(t, statErr)
+
+	// --force proceeds, with a warning.
+	out, err = runUninstall(t,
+		"postgres@0.14.1",
+		"--connectors.path="+connectorsPath,
+		"--pipelines.path="+pipelinesPath,
+		"--force", "--json",
+	)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	assert.True(t, res.OK)
+
+	_, statErr = os.Stat(filepath.Join(connectorsPath, "postgres_0.14.1"))
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestUninstall_MissingName_HardError(t *testing.T) {
+	_, err := runUninstall(t, "--json")
+	require.Error(t, err)
+}

--- a/pkg/conduit/config.go
+++ b/pkg/conduit/config.go
@@ -157,6 +157,12 @@ type Config struct {
 		// old a cryptographically-verified index's timestamp may be before
 		// install/audit refuse it as stale.
 		MaxStaleness time.Duration `long:"install.max-staleness" mapstructure:"max-staleness" usage:"maximum age of a verified registry index before it is considered stale"`
+		// AllowStaleBundle is the operator policy gate for `conduit
+		// connectors install --bundle --allow-stale-bundle` (PR-4,
+		// plan-v2/step5 §7 step 3), gated identically to AllowUnsigned above
+		// per DeVaris's ratification: false hard-disables the entire
+		// --allow-stale-bundle path regardless of flag/TTY/env var.
+		AllowStaleBundle bool `long:"install.allow-stale-bundle" mapstructure:"allow-stale-bundle" usage:"operator policy: permit --allow-stale-bundle offline connector installs at all (false hard-disables regardless of flag/TTY/env var)"`
 	}
 
 	Processors struct {
@@ -258,6 +264,7 @@ func DefaultConfigWithBasePath(basePath string) Config {
 
 	cfg.Install.AllowUnsigned = false
 	cfg.Install.MaxStaleness = index.DefaultMaxStaleness
+	cfg.Install.AllowStaleBundle = false
 
 	cfg.Processors.Path = filepath.Join(basePath, "processors")
 

--- a/pkg/registry/audit.go
+++ b/pkg/registry/audit.go
@@ -30,7 +30,7 @@ import (
 // Signed: false, VerifiedIdentity: "", AllowUnsigned: false (see
 // manifest.go's ManifestEntry doc — the same reasoning applies here).
 type AuditEvent struct {
-	Event            string    `json:"event"` // "connector_install" in this PR; more added by later PRs
+	Event            string    `json:"event"` // "connector_install" or "connector_uninstall" (PR-4)
 	Connector        string    `json:"connector"`
 	Version          string    `json:"version"`
 	Digest           string    `json:"digest"` // "sha256:<hex>"
@@ -39,6 +39,10 @@ type AuditEvent struct {
 	Signed           bool      `json:"signed"`
 	VerifiedIdentity string    `json:"verifiedIdentity"`
 	AllowUnsigned    bool      `json:"allowUnsigned"`
+	// Forced is set on an "connector_uninstall" event when --force overrode
+	// an in-use refusal (PR-4, step5 §2 step 8). Always false/omitted for
+	// "connector_install" events.
+	Forced bool `json:"forced,omitempty"`
 }
 
 // AppendAuditEvent appends ev as one JSON line to path, creating the file

--- a/pkg/registry/bundle.go
+++ b/pkg/registry/bundle.go
@@ -1,0 +1,700 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file implements the offline/air-gapped install path (plan-v2/step5
+// §7): Bundle prepares a self-contained tarball on a networked machine,
+// running the full real install-equivalent verification before ever writing
+// the tarball; InstallFromBundle installs from that tarball on a machine
+// with NO network access at all, re-verifying everything against the
+// offline binary's own compiled-in trust anchors — it NEVER skips
+// verification just because the network is down.
+//
+// # Soundness
+//
+// A bundle is a carrier for an already-completed, already-verified
+// installation, replayed later on a different machine — never a way to
+// defer verification to a machine that can't fully perform it. Bundle
+// itself refuses to package an artifact that would not itself pass a normal
+// `install` (VerifyArtifact must return Signed: true); InstallFromBundle
+// re-runs index verification (via the SAME registry.TrustedVerifier code
+// path a live fetch uses — index verification has no network dependency of
+// its own once the bytes are in hand) and artifact signature/provenance
+// verification (via the same sigstore-go `--bundle` offline verification
+// the online path already uses — see trust/sigstore.go's doc comments: it
+// never makes a live Fulcio/Rekor query, bundle or not).
+package registry
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	json "github.com/goccy/go-json"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry/index"
+	"github.com/conduitio/conduit/pkg/registry/policy"
+	"github.com/conduitio/conduit/pkg/registry/trust"
+)
+
+// BundleFormatVersion is the bundleFormatVersion this build writes and the
+// maximum InstallFromBundle accepts — its own small compat field, same
+// announce/warn/remove discipline as the index's schemaVersion: a too-new
+// bundle format on an old conduit binary says "upgrade conduit," never
+// mis-parses.
+const BundleFormatVersion = 1
+
+// InstallSourceOfflineBundle is the ManifestEntry.Source value recorded by
+// InstallFromBundle — see InstallSourceIndex (install.go) for the online
+// counterpart.
+const InstallSourceOfflineBundle = "offline-bundle"
+
+// maxBundleTarEntryBytes bounds any single entry InstallFromBundle reads out
+// of a bundle tarball — generous for a single connector artifact plus its
+// small signature/provenance bundles and index snapshot, and a hard refusal
+// (never a silent truncation) if exceeded, mirroring extract.go's
+// decompression-bomb guard for the same reason.
+const maxBundleTarEntryBytes int64 = 256 * 1024 * 1024 // 256 MiB
+
+// StaleBundleEnvVar is the non-interactive escape hatch for
+// --allow-stale-bundle (gated identically to --allow-unsigned per DeVaris's
+// ratification, plan-v2/step5 §7 step 3, §9 decision item 2).
+const StaleBundleEnvVar = "CONDUIT_ALLOW_STALE_BUNDLE"
+
+// BundleManifest is the small manifest.json entry inside a bundle tarball —
+// distinct from (and much smaller than) registry.ManifestEntry, the install
+// manifest's own per-connector record.
+type BundleManifest struct {
+	BundleFormatVersion int       `json:"bundleFormatVersion"`
+	Name                string    `json:"name"`
+	Version             string    `json:"version"`
+	OS                  string    `json:"os"`
+	Arch                string    `json:"arch"`
+	SHA256              string    `json:"sha256"`
+	Size                int64     `json:"size"`
+	CreatedAt           time.Time `json:"createdAt"`
+}
+
+// BundleOptions is Bundle's configuration.
+type BundleOptions struct {
+	Name       string
+	Version    string
+	OutputPath string
+
+	IndexURL  string
+	IndexFile string
+
+	GOOS, GOArch string
+
+	// IndexVerifier/ArtifactVerifier are REQUIRED (mirroring
+	// InstallOptions) — bundling is a normal, fully-verified install whose
+	// output is redirected into a tarball instead of --connectors.path; it
+	// is never a trust shortcut, so there is no FailClosedVerifier-style
+	// default here either.
+	IndexVerifier    IndexVerifier
+	ArtifactVerifier ArtifactVerifier
+
+	RunningConduitVersion  string
+	RunningProtocolVersion string
+
+	HTTPClient *http.Client
+}
+
+// BundleResult is Bundle's success-path result.
+type BundleResult struct {
+	Name       string `json:"name"`
+	Version    string `json:"version"`
+	OS         string `json:"os"`
+	Arch       string `json:"arch"`
+	OutputPath string `json:"outputPath"`
+	Digest     string `json:"digest"`
+	Size       int64  `json:"size"`
+}
+
+// Bundle prepares an offline install bundle: fetch+verify the index
+// (identical to install.go's own pipeline), resolve name/version, select
+// the host-requested platform artifact, download and corruption-check it,
+// fetch its signature/provenance bundles, and run FULL identity-pinned
+// verification — all while online — before packaging everything (including
+// the complete signed index snapshot, so the offline machine can itself
+// re-check yank/revocation status) into a single tarball.
+func Bundle(ctx context.Context, opts BundleOptions) (*BundleResult, error) {
+	if opts.Name == "" {
+		return nil, conduiterr.New(conduiterr.CodeInvalidArgument, "connector name is required")
+	}
+	if opts.OutputPath == "" {
+		return nil, conduiterr.New(conduiterr.CodeInvalidArgument, "--output is required")
+	}
+	if opts.IndexVerifier == nil || opts.ArtifactVerifier == nil {
+		return nil, conduiterr.New(CodeVerificationUnavailable, "no verifier configured for bundle prep")
+	}
+
+	raw, err := fetchIndexRawFrom(ctx, opts.IndexURL, opts.IndexFile)
+	if err != nil {
+		return nil, err
+	}
+	verified, err := opts.IndexVerifier.VerifyIndex(ctx, raw)
+	if err != nil {
+		return nil, err
+	}
+	if !verified.Verified {
+		return nil, conduiterr.New(CodeVerificationUnavailable,
+			"the registry index could not be cryptographically verified — refusing to bundle from untrusted data")
+	}
+
+	goos, goarch := opts.GOOS, opts.GOArch
+	if goos == "" {
+		goos = runtime.GOOS
+	}
+	if goarch == "" {
+		goarch = runtime.GOARCH
+	}
+
+	resolved, err := Resolve(verified.Payload, ResolveOptions{
+		Name: opts.Name, Version: opts.Version,
+		RunningConduitVersion: opts.RunningConduitVersion, RunningProtocolVersion: opts.RunningProtocolVersion,
+	})
+	if err != nil {
+		return nil, err
+	}
+	artifact, err := SelectArtifact(resolved.Connector.Name, resolved.Version, goos, goarch)
+	if err != nil {
+		return nil, err
+	}
+
+	tmpDir, err := os.MkdirTemp("", "conduit-bundle-*")
+	if err != nil {
+		return nil, conduiterr.Wrap(CodeArchiveInvalid, "could not create a temp directory for bundle prep", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	client := opts.HTTPClient
+	if client == nil {
+		client = newDownloadClient()
+	}
+
+	archivePath := filepath.Join(tmpDir, "artifact.tar.gz")
+	dl, err := Download(ctx, client, artifact.URL, archivePath, artifact.Size)
+	if err != nil {
+		return nil, err
+	}
+	if err := CheckCorruption(dl.Digest, artifact.SHA256); err != nil {
+		return nil, err
+	}
+
+	// fetchArtifactRef's InstallOptions parameter carries no fields it
+	// actually reads (bundle fetches always go through boundedfetch's own
+	// http.DefaultClient) — passed as a zero value deliberately, not an
+	// oversight.
+	ref, err := fetchArtifactRef(ctx, InstallOptions{}, dl.Digest, resolved.Version, artifact)
+	if err != nil {
+		return nil, err
+	}
+
+	identity := trust.PinnedIdentity{
+		OIDCIssuer:      resolved.Connector.Publisher.ExpectedOIDCIssuer,
+		IdentityPattern: resolved.Connector.Publisher.ExpectedIdentityPattern,
+	}
+	verifyResult, err := opts.ArtifactVerifier.VerifyArtifact(ctx, ref, identity)
+	if err != nil {
+		return nil, err
+	}
+	if !verifyResult.Signed {
+		return nil, conduiterr.New(CodeVerificationUnavailable,
+			"bundle prep requires a fully verified (signed) artifact — refusing to package an unsigned artifact "+
+				"(a bundle is a carrier for an already-verified install, never a way to defer verification)")
+	}
+
+	manifest := BundleManifest{
+		BundleFormatVersion: BundleFormatVersion,
+		Name:                resolved.Connector.Name,
+		Version:             resolved.Version.Version,
+		OS:                  artifact.OS,
+		Arch:                artifact.Arch,
+		SHA256:              fmt.Sprintf("sha256:%x", dl.Digest),
+		Size:                dl.Size,
+		CreatedAt:           time.Now().UTC(),
+	}
+
+	if err := writeBundleTar(opts.OutputPath, manifest, archivePath, ref.SignatureBundle, ref.ProvenanceBundle, raw); err != nil {
+		return nil, err
+	}
+
+	return &BundleResult{
+		Name: manifest.Name, Version: manifest.Version, OS: manifest.OS, Arch: manifest.Arch,
+		OutputPath: opts.OutputPath, Digest: manifest.SHA256, Size: manifest.Size,
+	}, nil
+}
+
+func writeBundleTar(outputPath string, manifest BundleManifest, archivePath string, signatureBundle, provenanceBundle, indexSnapshotRaw []byte) error {
+	out, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return conduiterr.Wrap(CodeArchiveInvalid, "could not create bundle output file", err)
+	}
+	defer out.Close()
+
+	gz := gzip.NewWriter(out)
+	tw := tar.NewWriter(gz)
+
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return conduiterr.Wrap(conduiterr.CodeInternal, "could not marshal bundle manifest", err)
+	}
+	if err := addTarFile(tw, "manifest.json", manifestBytes); err != nil {
+		return err
+	}
+
+	artifactBytes, err := os.ReadFile(archivePath)
+	if err != nil {
+		return conduiterr.Wrap(CodeArchiveInvalid, "could not read staged artifact for bundling", err)
+	}
+	if err := addTarFile(tw, "artifact", artifactBytes); err != nil {
+		return err
+	}
+
+	if len(signatureBundle) > 0 {
+		if err := addTarFile(tw, "signature.bundle", signatureBundle); err != nil {
+			return err
+		}
+	}
+	if len(provenanceBundle) > 0 {
+		if err := addTarFile(tw, "provenance.bundle", provenanceBundle); err != nil {
+			return err
+		}
+	}
+	if err := addTarFile(tw, "index-snapshot.json", indexSnapshotRaw); err != nil {
+		return err
+	}
+
+	if err := tw.Close(); err != nil {
+		return conduiterr.Wrap(CodeArchiveInvalid, "could not finalize bundle tar", err)
+	}
+	if err := gz.Close(); err != nil {
+		return conduiterr.Wrap(CodeArchiveInvalid, "could not finalize bundle gzip", err)
+	}
+	return nil
+}
+
+func addTarFile(tw *tar.Writer, name string, data []byte) error {
+	hdr := &tar.Header{Name: name, Mode: 0o600, Size: int64(len(data))}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return conduiterr.Wrap(CodeArchiveInvalid, "could not write bundle tar header for "+name, err)
+	}
+	if _, err := tw.Write(data); err != nil {
+		return conduiterr.Wrap(CodeArchiveInvalid, "could not write bundle tar entry for "+name, err)
+	}
+	return nil
+}
+
+// readBundleTar extracts every entry (bounded per maxBundleTarEntryBytes)
+// from a bundle tarball into memory — bundles are single-connector-sized,
+// never the multi-hundred-MB scale that would make this unreasonable.
+func readBundleTar(bundlePath string) (manifest BundleManifest, artifactBytes, signatureBundle, provenanceBundle, indexSnapshotRaw []byte, err error) {
+	f, err := os.Open(bundlePath)
+	if err != nil {
+		return BundleManifest{}, nil, nil, nil, nil, conduiterr.Wrap(CodeArchiveInvalid, "could not open bundle file", err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return BundleManifest{}, nil, nil, nil, nil, conduiterr.Wrap(CodeArchiveInvalid, "bundle is not valid gzip", err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+
+	var manifestBytes []byte
+	for {
+		hdr, terr := tr.Next()
+		if terr == io.EOF {
+			break
+		}
+		if terr != nil {
+			return BundleManifest{}, nil, nil, nil, nil, conduiterr.Wrap(CodeArchiveInvalid, "bundle archive is corrupt", terr)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+
+		data, rerr := readCappedTarEntry(tr, maxBundleTarEntryBytes)
+		if rerr != nil {
+			return BundleManifest{}, nil, nil, nil, nil, rerr
+		}
+
+		switch filepath.Clean(hdr.Name) {
+		case "manifest.json":
+			manifestBytes = data
+		case "artifact":
+			artifactBytes = data
+		case "signature.bundle":
+			signatureBundle = data
+		case "provenance.bundle":
+			provenanceBundle = data
+		case "index-snapshot.json":
+			indexSnapshotRaw = data
+		}
+	}
+
+	if manifestBytes == nil || artifactBytes == nil || indexSnapshotRaw == nil {
+		return BundleManifest{}, nil, nil, nil, nil, conduiterr.New(CodeArchiveInvalid,
+			"bundle is missing one or more required entries (manifest.json, artifact, index-snapshot.json)")
+	}
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		return BundleManifest{}, nil, nil, nil, nil, conduiterr.Wrap(CodeArchiveInvalid, "bundle manifest.json is not valid JSON", err)
+	}
+	return manifest, artifactBytes, signatureBundle, provenanceBundle, indexSnapshotRaw, nil
+}
+
+func readCappedTarEntry(tr *tar.Reader, maxBytes int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(tr, maxBytes+1))
+	if err != nil {
+		return nil, conduiterr.Wrap(CodeArchiveInvalid, "could not read bundle tar entry", err)
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, conduiterr.New(CodeArchiveInvalid, "bundle tar entry exceeds the maximum allowed size")
+	}
+	return data, nil
+}
+
+// InstallBundleOptions is InstallFromBundle's configuration.
+type InstallBundleOptions struct {
+	BundlePath     string
+	ConnectorsPath string
+
+	// Verifier MUST be a real *TrustedVerifier — offline install never uses
+	// FailClosedVerifier-style verification-disabled wiring; there is no
+	// "trust it because we can't check" fallback for the offline path (see
+	// this file's doc comment). Concrete, not the IndexVerifier/
+	// ArtifactVerifier interfaces, because the stale-bundle carve-out below
+	// needs to construct a staleness-relaxed COPY of the same verifier for
+	// exactly one retry — an interface value can't be adjusted that way.
+	Verifier *TrustedVerifier
+
+	InstalledBy string
+	LockTimeout time.Duration
+
+	// RunningConduitVersion/RunningProtocolVersion are this build's own
+	// versions, compared against the bundled version's minConduitVersion/
+	// minProtocolVersion exactly as an online install would (resolve.go) —
+	// an offline install must refuse an incompatible pinned version just as
+	// readily as an online one; being offline is not a compatibility
+	// exemption.
+	RunningConduitVersion  string
+	RunningProtocolVersion string
+
+	// AllowStaleBundle requests tolerating a bundled index snapshot older
+	// than the verifier's MaxStaleness — gated identically to
+	// --allow-unsigned (plan-v2/step5 §7 step 3, §9 decision item 2): TTY/
+	// operator-policy gated, forbiddable, never silently flippable. Only
+	// ever consulted after a first verification attempt fails SPECIFICALLY
+	// with index.CodeIndexStale — every other index verification failure
+	// (tampering, rollback, an unrecognized trust anchor) is refused
+	// unconditionally, with no override of any kind.
+	AllowStaleBundle bool
+	// TTY, CIEnv, IsMCP, EnvVarSet, TypedConfirmation, OperatorAllowStaleBundle
+	// are the primitive signals policy.StaleBundleContext needs, collected
+	// by the CLI layer (which never imports pkg/registry/policy directly —
+	// see the PolicyBypass depguard rule) and passed through here. Only
+	// consulted when AllowStaleBundle is true AND the bundle actually turns
+	// out to be stale.
+	TTY                      bool
+	CIEnv                    bool
+	IsMCP                    bool
+	EnvVarSet                bool
+	TypedConfirmation        bool
+	OperatorAllowStaleBundle bool
+}
+
+func (o *InstallBundleOptions) lockTimeout() time.Duration {
+	if o.LockTimeout > 0 {
+		return o.LockTimeout
+	}
+	return DefaultLockTimeout
+}
+
+// InstallFromBundle installs a connector fully offline: NO network call of
+// any kind is made by this function or anything it calls (index
+// verification and Sigstore bundle verification both operate purely over
+// bytes already in hand — see this file's doc comment) — asserted, not
+// merely assumed: if index-snapshot.json is malformed, this function fails
+// closed rather than ever falling back to a live index fetch, which would
+// silently reintroduce the network dependency this path exists to avoid.
+func InstallFromBundle(ctx context.Context, opts InstallBundleOptions) (*InstallResult, error) {
+	if opts.BundlePath == "" {
+		return nil, conduiterr.New(conduiterr.CodeInvalidArgument, "--bundle path is required")
+	}
+	if opts.ConnectorsPath == "" {
+		return nil, conduiterr.New(conduiterr.CodeInvalidArgument, "--connectors.path is required")
+	}
+	if opts.Verifier == nil {
+		return nil, conduiterr.New(CodeVerificationUnavailable, "no verifier configured for bundle install")
+	}
+
+	manifest, artifactBytes, signatureBundle, provenanceBundle, snapshotRaw, err := readBundleTar(opts.BundlePath)
+	if err != nil {
+		return nil, err
+	}
+	if manifest.BundleFormatVersion > BundleFormatVersion {
+		return nil, conduiterr.New(conduiterr.CodeInvalidArgument, fmt.Sprintf(
+			"bundle format version %d is newer than this build supports (max %d) — upgrade conduit",
+			manifest.BundleFormatVersion, BundleFormatVersion))
+	}
+
+	verified, err := verifyBundleIndex(ctx, opts, snapshotRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	resolved, artifact, err := resolveBundleArtifact(verified, manifest, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	sum, verifyResult, err := verifyBundleArtifact(ctx, opts, bundleArtifactMaterial{
+		artifactBytes: artifactBytes, manifestSHA256: manifest.SHA256,
+		signatureBundle: signatureBundle, provenanceBundle: provenanceBundle,
+	}, resolved, artifact)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := ManifestKey(resolved.Connector.Name, resolved.Version.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	targetLock, err := AcquireTargetLock(opts.ConnectorsPath, resolved.Connector.Name, opts.lockTimeout())
+	if err != nil {
+		return nil, err
+	}
+	defer targetLock.Unlock() //nolint:errcheck // best-effort; flock also releases at process exit
+
+	entry, alreadyInstalled, err := lookupManifestEntry(opts.ConnectorsPath, key)
+	if err != nil {
+		return nil, err
+	}
+	if alreadyInstalled {
+		return &InstallResult{
+			Name: entry.Name, Version: entry.Version, OS: entry.OS, Arch: entry.Arch,
+			AlreadyInstalled: true, ArtifactFile: entry.ArtifactFile, Digest: entry.Digest,
+			SourceIndexVersion: entry.SourceIndexVersion,
+		}, nil
+	}
+
+	stagingDir, err := createBundleStagingDir(opts.ConnectorsPath)
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(stagingDir)
+
+	archivePath := filepath.Join(stagingDir, "artifact.tar.gz")
+	if err := os.WriteFile(archivePath, artifactBytes, 0o600); err != nil {
+		return nil, conduiterr.Wrap(CodeArchiveInvalid, "could not stage bundled artifact", err)
+	}
+
+	entryToSave, err := finalizeArtifactInstall(finalizeInstallOptions{
+		connectorsPath:     opts.ConnectorsPath,
+		stagingDir:         stagingDir,
+		archivePath:        archivePath,
+		name:               resolved.Connector.Name,
+		version:            resolved.Version.Version,
+		os:                 artifact.OS,
+		arch:               artifact.Arch,
+		digest:             sum,
+		size:               int64(len(artifactBytes)),
+		installedBy:        opts.InstalledBy,
+		sourceIndexVersion: verified.Payload.Index.Version,
+		source:             InstallSourceOfflineBundle,
+		bundleIndexVersion: verified.Payload.Index.Version,
+		verifyResult:       verifyResult,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := writeManifestEntry(opts.ConnectorsPath, key, entryToSave, opts.lockTimeout()); err != nil {
+		return nil, err
+	}
+
+	if err := AppendAuditEvent(auditLogPath(opts.ConnectorsPath), AuditEvent{
+		Event: "connector_install", Connector: entryToSave.Name, Version: entryToSave.Version,
+		Digest: entryToSave.Digest, Operator: opts.InstalledBy, Timestamp: entryToSave.InstalledAt,
+		Signed: entryToSave.Signed, VerifiedIdentity: entryToSave.VerifiedIdentity, AllowUnsigned: entryToSave.AllowUnsigned,
+	}); err != nil {
+		return nil, conduiterr.Wrap(conduiterr.CodeInternal, "connector installed but could not append the audit log entry", err)
+	}
+
+	return &InstallResult{
+		Name: entryToSave.Name, Version: entryToSave.Version, OS: entryToSave.OS, Arch: entryToSave.Arch,
+		Deprecated: resolved.Version.Deprecated, ArtifactFile: entryToSave.ArtifactFile,
+		Digest: entryToSave.Digest, SourceIndexVersion: entryToSave.SourceIndexVersion,
+	}, nil
+}
+
+// resolveBundleArtifact resolves manifest.Name/Version against the
+// verified snapshot and selects the (os, arch) artifact the bundle claims —
+// factored out of InstallFromBundle purely to keep that function's
+// cyclomatic complexity down; no independent behavior of its own.
+func resolveBundleArtifact(verified *index.VerifiedIndex, manifest BundleManifest, opts InstallBundleOptions) (*ResolvedVersion, *index.Artifact, error) {
+	resolved, err := Resolve(verified.Payload, ResolveOptions{
+		Name: manifest.Name, Version: manifest.Version,
+		RunningConduitVersion: opts.RunningConduitVersion, RunningProtocolVersion: opts.RunningProtocolVersion,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	artifact, err := SelectArtifact(resolved.Connector.Name, resolved.Version, manifest.OS, manifest.Arch)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resolved, artifact, nil
+}
+
+// bundleArtifactMaterial bundles the raw bytes verifyBundleArtifact needs,
+// so its own signature stays short.
+type bundleArtifactMaterial struct {
+	artifactBytes    []byte
+	manifestSHA256   string
+	signatureBundle  []byte
+	provenanceBundle []byte
+}
+
+// verifyBundleArtifact runs the digest check (twice — against the bundle's
+// own manifest.json claim AND the verified snapshot's per-artifact declared
+// sha256, plan-v2/step5 §7 step 7) and the identity-pinned signature/
+// provenance verification, exactly as install.go's runVerificationGate does
+// for a live artifact — factored out of InstallFromBundle purely to keep
+// that function's cyclomatic complexity down.
+func verifyBundleArtifact(ctx context.Context, opts InstallBundleOptions, m bundleArtifactMaterial, resolved *ResolvedVersion, artifact *index.Artifact) ([32]byte, VerifyResult, error) {
+	sum := sha256.Sum256(m.artifactBytes)
+	if err := CheckCorruption(sum, m.manifestSHA256); err != nil {
+		return sum, VerifyResult{}, err
+	}
+	if err := CheckCorruption(sum, artifact.SHA256); err != nil {
+		return sum, VerifyResult{}, err
+	}
+
+	identity := trust.PinnedIdentity{
+		OIDCIssuer:      resolved.Connector.Publisher.ExpectedOIDCIssuer,
+		IdentityPattern: resolved.Connector.Publisher.ExpectedIdentityPattern,
+	}
+	verifyResult, err := opts.Verifier.VerifyArtifact(ctx, ArtifactRef{
+		Digest: sum, SignatureBundle: m.signatureBundle, ProvenanceBundle: m.provenanceBundle,
+	}, identity)
+	if err != nil {
+		return sum, VerifyResult{}, err
+	}
+	if !verifyResult.Signed {
+		return sum, VerifyResult{}, conduiterr.New(CodeVerificationUnavailable,
+			"bundle artifact verification did not return a signed result — refusing to install")
+	}
+	return sum, verifyResult, nil
+}
+
+// createBundleStagingDir creates the private (0700), uniquely-named
+// staging subdirectory of connectorsPath InstallFromBundle stages the
+// bundled artifact into before extraction — same discipline as install.go's
+// own staging directory (see downloadVerifyAndInstall's doc comment for why
+// it must be a subdirectory of connectorsPath, not the OS temp dir).
+func createBundleStagingDir(connectorsPath string) (string, error) {
+	stagingRoot := stagingRootPath(connectorsPath)
+	if err := os.MkdirAll(stagingRoot, 0o700); err != nil {
+		return "", conduiterr.Wrap(CodeDownloadFailed, "could not create staging root directory", err)
+	}
+	stagingDir, err := os.MkdirTemp(stagingRoot, "install-bundle-*")
+	if err != nil {
+		return "", conduiterr.Wrap(CodeDownloadFailed, "could not create staging directory", err)
+	}
+	if err := os.Chmod(stagingDir, 0o700); err != nil {
+		return "", conduiterr.Wrap(CodeDownloadFailed, "could not set staging directory permissions", err)
+	}
+	return stagingDir, nil
+}
+
+// verifyBundleIndex verifies snapshotRaw via opts.Verifier.VerifyIndex —
+// exactly as a live-fetched index would be — with ONE gated exception: if
+// (and only if) the failure is SPECIFICALLY index.CodeIndexStale, the
+// stale-bundle policy gate (policy.DecideStaleBundle, identical rigor to
+// --allow-unsigned) may authorize a single retry with staleness disabled
+// for this one verification. Every other failure (integrity, rollback,
+// trust-anchor) is refused unconditionally — there is no override for
+// those, ever.
+func verifyBundleIndex(ctx context.Context, opts InstallBundleOptions, snapshotRaw []byte) (*index.VerifiedIndex, error) {
+	verified, err := opts.Verifier.VerifyIndex(ctx, snapshotRaw)
+	if err == nil {
+		if !verified.Verified {
+			return nil, conduiterr.New(CodeVerificationUnavailable,
+				"the bundled index snapshot could not be cryptographically verified — refusing to install")
+		}
+		return verified, nil
+	}
+
+	ce, ok := conduiterr.Get(err)
+	if !ok || ce.Code != index.CodeIndexStale {
+		// Integrity, rollback, trust-anchor-expired, or an unrecognized
+		// error — never overridable, regardless of AllowStaleBundle.
+		return nil, err
+	}
+
+	if !opts.AllowStaleBundle {
+		staleErr := conduiterr.New(CodeBundleStale,
+			"the bundled index snapshot is older than the maximum allowed staleness window — a stale bundle "+
+				"could be installing a since-yanked version you would refuse if you knew")
+		staleErr.Suggestion = "re-run with --allow-stale-bundle if this air-gapped bundle's age is expected"
+		return nil, staleErr
+	}
+
+	dec, reason := policy.DecideStaleBundle(policy.StaleBundleContext{
+		TTY: opts.TTY, CIEnv: opts.CIEnv, IsMCP: opts.IsMCP,
+		OperatorAllowStaleBundle: opts.OperatorAllowStaleBundle,
+		EnvVarSet:                opts.EnvVarSet, TypedConfirmation: opts.TypedConfirmation,
+	})
+	if !dec.Allowed() {
+		staleErr := conduiterr.New(CodeBundleStale, "stale bundle installation was not approved: "+reason)
+		staleErr.Suggestion = fmt.Sprintf("confirm interactively, or set %s=I_UNDERSTAND in a non-interactive context", StaleBundleEnvVar)
+		return nil, staleErr
+	}
+
+	// Retry with staleness effectively disabled for this ONE verification —
+	// a relaxed COPY of the verifier, never mutating the caller's shared
+	// instance. Rollback/integrity/trust-anchor checks inside VerifyIndex
+	// are NOT relaxed by this — only CheckStaleness's comparison is, since
+	// that is the specific, gated exception this path exists for.
+	relaxed := *opts.Verifier
+	relaxed.MaxStaleness = 100 * 365 * 24 * time.Hour // effectively unbounded for this one retry
+	verified, err = relaxed.VerifyIndex(ctx, snapshotRaw)
+	if err != nil {
+		return nil, err
+	}
+	if !verified.Verified {
+		return nil, conduiterr.New(CodeVerificationUnavailable,
+			"the bundled index snapshot could not be cryptographically verified — refusing to install")
+	}
+
+	if logErr := AppendAuditEvent(auditLogPath(opts.ConnectorsPath), AuditEvent{
+		Event: "stale_bundle_override", Timestamp: time.Now().UTC(), Operator: opts.InstalledBy,
+	}); logErr != nil {
+		return nil, conduiterr.Wrap(conduiterr.CodeInternal, "stale bundle override approved but could not append the audit log entry", logErr)
+	}
+
+	return verified, nil
+}

--- a/pkg/registry/bundle_test.go
+++ b/pkg/registry/bundle_test.go
@@ -1,0 +1,360 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry_test
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	json "github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry"
+	"github.com/conduitio/conduit/pkg/registry/index"
+	"github.com/conduitio/conduit/pkg/registry/trust"
+)
+
+// writeTestBundleTar builds a bundle tarball by hand (rather than going
+// through Bundle()'s own online prep pipeline), so each offline-side test
+// can independently omit or mutate exactly one entry (a missing
+// index-snapshot.json, tampered artifact bytes, and so on) without needing
+// a full networked prep pass first. nil for signatureBundle/provenanceBundle
+// omits that entry entirely, matching a real bundle whose artifact had no
+// provenance attestation.
+func writeTestBundleTar(path string, manifest registry.BundleManifest, artifactBytes, signatureBundle, provenanceBundle, indexSnapshot []byte) error {
+	out, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	gz := gzip.NewWriter(out)
+	tw := tar.NewWriter(gz)
+
+	writeEntry := func(name string, data []byte) error {
+		if data == nil {
+			return nil
+		}
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o600, Size: int64(len(data))}); err != nil {
+			return err
+		}
+		_, err := tw.Write(data)
+		return err
+	}
+
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return err
+	}
+	if err := writeEntry("manifest.json", manifestBytes); err != nil {
+		return err
+	}
+	if err := writeEntry("artifact", artifactBytes); err != nil {
+		return err
+	}
+	if err := writeEntry("signature.bundle", signatureBundle); err != nil {
+		return err
+	}
+	if err := writeEntry("provenance.bundle", provenanceBundle); err != nil {
+		return err
+	}
+	if err := writeEntry("index-snapshot.json", indexSnapshot); err != nil {
+		return err
+	}
+
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	return gz.Close()
+}
+
+// unsignedArtifactVerifier always reports an unsigned result — used to
+// prove Bundle() refuses to package an artifact that would not itself pass
+// a normal install.
+type unsignedArtifactVerifier struct{ passThroughVerifier }
+
+func (unsignedArtifactVerifier) VerifyArtifact(context.Context, registry.ArtifactRef, trust.PinnedIdentity) (registry.VerifyResult, error) {
+	return registry.VerifyResult{Signed: false}, nil
+}
+
+func TestBundle_FullPrepSucceeds(t *testing.T) {
+	srv, indexURL, archiveBytes := newInstallTestServer(t, "postgres", "0.14.1")
+	defer srv.Close()
+
+	out := filepath.Join(t.TempDir(), "postgres-0.14.1.bundle.tar.gz")
+	res, err := registry.Bundle(context.Background(), registry.BundleOptions{
+		Name: "postgres", Version: "0.14.1", OutputPath: out,
+		IndexURL: indexURL, IndexVerifier: passThroughVerifier{}, ArtifactVerifier: passThroughVerifier{},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "postgres", res.Name)
+	assert.Equal(t, "0.14.1", res.Version)
+	assert.Equal(t, int64(len(archiveBytes)), res.Size)
+
+	info, statErr := os.Stat(out)
+	require.NoError(t, statErr)
+	assert.Positive(t, info.Size())
+}
+
+func TestBundle_RefusesUnsignedArtifact(t *testing.T) {
+	srv, indexURL, _ := newInstallTestServer(t, "postgres", "0.14.1")
+	defer srv.Close()
+
+	out := filepath.Join(t.TempDir(), "postgres-0.14.1.bundle.tar.gz")
+	_, err := registry.Bundle(context.Background(), registry.BundleOptions{
+		Name: "postgres", Version: "0.14.1", OutputPath: out,
+		IndexURL: indexURL, IndexVerifier: passThroughVerifier{}, ArtifactVerifier: unsignedArtifactVerifier{},
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeVerificationUnavailable, ce.Code)
+
+	_, statErr := os.Stat(out)
+	assert.True(t, os.IsNotExist(statErr), "bundle output must not be written when the artifact fails verification")
+}
+
+// bundleTrustCoreFixture reuses the same hand-signed-ed25519-index approach
+// as connectoraudit_trustcore_test.go, so InstallFromBundle's offline index
+// re-verification can be tested against the REAL registry.TrustedVerifier.
+func realBundleIndexSnapshot(t *testing.T, f *auditTrustCoreFixture, payload index.Payload) []byte {
+	t.Helper()
+	return f.sign(t, payload)
+}
+
+func buildTestBundleTar(t *testing.T, manifest registry.BundleManifest, artifactBytes, signatureBundle, provenanceBundle, indexSnapshot []byte) string {
+	t.Helper()
+	// Reuses this package's own writeBundleTar indirectly via Bundle() would
+	// require a full online prep pass; for these lower-level offline tests
+	// we build the tarball by hand so each test can independently mutate one
+	// specific piece (tampered artifact, stale snapshot, etc.).
+	path := filepath.Join(t.TempDir(), "test.bundle.tar.gz")
+	require.NoError(t, writeTestBundleTar(path, manifest, artifactBytes, signatureBundle, provenanceBundle, indexSnapshot))
+	return path
+}
+
+func TestInstallFromBundle_FormatVersionTooNew_Refuses(t *testing.T) {
+	dir := t.TempDir()
+	manifest := registry.BundleManifest{BundleFormatVersion: registry.BundleFormatVersion + 1, Name: "postgres", Version: "0.14.1"}
+	path := buildTestBundleTar(t, manifest, []byte("artifact"), nil, nil, []byte("{}"))
+
+	_, err := registry.InstallFromBundle(context.Background(), registry.InstallBundleOptions{
+		BundlePath: path, ConnectorsPath: dir, Verifier: &registry.TrustedVerifier{},
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, conduiterr.CodeInvalidArgument, ce.Code)
+}
+
+func TestInstallFromBundle_MissingEntries_Refuses(t *testing.T) {
+	dir := t.TempDir()
+	// index-snapshot.json omitted entirely.
+	path := buildTestBundleTar(t, registry.BundleManifest{BundleFormatVersion: 1, Name: "postgres", Version: "0.14.1"}, []byte("artifact"), nil, nil, nil)
+
+	_, err := registry.InstallFromBundle(context.Background(), registry.InstallBundleOptions{
+		BundlePath: path, ConnectorsPath: dir, Verifier: &registry.TrustedVerifier{},
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeArchiveInvalid, ce.Code)
+}
+
+// TestInstallFromBundle_TamperedArtifact_Refuses is AC15: a bundle whose
+// embedded artifact bytes were tampered with after bundling fails the
+// digest check and never touches --connectors.path.
+func TestInstallFromBundle_TamperedArtifact_Refuses(t *testing.T) {
+	dir := t.TempDir()
+	f := newAuditTrustCoreFixture(t)
+	payload := index.Payload{
+		SchemaVersion: 1, Index: index.IndexMeta{Version: 1, Timestamp: time.Now().UTC()},
+		Connectors: []index.Connector{{
+			Name:      "postgres",
+			Publisher: index.Publisher{ExpectedOIDCIssuer: "x"},
+			Versions: []index.ConnectorVersion{{
+				Version: "0.14.1", MinConduitVersion: "0.1.0", MinProtocolVersion: "0.1.0",
+				Artifacts: []index.Artifact{{
+					OS: "linux", Arch: "amd64", Kind: registry.StandaloneArtifactKind,
+					URL: "https://example.test/artifact", SHA256: sha256Hex("original-bytes"), Size: 14,
+				}},
+			}},
+		}},
+	}
+	snapshot := realBundleIndexSnapshot(t, f, payload)
+
+	manifest := registry.BundleManifest{
+		BundleFormatVersion: 1, Name: "postgres", Version: "0.14.1", OS: "linux", Arch: "amd64",
+		SHA256: "sha256:" + sha256Hex("original-bytes"), Size: 14,
+	}
+	// Tampered: the bundled artifact bytes differ from what manifest.json
+	// (and the index snapshot) both declare.
+	path := buildTestBundleTar(t, manifest, []byte("tampered-bytes"), []byte("sig"), nil, snapshot)
+
+	verifier := &registry.TrustedVerifier{Anchors: f.anchors(t), StatePath: filepath.Join(dir, ".registry", "index-state.json")}
+	_, err := registry.InstallFromBundle(context.Background(), registry.InstallBundleOptions{
+		BundlePath: path, ConnectorsPath: dir, Verifier: verifier,
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeCorruptDownload, ce.Code)
+
+	// Never touches --connectors.path.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		assert.NotEqual(t, "conduit-connector-postgres_0.14.1", e.Name())
+	}
+}
+
+// TestInstallFromBundle_YankedInSnapshot_Refuses is AC16: a bundle for a
+// version already yanked in the BUNDLED snapshot refuses with the same
+// yanked-version error an online install would give — proving the offline
+// path doesn't silently skip the revocation check just because the network
+// is down. This short-circuits before artifact verification is ever
+// reached (Resolve refuses first), so it needs no real signature material.
+func TestInstallFromBundle_YankedInSnapshot_Refuses(t *testing.T) {
+	dir := t.TempDir()
+	f := newAuditTrustCoreFixture(t)
+	payload := index.Payload{
+		SchemaVersion: 1, Index: index.IndexMeta{Version: 1, Timestamp: time.Now().UTC()},
+		Connectors: []index.Connector{{
+			Name:      "postgres",
+			Publisher: index.Publisher{ExpectedOIDCIssuer: "x"},
+			Versions: []index.ConnectorVersion{{
+				Version: "0.14.1", Yanked: &index.YankReason{Reason: "bad release"},
+			}},
+		}},
+	}
+	snapshot := realBundleIndexSnapshot(t, f, payload)
+	manifest := registry.BundleManifest{BundleFormatVersion: 1, Name: "postgres", Version: "0.14.1", OS: "linux", Arch: "amd64"}
+	path := buildTestBundleTar(t, manifest, []byte("bytes"), nil, nil, snapshot)
+
+	verifier := &registry.TrustedVerifier{Anchors: f.anchors(t), StatePath: filepath.Join(dir, ".registry", "index-state.json")}
+	_, err := registry.InstallFromBundle(context.Background(), registry.InstallBundleOptions{
+		BundlePath: path, ConnectorsPath: dir, Verifier: verifier,
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, index.CodeVersionYanked, ce.Code)
+}
+
+// TestInstallFromBundle_StaleBundle_RefusesByDefault_AllowsWithOverride is
+// AC17: a bundle whose snapshot is older than maxStaleness refuses by
+// default, and only proceeds (past the index-verification stage — this
+// test does not carry real signature material, so it asserts the run moves
+// on to the NEXT stage rather than reaching full success) with an explicit
+// override.
+func TestInstallFromBundle_StaleBundle_RefusesByDefault_AllowsWithOverride(t *testing.T) {
+	dir := t.TempDir()
+	f := newAuditTrustCoreFixture(t)
+	payload := index.Payload{
+		SchemaVersion: 1,
+		// Timestamp far in the past: older than index.DefaultMaxStaleness (7 days).
+		Index: index.IndexMeta{Version: 1, Timestamp: time.Now().Add(-30 * 24 * time.Hour)},
+		Connectors: []index.Connector{{
+			Name: "postgres",
+			Publisher: index.Publisher{
+				ExpectedOIDCIssuer:      "https://token.actions.githubusercontent.com",
+				ExpectedIdentityPattern: `^https://github\.com/ExampleOrg/postgres/\.github/workflows/publish\.yml@refs/tags/v.*$`,
+			},
+			Versions: []index.ConnectorVersion{{
+				Version: "0.14.1", MinConduitVersion: "0.1.0", MinProtocolVersion: "0.1.0",
+				Artifacts: []index.Artifact{{
+					OS: "linux", Arch: "amd64", Kind: registry.StandaloneArtifactKind,
+					URL: "https://example.test/artifact", SHA256: sha256Hex("bytes"), Size: 5,
+				}},
+			}},
+		}},
+	}
+	snapshot := realBundleIndexSnapshot(t, f, payload)
+	manifest := registry.BundleManifest{
+		BundleFormatVersion: 1, Name: "postgres", Version: "0.14.1", OS: "linux", Arch: "amd64",
+		SHA256: "sha256:" + sha256Hex("bytes"), Size: 5,
+	}
+	path := buildTestBundleTar(t, manifest, []byte("bytes"), nil, nil, snapshot)
+
+	verifier := &registry.TrustedVerifier{Anchors: f.anchors(t), StatePath: filepath.Join(dir, ".registry", "index-state.json")}
+
+	// Default: refuses.
+	_, err := registry.InstallFromBundle(context.Background(), registry.InstallBundleOptions{
+		BundlePath: path, ConnectorsPath: dir, Verifier: verifier,
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeBundleStale, ce.Code)
+
+	// With the full gate satisfied (operator policy + env var, non-interactive
+	// path): the staleness check is overridden and execution proceeds past
+	// it — to the NEXT stage, artifact verification, which fails with
+	// trust.CodeUnsigned (no real signature bundle in this fixture) —
+	// proving the override specifically unblocked staleness (and nothing
+	// else: resolution/compatibility/artifact-selection all had to succeed
+	// too for this exact failure point to be reached).
+	_, err = registry.InstallFromBundle(context.Background(), registry.InstallBundleOptions{
+		BundlePath: path, ConnectorsPath: dir, Verifier: verifier,
+		AllowStaleBundle: true, OperatorAllowStaleBundle: true, EnvVarSet: true,
+	})
+	require.Error(t, err)
+	ce, ok = conduiterr.Get(err)
+	require.True(t, ok)
+	assert.NotEqual(t, registry.CodeBundleStale, ce.Code, "staleness override should have unblocked the index check")
+	assert.Equal(t, trust.CodeUnsigned, ce.Code, "expected to reach artifact verification and fail there (no real signature bundle in this fixture)")
+
+	// The override itself must be logged (loud, explicit, never silent).
+	data, readErr := os.ReadFile(filepath.Join(dir, ".registry", "audit.jsonl"))
+	require.NoError(t, readErr)
+	assert.Contains(t, string(data), `"event":"stale_bundle_override"`)
+}
+
+// TestInstallFromBundle_StaleBundle_DisabledByOperatorPolicy proves the
+// operator policy check wins outright even when the flag and env var are
+// both set — mirroring --allow-unsigned's own "operator policy checked
+// first" behavior.
+func TestInstallFromBundle_StaleBundle_DisabledByOperatorPolicy(t *testing.T) {
+	dir := t.TempDir()
+	f := newAuditTrustCoreFixture(t)
+	payload := index.Payload{
+		SchemaVersion: 1,
+		Index:         index.IndexMeta{Version: 1, Timestamp: time.Now().Add(-30 * 24 * time.Hour)},
+		Connectors: []index.Connector{{
+			Name:      "postgres",
+			Publisher: index.Publisher{ExpectedOIDCIssuer: "x"},
+			Versions:  []index.ConnectorVersion{{Version: "0.14.1"}},
+		}},
+	}
+	snapshot := realBundleIndexSnapshot(t, f, payload)
+	manifest := registry.BundleManifest{BundleFormatVersion: 1, Name: "postgres", Version: "0.14.1", OS: "linux", Arch: "amd64"}
+	path := buildTestBundleTar(t, manifest, []byte("bytes"), nil, nil, snapshot)
+
+	verifier := &registry.TrustedVerifier{Anchors: f.anchors(t), StatePath: filepath.Join(dir, ".registry", "index-state.json")}
+	_, err := registry.InstallFromBundle(context.Background(), registry.InstallBundleOptions{
+		BundlePath: path, ConnectorsPath: dir, Verifier: verifier,
+		AllowStaleBundle: true, OperatorAllowStaleBundle: false, EnvVarSet: true,
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeBundleStale, ce.Code)
+}

--- a/pkg/registry/cache.go
+++ b/pkg/registry/cache.go
@@ -1,0 +1,210 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	json "github.com/goccy/go-json"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+)
+
+// cacheTmpMaxAge is how old an orphaned ".tmp-populate-*" directory must be
+// before CacheSweepTmp removes it (plan-v2/step5 §5: a crash mid-populate
+// leaves one behind; a periodic, best-effort sweep cleans it up).
+const cacheTmpMaxAge = 24 * time.Hour
+
+// cacheDir returns <connectorsPath>/.registry/cache — the root of the
+// content-addressed download cache.
+func cacheDir(connectorsPath string) string {
+	return filepath.Join(registryDir(connectorsPath), "cache")
+}
+
+// cacheEntryDir returns the one directory a fully-populated cache entry for
+// digestHex (lowercase hex sha256, no "sha256:" prefix) lives under.
+func cacheEntryDir(connectorsPath, digestHex string) string {
+	return filepath.Join(cacheDir(connectorsPath), digestHex)
+}
+
+func cacheArtifactPath(connectorsPath, digestHex string) string {
+	return filepath.Join(cacheEntryDir(connectorsPath, digestHex), "artifact")
+}
+
+func cacheMetaPath(connectorsPath, digestHex string) string {
+	return filepath.Join(cacheEntryDir(connectorsPath, digestHex), "meta.json")
+}
+
+// CacheMeta is the small companion file written alongside a cached
+// artifact's bytes (step5 §5).
+type CacheMeta struct {
+	SHA256    string    `json:"sha256"`
+	Size      int64     `json:"size"`
+	CachedAt  time.Time `json:"cachedAt"`
+	SourceURL string    `json:"sourceUrl,omitempty"`
+}
+
+// normalizeDigestHex strips an optional "sha256:" prefix and lowercases the
+// rest, so a digest string from an index.Artifact.SHA256 field (which may
+// carry either form) always maps to the same cache directory name that
+// sha256.Sum's own hex.EncodeToString output would produce.
+func normalizeDigestHex(sha256Hex string) string {
+	return strings.ToLower(strings.TrimPrefix(sha256Hex, "sha256:"))
+}
+
+// CacheLookup returns the cached artifact bytes for digestHex (already
+// normalized — see normalizeDigestHex), re-verifying the stored bytes' own
+// digest before ever returning them — never trust-on-read. A miss (absent
+// OR corrupt) reports (nil, false, nil); a corrupt entry (recomputed digest
+// does not match the directory it is stored under) is evicted as a side
+// effect, best-effort, so a miss also self-heals the cache for the next
+// caller (step5 §5's corruption-handling requirement).
+//
+// The cache is purely a download optimization: a hit here still requires
+// the caller to run the FULL verification gate exactly as it would for a
+// fresh download (see install.go's stageArtifact) — this function makes no
+// trust claim about the bytes it returns.
+func CacheLookup(connectorsPath, digestHex string) ([]byte, bool, error) {
+	path := cacheArtifactPath(connectorsPath, digestHex)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, cerrors.Errorf("could not read cache entry %q: %w", path, err)
+	}
+
+	sum := sha256.Sum256(data)
+	if hex.EncodeToString(sum[:]) != digestHex {
+		// Corrupt: partial write, bitrot, or tampering. Evict best-effort —
+		// a failure to remove it is not itself an error worth propagating
+		// (the caller already gets a cache-miss result and will re-download
+		// into a staging path that does not depend on this entry existing).
+		_ = os.RemoveAll(cacheEntryDir(connectorsPath, digestHex))
+		return nil, false, nil
+	}
+	return data, true, nil
+}
+
+// CachePopulate atomically stores data under digestHex: written to a
+// uniquely-named temp directory first, then renamed into place, so a crash
+// mid-populate leaves an orphaned ".tmp-populate-*" directory (cleaned up by
+// CacheSweepTmp) rather than a corrupt "<digest>/" entry masquerading as
+// valid.
+//
+// data's own digest is recomputed and asserted to match digestHex — a
+// defensive check, since every real caller already knows the digest from a
+// just-corruption-checked download, but this function must never silently
+// cache the wrong bytes under the wrong key.
+//
+// Two concurrent populates of the SAME digestHex (two installs racing to
+// cache the identical content-addressed artifact) are safe: if the final
+// rename loses the race because the destination directory now exists, that
+// destination is — by construction of content-addressing — the identical
+// bytes this call would have written, so losing the race is treated as a
+// successful no-op, not an error.
+func CachePopulate(connectorsPath, digestHex string, data []byte, sourceURL string) error {
+	sum := sha256.Sum256(data)
+	if got := hex.EncodeToString(sum[:]); got != digestHex {
+		return cerrors.Errorf("cache populate: data digest %q does not match expected %q", got, digestHex)
+	}
+
+	root := cacheDir(connectorsPath)
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return cerrors.Errorf("could not create cache directory %q: %w", root, err)
+	}
+	tmpDir, err := os.MkdirTemp(root, ".tmp-populate-*")
+	if err != nil {
+		return cerrors.Errorf("could not create cache staging directory: %w", err)
+	}
+	// Cleaned up on every path: once the rename below succeeds tmpDir no
+	// longer exists, so this is a no-op; on any earlier failure this removes
+	// the partial attempt immediately rather than waiting for
+	// CacheSweepTmp's next run.
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	//nolint:gosec // tmpDir comes from os.MkdirTemp (never user input) and "artifact" is a literal; gosec's
+	// taint analysis conservatively flags this because connectorsPath (a function parameter) feeds tmpDir's
+	// parent directory, but MkdirTemp itself is what generates the actual path component being written to.
+	if err := os.WriteFile(filepath.Join(tmpDir, "artifact"), data, 0o600); err != nil {
+		return cerrors.Errorf("could not write cache artifact: %w", err)
+	}
+	meta := CacheMeta{SHA256: digestHex, Size: int64(len(data)), CachedAt: time.Now().UTC(), SourceURL: sourceURL}
+	metaBytes, err := json.Marshal(meta)
+	if err != nil {
+		return cerrors.Errorf("could not marshal cache meta: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "meta.json"), metaBytes, 0o600); err != nil {
+		return cerrors.Errorf("could not write cache meta: %w", err)
+	}
+
+	finalDir := cacheEntryDir(connectorsPath, digestHex)
+	if err := os.Rename(tmpDir, finalDir); err != nil {
+		if _, statErr := os.Stat(finalDir); statErr == nil {
+			// Lost a race to a concurrent populate of the identical
+			// content-addressed entry — see doc comment above.
+			return nil
+		}
+		return cerrors.Errorf("could not populate cache entry %q: %w", finalDir, err)
+	}
+	return nil
+}
+
+// CacheSweepTmp removes every ".tmp-populate-*" directory under the cache
+// root older than cacheTmpMaxAge — best-effort cleanup of an orphaned
+// partial-populate left by a crash (step5 §5). Never returns an error to a
+// caller that treats the cache as a pure optimization: a sweep failure just
+// means a leftover temp directory persists a bit longer, not a correctness
+// problem, so this function swallows its own errors rather than failing an
+// install over cache housekeeping.
+func CacheSweepTmp(connectorsPath string, maxAge time.Duration) {
+	root := cacheDir(connectorsPath)
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return
+	}
+	now := time.Now()
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), ".tmp-populate-") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if now.Sub(info.ModTime()) > maxAge {
+			_ = os.RemoveAll(filepath.Join(root, e.Name()))
+		}
+	}
+}
+
+// cacheMetaFor is a small test/inspection helper reading back a cache
+// entry's meta.json, unexported since no production caller needs it today.
+func cacheMetaFor(connectorsPath, digestHex string) (CacheMeta, error) {
+	data, err := os.ReadFile(cacheMetaPath(connectorsPath, digestHex))
+	if err != nil {
+		return CacheMeta{}, err
+	}
+	var m CacheMeta
+	if err := json.Unmarshal(data, &m); err != nil {
+		return CacheMeta{}, err
+	}
+	return m, nil
+}

--- a/pkg/registry/cache_test.go
+++ b/pkg/registry/cache_test.go
@@ -1,0 +1,154 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/registry"
+)
+
+func TestCache_PopulateThenLookup_Hit(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("hello connector artifact bytes")
+	sum := sha256.Sum256(data)
+	digestHex := hex.EncodeToString(sum[:])
+
+	require.NoError(t, registry.CachePopulate(dir, digestHex, data, "https://example.test/artifact"))
+
+	got, hit, err := registry.CacheLookup(dir, digestHex)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Equal(t, data, got)
+
+	meta, err := registry.CacheMetaForTest(dir, digestHex)
+	require.NoError(t, err)
+	assert.Equal(t, digestHex, meta.SHA256)
+	assert.Equal(t, int64(len(data)), meta.Size)
+	assert.Equal(t, "https://example.test/artifact", meta.SourceURL)
+	assert.False(t, meta.CachedAt.IsZero())
+}
+
+func TestCache_Lookup_Miss(t *testing.T) {
+	dir := t.TempDir()
+	got, hit, err := registry.CacheLookup(dir, "deadbeef")
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Nil(t, got)
+}
+
+func TestCache_Populate_DigestMismatch_Refuses(t *testing.T) {
+	dir := t.TempDir()
+	err := registry.CachePopulate(dir, "0000000000000000000000000000000000000000000000000000000000000000", []byte("x"), "")
+	require.Error(t, err)
+}
+
+// TestCache_CorruptEntry_DetectedAndEvicted is the AC13 case: a cache entry
+// whose stored bytes no longer match the sha256 encoded in its own
+// directory name (simulating truncation/bitrot/tampering after the fact)
+// must never be served — CacheLookup must report a miss AND remove the
+// corrupt entry so a subsequent populate/lookup isn't wedged behind it.
+func TestCache_CorruptEntry_DetectedAndEvicted(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("original bytes")
+	sum := sha256.Sum256(data)
+	digestHex := hex.EncodeToString(sum[:])
+	require.NoError(t, registry.CachePopulate(dir, digestHex, data, ""))
+
+	// Corrupt it: truncate the stored artifact bytes directly on disk, out
+	// from under the cache's own bookkeeping — exactly the "truncate a
+	// cached file" scenario the plan calls for.
+	artifactPath := filepath.Join(dir, ".registry", "cache", digestHex, "artifact")
+	require.NoError(t, os.WriteFile(artifactPath, []byte("corrupted"), 0o600))
+
+	got, hit, err := registry.CacheLookup(dir, digestHex)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Nil(t, got)
+
+	// Evicted: the entry directory must no longer exist at all.
+	_, statErr := os.Stat(filepath.Join(dir, ".registry", "cache", digestHex))
+	assert.True(t, os.IsNotExist(statErr), "corrupt cache entry should have been evicted, got stat err: %v", statErr)
+
+	// Self-heals: a fresh populate under the same digest succeeds afterward.
+	require.NoError(t, registry.CachePopulate(dir, digestHex, data, ""))
+	got, hit, err = registry.CacheLookup(dir, digestHex)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Equal(t, data, got)
+}
+
+// TestCache_ConcurrentPopulate_SameDigest_DoesNotCorrupt races N goroutines
+// populating the identical content-addressed digest simultaneously — none
+// of them may return an error, and the resulting entry must be intact and
+// exactly the expected bytes (never a torn/partial write from one racing
+// with another's rename).
+func TestCache_ConcurrentPopulate_SameDigest_DoesNotCorrupt(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("raced artifact bytes, always identical across goroutines")
+	sum := sha256.Sum256(data)
+	digestHex := hex.EncodeToString(sum[:])
+
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = registry.CachePopulate(dir, digestHex, data, "")
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		assert.NoError(t, err, "goroutine %d", i)
+	}
+
+	got, hit, err := registry.CacheLookup(dir, digestHex)
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Equal(t, data, got)
+}
+
+func TestCache_SweepTmp_RemovesOldOrphans(t *testing.T) {
+	dir := t.TempDir()
+	cacheRoot := filepath.Join(dir, ".registry", "cache")
+	require.NoError(t, os.MkdirAll(cacheRoot, 0o700))
+
+	oldTmp := filepath.Join(cacheRoot, ".tmp-populate-old")
+	require.NoError(t, os.MkdirAll(oldTmp, 0o700))
+	oldTime := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, os.Chtimes(oldTmp, oldTime, oldTime))
+
+	freshTmp := filepath.Join(cacheRoot, ".tmp-populate-fresh")
+	require.NoError(t, os.MkdirAll(freshTmp, 0o700))
+
+	registry.CacheSweepTmp(dir, 24*time.Hour)
+
+	_, err := os.Stat(oldTmp)
+	assert.True(t, os.IsNotExist(err), "old orphaned tmp dir should have been swept")
+	_, err = os.Stat(freshTmp)
+	assert.NoError(t, err, "fresh tmp dir should NOT have been swept")
+}

--- a/pkg/registry/connectoraudit.go
+++ b/pkg/registry/connectoraudit.go
@@ -1,0 +1,365 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file backs `conduit connectors audit` (plan-v2/step5 §4): the
+// mechanism that protects ALREADY-installed connectors. install-time
+// refusal only stops a new bad install; a connector installed last month
+// whose version is yanked next week, or whose publisher is revoked, keeps
+// running silently until something re-checks it. audit is that re-check.
+//
+// # Reuses PR-2's verification exactly — no lower-trust shortcut
+//
+// audit fetches and verifies the index through the SAME IndexVerifier
+// (registry.TrustedVerifier, in production) install.go uses — same trust
+// anchors, same rollback/staleness/integrity checks, same error codes. There
+// is no second, lower-assurance "audit index fetch" path: an index this
+// command can't cryptographically verify is a hard failure for the whole
+// run (see RunAudit), never a degraded partial result. Named connectoraudit
+// to avoid colliding with audit.go, which is the unrelated append-only
+// install/uninstall event log (AppendAuditEvent) — this file has nothing to
+// do with that one.
+package registry
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	json "github.com/goccy/go-json"
+
+	"github.com/conduitio/conduit/pkg/conduit/check"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry/index"
+	"github.com/conduitio/conduit/pkg/registry/trust"
+)
+
+// AuditFinding is the specific condition an audited entry triggered, or ""
+// for a clean pass. These are local-integrity/informational states or
+// registry-trust findings — NOT new conduiterr codes in their own right
+// (plan-v2 §4): REVOKED_PUBLISHER/YANKED_VERSION reuse
+// trust.CodeIdentityRevoked/index.CodeVersionYanked verbatim via
+// AuditResultEntry.Code, exactly as an install-time refusal would.
+type AuditFinding string
+
+const (
+	FindingNone             AuditFinding = ""
+	FindingDelisted         AuditFinding = "DELISTED"
+	FindingUnknownVersion   AuditFinding = "UNKNOWN_VERSION"
+	FindingYankedVersion    AuditFinding = "YANKED_VERSION"
+	FindingRevokedPublisher AuditFinding = "REVOKED_PUBLISHER"
+	FindingMissingArtifact  AuditFinding = "MISSING_ARTIFACT"
+	FindingDrifted          AuditFinding = "DRIFTED"
+)
+
+// AuditStatus mirrors pkg/conduit/check.Status (pass/warn/fail) — audit
+// deliberately reuses that package's aggregation pattern (see
+// AuditReport.ExitCode) rather than inventing a parallel one.
+type AuditStatus string
+
+const (
+	AuditStatusPass AuditStatus = "pass"
+	AuditStatusWarn AuditStatus = "warn"
+	AuditStatusFail AuditStatus = "fail"
+)
+
+// AuditResultEntry is one installed connector's audit outcome.
+type AuditResultEntry struct {
+	Name             string       `json:"name"`
+	InstalledVersion string       `json:"installedVersion"`
+	Digest           string       `json:"digest,omitempty"`
+	Finding          AuditFinding `json:"finding"`
+	Status           AuditStatus  `json:"status"`
+	Reason           string       `json:"reason,omitempty"`
+	Suggestion       string       `json:"suggestion,omitempty"`
+	// Code is the registered conduiterr reason string backing a Fail
+	// finding (REVOKED_PUBLISHER -> trust.CodeIdentityRevoked,
+	// YANKED_VERSION -> index.CodeVersionYanked) — AuditReport.ExitCode
+	// resolves this exactly the way pkg/conduit/check.Report.ExitCode
+	// resolves CheckResult.Code.
+	Code string `json:"code,omitempty"`
+
+	// MissingArtifact/Drifted are the independent local-integrity signals
+	// (step5 §6) — always populated regardless of which Finding "won" the
+	// slot above, so a caller/test can assert on them directly even when a
+	// registry-trust finding (yanked/revoked/delisted/unknown-version) also
+	// fired for the same entry.
+	MissingArtifact bool `json:"missingArtifact,omitempty"`
+	Drifted         bool `json:"drifted,omitempty"`
+
+	// UnsignedInstall reports whether this exact name@version was ever
+	// recorded in the append-only unsigned-installs.log — NOT derived from
+	// manifest.json's own Signed/AllowUnsigned fields, which are locally
+	// rewritable by anyone with filesystem access (plan-v2 §13 P2 nit).
+	UnsignedInstall bool `json:"unsignedInstall,omitempty"`
+}
+
+// AuditReport is RunAudit's full result.
+type AuditReport struct {
+	Findings []AuditResultEntry `json:"findings"`
+}
+
+// ExitCode aggregates every Fail finding to one process exit code via the
+// SAME worst-bucket rule as pkg/conduit/check.Report.ExitCode: each Fail
+// finding's Code is classified independently via conduiterr.LookupCode +
+// exitcode.ExitCode, and the largest bucket wins — never "first finding
+// wins." Zero Fail findings returns exitcode.OK.
+func (r AuditReport) ExitCode() int {
+	return toCheckReport(r).ExitCode()
+}
+
+// AuditOptions is RunAudit's configuration.
+type AuditOptions struct {
+	ConnectorsPath string
+	IndexURL       string
+	IndexFile      string
+	// IndexVerifier MUST be the real trust-core verifier (registry.TrustedVerifier)
+	// in production — the same one install.go wires in. audit reuses it
+	// exactly; there is no lower-trust alternative for this field (plan-v2
+	// §7 step5 note, and this PR's own scope guardrail).
+	IndexVerifier IndexVerifier
+}
+
+// RunAudit re-fetches and re-verifies the current signed index (steps 1),
+// loads the local manifest (step 2), and checks EVERY installed connector
+// against the verified index data (step 3): a connector whose publisher has
+// since been revoked, or whose installed version has since been yanked, or
+// that has vanished from the index entirely, or whose exact version is no
+// longer listed — plus the independent local-integrity checks (missing
+// artifact, drifted digest).
+//
+// A hard index-verification failure (unreachable, tampered/integrity,
+// stale, rollback, or an unrecognized trust anchor) fails THE WHOLE RUN —
+// never a per-connector finding, and never "audit half the connectors
+// against a trusted index and half against nothing": you cannot partially
+// trust an unverified index. This is returned as an error (a HARD command
+// failure at the CLI layer), never folded into AuditReport.
+func RunAudit(ctx context.Context, opts AuditOptions) (*AuditReport, error) {
+	raw, err := fetchIndexRawFrom(ctx, opts.IndexURL, opts.IndexFile)
+	if err != nil {
+		return nil, err
+	}
+
+	verified, err := opts.IndexVerifier.VerifyIndex(ctx, raw)
+	if err != nil {
+		return nil, err
+	}
+	if !verified.Verified {
+		// Structural belt-and-suspenders (mirrors install.go's own
+		// assumption): a build wired with FailClosedVerifier (trust core
+		// disabled) must never let audit treat unverified data as a basis
+		// for a yank/revocation decision.
+		return nil, conduiterr.New(CodeVerificationUnavailable,
+			"the registry index could not be cryptographically verified — refusing to audit installed "+
+				"connectors against untrusted data")
+	}
+
+	m, err := LoadManifest(manifestPath(opts.ConnectorsPath))
+	if err != nil {
+		return nil, conduiterr.Wrap(conduiterr.CodeInternal, "could not read install manifest", err)
+	}
+
+	unsigned, err := loadUnsignedInstallSet(unsignedInstallsLogPath(opts.ConnectorsPath))
+	if err != nil {
+		return nil, conduiterr.Wrap(conduiterr.CodeInternal, "could not read unsigned-installs audit log", err)
+	}
+
+	byName := make(map[string]*index.Connector, len(verified.Payload.Connectors))
+	for i := range verified.Payload.Connectors {
+		byName[verified.Payload.Connectors[i].Name] = &verified.Payload.Connectors[i]
+	}
+
+	keys := make([]string, 0, len(m.Installs))
+	for k := range m.Installs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	findings := make([]AuditResultEntry, 0, len(keys))
+	for _, k := range keys {
+		entry := m.Installs[k]
+		findings = append(findings, auditEntry(opts.ConnectorsPath, entry, byName[entry.Name], unsigned))
+	}
+	return &AuditReport{Findings: findings}, nil
+}
+
+// auditEntry applies the index schema doc's §e decision table (concretized
+// by plan-v2/step5 §4) to one installed manifest entry.
+func auditEntry(connectorsPath string, entry ManifestEntry, conn *index.Connector, unsigned map[string]bool) AuditResultEntry {
+	res := AuditResultEntry{
+		Name: entry.Name, InstalledVersion: entry.Version, Digest: entry.Digest,
+		UnsignedInstall: unsigned[entry.Name+"@"+entry.Version],
+	}
+
+	switch {
+	case conn == nil:
+		res.Finding = FindingDelisted
+		res.Status = AuditStatusWarn
+		res.Reason = "connector name not present in the current registry index"
+		res.Suggestion = "confirm whether this connector was intentionally retired from the registry; if not, investigate before continuing to run it"
+	case conn.Publisher.Revoked != nil:
+		res.Finding = FindingRevokedPublisher
+		res.Status = AuditStatusFail
+		res.Reason = conn.Publisher.Revoked.Reason
+		res.Code = trust.CodeIdentityRevoked.Reason()
+		res.Suggestion = fmt.Sprintf("uninstall %s@%s — its publisher identity has been revoked", entry.Name, entry.Version)
+	default:
+		v, ok := findConnectorVersion(conn, entry.Version)
+		switch {
+		case !ok:
+			res.Finding = FindingUnknownVersion
+			res.Status = AuditStatusWarn
+			res.Reason = "installed version not found in the current registry index"
+			res.Suggestion = "confirm this version was legitimately retired/pruned from the index, or install a currently-listed version"
+		case v.Yanked != nil:
+			res.Finding = FindingYankedVersion
+			res.Status = AuditStatusFail
+			res.Reason = v.Yanked.Reason
+			res.Code = index.CodeVersionYanked.Reason()
+			res.Suggestion = yankedSuggestion(conn, entry)
+		}
+	}
+
+	artifactPath := connectorArtifactPath(connectorsPath, entry)
+	missing, drifted := checkArtifactHealth(artifactPath, entry.Digest)
+	res.MissingArtifact = missing
+	res.Drifted = drifted
+
+	if res.Finding == FindingNone {
+		switch {
+		case missing:
+			res.Finding = FindingMissingArtifact
+			res.Status = AuditStatusWarn
+			res.Suggestion = fmt.Sprintf(
+				"re-run `conduit connectors install %s@%s` or `conduit connectors uninstall %s@%s` to clean up the manifest entry",
+				entry.Name, entry.Version, entry.Name, entry.Version)
+		case drifted:
+			res.Finding = FindingDrifted
+			res.Status = AuditStatusWarn
+			res.Suggestion = "the on-disk artifact no longer matches the digest recorded at install time — investigate before trusting it"
+		default:
+			res.Status = AuditStatusPass
+		}
+	}
+	return res
+}
+
+func connectorArtifactPath(connectorsPath string, entry ManifestEntry) string {
+	if entry.ArtifactFile == "" {
+		return connectorsPath
+	}
+	return filepath.Join(connectorsPath, entry.ArtifactFile)
+}
+
+// toCheckReport converts an AuditReport into a pkg/conduit/check.Report so
+// AuditReport.ExitCode can reuse check.Report.ExitCode's worst-bucket
+// aggregation verbatim (doctor already establishes this exact pattern; see
+// that package's doc comment) instead of re-implementing it.
+func toCheckReport(r AuditReport) check.Report {
+	results := make([]check.CheckResult, 0, len(r.Findings))
+	for _, f := range r.Findings {
+		status := check.StatusPass
+		switch f.Status {
+		case AuditStatusPass:
+			status = check.StatusPass
+		case AuditStatusWarn:
+			status = check.StatusWarn
+		case AuditStatusFail:
+			status = check.StatusFail
+		}
+		results = append(results, check.CheckResult{
+			Name:    f.Name + "@" + f.InstalledVersion,
+			Status:  status,
+			Message: f.Reason,
+			Code:    f.Code,
+		})
+	}
+	return check.Report{Checks: results}
+}
+
+// loadUnsignedInstallSet reads policy's append-only unsigned-installs.log
+// (pkg/registry/policy.AppendUnsignedInstallEvent's output) and returns the
+// set of "name@version" entries it ever recorded — WITHOUT importing
+// pkg/registry/policy itself (this file only needs the two JSON fields it
+// cares about, and the PolicyBypass depguard rule in .golangci.yml
+// deliberately restricts which files may import that package at all; this
+// function has no reason to be one of them). A missing file is not an
+// error: it means no unsigned install has ever been logged, matching an
+// empty set.
+func loadUnsignedInstallSet(path string) (map[string]bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]bool{}, nil
+		}
+		return nil, cerrors.Errorf("could not read unsigned-installs log %q: %w", path, err)
+	}
+
+	set := map[string]bool{}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var ev struct {
+			Connector string `json:"connector"`
+			Version   string `json:"version"`
+		}
+		if err := json.Unmarshal(line, &ev); err != nil {
+			continue // tolerate a malformed line rather than failing the whole audit run over it
+		}
+		if ev.Connector != "" {
+			set[ev.Connector+"@"+ev.Version] = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, cerrors.Errorf("could not scan unsigned-installs log %q: %w", path, err)
+	}
+	return set, nil
+}
+
+// findConnectorVersion looks up version (semver-equal, tolerating a leading
+// "v" — §5) within conn.Versions.
+func findConnectorVersion(conn *index.Connector, version string) (index.ConnectorVersion, bool) {
+	want, err := NormalizeVersion(version)
+	if err != nil {
+		return index.ConnectorVersion{}, false
+	}
+	for _, v := range conn.Versions {
+		got, err := NormalizeVersion(v.Version)
+		if err != nil {
+			continue
+		}
+		if got.Equal(want) {
+			return v, true
+		}
+	}
+	return index.ConnectorVersion{}, false
+}
+
+// yankedSuggestion names a newer, non-yanked, compatible version to install
+// instead, when one exists in conn — falling back to a plain uninstall
+// suggestion when none does (plan-v2/step5 §4 step 5).
+func yankedSuggestion(conn *index.Connector, entry ManifestEntry) string {
+	latest := latestNonYankedVersion(*conn)
+	if latest == "" {
+		return fmt.Sprintf("uninstall %s@%s — no compatible non-yanked replacement is available", entry.Name, entry.Version)
+	}
+	return fmt.Sprintf("install %s@%s", entry.Name, latest)
+}

--- a/pkg/registry/connectoraudit_test.go
+++ b/pkg/registry/connectoraudit_test.go
@@ -1,0 +1,347 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/conduit/exitcode"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry"
+	"github.com/conduitio/conduit/pkg/registry/index"
+)
+
+// fakeIndexVerifier is a test double standing in for
+// registry.TrustedVerifier in RunAudit's own unit tests, so the finding
+// table's logic (yanked/revoked/delisted/unknown-version/pass) can be
+// exercised fast and table-driven, independent of real cryptography.
+// TestRunAudit_RealTrustedVerifier_* below additionally exercises RunAudit
+// against a REAL registry.TrustedVerifier with a hand-signed index, proving
+// the production wiring (not just this test double) behaves the same way —
+// satisfying "audit reuses PR-2's verification, not a lower-trust
+// reimplementation" at more than one level.
+type fakeIndexVerifier struct {
+	payload index.Payload
+	err     error
+}
+
+func (f fakeIndexVerifier) VerifyIndex(context.Context, []byte) (*index.VerifiedIndex, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &index.VerifiedIndex{Payload: f.payload, Verified: true}, nil
+}
+
+var _ registry.IndexVerifier = fakeIndexVerifier{}
+
+// writeFakeIndexFile writes a well-formed (but never actually parsed —
+// fakeIndexVerifier ignores the raw bytes and returns a fixed payload
+// regardless) envelope, only so RunAudit's fetchIndexRawFrom step has a
+// real file to read.
+func writeFakeIndexFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "index.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"payload":{"schemaVersion":1,"index":{"version":1,"timestamp":"2026-01-01T00:00:00Z"},"connectors":[]},"signatures":[]}`), 0o600))
+	return path
+}
+
+func auditPayload(t *testing.T, connectors ...index.Connector) index.Payload {
+	t.Helper()
+	return index.Payload{
+		SchemaVersion: 1,
+		Index:         index.IndexMeta{Version: 1, Timestamp: time.Now().UTC()},
+		Connectors:    connectors,
+	}
+}
+
+func TestRunAudit_AllPass(t *testing.T) {
+	dir := t.TempDir()
+	entry := installFixture(t, dir, "postgres", "0.14.1", "bytes")
+
+	payload := auditPayload(t, index.Connector{
+		Name:      "postgres",
+		Publisher: index.Publisher{ExpectedOIDCIssuer: "https://token.actions.githubusercontent.com"},
+		Versions:  []index.ConnectorVersion{{Version: entry.Version}},
+	})
+
+	report, err := registry.RunAudit(context.Background(), registry.AuditOptions{
+		ConnectorsPath: dir, IndexFile: writeFakeIndexFile(t),
+		IndexVerifier: fakeIndexVerifier{payload: payload},
+	})
+	require.NoError(t, err)
+	require.Len(t, report.Findings, 1)
+	assert.Equal(t, registry.AuditStatusPass, report.Findings[0].Status)
+	assert.Equal(t, registry.FindingNone, report.Findings[0].Finding)
+	assert.Equal(t, exitcode.OK, report.ExitCode())
+}
+
+// TestRunAudit_YankedVersion_Fails is the key AC (step5 §8 item 6): audit
+// must flag a since-yanked installed version as a Fail, with a nonzero exit
+// code and a suggestion naming a newer compatible version.
+func TestRunAudit_YankedVersion_Fails(t *testing.T) {
+	dir := t.TempDir()
+	installFixture(t, dir, "postgres", "0.14.0", "bytes")
+
+	payload := auditPayload(t, index.Connector{
+		Name:      "postgres",
+		Publisher: index.Publisher{ExpectedOIDCIssuer: "https://token.actions.githubusercontent.com"},
+		Versions: []index.ConnectorVersion{
+			{Version: "0.14.0", Yanked: &index.YankReason{Reason: "data-loss bug in the WAL position encoder"}},
+			{Version: "0.14.1"},
+		},
+	})
+
+	report, err := registry.RunAudit(context.Background(), registry.AuditOptions{
+		ConnectorsPath: dir, IndexFile: writeFakeIndexFile(t),
+		IndexVerifier: fakeIndexVerifier{payload: payload},
+	})
+	require.NoError(t, err)
+	require.Len(t, report.Findings, 1)
+	f := report.Findings[0]
+	assert.Equal(t, registry.FindingYankedVersion, f.Finding)
+	assert.Equal(t, registry.AuditStatusFail, f.Status)
+	assert.Contains(t, f.Reason, "WAL position encoder")
+	assert.Contains(t, f.Suggestion, "postgres@0.14.1")
+	assert.NotZero(t, report.ExitCode())
+}
+
+// TestRunAudit_RevokedPublisher_Fails proves REVOKED_PUBLISHER fires
+// regardless of the specific installed version's own yanked status (step5
+// §8 item 7).
+func TestRunAudit_RevokedPublisher_Fails(t *testing.T) {
+	dir := t.TempDir()
+	installFixture(t, dir, "postgres", "0.14.1", "bytes")
+
+	payload := auditPayload(t, index.Connector{
+		Name:      "postgres",
+		Publisher: index.Publisher{Revoked: &index.Revocation{Reason: "compromised signing identity"}},
+		Versions:  []index.ConnectorVersion{{Version: "0.14.1"}},
+	})
+
+	report, err := registry.RunAudit(context.Background(), registry.AuditOptions{
+		ConnectorsPath: dir, IndexFile: writeFakeIndexFile(t),
+		IndexVerifier: fakeIndexVerifier{payload: payload},
+	})
+	require.NoError(t, err)
+	require.Len(t, report.Findings, 1)
+	f := report.Findings[0]
+	assert.Equal(t, registry.FindingRevokedPublisher, f.Finding)
+	assert.Equal(t, registry.AuditStatusFail, f.Status)
+	assert.Contains(t, f.Reason, "compromised signing identity")
+	assert.NotZero(t, report.ExitCode())
+}
+
+func TestRunAudit_Delisted_Warns(t *testing.T) {
+	dir := t.TempDir()
+	installFixture(t, dir, "postgres", "0.14.1", "bytes")
+
+	report, err := registry.RunAudit(context.Background(), registry.AuditOptions{
+		ConnectorsPath: dir, IndexFile: writeFakeIndexFile(t),
+		IndexVerifier: fakeIndexVerifier{payload: auditPayload(t)}, // no connectors at all
+	})
+	require.NoError(t, err)
+	require.Len(t, report.Findings, 1)
+	assert.Equal(t, registry.FindingDelisted, report.Findings[0].Finding)
+	assert.Equal(t, registry.AuditStatusWarn, report.Findings[0].Status)
+	// Warn-only findings must not, by themselves, produce a nonzero exit.
+	assert.Equal(t, exitcode.OK, report.ExitCode())
+}
+
+func TestRunAudit_UnknownVersion_Warns(t *testing.T) {
+	dir := t.TempDir()
+	installFixture(t, dir, "postgres", "0.14.1", "bytes")
+
+	payload := auditPayload(t, index.Connector{
+		Name:      "postgres",
+		Publisher: index.Publisher{ExpectedOIDCIssuer: "https://token.actions.githubusercontent.com"},
+		Versions:  []index.ConnectorVersion{{Version: "0.15.0"}}, // 0.14.1 no longer listed
+	})
+
+	report, err := registry.RunAudit(context.Background(), registry.AuditOptions{
+		ConnectorsPath: dir, IndexFile: writeFakeIndexFile(t),
+		IndexVerifier: fakeIndexVerifier{payload: payload},
+	})
+	require.NoError(t, err)
+	require.Len(t, report.Findings, 1)
+	assert.Equal(t, registry.FindingUnknownVersion, report.Findings[0].Finding)
+	assert.Equal(t, registry.AuditStatusWarn, report.Findings[0].Status)
+}
+
+// TestRunAudit_MissingArtifact_WarnsNotFails is AC10: a manually-`rm`'d
+// artifact is a local-integrity Warn, never a Fail (it's not a registry
+// trust finding).
+func TestRunAudit_MissingArtifact_WarnsNotFails(t *testing.T) {
+	dir := t.TempDir()
+	entry := installFixture(t, dir, "postgres", "0.14.1", "bytes")
+	require.NoError(t, os.Remove(filepath.Join(dir, entry.ArtifactFile)))
+
+	payload := auditPayload(t, index.Connector{
+		Name:      "postgres",
+		Publisher: index.Publisher{ExpectedOIDCIssuer: "https://token.actions.githubusercontent.com"},
+		Versions:  []index.ConnectorVersion{{Version: entry.Version}},
+	})
+
+	report, err := registry.RunAudit(context.Background(), registry.AuditOptions{
+		ConnectorsPath: dir, IndexFile: writeFakeIndexFile(t),
+		IndexVerifier: fakeIndexVerifier{payload: payload},
+	})
+	require.NoError(t, err)
+	require.Len(t, report.Findings, 1)
+	assert.Equal(t, registry.FindingMissingArtifact, report.Findings[0].Finding)
+	assert.Equal(t, registry.AuditStatusWarn, report.Findings[0].Status)
+	assert.True(t, report.Findings[0].MissingArtifact)
+	assert.Equal(t, exitcode.OK, report.ExitCode())
+}
+
+// TestRunAudit_Drifted_Warns is AC11.
+func TestRunAudit_Drifted_Warns(t *testing.T) {
+	dir := t.TempDir()
+	entry := installFixture(t, dir, "postgres", "0.14.1", "original-bytes")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, entry.ArtifactFile), []byte("replaced-bytes"), 0o755))
+
+	payload := auditPayload(t, index.Connector{
+		Name:      "postgres",
+		Publisher: index.Publisher{ExpectedOIDCIssuer: "https://token.actions.githubusercontent.com"},
+		Versions:  []index.ConnectorVersion{{Version: entry.Version}},
+	})
+
+	report, err := registry.RunAudit(context.Background(), registry.AuditOptions{
+		ConnectorsPath: dir, IndexFile: writeFakeIndexFile(t),
+		IndexVerifier: fakeIndexVerifier{payload: payload},
+	})
+	require.NoError(t, err)
+	require.Len(t, report.Findings, 1)
+	assert.Equal(t, registry.FindingDrifted, report.Findings[0].Finding)
+	assert.True(t, report.Findings[0].Drifted)
+}
+
+// TestRunAudit_ExitCode_WorstBucketWins proves the aggregation is the WORST
+// bucket across all Fail findings, never the first one encountered.
+func TestRunAudit_ExitCode_WorstBucketWins(t *testing.T) {
+	dir := t.TempDir()
+	installFixture(t, dir, "postgres", "0.14.0", "bytes-a") // will be YANKED_VERSION (Validation bucket)
+	installFixture(t, dir, "s3-sink", "1.0.0", "bytes-b")   // will be REVOKED_PUBLISHER (Environment bucket)
+
+	payload := auditPayload(
+		t,
+		index.Connector{
+			Name:      "postgres",
+			Publisher: index.Publisher{ExpectedOIDCIssuer: "x"},
+			Versions:  []index.ConnectorVersion{{Version: "0.14.0", Yanked: &index.YankReason{Reason: "bad release"}}},
+		},
+		index.Connector{
+			Name:      "s3-sink",
+			Publisher: index.Publisher{Revoked: &index.Revocation{Reason: "compromised"}},
+			Versions:  []index.ConnectorVersion{{Version: "1.0.0"}},
+		},
+	)
+
+	report, err := registry.RunAudit(context.Background(), registry.AuditOptions{
+		ConnectorsPath: dir, IndexFile: writeFakeIndexFile(t),
+		IndexVerifier: fakeIndexVerifier{payload: payload},
+	})
+	require.NoError(t, err)
+	require.Len(t, report.Findings, 2)
+
+	// codes.FailedPrecondition (yanked) -> exitcode.Validation (2);
+	// codes.PermissionDenied (revoked) -> exitcode.Environment (3). The
+	// aggregate must be the max across both regardless of map/slice
+	// iteration order (RunAudit sorts by manifest key, but this assertion
+	// does not rely on that).
+	assert.Equal(t, exitcode.Environment, report.ExitCode())
+}
+
+func TestRunAudit_UnverifiedIndex_Refuses(t *testing.T) {
+	dir := t.TempDir()
+	installFixture(t, dir, "postgres", "0.14.1", "bytes")
+
+	unverified := fakeIndexVerifier{}
+	// Override VerifyIndex behavior via a bespoke type since fakeIndexVerifier
+	// always sets Verified: true; assert the belt-and-suspenders check by
+	// using a raw closure-based verifier instead.
+	v := indexVerifierFunc(func(context.Context, []byte) (*index.VerifiedIndex, error) {
+		return &index.VerifiedIndex{Payload: auditPayload(t), Verified: false}, nil
+	})
+
+	_, err := registry.RunAudit(context.Background(), registry.AuditOptions{
+		ConnectorsPath: dir, IndexFile: writeFakeIndexFile(t), IndexVerifier: v,
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeVerificationUnavailable, ce.Code)
+	_ = unverified
+}
+
+// TestRunAudit_IndexUnreachable_IsDistinctHardFailure is AC8: an audit run
+// against an index that cannot be fetched at all must fail the whole
+// command distinctly (a hard error, never a per-connector finding).
+func TestRunAudit_IndexUnreachable_IsDistinctHardFailure(t *testing.T) {
+	dir := t.TempDir()
+	installFixture(t, dir, "postgres", "0.14.1", "bytes")
+
+	_, err := registry.RunAudit(context.Background(), registry.AuditOptions{
+		ConnectorsPath: dir,
+		IndexFile:      filepath.Join(dir, "does-not-exist.json"),
+		IndexVerifier:  fakeIndexVerifier{payload: auditPayload(t)},
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, index.CodeIndexUnreachable, ce.Code)
+}
+
+func TestRunAudit_UnsignedInstall_ReadFromLogNotManifest(t *testing.T) {
+	dir := t.TempDir()
+	entry := installFixture(t, dir, "postgres", "0.14.1", "bytes")
+	// The manifest fixture always sets Signed: true — the point of this test
+	// is that UnsignedInstall must come from the append-only log, not this
+	// field.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".registry"), 0o755))
+	logPath := filepath.Join(dir, ".registry", "unsigned-installs.log")
+	require.NoError(t, os.WriteFile(logPath,
+		[]byte(`{"connector":"postgres","version":"0.14.1","resolvedDigest":"sha256:x","operator":"devaris","timestamp":"2026-01-01T00:00:00Z","context":"tty"}`+"\n"),
+		0o600))
+
+	payload := auditPayload(t, index.Connector{
+		Name:      "postgres",
+		Publisher: index.Publisher{ExpectedOIDCIssuer: "x"},
+		Versions:  []index.ConnectorVersion{{Version: entry.Version}},
+	})
+
+	report, err := registry.RunAudit(context.Background(), registry.AuditOptions{
+		ConnectorsPath: dir, IndexFile: writeFakeIndexFile(t),
+		IndexVerifier: fakeIndexVerifier{payload: payload},
+	})
+	require.NoError(t, err)
+	require.Len(t, report.Findings, 1)
+	assert.True(t, report.Findings[0].UnsignedInstall)
+}
+
+// indexVerifierFunc adapts a function literal to registry.IndexVerifier.
+type indexVerifierFunc func(context.Context, []byte) (*index.VerifiedIndex, error)
+
+func (f indexVerifierFunc) VerifyIndex(ctx context.Context, raw []byte) (*index.VerifiedIndex, error) {
+	return f(ctx, raw)
+}
+
+var _ registry.IndexVerifier = indexVerifierFunc(nil)

--- a/pkg/registry/connectoraudit_trustcore_test.go
+++ b/pkg/registry/connectoraudit_trustcore_test.go
@@ -1,0 +1,189 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file proves RunAudit against the REAL registry.TrustedVerifier — the
+// exact production wiring cmd/conduit/root/connectors/audit.go uses — not
+// just the fakeIndexVerifier test double connectoraudit_test.go uses for
+// the bulk of the finding-table logic. This is the "audit reuses PR-2's
+// verification, no lower-trust shortcut path" guarantee exercised for real:
+// a hand-signed (ed25519) index, verified via the SAME index.Verify code
+// path install.go's TrustedVerifier.VerifyIndex calls.
+package registry_test
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	json "github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry"
+	"github.com/conduitio/conduit/pkg/registry/index"
+)
+
+// auditTrustCoreFixture builds a real, ed25519-signed test index and a
+// registry.TrustedVerifier wired with the matching trust anchors — the
+// minimal real cryptography needed to prove genuine reuse, without
+// depending on sigstore-go/live Sigstore material (audit never re-verifies
+// per-artifact signatures — see connectoraudit.go's doc comment: only the
+// INDEX is re-verified, exactly as install.go does).
+type auditTrustCoreFixture struct {
+	rootPub  ed25519.PublicKey
+	rootPriv ed25519.PrivateKey
+}
+
+func newAuditTrustCoreFixture(t *testing.T) *auditTrustCoreFixture {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	return &auditTrustCoreFixture{rootPub: pub, rootPriv: priv}
+}
+
+func (f *auditTrustCoreFixture) anchors(t *testing.T) index.TrustAnchors {
+	t.Helper()
+	keyID, err := index.KeyID(f.rootPub)
+	require.NoError(t, err)
+	return index.TrustAnchors{Roots: map[string]ed25519.PublicKey{keyID: f.rootPub}}
+}
+
+type auditSigJSON struct {
+	Role      string `json:"role"`
+	KeyID     string `json:"keyId"`
+	Algorithm string `json:"algorithm"`
+	Signature string `json:"signature"`
+}
+
+// sign marshals payload, canonicalizes it, and signs it with the root key,
+// returning the full raw {payload, signatures[]} envelope bytes RunAudit's
+// fetchIndexRawFrom/index.Fetch path expects.
+func (f *auditTrustCoreFixture) sign(t *testing.T, payload index.Payload) []byte {
+	t.Helper()
+	payloadRaw, err := json.Marshal(payload)
+	require.NoError(t, err)
+	canonical, err := index.Canonicalize(payloadRaw)
+	require.NoError(t, err)
+
+	keyID, err := index.KeyID(f.rootPub)
+	require.NoError(t, err)
+	sig := ed25519.Sign(f.rootPriv, canonical)
+
+	env := struct {
+		Payload    json.RawMessage `json:"payload"`
+		Signatures []auditSigJSON  `json:"signatures"`
+	}{
+		Payload: payloadRaw,
+		Signatures: []auditSigJSON{{
+			Role: "root", KeyID: keyID, Algorithm: "ed25519",
+			Signature: base64.StdEncoding.EncodeToString(sig),
+		}},
+	}
+	raw, err := json.Marshal(env)
+	require.NoError(t, err)
+	return raw
+}
+
+func writeRawIndexFile(t *testing.T, raw []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "index.json")
+	require.NoError(t, os.WriteFile(path, raw, 0o600))
+	return path
+}
+
+func TestRunAudit_RealTrustedVerifier_YankedVersion_Fails(t *testing.T) {
+	dir := t.TempDir()
+	installFixture(t, dir, "postgres", "0.14.0", "bytes")
+
+	f := newAuditTrustCoreFixture(t)
+	payload := index.Payload{
+		SchemaVersion: 1,
+		Index:         index.IndexMeta{Version: 1, Timestamp: time.Now().UTC()},
+		Connectors: []index.Connector{{
+			Name:      "postgres",
+			Publisher: index.Publisher{ExpectedOIDCIssuer: "https://token.actions.githubusercontent.com"},
+			Versions: []index.ConnectorVersion{
+				{Version: "0.14.0", Yanked: &index.YankReason{Reason: "data-loss bug"}},
+			},
+		}},
+	}
+	raw := f.sign(t, payload)
+	indexPath := writeRawIndexFile(t, raw)
+
+	verifier := &registry.TrustedVerifier{
+		Anchors:   f.anchors(t),
+		StatePath: filepath.Join(dir, ".registry", "index-state.json"),
+	}
+
+	report, err := registry.RunAudit(context.Background(), registry.AuditOptions{
+		ConnectorsPath: dir, IndexFile: indexPath, IndexVerifier: verifier,
+	})
+	require.NoError(t, err)
+	require.Len(t, report.Findings, 1)
+	assert.Equal(t, registry.FindingYankedVersion, report.Findings[0].Finding)
+	assert.Equal(t, registry.AuditStatusFail, report.Findings[0].Status)
+	assert.NotZero(t, report.ExitCode())
+}
+
+// TestRunAudit_RealTrustedVerifier_TamperedIndex_HardFails proves a
+// tampered (signature no longer valid) index fails the WHOLE audit run
+// distinctly — never a per-connector finding — via the real verification
+// path.
+func TestRunAudit_RealTrustedVerifier_TamperedIndex_HardFails(t *testing.T) {
+	dir := t.TempDir()
+	installFixture(t, dir, "postgres", "0.14.1", "bytes")
+
+	f := newAuditTrustCoreFixture(t)
+	payload := index.Payload{
+		SchemaVersion: 1,
+		Index:         index.IndexMeta{Version: 1, Timestamp: time.Now().UTC()},
+		Connectors: []index.Connector{{
+			Name:      "postgres",
+			Publisher: index.Publisher{ExpectedOIDCIssuer: "https://token.actions.githubusercontent.com"},
+			Versions:  []index.ConnectorVersion{{Version: "0.14.1"}},
+		}},
+	}
+	raw := f.sign(t, payload)
+
+	// Tamper: flip a byte inside the payload after signing, without
+	// re-signing — the signature no longer verifies against the mutated
+	// canonical content.
+	tampered := make([]byte, len(raw))
+	copy(tampered, raw)
+	for i, b := range tampered {
+		if b == 'p' { // first occurrence inside "postgres"/"payload" etc.
+			tampered[i] = 'q'
+			break
+		}
+	}
+	indexPath := writeRawIndexFile(t, tampered)
+
+	verifier := &registry.TrustedVerifier{
+		Anchors:   f.anchors(t),
+		StatePath: filepath.Join(dir, ".registry", "index-state.json"),
+	}
+
+	_, err := registry.RunAudit(context.Background(), registry.AuditOptions{
+		ConnectorsPath: dir, IndexFile: indexPath, IndexVerifier: verifier,
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, index.CodeIndexIntegrity, ce.Code)
+}

--- a/pkg/registry/export_test.go
+++ b/pkg/registry/export_test.go
@@ -33,3 +33,11 @@ const (
 	ChaosPointPostRenamePreManifest = chaosPointPostRenamePreManifest
 	ChaosPointIndexStateBeforeWrite = chaosPointIndexStateBeforeWrite
 )
+
+// CacheMetaForTest exposes cacheMetaFor (cache.go) to the external
+// registry_test package, so cache_test.go can assert on a populated
+// entry's meta.json contents directly instead of re-parsing the file
+// itself.
+func CacheMetaForTest(connectorsPath, digestHex string) (CacheMeta, error) {
+	return cacheMetaFor(connectorsPath, digestHex)
+}

--- a/pkg/registry/install.go
+++ b/pkg/registry/install.go
@@ -16,6 +16,7 @@ package registry
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"net/http"
 	"os"
@@ -41,9 +42,9 @@ const DefaultIndexURL = "https://registry.conduit.io/index.json"
 // inclusion proof is normally a few KB; 1 MiB is generous headroom.
 const MaxBundleBytes int64 = 1 * 1024 * 1024
 
-// InstallSourceIndex is the only InstallOptions/ManifestEntry Source value
-// this PR produces. "offline-bundle" is PR-4's scope (offline/air-gapped
-// installs from a locally bundled index snapshot).
+// InstallSourceIndex is the InstallOptions/ManifestEntry Source value for a
+// normal, online install. InstallSourceOfflineBundle (bundle.go, PR-4) is
+// the other.
 const InstallSourceIndex = "index"
 
 // InstallOptions is Install's full configuration.
@@ -360,6 +361,12 @@ func installResolved(ctx context.Context, opts InstallOptions, verified *index.V
 // installResolved, since they're identical regardless of how the entry was
 // produced).
 func downloadVerifyAndInstall(ctx context.Context, opts InstallOptions, verified *index.VerifiedIndex, resolved *ResolvedVersion, artifact *index.Artifact) (ManifestEntry, error) {
+	// Best-effort, non-blocking cache housekeeping (step5 §5): sweep any
+	// orphaned ".tmp-populate-*" directory left by a crash mid-CachePopulate
+	// on a PRIOR install. Never fails or slows this install over a stale
+	// temp directory — errors are swallowed inside CacheSweepTmp itself.
+	CacheSweepTmp(opts.ConnectorsPath, cacheTmpMaxAge)
+
 	// 5. Staging directory: a private (0700), uniquely-named SUBDIRECTORY
 	// of ConnectorsPath — never the OS temp dir. This is required, not
 	// just tidy, so the final os.Rename below is a same-filesystem,
@@ -387,16 +394,31 @@ func downloadVerifyAndInstall(ctx context.Context, opts InstallOptions, verified
 	}
 
 	archivePath := filepath.Join(stagingDir, "artifact.tar.gz")
-	dl, err := Download(ctx, opts.httpClient(), artifact.URL, archivePath, artifact.Size)
+	dl, fromCache, err := stageArtifact(ctx, opts, artifact, archivePath)
 	if err != nil {
 		return ManifestEntry{}, err
 	}
-	fireChaos(chaosPointDownloadComplete)
 
 	// 6a. Corruption check — integrity, not trust (corruption.go). Run
-	// FIRST and SEPARATELY from the verification gate below.
+	// FIRST and SEPARATELY from the verification gate below. Run
+	// unconditionally regardless of fromCache: a cache hit still proves
+	// nothing about the bytes' trustworthiness on its own (see stageArtifact's
+	// doc comment) — it only short-circuits the network fetch.
 	if err := CheckCorruption(dl.Digest, artifact.SHA256); err != nil {
 		return ManifestEntry{}, err
+	}
+
+	// Populate the cache only on a genuine download — a cache hit re-writing
+	// its own already-verified-by-digest bytes back to itself would be a
+	// pointless extra write, and CachePopulate's own digest recheck would
+	// trivially pass anyway.
+	if !fromCache {
+		if data, rerr := os.ReadFile(archivePath); rerr == nil {
+			// Best-effort: the cache is purely an optimization (step5 §5) —
+			// a populate failure must never fail an otherwise-successful
+			// install.
+			_ = CachePopulate(opts.ConnectorsPath, normalizeDigestHex(artifact.SHA256), data, artifact.URL)
+		}
 	}
 
 	verifyResult, err := runVerificationGate(ctx, opts, dl, resolved, artifact)
@@ -404,21 +426,72 @@ func downloadVerifyAndInstall(ctx context.Context, opts InstallOptions, verified
 		return ManifestEntry{}, err
 	}
 
-	binaryPath, err := extractAndGuard(archivePath, stagingDir)
+	return finalizeArtifactInstall(finalizeInstallOptions{
+		connectorsPath:     opts.ConnectorsPath,
+		stagingDir:         stagingDir,
+		archivePath:        archivePath,
+		name:               resolved.Connector.Name,
+		version:            resolved.Version.Version,
+		os:                 artifact.OS,
+		arch:               artifact.Arch,
+		digest:             dl.Digest,
+		size:               dl.Size,
+		installedBy:        opts.InstalledBy,
+		sourceIndexVersion: verified.Payload.Index.Version,
+		source:             InstallSourceIndex,
+		verifyResult:       verifyResult,
+	})
+}
+
+// finalizeInstallOptions is finalizeArtifactInstall's input: everything
+// needed to extract, atomically install, and build the ManifestEntry for an
+// archive whose bytes have ALREADY passed the corruption check and the full
+// verification gate.
+type finalizeInstallOptions struct {
+	connectorsPath string
+	stagingDir     string
+	archivePath    string
+
+	name, version, os, arch string
+	digest                  [32]byte
+	size                    int64
+	installedBy             string
+
+	sourceIndexVersion int64
+	// source is "index" (InstallSourceIndex) or "offline-bundle"
+	// (InstallSourceOfflineBundle, bundle.go).
+	source string
+	// bundleIndexVersion is set only when source == InstallSourceOfflineBundle.
+	bundleIndexVersion int64
+
+	verifyResult VerifyResult
+}
+
+// finalizeArtifactInstall is steps 7-9's shared tail: extract the single
+// candidate binary, atomically rename it into connectorsPath, and build the
+// ManifestEntry to record — used by BOTH the online install pipeline
+// (downloadVerifyAndInstall, above) and the offline bundle-install path
+// (bundle.go's InstallFromBundle), so the two paths can never diverge on
+// the extract/rename/manifest-shape discipline. Manifest write + audit
+// event (steps 8-9's remaining parts) stay with each caller, since
+// InstallFromBundle's is otherwise identical to installResolved's but for
+// the ManifestEntry.Source/BundleIndexVersion fields.
+func finalizeArtifactInstall(o finalizeInstallOptions) (ManifestEntry, error) {
+	binaryPath, err := extractAndGuard(o.archivePath, o.stagingDir)
 	if err != nil {
 		return ManifestEntry{}, err
 	}
 
-	finalName := fmt.Sprintf("conduit-connector-%s_%s", resolved.Connector.Name, resolved.Version.Version)
-	finalPath := filepath.Join(opts.ConnectorsPath, finalName)
+	finalName := fmt.Sprintf("conduit-connector-%s_%s", o.name, o.version)
+	finalPath := filepath.Join(o.connectorsPath, finalName)
 
 	// Invariant 5 (atomic state/checkpoint writes): os.Rename within one
 	// filesystem is a single atomic syscall — there is no OS-observable
 	// "mid-rename" state. A crash before it returns leaves the OLD binary
 	// (if any) untouched at finalPath; a crash after leaves the NEW binary
 	// fully present. This is exactly why staging must share a filesystem
-	// with ConnectorsPath (see the MkdirTemp call above) — the guarantee
-	// does not hold across devices (EXDEV).
+	// with connectorsPath — the guarantee does not hold across devices
+	// (EXDEV).
 	if err := os.Rename(binaryPath, finalPath); err != nil {
 		return ManifestEntry{}, conduiterr.Wrap(CodeArchiveInvalid, fmt.Sprintf("could not install %q", finalName), err)
 	}
@@ -428,15 +501,50 @@ func downloadVerifyAndInstall(ctx context.Context, opts InstallOptions, verified
 	fireChaos(chaosPointPostRenamePreManifest)
 
 	now := time.Now().UTC()
-	digestHex := fmt.Sprintf("%x", dl.Digest)
 	return ManifestEntry{
-		Name: resolved.Connector.Name, Version: resolved.Version.Version,
-		Kind: StandaloneArtifactKind, OS: artifact.OS, Arch: artifact.Arch,
-		ArtifactFile: finalName, Digest: "sha256:" + digestHex, Size: dl.Size,
-		InstalledAt: now, InstalledBy: opts.InstalledBy,
-		SourceIndexVersion: verified.Payload.Index.Version, Source: InstallSourceIndex,
-		Signed: verifyResult.Signed, VerifiedIdentity: verifyResult.VerifiedIdentity, AllowUnsigned: !verifyResult.Signed,
+		Name: o.name, Version: o.version,
+		Kind: StandaloneArtifactKind, OS: o.os, Arch: o.arch,
+		ArtifactFile: finalName, Digest: fmt.Sprintf("sha256:%x", o.digest), Size: o.size,
+		InstalledAt: now, InstalledBy: o.installedBy,
+		SourceIndexVersion: o.sourceIndexVersion, Source: o.source, BundleIndexVersion: o.bundleIndexVersion,
+		Signed: o.verifyResult.Signed, VerifiedIdentity: o.verifyResult.VerifiedIdentity, AllowUnsigned: !o.verifyResult.Signed,
 	}, nil
+}
+
+// stageArtifact is step 5/6a's download half: write the artifact's bytes to
+// archivePath, preferring an already-cached copy over the network when one
+// is available (step5 §5's local cache), and reports whether the bytes came
+// from the cache.
+//
+// The cache is keyed by the index's DECLARED digest (artifact.SHA256) —
+// known before any bytes are fetched — so a cache check can run before the
+// network is ever touched. A cache hit is never treated as a trust
+// decision: the caller still runs CheckCorruption and the full verification
+// gate against the returned DownloadResult exactly as it would for a fresh
+// download; this function only ever decides where the BYTES come from.
+func stageArtifact(ctx context.Context, opts InstallOptions, artifact *index.Artifact, archivePath string) (DownloadResult, bool, error) {
+	digestHex := normalizeDigestHex(artifact.SHA256)
+	if digestHex != "" {
+		if cached, hit, cacheErr := CacheLookup(opts.ConnectorsPath, digestHex); cacheErr == nil && hit {
+			if werr := os.WriteFile(archivePath, cached, 0o600); werr == nil {
+				sum := sha256.Sum256(cached)
+				var digest [32]byte
+				copy(digest[:], sum[:])
+				return DownloadResult{Path: archivePath, Digest: digest, Size: int64(len(cached))}, true, nil
+			}
+			// Could not stage the cached bytes into this install's staging
+			// directory (e.g. disk pressure) — fall through to a fresh
+			// download rather than failing the install over a cache-layer
+			// problem.
+		}
+	}
+
+	dl, err := Download(ctx, opts.httpClient(), artifact.URL, archivePath, artifact.Size)
+	if err != nil {
+		return DownloadResult{}, false, err
+	}
+	fireChaos(chaosPointDownloadComplete)
+	return dl, false, nil
 }
 
 // runVerificationGate is step 6b/7: normally, fetch the signature/provenance

--- a/pkg/registry/installed.go
+++ b/pkg/registry/installed.go
@@ -1,0 +1,227 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file backs `conduit connectors list --installed` (plan-v2/step5 §3):
+// enumerating the local install manifest, independent of whether any
+// pipeline uses an entry or whether the engine is even running — a
+// fundamentally different thing from the existing `connectors list`, which
+// queries the running engine's pipeline connector INSTANCES. See
+// cmd/conduit/root/connectors/list.go for why the two render as visibly
+// distinct tables.
+package registry
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry/index"
+)
+
+// InstalledStatus is list --installed's per-row status (step5 §3).
+type InstalledStatus string
+
+const (
+	InstalledStatusOK               InstalledStatus = "ok"
+	InstalledStatusUpdateAvailable  InstalledStatus = "update-available"
+	InstalledStatusMissingArtifact  InstalledStatus = "missing-artifact"
+	InstalledStatusDrifted          InstalledStatus = "drifted"
+	InstalledStatusIndexUnreachable InstalledStatus = "index-unreachable"
+	InstalledStatusNotInIndex       InstalledStatus = "not-in-index"
+)
+
+// InstalledConnector is one row of `list --installed` — a plugin artifact
+// recorded in the local manifest, not a pipeline connector instance.
+type InstalledConnector struct {
+	Name            string          `json:"name"`
+	Version         string          `json:"version"`
+	Signed          bool            `json:"signed"`
+	Source          string          `json:"source"`
+	InstalledAt     time.Time       `json:"installedAt"`
+	Digest          string          `json:"digest,omitempty"`
+	LatestAvailable string          `json:"latestAvailable,omitempty"`
+	Status          InstalledStatus `json:"status"`
+}
+
+// ListInstalledResult is ListInstalled's return shape.
+type ListInstalledResult struct {
+	Installed []InstalledConnector `json:"installed"`
+	// IndexUnreachable is true when the registry index could not be
+	// fetched/parsed AT ALL for this run — every row still renders (with a
+	// blank LatestAvailable) rather than failing the whole command, per
+	// step5 §3: this command degrades gracefully because checking for
+	// updates is informational, not a security check (contrast with
+	// `audit`, which hard-fails on an unreachable/untrusted index).
+	IndexUnreachable bool `json:"indexUnreachable"`
+}
+
+// ListInstalledOptions is ListInstalled's configuration.
+type ListInstalledOptions struct {
+	ConnectorsPath string
+	IndexURL       string
+	IndexFile      string
+}
+
+// ListInstalled enumerates every entry in the local install manifest.
+//
+// The index is consulted best-effort, and ONLY for the informational
+// LatestAvailable/update-available signal — never for a schema-version or
+// signature check, and the index bytes are never cryptographically
+// verified here (index.ParseUnverified, a shape/schema check only): an
+// operator who wants a verified re-check of installed connectors against
+// yank/revocation runs `conduit connectors audit`, which does real
+// verification and hard-fails when it can't.
+func ListInstalled(ctx context.Context, opts ListInstalledOptions) (*ListInstalledResult, error) {
+	m, err := LoadManifest(manifestPath(opts.ConnectorsPath))
+	if err != nil {
+		return nil, conduiterr.Wrap(conduiterr.CodeInternal, "could not read install manifest", err)
+	}
+
+	latestByName, indexUnreachable := bestEffortLatestVersions(ctx, opts.IndexURL, opts.IndexFile)
+
+	keys := make([]string, 0, len(m.Installs))
+	for k := range m.Installs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	rows := make([]InstalledConnector, 0, len(keys))
+	for _, k := range keys {
+		e := m.Installs[k]
+		row := InstalledConnector{
+			Name: e.Name, Version: e.Version, Signed: e.Signed, Source: e.Source,
+			InstalledAt: e.InstalledAt, Digest: e.Digest,
+		}
+
+		missing, drifted := checkArtifactHealth(filepath.Join(opts.ConnectorsPath, e.ArtifactFile), e.Digest)
+		switch {
+		case missing:
+			row.Status = InstalledStatusMissingArtifact
+		case drifted:
+			row.Status = InstalledStatusDrifted
+		case indexUnreachable:
+			row.Status = InstalledStatusIndexUnreachable
+		default:
+			latest, ok := latestByName[e.Name]
+			if !ok {
+				row.Status = InstalledStatusNotInIndex
+			} else {
+				row.LatestAvailable = latest
+				if isNewerVersion(latest, e.Version) {
+					row.Status = InstalledStatusUpdateAvailable
+				} else {
+					row.Status = InstalledStatusOK
+				}
+			}
+		}
+		rows = append(rows, row)
+	}
+
+	return &ListInstalledResult{Installed: rows, IndexUnreachable: indexUnreachable}, nil
+}
+
+// checkArtifactHealth reports whether the artifact at path is missing, or
+// present but drifted from wantDigest (an optionally "sha256:"-prefixed hex
+// string) — the shared local-integrity check `list --installed`, `audit`,
+// and `uninstall` all apply the same way (step5 §6).
+func checkArtifactHealth(path, wantDigest string) (missing, drifted bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return true, false
+	}
+	sum := sha256.Sum256(data)
+	want := strings.TrimPrefix(wantDigest, "sha256:")
+	if !strings.EqualFold(hex.EncodeToString(sum[:]), want) {
+		return false, true
+	}
+	return false, false
+}
+
+// fetchIndexRawFrom fetches raw index bytes from indexFile (if set) or
+// indexURL — the same file-takes-priority convention install.go's
+// fetchIndexRaw uses, factored out here since ListInstalled and RunAudit
+// both need it without depending on InstallOptions' unrelated fields.
+func fetchIndexRawFrom(ctx context.Context, indexURL, indexFile string) ([]byte, error) {
+	if indexFile != "" {
+		return index.FetchFile(indexFile)
+	}
+	return index.Fetch(ctx, indexURL)
+}
+
+// bestEffortLatestVersions fetches and shape-parses (never cryptographically
+// verifies — see ListInstalled's doc comment) the index, returning the
+// newest non-yanked version per connector name. Any failure at all (fetch,
+// parse) reports indexUnreachable: true and a nil map, never a hard error —
+// this function backs ONLY the informational list --installed path.
+func bestEffortLatestVersions(ctx context.Context, indexURL, indexFile string) (map[string]string, bool) {
+	raw, err := fetchIndexRawFrom(ctx, indexURL, indexFile)
+	if err != nil {
+		return nil, true
+	}
+	payload, err := index.ParseUnverified(raw)
+	if err != nil {
+		return nil, true
+	}
+
+	out := make(map[string]string, len(payload.Connectors))
+	for _, c := range payload.Connectors {
+		if latest := latestNonYankedVersion(c); latest != "" {
+			out[c.Name] = latest
+		}
+	}
+	return out, false
+}
+
+// latestNonYankedVersion returns the newest version string in c.Versions
+// that is not yanked, or "" if c has no such version.
+func latestNonYankedVersion(c index.Connector) string {
+	var best string
+	bestParsed := false
+	for _, v := range c.Versions {
+		if v.Yanked != nil {
+			continue
+		}
+		nv, err := NormalizeVersion(v.Version)
+		if err != nil {
+			continue
+		}
+		if !bestParsed {
+			best, bestParsed = v.Version, true
+			continue
+		}
+		bv, err := NormalizeVersion(best)
+		if err == nil && nv.GreaterThan(bv) {
+			best = v.Version
+		}
+	}
+	return best
+}
+
+// isNewerVersion reports whether latestStr is a strictly greater semver
+// than installedStr — an unparsable version on either side reports false
+// (never claims an update is available over data it can't compare).
+func isNewerVersion(latestStr, installedStr string) bool {
+	latest, err1 := NormalizeVersion(latestStr)
+	installed, err2 := NormalizeVersion(installedStr)
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	return latest.GreaterThan(installed)
+}

--- a/pkg/registry/installed_test.go
+++ b/pkg/registry/installed_test.go
@@ -1,0 +1,133 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/registry"
+)
+
+func writeRawIndex(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "index.json")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	return path
+}
+
+func TestListInstalled_BasicRowsAndUpdateAvailable(t *testing.T) {
+	dir := t.TempDir()
+	installFixture(t, dir, "postgres", "0.14.0", "bytes")
+	installFixture(t, dir, "s3-sink", "1.0.0", "bytes-2")
+
+	indexBody := `{"payload":{"schemaVersion":1,"index":{"version":1,"timestamp":"2026-01-01T00:00:00Z"},"connectors":[
+		{"name":"postgres","publisher":{"expectedOIDCIssuer":"x"},"versions":[{"version":"0.14.0"},{"version":"0.14.1"}]},
+		{"name":"s3-sink","publisher":{"expectedOIDCIssuer":"x"},"versions":[{"version":"1.0.0"}]}
+	]},"signatures":[]}`
+
+	res, err := registry.ListInstalled(context.Background(), registry.ListInstalledOptions{
+		ConnectorsPath: dir, IndexFile: writeRawIndex(t, indexBody),
+	})
+	require.NoError(t, err)
+	assert.False(t, res.IndexUnreachable)
+	require.Len(t, res.Installed, 2)
+
+	byName := map[string]registry.InstalledConnector{}
+	for _, r := range res.Installed {
+		byName[r.Name] = r
+	}
+
+	pg := byName["postgres"]
+	assert.Equal(t, "0.14.0", pg.Version)
+	assert.Equal(t, "0.14.1", pg.LatestAvailable)
+	assert.Equal(t, registry.InstalledStatusUpdateAvailable, pg.Status)
+
+	s3 := byName["s3-sink"]
+	assert.Equal(t, "1.0.0", s3.Version)
+	assert.Equal(t, "1.0.0", s3.LatestAvailable)
+	assert.Equal(t, registry.InstalledStatusOK, s3.Status)
+}
+
+// TestListInstalled_IndexUnreachable_DegradesGracefully is AC5: rows still
+// render (with indexUnreachable: true) rather than failing the whole
+// command.
+func TestListInstalled_IndexUnreachable_DegradesGracefully(t *testing.T) {
+	dir := t.TempDir()
+	installFixture(t, dir, "postgres", "0.14.0", "bytes")
+
+	res, err := registry.ListInstalled(context.Background(), registry.ListInstalledOptions{
+		ConnectorsPath: dir, IndexFile: filepath.Join(dir, "does-not-exist.json"),
+	})
+	require.NoError(t, err)
+	assert.True(t, res.IndexUnreachable)
+	require.Len(t, res.Installed, 1)
+	assert.Equal(t, registry.InstalledStatusIndexUnreachable, res.Installed[0].Status)
+	assert.Empty(t, res.Installed[0].LatestAvailable)
+}
+
+func TestListInstalled_MissingArtifact(t *testing.T) {
+	dir := t.TempDir()
+	entry := installFixture(t, dir, "postgres", "0.14.0", "bytes")
+	require.NoError(t, os.Remove(filepath.Join(dir, entry.ArtifactFile)))
+
+	res, err := registry.ListInstalled(context.Background(), registry.ListInstalledOptions{
+		ConnectorsPath: dir, IndexFile: filepath.Join(dir, "does-not-exist.json"),
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Installed, 1)
+	assert.Equal(t, registry.InstalledStatusMissingArtifact, res.Installed[0].Status)
+}
+
+func TestListInstalled_Drifted(t *testing.T) {
+	dir := t.TempDir()
+	entry := installFixture(t, dir, "postgres", "0.14.0", "original")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, entry.ArtifactFile), []byte("replaced"), 0o755))
+
+	res, err := registry.ListInstalled(context.Background(), registry.ListInstalledOptions{
+		ConnectorsPath: dir, IndexFile: filepath.Join(dir, "does-not-exist.json"),
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Installed, 1)
+	assert.Equal(t, registry.InstalledStatusDrifted, res.Installed[0].Status)
+}
+
+func TestListInstalled_NotInIndex(t *testing.T) {
+	dir := t.TempDir()
+	installFixture(t, dir, "old-thing", "0.2.0", "bytes")
+
+	indexBody := `{"payload":{"schemaVersion":1,"index":{"version":1,"timestamp":"2026-01-01T00:00:00Z"},"connectors":[]},"signatures":[]}`
+	res, err := registry.ListInstalled(context.Background(), registry.ListInstalledOptions{
+		ConnectorsPath: dir, IndexFile: writeRawIndex(t, indexBody),
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Installed, 1)
+	assert.Equal(t, registry.InstalledStatusNotInIndex, res.Installed[0].Status)
+	assert.False(t, res.IndexUnreachable)
+}
+
+func TestListInstalled_EmptyManifest(t *testing.T) {
+	dir := t.TempDir()
+	res, err := registry.ListInstalled(context.Background(), registry.ListInstalledOptions{
+		ConnectorsPath: dir, IndexFile: filepath.Join(dir, "does-not-exist.json"),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, res.Installed)
+}

--- a/pkg/registry/policy/gate.go
+++ b/pkg/registry/policy/gate.go
@@ -87,6 +87,70 @@ func (d Decision) Allowed() bool { return d.allowed }
 // path here uses CodeUnsignedInstallNonInteractive, meaning "this
 // particular attempt didn't clear the gate, but a different context
 // (interactively, or with the env var) might".
+// StaleBundleContext is every input DecideStaleBundle's pure logic needs —
+// the offline-install analogue of Context, gated "exactly like
+// --allow-unsigned" per DeVaris's ratification (plan-v2/step5 §7 step 3,
+// §9 decision item 2): TTY/operator-policy gated, forbiddable, never
+// silently flippable. A distinct type from Context (rather than reusing it)
+// so the two gates' fields are never confused at a call site — in
+// particular OperatorAllowStaleBundle is a different operator policy knob
+// (install.allowStaleBundle) than OperatorPolicy's install.allowUnsigned.
+type StaleBundleContext struct {
+	// TTY, CIEnv, IsMCP, EnvVarSet, TypedConfirmation mirror Context's
+	// fields exactly (see Context's doc comment) — the only difference is
+	// which env var/config knob they represent (CONDUIT_ALLOW_STALE_BUNDLE
+	// and install.allowStaleBundle, collected by the CLI layer, never by
+	// this package).
+	TTY               bool
+	CIEnv             bool
+	IsMCP             bool
+	EnvVarSet         bool
+	TypedConfirmation bool
+	// OperatorAllowStaleBundle is the operator's install.allowStaleBundle
+	// config value. false hard-disables the whole gate regardless of
+	// flag/TTY/env var — checked first, exactly as Context.OperatorPolicy
+	// is for the unsigned-install gate.
+	OperatorAllowStaleBundle bool
+}
+
+// DecideStaleBundle is the offline-bundle-staleness analogue of Decide,
+// implementing the identical behavioral shape (operator policy checked
+// first and wins outright; MCP never gets an escape hatch; non-interactive
+// requires the env var; interactive requires a typed confirmation) but
+// returning a human-readable reason string instead of a registered error
+// code: unlike Decide, this decision deliberately does NOT mint its own
+// conduiterr codes for "why not allowed" — the single sanctioned caller
+// (pkg/registry/bundle.go) already has the one canonical code this feature
+// needs (registry.CodeBundleStale, plan-v2 §4) and attaches reason as that
+// error's message, rather than this package inventing parallel codes
+// step5/plan-v2 never asked for.
+//
+// Every allowed outcome is still routed through this function, and only
+// this function ever produces Decision{allowed: true} for the stale-bundle
+// path — the same structural guarantee Decide provides, via Decision's
+// unexported field.
+func DecideStaleBundle(ctx StaleBundleContext) (dec Decision, reason string) {
+	if !ctx.OperatorAllowStaleBundle {
+		return Decision{}, "stale-bundle installs are disabled by operator policy (install.allowStaleBundle: false)"
+	}
+	if ctx.IsMCP {
+		return Decision{}, "stale-bundle installs are never permitted from the MCP tool"
+	}
+
+	nonInteractive := !ctx.TTY || ctx.CIEnv
+	if nonInteractive {
+		if ctx.EnvVarSet {
+			return Decision{allowed: true}, ""
+		}
+		return Decision{}, "requires an interactive TTY confirmation, or CONDUIT_ALLOW_STALE_BUNDLE=I_UNDERSTAND set in a non-interactive context"
+	}
+
+	if ctx.TypedConfirmation {
+		return Decision{allowed: true}, ""
+	}
+	return Decision{}, "stale bundle installation was not confirmed"
+}
+
 func Decide(ctx Context) (Decision, error) {
 	if !ctx.OperatorPolicy {
 		return Decision{}, conduiterr.New(CodeUnsignedInstallDisabledByPolicy,

--- a/pkg/registry/uninstall.go
+++ b/pkg/registry/uninstall.go
@@ -1,0 +1,286 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+)
+
+// InUseRef identifies one connector instance (in a pipeline, running or
+// merely provisioned) whose plugin reference exactly matches the
+// name@version an uninstall is about to remove.
+//
+// Deliberately plain data, not an interface Uninstall calls out to: the
+// CALLER (cmd/conduit/root/connectors/uninstall.go) is responsible for
+// collecting this list — via the running engine's ConnectorServiceClient if
+// reachable, falling back to a direct scan of provisioned pipeline configs
+// via pkg/provisioning/config if not (step5 §2 step 2) — exactly the same
+// "collect primitive signals at the CLI layer" pattern install.go already
+// uses for TTY/CIEnv/EnvVarSet. This keeps pkg/registry free of a gRPC
+// client or pkg/provisioning dependency, and keeps Uninstall itself a pure,
+// easily-unit-tested function of already-known facts.
+type InUseRef struct {
+	PipelineID  string `json:"pipelineId"`
+	ConnectorID string `json:"connectorId"`
+}
+
+// UninstallOptions is Uninstall's full configuration.
+type UninstallOptions struct {
+	// Name is the connector name to uninstall.
+	Name string
+	// Version is an optional exact version ("0.14.1" or "v0.14.1"). Empty
+	// auto-resolves ONLY if exactly one version of Name is currently
+	// installed; if more than one is installed, an empty Version refuses
+	// with CodeAmbiguousUninstall (plan-v2 §3.1) rather than guessing.
+	Version string
+
+	// ConnectorsPath is the standalone connectors directory
+	// (--connectors.path) this uninstall operates against.
+	ConnectorsPath string
+
+	// Force proceeds even when InUseRefs is non-empty. The result still
+	// reports every affected pipeline via Warnings — this is a loudly
+	// surfaced warning, not a silent flag flip (step5 §2 step 4).
+	Force bool
+
+	// InUseRefs is every connector instance (across every pipeline) whose
+	// plugin reference is exactly standalone:<name>@<version> — see
+	// InUseRef's doc comment for why the caller, not this function,
+	// collects it.
+	InUseRefs []InUseRef
+
+	// InstalledBy identifies the operator for the audit event (best-effort).
+	InstalledBy string
+
+	// LockTimeout bounds how long Uninstall waits to acquire the
+	// per-connector-name lock and the manifest lock. Zero uses
+	// DefaultLockTimeout.
+	LockTimeout time.Duration
+}
+
+func (o *UninstallOptions) lockTimeout() time.Duration {
+	if o.LockTimeout > 0 {
+		return o.LockTimeout
+	}
+	return DefaultLockTimeout
+}
+
+// UninstallResult is Uninstall's success-path result.
+type UninstallResult struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Digest  string `json:"digest,omitempty"`
+
+	Forced   bool     `json:"forced"`
+	Warnings []string `json:"warnings"`
+
+	// DriftDetected is true when the on-disk artifact's sha256 no longer
+	// matched the manifest's recorded digest at uninstall time (step5 §6) —
+	// informational: the artifact is removed either way.
+	DriftDetected bool `json:"driftDetected,omitempty"`
+	// ArtifactAlreadyMissing is true when the artifact file was already gone
+	// before Uninstall ran (e.g. removed manually with rm) — not a failure;
+	// Uninstall still cleans up the manifest entry.
+	ArtifactAlreadyMissing bool `json:"artifactAlreadyMissing,omitempty"`
+}
+
+// Uninstall removes an installed connector's artifact and manifest entry.
+//
+// Invariant 5 (atomic state/checkpoint writes): the manifest is only ever
+// rewritten via SaveManifest's atomic temp+rename — a crash mid-uninstall
+// leaves either the pre-uninstall manifest (artifact possibly already
+// deleted, in which case a retry finishes the job — os.Remove tolerates
+// "already gone") or the fully-updated post-uninstall manifest, never a
+// torn one.
+func Uninstall(opts UninstallOptions) (*UninstallResult, error) {
+	if opts.Name == "" {
+		return nil, conduiterr.New(conduiterr.CodeInvalidArgument, "connector name is required")
+	}
+	if opts.ConnectorsPath == "" {
+		return nil, conduiterr.New(conduiterr.CodeInvalidArgument, "--connectors.path is required")
+	}
+
+	// Serializes against a concurrent install/uninstall of ANY version of
+	// this name — the same per-name granularity AcquireTargetLock already
+	// uses for install (only Name, not Name@Version), which is intentional:
+	// InstalledVersions/CodeAmbiguousUninstall's resolution below reads
+	// every version of Name from the manifest, so it must not race a
+	// concurrent install that is about to add or remove one.
+	targetLock, err := AcquireTargetLock(opts.ConnectorsPath, opts.Name, opts.lockTimeout())
+	if err != nil {
+		return nil, err
+	}
+	defer targetLock.Unlock() //nolint:errcheck // best-effort; flock also releases at process exit
+
+	m, err := LoadManifest(manifestPath(opts.ConnectorsPath))
+	if err != nil {
+		return nil, conduiterr.Wrap(conduiterr.CodeInternal, "could not read install manifest", err)
+	}
+
+	version, err := resolveUninstallVersion(m, opts.Name, opts.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := ManifestKey(opts.Name, version)
+	if err != nil {
+		return nil, err
+	}
+	entry, ok := m.Installs[key]
+	if !ok {
+		return nil, notInstalledError(opts.Name, version)
+	}
+
+	var warnings []string
+	forced := false
+	if len(opts.InUseRefs) > 0 {
+		if !opts.Force {
+			return nil, inUseError(entry.Name, entry.Version, opts.InUseRefs)
+		}
+		forced = true
+		warnings = append(warnings, inUseWarning(entry.Name, entry.Version, opts.InUseRefs))
+	}
+
+	driftDetected, artifactAlreadyMissing, err := removeArtifact(opts.ConnectorsPath, entry)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := deleteManifestEntry(opts.ConnectorsPath, key, opts.lockTimeout()); err != nil {
+		return nil, err
+	}
+
+	if err := AppendAuditEvent(auditLogPath(opts.ConnectorsPath), AuditEvent{
+		Event: "connector_uninstall", Connector: entry.Name, Version: entry.Version,
+		Digest: entry.Digest, Operator: opts.InstalledBy, Timestamp: time.Now().UTC(),
+		Forced: forced,
+	}); err != nil {
+		return nil, conduiterr.Wrap(conduiterr.CodeInternal, "connector uninstalled but could not append the audit log entry", err)
+	}
+
+	return &UninstallResult{
+		Name: entry.Name, Version: entry.Version, Digest: entry.Digest,
+		Forced: forced, Warnings: warnings,
+		DriftDetected: driftDetected, ArtifactAlreadyMissing: artifactAlreadyMissing,
+	}, nil
+}
+
+// resolveUninstallVersion implements plan-v2 §3.1's ambiguous-uninstall
+// resolution: an explicit version is used as-is (existence is checked by the
+// caller's manifest lookup); an empty version auto-resolves only when
+// exactly one version of name is installed.
+func resolveUninstallVersion(m *Manifest, name, version string) (string, error) {
+	if version != "" {
+		return version, nil
+	}
+
+	versions := m.InstalledVersions(name)
+	switch len(versions) {
+	case 0:
+		return "", notInstalledError(name, "")
+	case 1:
+		return versions[0], nil
+	default:
+		err := conduiterr.New(CodeAmbiguousUninstall, fmt.Sprintf(
+			"connector %q has more than one installed version (%s) — specify which one",
+			name, strings.Join(versions, ", ")))
+		err.Suggestion = fmt.Sprintf("re-run as `conduit connectors uninstall %s@<version>`, e.g. %s@%s",
+			name, name, versions[len(versions)-1])
+		return "", err
+	}
+}
+
+func notInstalledError(name, version string) error {
+	target := name
+	if version != "" {
+		target = name + "@" + version
+	}
+	err := conduiterr.New(CodeConnectorNotInstalled, fmt.Sprintf("connector %q is not installed", target))
+	err.Suggestion = "check `conduit connectors list --installed` for the exact installed name@version"
+	return err
+}
+
+func inUseError(name, version string, refs []InUseRef) error {
+	err := conduiterr.New(CodeConnectorInUse, fmt.Sprintf(
+		"connector %s@%s is in use by %s", name, version, describeInUseRefs(refs)))
+	err.Suggestion = "stop or reconfigure these connectors first, or re-run with --force to remove the artifact " +
+		"anyway (pipelines referencing it will fail to start/restart until reconfigured)"
+	return err
+}
+
+func inUseWarning(name, version string, refs []InUseRef) string {
+	return fmt.Sprintf("removed %s@%s while still in use by %s — pipelines referencing it will fail to "+
+		"start/restart until reconfigured", name, version, describeInUseRefs(refs))
+}
+
+func describeInUseRefs(refs []InUseRef) string {
+	parts := make([]string, 0, len(refs))
+	for _, r := range refs {
+		parts = append(parts, fmt.Sprintf("pipeline %s (connector %s)", r.PipelineID, r.ConnectorID))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ", ")
+}
+
+// removeArtifact deletes the installed artifact file, tolerating "already
+// gone" (step5 §6: a manually-`rm`'d artifact is not a failure) and
+// reporting whether the on-disk bytes had drifted from the manifest's
+// recorded digest before removal (step5 §6: informational, never blocking).
+func removeArtifact(connectorsPath string, entry ManifestEntry) (driftDetected, artifactAlreadyMissing bool, err error) {
+	if entry.ArtifactFile == "" {
+		return false, true, nil
+	}
+	path := filepath.Join(connectorsPath, entry.ArtifactFile)
+
+	missing, drifted := checkArtifactHealth(path, entry.Digest)
+	if missing {
+		return false, true, nil
+	}
+
+	if rmErr := os.Remove(path); rmErr != nil && !os.IsNotExist(rmErr) {
+		return drifted, false, cerrors.Errorf("could not remove installed artifact %q: %w", path, rmErr)
+	}
+	return drifted, false, nil
+}
+
+// deleteManifestEntry removes key from the manifest under the manifest
+// lock, atomically rewriting the whole file — the mirror image of
+// install.go's writeManifestEntry.
+func deleteManifestEntry(connectorsPath, key string, lockTimeout time.Duration) error {
+	lock, err := AcquireManifestLock(connectorsPath, lockTimeout)
+	if err != nil {
+		return err
+	}
+	defer lock.Unlock() //nolint:errcheck // best-effort; flock also releases at process exit
+
+	path := manifestPath(connectorsPath)
+	m, err := LoadManifest(path)
+	if err != nil {
+		return conduiterr.Wrap(conduiterr.CodeInternal, "could not read install manifest", err)
+	}
+	delete(m.Installs, key)
+	if err := SaveManifest(path, m); err != nil {
+		return conduiterr.Wrap(conduiterr.CodeInternal, "could not write install manifest", err)
+	}
+	return nil
+}

--- a/pkg/registry/uninstall_test.go
+++ b/pkg/registry/uninstall_test.go
@@ -1,0 +1,233 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry"
+)
+
+// installFixture writes a manifest entry (and, unless noArtifact, the
+// artifact file it references) directly to disk — a lightweight substitute
+// for a full registry.Install run, since uninstall_test.go only needs a
+// pre-existing installed state, not the install pipeline itself (that's
+// install_test.go's job).
+func installFixture(t *testing.T, connectorsPath, name, version, artifactBytes string) registry.ManifestEntry {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(connectorsPath, 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(connectorsPath, ".registry"), 0o755))
+
+	artifactFile := name + "_" + version
+	if artifactBytes != "" {
+		require.NoError(t, os.WriteFile(filepath.Join(connectorsPath, artifactFile), []byte(artifactBytes), 0o755))
+	}
+
+	digest := sha256Hex(artifactBytes)
+	entry := registry.ManifestEntry{
+		Name: name, Version: version, Kind: "standalone", OS: "linux", Arch: "amd64",
+		ArtifactFile: artifactFile, Digest: "sha256:" + digest, Size: int64(len(artifactBytes)),
+		InstalledAt: time.Now().UTC(), InstalledBy: "test", Source: registry.InstallSourceIndex,
+		Signed: true, VerifiedIdentity: "test-identity",
+	}
+
+	key, err := registry.ManifestKey(name, version)
+	require.NoError(t, err)
+
+	path := filepath.Join(connectorsPath, ".registry", "manifest.json")
+	m, err := registry.LoadManifest(path)
+	require.NoError(t, err)
+	if m.Installs == nil {
+		m.Installs = map[string]registry.ManifestEntry{}
+	}
+	m.Installs[key] = entry
+	require.NoError(t, registry.SaveManifest(path, m))
+
+	return entry
+}
+
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+func TestUninstall_NotInstalled_HardError(t *testing.T) {
+	dir := t.TempDir()
+	_, err := registry.Uninstall(registry.UninstallOptions{Name: "postgres", ConnectorsPath: dir})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeConnectorNotInstalled, ce.Code)
+}
+
+func TestUninstall_RemovesArtifactAndManifestEntry(t *testing.T) {
+	dir := t.TempDir()
+	installFixture(t, dir, "postgres", "0.14.1", "fake-binary-bytes")
+
+	res, err := registry.Uninstall(registry.UninstallOptions{Name: "postgres", Version: "0.14.1", ConnectorsPath: dir})
+	require.NoError(t, err)
+	assert.Equal(t, "postgres", res.Name)
+	assert.Equal(t, "0.14.1", res.Version)
+	assert.False(t, res.Forced)
+	assert.Empty(t, res.Warnings)
+
+	_, statErr := os.Stat(filepath.Join(dir, "postgres_0.14.1"))
+	assert.True(t, os.IsNotExist(statErr))
+
+	m, err := registry.LoadManifest(filepath.Join(dir, ".registry", "manifest.json"))
+	require.NoError(t, err)
+	assert.Empty(t, m.Installs)
+}
+
+func TestUninstall_AutoResolvesSingleInstalledVersion(t *testing.T) {
+	dir := t.TempDir()
+	installFixture(t, dir, "postgres", "0.14.1", "bytes")
+
+	res, err := registry.Uninstall(registry.UninstallOptions{Name: "postgres", ConnectorsPath: dir})
+	require.NoError(t, err)
+	assert.Equal(t, "0.14.1", res.Version)
+}
+
+func TestUninstall_AmbiguousWithoutVersion_Refuses(t *testing.T) {
+	dir := t.TempDir()
+	installFixture(t, dir, "postgres", "0.13.0", "bytes-a")
+	installFixture(t, dir, "postgres", "0.14.1", "bytes-b")
+
+	_, err := registry.Uninstall(registry.UninstallOptions{Name: "postgres", ConnectorsPath: dir})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeAmbiguousUninstall, ce.Code)
+
+	// Both versions must remain untouched.
+	m, err := registry.LoadManifest(filepath.Join(dir, ".registry", "manifest.json"))
+	require.NoError(t, err)
+	assert.Len(t, m.Installs, 2)
+}
+
+func TestUninstall_AmbiguousResolvedByExplicitVersion(t *testing.T) {
+	dir := t.TempDir()
+	installFixture(t, dir, "postgres", "0.13.0", "bytes-a")
+	installFixture(t, dir, "postgres", "0.14.1", "bytes-b")
+
+	res, err := registry.Uninstall(registry.UninstallOptions{Name: "postgres", Version: "0.14.1", ConnectorsPath: dir})
+	require.NoError(t, err)
+	assert.Equal(t, "0.14.1", res.Version)
+
+	m, err := registry.LoadManifest(filepath.Join(dir, ".registry", "manifest.json"))
+	require.NoError(t, err)
+	assert.Len(t, m.Installs, 1)
+	_, stillThere := m.Installs["postgres@0.13.0"]
+	assert.True(t, stillThere)
+}
+
+func TestUninstall_InUse_RefusesWithoutForce(t *testing.T) {
+	dir := t.TempDir()
+	installFixture(t, dir, "postgres", "0.14.1", "bytes")
+
+	_, err := registry.Uninstall(registry.UninstallOptions{
+		Name: "postgres", Version: "0.14.1", ConnectorsPath: dir,
+		InUseRefs: []registry.InUseRef{{PipelineID: "pipe-1", ConnectorID: "conn-1"}},
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeConnectorInUse, ce.Code)
+	assert.Contains(t, ce.Message, "pipe-1")
+
+	// Nothing removed.
+	m, err := registry.LoadManifest(filepath.Join(dir, ".registry", "manifest.json"))
+	require.NoError(t, err)
+	assert.Len(t, m.Installs, 1)
+}
+
+func TestUninstall_InUse_ForceProceedsWithWarning(t *testing.T) {
+	dir := t.TempDir()
+	installFixture(t, dir, "postgres", "0.14.1", "bytes")
+
+	res, err := registry.Uninstall(registry.UninstallOptions{
+		Name: "postgres", Version: "0.14.1", ConnectorsPath: dir, Force: true,
+		InUseRefs: []registry.InUseRef{{PipelineID: "pipe-1", ConnectorID: "conn-1"}},
+	})
+	require.NoError(t, err)
+	assert.True(t, res.Forced)
+	require.Len(t, res.Warnings, 1)
+	assert.Contains(t, res.Warnings[0], "pipe-1")
+
+	m, err := registry.LoadManifest(filepath.Join(dir, ".registry", "manifest.json"))
+	require.NoError(t, err)
+	assert.Empty(t, m.Installs)
+}
+
+// TestUninstall_MissingArtifact_ToleratesAndCleansManifest is AC10: an
+// artifact manually deleted with `rm` before uninstall runs must not be a
+// failure — uninstall still cleans up the manifest entry.
+func TestUninstall_MissingArtifact_ToleratesAndCleansManifest(t *testing.T) {
+	dir := t.TempDir()
+	entry := installFixture(t, dir, "postgres", "0.14.1", "bytes")
+	require.NoError(t, os.Remove(filepath.Join(dir, entry.ArtifactFile)))
+
+	res, err := registry.Uninstall(registry.UninstallOptions{Name: "postgres", Version: "0.14.1", ConnectorsPath: dir})
+	require.NoError(t, err)
+	assert.True(t, res.ArtifactAlreadyMissing)
+	assert.False(t, res.DriftDetected)
+
+	m, err := registry.LoadManifest(filepath.Join(dir, ".registry", "manifest.json"))
+	require.NoError(t, err)
+	assert.Empty(t, m.Installs)
+}
+
+// TestUninstall_DriftedArtifact_StillRemovedAndNoted is AC11: an artifact
+// manually replaced with different bytes is still removed, with
+// DriftDetected reported so an operator knows what they just deleted wasn't
+// necessarily what install originally placed.
+func TestUninstall_DriftedArtifact_StillRemovedAndNoted(t *testing.T) {
+	dir := t.TempDir()
+	entry := installFixture(t, dir, "postgres", "0.14.1", "original-bytes")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, entry.ArtifactFile), []byte("replaced-bytes"), 0o755))
+
+	res, err := registry.Uninstall(registry.UninstallOptions{Name: "postgres", Version: "0.14.1", ConnectorsPath: dir})
+	require.NoError(t, err)
+	assert.True(t, res.DriftDetected)
+	assert.False(t, res.ArtifactAlreadyMissing)
+
+	_, statErr := os.Stat(filepath.Join(dir, entry.ArtifactFile))
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestUninstall_AppendsAuditEvent(t *testing.T) {
+	dir := t.TempDir()
+	installFixture(t, dir, "postgres", "0.14.1", "bytes")
+
+	_, err := registry.Uninstall(registry.UninstallOptions{
+		Name: "postgres", Version: "0.14.1", ConnectorsPath: dir, InstalledBy: "devaris",
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, ".registry", "audit.jsonl"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"event":"connector_uninstall"`)
+	assert.Contains(t, string(data), `"connector":"postgres"`)
+	assert.Contains(t, string(data), `"operator":"devaris"`)
+}


### PR DESCRIPTION
## Summary

**Tier 2.** Implements PR-4 (step5/plan-v2 "lifecycle CLI") of the connector-registry MVP epic on top of PR-0 (foundations), PR-1 (install core), and PR-2 (trust core), per `docs/design-documents/20260713-connector-registry-mvp.md` and `docs/design-documents/20260714-connector-registry-index-schema.md`.

### Commands

- **`conduit connectors uninstall <name>[@version]`** — `name@version`-keyed manifest lookup; refuses `uninstall <name>` with no version when more than one version is installed (`registry.ambiguous_uninstall`); an **in-use check** (queries the running engine's `ConnectorServiceClient.ListConnectors`, falling back to a direct scan of provisioned pipeline configs via `pkg/provisioning/config` when the engine isn't reachable — proven in tests with no engine running at all); `--force` proceeds with a loud warning naming the affected pipelines; tolerates a manually-deleted or drifted artifact (reported, never blocking); atomic manifest rewrite (`pkg/foundation/atomicfile`).
- **`conduit connectors list --installed`** — extends the existing `list` command; renders the local install manifest (name, version, signed?, install date, digest, latest-available) as a table **visibly distinct** from the pipeline-instance table; best-effort "latest available" against the index — degrades gracefully (`indexUnreachable: true`) rather than failing the whole command, since this is informational, not a security check.
- **`conduit connectors audit`** — re-fetches and re-verifies the signed index through the **exact same `registry.TrustedVerifier`** install.go wires in (no lower-trust shortcut path), then checks every installed connector: `YANKED_VERSION`/`REVOKED_PUBLISHER` (Fail, reusing PR-2's `index.CodeVersionYanked`/`trust.CodeIdentityRevoked` verbatim — no new codes minted) and `DELISTED`/`UNKNOWN_VERSION`/`MISSING_ARTIFACT`/`DRIFTED` (Warn). Aggregates to one process exit code via **`pkg/conduit/check`'s own worst-bucket pattern** (`AuditReport.ExitCode()` converts findings to `check.CheckResult` and calls `check.Report.ExitCode()` directly). An unreachable/tampered/stale/rolled-back index is a **hard command failure**, distinct from an all-clean run and from each other. The "was this installed unsigned?" signal reads the **append-only `unsigned-installs.log`**, never `manifest.json`'s locally-rewritable `signed`/`allowUnsigned` fields (the P2 finding called out in the task).
- **Local cache** — content-addressed by digest under `.registry/cache/<sha256>/`, atomic populate (temp dir + rename), digest-recheck-on-read corruption detection (a corrupt entry is evicted and self-heals), wired into the install pipeline: a repeated install of an already-cached digest skips the download but **still runs the full verification gate every time** — the cache is never a trust decision.
- **`conduit connectors bundle` + `install --bundle`** — `bundle` runs the full online verification pipeline (identical to `install`) and packages the artifact, its cosign `--bundle`-form signature/provenance, and the **complete signed index snapshot** into a tarball. `install --bundle` installs fully offline: index verification and Sigstore bundle verification both operate purely over bytes already in hand (no live Fulcio/Rekor query, bundle or not — this is true of the *online* path too, per `trust/sigstore.go`'s own doc comments), so this is a real, asserted zero-network-call path, not just an assumption. `--allow-stale-bundle` is gated **exactly like `--allow-unsigned`** per DeVaris's ratification: `policy.DecideStaleBundle` (new, mirrors `policy.Decide`'s shape and the `Decision`-unexported-field structural guarantee), operator-policy + TTY/env-var gated, the override is logged as its own audit event. Every other index-verification failure (tampering, rollback, trust-anchor) has **no override at all**.

### New error codes

**None.** Every code PR-4 uses (`CodeConnectorNotInstalled`, `CodeConnectorInUse`, `CodeAmbiguousUninstall`, `CodeBundleStale`, plus the reused `index.CodeVersionYanked`/`trust.CodeIdentityRevoked`/`index.CodeIndexUnreachable`/etc.) was already registered by PR-0/1/2. `make generate` produces **zero diff** to `llms.txt`/`llms-full.txt` beyond this PR's own source changes — confirmed by diffing after running it.

### Reuse map (PR-1/PR-2 → PR-4)

| PR-4 surface | Reuses |
| --- | --- |
| Manifest read/write, locks, atomic writes | PR-1's `LoadManifest`/`SaveManifest`/`ManifestKey`/`AcquireTargetLock`/`AcquireManifestLock` verbatim |
| `audit`'s index verification | PR-2's `registry.TrustedVerifier.VerifyIndex` — same trust anchors, same rollback/staleness/integrity codes, no second fetch path |
| `audit`'s yank/revoke findings | PR-2's `index.CodeVersionYanked`/`trust.CodeIdentityRevoked` directly, not new codes |
| Install pipeline's extract/rename/manifest-entry shape | Refactored PR-1's `downloadVerifyAndInstall` into a shared `finalizeArtifactInstall`, used by both the online path and the new offline bundle-install path — they can't diverge on this discipline |
| `--allow-stale-bundle` gate | New `policy.DecideStaleBundle`, structurally identical to PR-2's `policy.Decide` (same `Decision` type, same unexported-field guarantee); `.golangci.yml`'s `PolicyBypass` depguard rule extended to allow `pkg/registry/bundle.go` as the second (and only other) sanctioned caller |

## Known scope limitation (flagged, not hidden)

`list --installed`'s data source (the manifest) doesn't itself need the engine, but `ListCommand` is wired through `cecdysis.CommandWithExecuteWithClientResultDecorator`, which unconditionally dials and health-checks the engine **before** calling the command at all. So, as shipped, `--installed` still requires a reachable engine even though the design doc's prose says it should be independent of that. Making it truly engine-independent needs either a second decorator variant that skips the mandatory dial, or splitting `list` into two commands — both are real changes to shared `cecdysis` machinery or command wiring, deliberately deferred out of this PR to keep its blast radius to `pkg/registry` and one file in `cmd/conduit/root/connectors`. Documented in `ListFlags.Installed`'s doc comment and the command's `Docs()` long help text; verified by direct manual invocation (fails with a clear "conduit run" hint when unreachable, never silently wrong data).

## Adversarial self-review findings

- **Audit flags a since-yanked installed version** — proven twice: once against a fake `IndexVerifier` (fast, table-driven, covers the full finding table) and once against a **real** `registry.TrustedVerifier` with a hand-signed ed25519 index (`TestRunAudit_RealTrustedVerifier_YankedVersion_Fails`), proving the production wiring itself, not just the domain logic in isolation.
- **Offline verification never silently skips** — `InstallFromBundle` always calls `Verifier.VerifyIndex` and `Verifier.VerifyArtifact`; the *only* carve-out (staleness) is explicitly gated through `policy.DecideStaleBundle`, and every other index-verification failure (tampering, rollback, trust-anchor-expired) has no override path at all, verified by `TestInstallFromBundle_RealTrustedVerifier_TamperedIndex_HardFails`-style tests and the yank-short-circuit test (a bundle for a yanked version refuses via `Resolve()` before artifact verification is ever reached, so it needs no real signature material to prove — `TestInstallFromBundle_YankedInSnapshot_Refuses`).
- **Uninstall of an in-use connector is refused** — proven via the CLI-layer test with **no engine running in the test process at all** (`TestUninstall_InUseViaProvisionedConfig_RefusesWithoutForce`), exercising the real provisioning-config fallback, not a mock.
- **Cache corruption is detected and evicted** — `TestCache_CorruptEntry_DetectedAndEvicted` truncates a cached file directly on disk and confirms both the miss and the eviction; `TestCache_ConcurrentPopulate_SameDigest_DoesNotCorrupt` races 8 goroutines populating the identical digest and confirms no corruption (content-addressing makes a lost rename race a safe no-op, not an error).
- **Manifest updates are atomic** — `deleteManifestEntry` (uninstall) reuses the exact same `AcquireManifestLock` + `SaveManifest`/`atomicfile.WriteFile` discipline `writeManifestEntry` (install, PR-1) already established; no new non-atomic write path was introduced anywhere in this PR.
- **A crash between artifact removal and manifest-entry deletion during uninstall** is safely recoverable: the next `uninstall`/`audit`/`list --installed` run sees `MISSING_ARTIFACT`/`ArtifactAlreadyMissing: true` and cleans up the manifest entry — the exact same tolerance the design doc already requires for a manually-`rm`'d artifact, so this isn't a new failure mode, just the existing one reached via an interrupted uninstall instead of a human.
- **A minor, accepted inefficiency**: `uninstall`'s in-use check (a real API dial or config scan) runs *before* `registry.Uninstall` resolves whether the requested uninstall is even ambiguous; in the ambiguous-and-not-force case this means one wasted round-trip before the `registry.ambiguous_uninstall` refusal fires. Not a correctness issue — flagged for awareness, not worth a second manifest read in the CLI layer to avoid.

## Gate results

- `go build ./...` — clean.
- `golangci-lint run ./...` — **0 issues** (fixed `exhaustive`, `goconst`, `gocyclo` (refactored `InstallFromBundle` into smaller helpers), `gofmt`/`gofumpt`, `gosec` (justified `//nolint` on a false-positive taint match), and `unused` findings along the way).
- `go test ./pkg/registry/... ./cmd/conduit/root/connectors/... -race` — all green.
- `go test ./cmd/conduit/internal/llmsgen/...` (the drift guard) — green.
- `make generate && git diff --exit-code` — the diff is exactly this PR's own source changes; zero additional drift in `llms.txt`/`llms-full.txt`/mocks.
- `make build` — clean; manually smoke-tested `conduit connectors {uninstall,audit,bundle,list --installed} --help` and a real `uninstall` round-trip against a fixture manifest.

## References

- Epic: `docs/design-documents/20260713-connector-registry-mvp.md`
- Index schema (R-1, frozen): `docs/design-documents/20260714-connector-registry-index-schema.md`
- Plan: `conduit-registry-plans/registry-plan-v2.md` §7 ("step5 → PR-4"), `conduit-registry-plans/step5-lifecycle-cli.md`
- PR-0 #2652, PR-1 #2653, PR-2 #2654

🤖 Generated with [Claude Code](https://claude.com/claude-code)