### PR TITLE
fix(registry): correct DefaultIndexURL to registry.conduitdata.io

### DIFF
--- a/pkg/registry/install.go
+++ b/pkg/registry/install.go
@@ -34,8 +34,9 @@ import (
 
 // DefaultIndexURL is the well-known registry index URL Install fetches from
 // when the caller does not set InstallOptions.IndexFile (plan-v2 §8: the
-// same GitHub Pages deployment that serves the human-facing site).
-const DefaultIndexURL = "https://registry.conduit.io/index.json"
+// same GitHub Pages deployment that serves the human-facing site). Served by
+// the conduit-connector-registry Pages deploy on the conduitdata.io domain.
+const DefaultIndexURL = "https://registry.conduitdata.io/index.json"
 
 // MaxBundleBytes caps a fetched signature/provenance bundle fetch (P0-2
 // item 1, plan-v2 §2.4): a Sigstore bundle with a cert chain and Rekor


### PR DESCRIPTION
The compiled-in `DefaultIndexURL` was `https://registry.conduit.io/index.json` — a domain never set up (DNS didn't resolve). A real bug in shipped code: any `conduit connectors install` without `--index-file` couldn't reach an index. The registry is served from **conduitdata.io** (`registry.conduitdata.io`, the conduit-connector-registry Pages deploy). Verification/anchors unchanged; no released build depends on the dead URL.

Found while wiring the index-serving bootstrap. Tier-2 (install-path URL constant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)