### PR TITLE
fix: `conduit open docs` opens conduitdata.io/docs (was dead conduit.io)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -83,7 +83,7 @@ release:
 nfpms:
   - license: Apache-2.0
     maintainer: Conduit Developers <conduit-dev@meroxa.io>
-    homepage: https://conduit.io/
+    homepage: https://conduitdata.io/
     description: "Conduit streams data between data stores. Kafka Connect replacement. No JVM required."
     section: utils
     formats:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ _Data Integration for Production Data Stores. :dizzy:_
 [![Discord](https://img.shields.io/discord/828680256877363200?label=discord&logo=discord)](https://discord.meroxa.com)
 [![Twitter](https://img.shields.io/static/v1?label=X/Twitter&message=Follow&color=1DA1F2&logo=twitter&logoColor=white)](https://x.com/ConduitIO)
 [![Go Reference](https://pkg.go.dev/badge/github.com/conduitio/conduit.svg)](https://pkg.go.dev/github.com/conduitio/conduit)
-[![Conduit docs](https://img.shields.io/badge/conduit-docs-blue)](https://conduit.io/docs/getting-started)
+[![Conduit docs](https://img.shields.io/badge/conduit-docs-blue)](https://conduitdata.io/docs/getting-started)
 [![API docs](https://img.shields.io/badge/HTTP_API-docs-blue)](https://docs.conduit.io/api)
 
 ## Overview
@@ -55,7 +55,7 @@ conduit quickstart
 
 Sample records flow to your console within seconds. State is in-memory and nothing
 is written to your working directory; press Ctrl-C to stop. For a full walkthrough,
-see <https://conduit.io/docs/getting-started>.
+see <https://conduitdata.io/docs/getting-started>.
 
 ## Installation guide
 
@@ -225,7 +225,7 @@ The full example in our case would be:
 ## Connectors
 
 For the full list of available connectors, see
-the [Connector List](https://conduit.io/docs/using/connectors/list). If
+the [Connector List](https://conduitdata.io/docs/using/connectors/list). If
 there's a connector that you're looking for that isn't available in Conduit,
 please file an [issue](https://github.com/ConduitIO/conduit/issues/new?assignees=&labels=triage&template=3-connector-request.yml&title=Connector%3A+%3Cresource%3E+%5BSource%2FDestination%5D)
 .
@@ -270,16 +270,16 @@ it out based on some criteria.
 
 Conduit provides a number of built-in processors, which can be used to
 manipulate fields, send requests to HTTP endpoints, and more,
-check [built-in processors](https://conduit.io/docs/using/processors/builtin/)
+check [built-in processors](https://conduitdata.io/docs/using/processors/builtin/)
 for the list of built-in processors and documentations.
 
 Conduit also provides the ability to write your
-own [standalone processor](https://conduit.io/docs/developing/processors/building),
-or you can use the built-in processor [`custom.javascript`](https://conduit.io/docs/using/processors/builtin/custom.javascript)
+own [standalone processor](https://conduitdata.io/docs/developing/processors/building),
+or you can use the built-in processor [`custom.javascript`](https://conduitdata.io/docs/using/processors/builtin/custom.javascript)
 to write custom processors in JavaScript.
 
 More detailed information as well as examples can be found in
-the [Processors documentation](https://conduit.io/docs/using/processors/getting-started).
+the [Processors documentation](https://conduitdata.io/docs/using/processors/getting-started).
 
 ## API
 
@@ -363,18 +363,18 @@ follow-ups — see
 ## Documentation
 
 To learn more about how to use Conduit
-visit [Conduit.io/docs](https://conduit.io/docs).
+visit [Conduit.io/docs](https://conduitdata.io/docs).
 
 If you are interested in internals of Conduit we have prepared some technical
 documentation:
 
-- [Pipeline Semantics](https://conduit.io/docs/core-concepts/pipeline-semantics) explains the internals of how
+- [Pipeline Semantics](https://conduitdata.io/docs/core-concepts/pipeline-semantics) explains the internals of how
   a Conduit pipeline works.
-- [Pipeline Configuration Files](https://conduit.io/docs/using/pipelines/configuration-file)
+- [Pipeline Configuration Files](https://conduitdata.io/docs/using/pipelines/configuration-file)
   explains how you can define pipelines using YAML files.
-- [Processors](https://conduit.io/docs/using/processors/getting-started) contains examples and more information about
+- [Processors](https://conduitdata.io/docs/using/processors/getting-started) contains examples and more information about
   Conduit processors.
-- [Conduit Architecture](https://conduit.io/docs/core-concepts/architecture)
+- [Conduit Architecture](https://conduitdata.io/docs/core-concepts/architecture)
   will give you a high-level overview of Conduit.
 - [Conduit Metrics](docs/metrics.md)
   provides more information about how Conduit exposes metrics.

--- a/cmd/conduit/root/open/docs.go
+++ b/cmd/conduit/root/open/docs.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pkg/browser"
 )
 
-const ConduitDocsURL = "https://conduit.io/docs"
+const ConduitDocsURL = "https://conduitdata.io/docs"
 
 var (
 	_ ecdysis.CommandWithDocs    = (*DocsCommand)(nil)

--- a/cmd/conduit/root/pipelines/init.go
+++ b/cmd/conduit/root/pipelines/init.go
@@ -265,7 +265,7 @@ func (c *InitCommand) getPipelineDescription() string {
 	if c.isDemoPipeline() {
 		dsc += fmt.Sprintf("It is a demo pipeline that connects a source connector (%s) to a destination connector (%s).\n"+
 			"The next step is to simply run `conduit run` in your terminal and you should see a new record being logged every second.\n"+
-			"Check out https://conduit.io/docs/using/pipelines/configuration-file "+
+			"Check out https://conduitdata.io/docs/using/pipelines/configuration-file "+
 			"to learn about how this file is structured.", c.sourceConnector, c.destinationConnector)
 	} else {
 		dsc += fmt.Sprintf("It is a pipeline that connects a source connector (%s) to a destination connector (%s).\n"+

--- a/cmd/conduit/root/pipelines/init_test.go
+++ b/cmd/conduit/root/pipelines/init_test.go
@@ -229,7 +229,7 @@ func TestInit_getPipelineDescription(t *testing.T) {
 	demoDesc := func(src, dst string) string {
 		return baseDesc + fmt.Sprintf("It is a demo pipeline that connects a source connector (%s) to a destination connector (%s).\n"+
 			"The next step is to simply run `conduit run` in your terminal and you should see a new record being logged every second.\n"+
-			"Check out https://conduit.io/docs/using/pipelines/configuration-file "+
+			"Check out https://conduitdata.io/docs/using/pipelines/configuration-file "+
 			"to learn about how this file is structured.", src, dst)
 	}
 

--- a/docs/connector_discovery.md
+++ b/docs/connector_discovery.md
@@ -3,9 +3,9 @@
 ## Connectors' location
 
 > [!IMPORTANT]  
-> The content of this page has been moved to [Conduit's documentation website](https://conduit.io/docs/using/connectors/installing/).
+> The content of this page has been moved to [Conduit's documentation website](https://conduitdata.io/docs/using/connectors/installing/).
 
 ## Referencing connectors
 
 > [!IMPORTANT]  
-> The content of this page has been moved to [Conduit's documentation website](https://conduit.io/docs/using/connectors/referencing).
+> The content of this page has been moved to [Conduit's documentation website](https://conduitdata.io/docs/using/connectors/referencing).

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -1,12 +1,12 @@
 # Conduit Connectors
 
 > [!IMPORTANT]  
-> The content of this page has been moved to [Conduit's documentation website](https://conduit.io/docs/core-concepts#connector).
+> The content of this page has been moved to [Conduit's documentation website](https://conduitdata.io/docs/core-concepts#connector).
 
 ## Roadmap & Feedback
 
 > [!IMPORTANT]  
-> The content of this page has been moved to [Conduit's documentation website](https://conduit.io/docs/future/roadmap).
+> The content of this page has been moved to [Conduit's documentation website](https://conduitdata.io/docs/future/roadmap).
 
 ## More about Connectors
 
@@ -14,18 +14,18 @@
 
 > [!IMPORTANT]  
 > The content of this page has been moved to Conduit's documentation website
-> [here](https://conduit.io/docs/core-concepts#built-in-connector), and [here](/docs/using/connectors/additional-built-in-plugins).
+> [here](https://conduitdata.io/docs/core-concepts#built-in-connector), and [here](/docs/using/connectors/additional-built-in-plugins).
 
 ### Standalone connectors
 
 > [!IMPORTANT]  
-> The content of this page has been moved to [Conduit's documentation website](https://conduit.io/docs/core-concepts#standalone-connector).
+> The content of this page has been moved to [Conduit's documentation website](https://conduitdata.io/docs/core-concepts#standalone-connector).
 
 ### Source & Destination
 
 > [!IMPORTANT]  
-> The content of this page has been moved to [Conduit's documentation website](https://conduit.io/docs/core-concepts#source-and-destination).
+> The content of this page has been moved to [Conduit's documentation website](https://conduitdata.io/docs/core-concepts#source-and-destination).
 
 ### The List
 
-A full list of connectors is hosted here: <https://conduit.io/docs/using/connectors/list/>.
+A full list of connectors is hosted here: <https://conduitdata.io/docs/using/connectors/list/>.

--- a/docs/package_structure.md
+++ b/docs/package_structure.md
@@ -37,7 +37,7 @@
 
 Other folders that don't contain Go code:
 
-- `docs` - Documentation regarding Conduit that's specific to this repository (more documentation can be found at [Conduit.io/docs](https://conduit.io/docs)).
+- `docs` - Documentation regarding Conduit that's specific to this repository (more documentation can be found at [Conduit.io/docs](https://conduitdata.io/docs)).
 - `proto` - Protobuf files (e.g. gRPC API definition).
 - `scripts` - Contains scripts that are useful for development.
 - `test` - Contains configurations needed for integration tests.

--- a/docs/writing-a-connector-guidelines.md
+++ b/docs/writing-a-connector-guidelines.md
@@ -1,4 +1,4 @@
 # Guidelines for writing a connector
 
 > [!IMPORTANT]  
-> The content of this page has been moved to [Conduit's documentation website](https://conduit.io/docs/developing/connectors).
+> The content of this page has been moved to [Conduit's documentation website](https://conduitdata.io/docs/developing/connectors).

--- a/pkg/plugin/processor/builtin/impl/avro/decode.go
+++ b/pkg/plugin/processor/builtin/impl/avro/decode.go
@@ -36,7 +36,7 @@ type decoder interface {
 type decodeConfig struct {
 	// The field that will be decoded.
 	//
-	// For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+	// For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
 	Field string `json:"field" default:".Payload.After"`
 
 	fieldResolver sdk.ReferenceResolver

--- a/pkg/plugin/processor/builtin/impl/avro/decode_paramgen.go
+++ b/pkg/plugin/processor/builtin/impl/avro/decode_paramgen.go
@@ -15,7 +15,7 @@ func (decodeConfig) Parameters() map[string]config.Parameter {
 	return map[string]config.Parameter{
 		decodeConfigField: {
 			Default:     ".Payload.After",
-			Description: "The field that will be decoded.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+			Description: "The field that will be decoded.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
 			Type:        config.ParameterTypeString,
 			Validations: []config.Validation{},
 		},

--- a/pkg/plugin/processor/builtin/impl/avro/encode.go
+++ b/pkg/plugin/processor/builtin/impl/avro/encode.go
@@ -37,7 +37,7 @@ type encoder interface {
 type encodeConfig struct {
 	// The field that will be encoded.
 	//
-	// For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+	// For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
 	Field string `json:"field" default:".Payload.After"`
 
 	Schema schemaConfig `json:"schema"`

--- a/pkg/plugin/processor/builtin/impl/avro/encode_paramgen.go
+++ b/pkg/plugin/processor/builtin/impl/avro/encode_paramgen.go
@@ -19,7 +19,7 @@ func (encodeConfig) Parameters() map[string]config.Parameter {
 	return map[string]config.Parameter{
 		encodeConfigField: {
 			Default:     ".Payload.After",
-			Description: "The field that will be encoded.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+			Description: "The field that will be encoded.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
 			Type:        config.ParameterTypeString,
 			Validations: []config.Validation{},
 		},

--- a/pkg/plugin/processor/builtin/impl/base64/decode.go
+++ b/pkg/plugin/processor/builtin/impl/base64/decode.go
@@ -38,7 +38,7 @@ type decodeConfig struct {
 	// Field is the reference to the target field. Note that it is not allowed to
 	// base64 decode the `.Position` field.
 	//
-	// For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+	// For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
 	Field string `json:"field" validate:"required,exclusion=.Position"`
 }
 

--- a/pkg/plugin/processor/builtin/impl/base64/decode_paramgen.go
+++ b/pkg/plugin/processor/builtin/impl/base64/decode_paramgen.go
@@ -15,7 +15,7 @@ func (decodeConfig) Parameters() map[string]config.Parameter {
 	return map[string]config.Parameter{
 		decodeConfigField: {
 			Default:     "",
-			Description: "Field is the reference to the target field. Note that it is not allowed to\nbase64 decode the `.Position` field.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+			Description: "Field is the reference to the target field. Note that it is not allowed to\nbase64 decode the `.Position` field.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
 			Type:        config.ParameterTypeString,
 			Validations: []config.Validation{
 				config.ValidationRequired{},

--- a/pkg/plugin/processor/builtin/impl/base64/encode.go
+++ b/pkg/plugin/processor/builtin/impl/base64/encode.go
@@ -39,7 +39,7 @@ type encodeConfig struct {
 	// Field is a reference to the target field. Note that it is not allowed to
 	// base64 encode the `.Position` field.
 	//
-	// For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+	// For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
 	Field string `json:"field" validate:"required,exclusion=.Position"`
 }
 

--- a/pkg/plugin/processor/builtin/impl/base64/encode_paramgen.go
+++ b/pkg/plugin/processor/builtin/impl/base64/encode_paramgen.go
@@ -15,7 +15,7 @@ func (encodeConfig) Parameters() map[string]config.Parameter {
 	return map[string]config.Parameter{
 		encodeConfigField: {
 			Default:     "",
-			Description: "Field is a reference to the target field. Note that it is not allowed to\nbase64 encode the `.Position` field.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+			Description: "Field is a reference to the target field. Note that it is not allowed to\nbase64 encode the `.Position` field.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
 			Type:        config.ParameterTypeString,
 			Validations: []config.Validation{
 				config.ValidationRequired{},

--- a/pkg/plugin/processor/builtin/impl/clone.go
+++ b/pkg/plugin/processor/builtin/impl/clone.go
@@ -50,7 +50,7 @@ outputs the original record plus N clones (for a total of N+1 records). Each clo
 is identical to the original, except the metadata field ` + "`clone.index`" + ` is
 set to the clone's index (0 for the original, 1 to N for the clones).
 
-**Important:** Add a [condition](https://conduit.io/docs/using/processors/conditions)
+**Important:** Add a [condition](https://conduitdata.io/docs/using/processors/conditions)
 to this processor if you only want to clone some records.
 
 **Important:** This processor currently only works using the pipeline architecture

--- a/pkg/plugin/processor/builtin/impl/error.go
+++ b/pkg/plugin/processor/builtin/impl/error.go
@@ -55,7 +55,7 @@ func (p *ErrorProcessor) Specification() (sdk.Specification, error) {
 		Description: `Any time a record is passed to this processor it returns an error,
 which results in the record being sent to the DLQ if it's configured, or the pipeline stopping.
 
-**Important:** Make sure to add a [condition](https://conduit.io/docs/using/processors/conditions)
+**Important:** Make sure to add a [condition](https://conduitdata.io/docs/using/processors/conditions)
 to this processor, otherwise all records will trigger an error.`,
 		Version:    "v0.1.0",
 		Author:     "Meroxa, Inc.",

--- a/pkg/plugin/processor/builtin/impl/field/convert.go
+++ b/pkg/plugin/processor/builtin/impl/field/convert.go
@@ -45,7 +45,7 @@ type convertConfig struct {
 	// Note that you can only convert fields in structured data under `.Key` and
 	// `.Payload`.
 	//
-	// For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+	// For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
 	Field string `json:"field" validate:"required,regex=^\\.(Payload|Key).*"`
 	// Type is the target field type after conversion, available options are: `string`, `int`, `float`, `bool`, `time`.
 	Type string `json:"type" validate:"required,inclusion=string|int|float|bool|time"`

--- a/pkg/plugin/processor/builtin/impl/field/convert_paramgen.go
+++ b/pkg/plugin/processor/builtin/impl/field/convert_paramgen.go
@@ -18,7 +18,7 @@ func (convertConfig) Parameters() map[string]config.Parameter {
 	return map[string]config.Parameter{
 		convertConfigField: {
 			Default:     "",
-			Description: "Field is the target field that should be converted.\nNote that you can only convert fields in structured data under `.Key` and\n`.Payload`.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+			Description: "Field is the target field that should be converted.\nNote that you can only convert fields in structured data under `.Key` and\n`.Payload`.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
 			Type:        config.ParameterTypeString,
 			Validations: []config.Validation{
 				config.ValidationRequired{},

--- a/pkg/plugin/processor/builtin/impl/field/exclude.go
+++ b/pkg/plugin/processor/builtin/impl/field/exclude.go
@@ -41,7 +41,7 @@ func NewExcludeProcessor(log.CtxLogger) *ExcludeProcessor {
 type excludeConfig struct {
 	// Fields is a comma separated list of target fields which should be excluded.
 	//
-	// For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+	// For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
 	Fields []string `json:"fields" validate:"required"`
 }
 

--- a/pkg/plugin/processor/builtin/impl/field/exclude_paramgen.go
+++ b/pkg/plugin/processor/builtin/impl/field/exclude_paramgen.go
@@ -15,7 +15,7 @@ func (excludeConfig) Parameters() map[string]config.Parameter {
 	return map[string]config.Parameter{
 		excludeConfigFields: {
 			Default:     "",
-			Description: "Fields is a comma separated list of target fields which should be excluded.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+			Description: "Fields is a comma separated list of target fields which should be excluded.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
 			Type:        config.ParameterTypeString,
 			Validations: []config.Validation{
 				config.ValidationRequired{},

--- a/pkg/plugin/processor/builtin/impl/field/rename.go
+++ b/pkg/plugin/processor/builtin/impl/field/rename.go
@@ -46,7 +46,7 @@ type renameConfig struct {
 	//
 	// For example: `.Metadata.key:id,.Payload.After.foo:bar`.
 	//
-	// For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+	// For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
 	Mapping []string `json:"mapping" validate:"required"`
 }
 

--- a/pkg/plugin/processor/builtin/impl/field/rename_paramgen.go
+++ b/pkg/plugin/processor/builtin/impl/field/rename_paramgen.go
@@ -15,7 +15,7 @@ func (renameConfig) Parameters() map[string]config.Parameter {
 	return map[string]config.Parameter{
 		renameConfigMapping: {
 			Default:     "",
-			Description: "Mapping is a comma separated list of keys and values for fields and their\nnew names (keys and values are separated by colons \":\").\n\nFor example: `.Metadata.key:id,.Payload.After.foo:bar`.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+			Description: "Mapping is a comma separated list of keys and values for fields and their\nnew names (keys and values are separated by colons \":\").\n\nFor example: `.Metadata.key:id,.Payload.After.foo:bar`.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
 			Type:        config.ParameterTypeString,
 			Validations: []config.Validation{
 				config.ValidationRequired{},

--- a/pkg/plugin/processor/builtin/impl/field/set.go
+++ b/pkg/plugin/processor/builtin/impl/field/set.go
@@ -44,7 +44,7 @@ type setConfig struct {
 	// Field is the target field that will be set. Note that it is not allowed
 	// to set the `.Position` field.
 	//
-	// For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+	// For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
 	Field string `json:"field" validate:"required,exclusion=.Position"`
 	// Value is a Go template expression which will be evaluated and stored in `field` (e.g. `{{ .Payload.After }}`).
 	Value string `json:"value" validate:"required"`

--- a/pkg/plugin/processor/builtin/impl/field/set_paramgen.go
+++ b/pkg/plugin/processor/builtin/impl/field/set_paramgen.go
@@ -16,7 +16,7 @@ func (setConfig) Parameters() map[string]config.Parameter {
 	return map[string]config.Parameter{
 		setConfigField: {
 			Default:     "",
-			Description: "Field is the target field that will be set. Note that it is not allowed\nto set the `.Position` field.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+			Description: "Field is the target field that will be set. Note that it is not allowed\nto set the `.Position` field.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
 			Type:        config.ParameterTypeString,
 			Validations: []config.Validation{
 				config.ValidationRequired{},

--- a/pkg/plugin/processor/builtin/impl/filter.go
+++ b/pkg/plugin/processor/builtin/impl/filter.go
@@ -38,7 +38,7 @@ func (p *FilterProcessor) Specification() (sdk.Specification, error) {
 the records will be filtered out if the condition provided to the processor is
 evaluated to ` + "`true`" + `.
 
-**Important:** Make sure to add a [condition](https://conduit.io/docs/using/processors/conditions)
+**Important:** Make sure to add a [condition](https://conduitdata.io/docs/using/processors/conditions)
 to this processor, otherwise all records will be filtered out.`,
 		Version:    "v0.1.0",
 		Author:     "Meroxa, Inc.",

--- a/pkg/plugin/processor/builtin/impl/json/decode.go
+++ b/pkg/plugin/processor/builtin/impl/json/decode.go
@@ -41,7 +41,7 @@ type decodeConfig struct {
 	// Field is a reference to the target field. Only fields that are under
 	// `.Key` and `.Payload` can be decoded.
 	//
-	// For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+	// For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
 	Field string `json:"field" validate:"required,regex=^\\.(Payload|Key).*,exclusion=.Payload"`
 }
 

--- a/pkg/plugin/processor/builtin/impl/json/decode_paramgen.go
+++ b/pkg/plugin/processor/builtin/impl/json/decode_paramgen.go
@@ -17,7 +17,7 @@ func (decodeConfig) Parameters() map[string]config.Parameter {
 	return map[string]config.Parameter{
 		decodeConfigField: {
 			Default:     "",
-			Description: "Field is a reference to the target field. Only fields that are under\n`.Key` and `.Payload` can be decoded.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+			Description: "Field is a reference to the target field. Only fields that are under\n`.Key` and `.Payload` can be decoded.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
 			Type:        config.ParameterTypeString,
 			Validations: []config.Validation{
 				config.ValidationRequired{},

--- a/pkg/plugin/processor/builtin/impl/json/encode.go
+++ b/pkg/plugin/processor/builtin/impl/json/encode.go
@@ -41,7 +41,7 @@ type encodeConfig struct {
 	// Field is a reference to the target field. Only fields that are under
 	// `.Key` and `.Payload` can be encoded.
 	//
-	// For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+	// For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
 	Field string `json:"field" validate:"required,regex=^\\.(Payload|Key).*,exclusion=.Payload"`
 }
 

--- a/pkg/plugin/processor/builtin/impl/json/encode_paramgen.go
+++ b/pkg/plugin/processor/builtin/impl/json/encode_paramgen.go
@@ -17,7 +17,7 @@ func (encodeConfig) Parameters() map[string]config.Parameter {
 	return map[string]config.Parameter{
 		encodeConfigField: {
 			Default:     "",
-			Description: "Field is a reference to the target field. Only fields that are under\n`.Key` and `.Payload` can be encoded.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+			Description: "Field is a reference to the target field. Only fields that are under\n`.Key` and `.Payload` can be encoded.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
 			Type:        config.ParameterTypeString,
 			Validations: []config.Validation{
 				config.ValidationRequired{},

--- a/pkg/plugin/processor/builtin/impl/split.go
+++ b/pkg/plugin/processor/builtin/impl/split.go
@@ -43,7 +43,7 @@ type splitConfig struct {
 	// returns an error. This also means you can only split on fields in
 	// structured data under `.Key` and `.Payload`.
 	//
-	// For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+	// For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
 	Field string `json:"field" validate:"required,regex=^\\.(Payload|Key).*"`
 }
 

--- a/pkg/plugin/processor/builtin/impl/split_paramgen.go
+++ b/pkg/plugin/processor/builtin/impl/split_paramgen.go
@@ -17,7 +17,7 @@ func (splitConfig) Parameters() map[string]config.Parameter {
 	return map[string]config.Parameter{
 		splitConfigField: {
 			Default:     "",
-			Description: "Field is the target field that should be split. Note that the target\nfield has to contain an array so it can be split, otherwise the processor\nreturns an error. This also means you can only split on fields in\nstructured data under `.Key` and `.Payload`.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+			Description: "Field is the target field that should be split. Note that the target\nfield has to contain an array so it can be split, otherwise the processor\nreturns an error. This also means you can only split on fields in\nstructured data under `.Key` and `.Payload`.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
 			Type:        config.ParameterTypeString,
 			Validations: []config.Validation{
 				config.ValidationRequired{},

--- a/pkg/plugin/processor/builtin/impl/unwrap/debezium.go
+++ b/pkg/plugin/processor/builtin/impl/unwrap/debezium.go
@@ -46,7 +46,7 @@ const (
 type debeziumConfig struct {
 	// Field is a reference to the field that contains the Debezium record.
 	//
-	// For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+	// For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
 	Field string `json:"field" validate:"regex=^.Payload" default:".Payload.After"`
 }
 
@@ -64,14 +64,14 @@ func NewDebeziumProcessor(logger log.CtxLogger) *DebeziumProcessor {
 func (d *DebeziumProcessor) Specification() (sdk.Specification, error) {
 	return sdk.Specification{
 		Name:    "unwrap.debezium",
-		Summary: "Unwraps a Debezium record from the input [OpenCDC record](https://conduit.io/docs/using/opencdc-record).",
+		Summary: "Unwraps a Debezium record from the input [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record).",
 		Description: `In this processor, the wrapped (Debezium) record replaces the wrapping record (being processed) 
 completely, except for the position.
 
 The Debezium record's metadata and the wrapping record's metadata is merged, with the Debezium metadata having precedence.
 
 This is useful in cases where Conduit acts as an intermediary between a Debezium source and a Debezium destination. 
-In such cases, the Debezium record is set as the [OpenCDC record](https://conduit.io/docs/using/opencdc-record)'s payload,` +
+In such cases, the Debezium record is set as the [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record)'s payload,` +
 			`and needs to be unwrapped for further usage.`,
 		Version:    "v0.1.0",
 		Author:     "Meroxa, Inc.",

--- a/pkg/plugin/processor/builtin/impl/unwrap/debezium_paramgen.go
+++ b/pkg/plugin/processor/builtin/impl/unwrap/debezium_paramgen.go
@@ -17,7 +17,7 @@ func (debeziumConfig) Parameters() map[string]config.Parameter {
 	return map[string]config.Parameter{
 		debeziumConfigField: {
 			Default:     ".Payload.After",
-			Description: "Field is a reference to the field that contains the Debezium record.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+			Description: "Field is a reference to the field that contains the Debezium record.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
 			Type:        config.ParameterTypeString,
 			Validations: []config.Validation{
 				config.ValidationRegex{Regex: regexp.MustCompile("^.Payload")},

--- a/pkg/plugin/processor/builtin/impl/unwrap/kafka_connect.go
+++ b/pkg/plugin/processor/builtin/impl/unwrap/kafka_connect.go
@@ -31,7 +31,7 @@ import (
 type kafkaConnectConfig struct {
 	// Field is a reference to the field that contains the Kafka Connect record.
 	//
-	// For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+	// For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
 	Field string `json:"field" validate:"regex=^.Payload" default:".Payload.After"`
 }
 
@@ -48,13 +48,13 @@ func NewKafkaConnectProcessor(log.CtxLogger) *KafkaConnectProcessor {
 func (u *KafkaConnectProcessor) Specification() (sdk.Specification, error) {
 	return sdk.Specification{
 		Name:    "unwrap.kafkaconnect",
-		Summary: "Unwraps a Kafka Connect record from an [OpenCDC record](https://conduit.io/docs/using/opencdc-record).",
-		Description: `This processor unwraps a Kafka Connect record from the input [OpenCDC record](https://conduit.io/docs/using/opencdc-record).
+		Summary: "Unwraps a Kafka Connect record from an [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record).",
+		Description: `This processor unwraps a Kafka Connect record from the input [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record).
 
 The input record's payload is replaced with the Kafka Connect record.
 
 This is useful in cases where Conduit acts as an intermediary between a Debezium source and a Debezium destination. 
-In such cases, the Debezium record is set as the [OpenCDC record](https://conduit.io/docs/using/opencdc-record)'s payload, and needs to be unwrapped for further usage.`,
+In such cases, the Debezium record is set as the [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record)'s payload, and needs to be unwrapped for further usage.`,
 		Version:    "v0.1.0",
 		Author:     "Meroxa, Inc.",
 		Parameters: kafkaConnectConfig{}.Parameters(),

--- a/pkg/plugin/processor/builtin/impl/unwrap/kafka_connect_paramgen.go
+++ b/pkg/plugin/processor/builtin/impl/unwrap/kafka_connect_paramgen.go
@@ -17,7 +17,7 @@ func (kafkaConnectConfig) Parameters() map[string]config.Parameter {
 	return map[string]config.Parameter{
 		kafkaConnectConfigField: {
 			Default:     ".Payload.After",
-			Description: "Field is a reference to the field that contains the Kafka Connect record.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+			Description: "Field is a reference to the field that contains the Kafka Connect record.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
 			Type:        config.ParameterTypeString,
 			Validations: []config.Validation{
 				config.ValidationRegex{Regex: regexp.MustCompile("^.Payload")},

--- a/pkg/plugin/processor/builtin/impl/unwrap/opencdc.go
+++ b/pkg/plugin/processor/builtin/impl/unwrap/opencdc.go
@@ -32,7 +32,7 @@ import (
 type openCDCConfig struct {
 	// Field is a reference to the field that contains the OpenCDC record.
 	//
-	// For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+	// For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
 	Field string `json:"field" default:".Payload.After"`
 }
 
@@ -50,12 +50,12 @@ func NewOpenCDCProcessor(logger log.CtxLogger) *OpenCDCProcessor {
 func (u *OpenCDCProcessor) Specification() (sdk.Specification, error) {
 	return sdk.Specification{
 		Name:    "unwrap.opencdc",
-		Summary: "Unwraps an [OpenCDC record](https://conduit.io/docs/using/opencdc-record) saved in one of the record's fields.",
+		Summary: "Unwraps an [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record) saved in one of the record's fields.",
 		Description: `The ` + "`unwrap.opencdc`" + ` processor is useful in situations where a record goes through intermediate
-systems before being written to a final destination. In these cases, the original [OpenCDC record](https://conduit.io/docs/using/opencdc-record) is part of the payload
+systems before being written to a final destination. In these cases, the original [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record) is part of the payload
 read from the intermediate system and needs to be unwrapped before being written.
 
-Note: if the wrapped [OpenCDC record](https://conduit.io/docs/using/opencdc-record) is not in a structured data field, then it's assumed that it's stored in JSON format.`,
+Note: if the wrapped [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record) is not in a structured data field, then it's assumed that it's stored in JSON format.`,
 		Version:    "v0.1.0",
 		Author:     "Meroxa, Inc.",
 		Parameters: openCDCConfig{}.Parameters(),

--- a/pkg/plugin/processor/builtin/impl/unwrap/opencdc_paramgen.go
+++ b/pkg/plugin/processor/builtin/impl/unwrap/opencdc_paramgen.go
@@ -15,7 +15,7 @@ func (openCDCConfig) Parameters() map[string]config.Parameter {
 	return map[string]config.Parameter{
 		openCDCConfigField: {
 			Default:     ".Payload.After",
-			Description: "Field is a reference to the field that contains the OpenCDC record.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+			Description: "Field is a reference to the field that contains the OpenCDC record.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
 			Type:        config.ParameterTypeString,
 			Validations: []config.Validation{},
 		},

--- a/pkg/plugin/processor/builtin/impl/webhook/http.go
+++ b/pkg/plugin/processor/builtin/impl/webhook/http.go
@@ -67,12 +67,12 @@ type httpConfig struct {
 	RequestBodyTmpl string `json:"request.body"`
 	// Specifies in which field should the response body be saved.
 	//
-	// For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+	// For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
 	ResponseBodyRef string `json:"response.body" default:".Payload.After"`
 	// Specifies in which field should the response status be saved. If no value
 	// is set, then the response status will NOT be saved.
 	//
-	// For more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).
+	// For more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).
 	ResponseStatusRef string `json:"response.status"`
 }
 

--- a/pkg/plugin/processor/builtin/impl/webhook/http_paramgen.go
+++ b/pkg/plugin/processor/builtin/impl/webhook/http_paramgen.go
@@ -85,13 +85,13 @@ func (httpConfig) Parameters() map[string]config.Parameter {
 		},
 		httpConfigResponseBody: {
 			Default:     ".Payload.After",
-			Description: "Specifies in which field should the response body be saved.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+			Description: "Specifies in which field should the response body be saved.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
 			Type:        config.ParameterTypeString,
 			Validations: []config.Validation{},
 		},
 		httpConfigResponseStatus: {
 			Default:     "",
-			Description: "Specifies in which field should the response status be saved. If no value\nis set, then the response status will NOT be saved.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+			Description: "Specifies in which field should the response status be saved. If no value\nis set, then the response status will NOT be saved.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
 			Type:        config.ParameterTypeString,
 			Validations: []config.Validation{},
 		},

--- a/pkg/plugin/processor/builtin/internal/exampleutil/specs/avro.decode.json
+++ b/pkg/plugin/processor/builtin/internal/exampleutil/specs/avro.decode.json
@@ -8,7 +8,7 @@
     "parameters": {
       "field": {
         "default": ".Payload.After",
-        "description": "The field that will be decoded.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "The field that will be decoded.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": []
       },

--- a/pkg/plugin/processor/builtin/internal/exampleutil/specs/avro.encode.json
+++ b/pkg/plugin/processor/builtin/internal/exampleutil/specs/avro.encode.json
@@ -8,7 +8,7 @@
     "parameters": {
       "field": {
         "default": ".Payload.After",
-        "description": "The field that will be encoded.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "The field that will be encoded.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": []
       },

--- a/pkg/plugin/processor/builtin/internal/exampleutil/specs/base64.decode.json
+++ b/pkg/plugin/processor/builtin/internal/exampleutil/specs/base64.decode.json
@@ -8,7 +8,7 @@
     "parameters": {
       "field": {
         "default": "",
-        "description": "Field is the reference to the target field. Note that it is not allowed to\nbase64 decode the `.Position` field.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Field is the reference to the target field. Note that it is not allowed to\nbase64 decode the `.Position` field.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/pkg/plugin/processor/builtin/internal/exampleutil/specs/base64.encode.json
+++ b/pkg/plugin/processor/builtin/internal/exampleutil/specs/base64.encode.json
@@ -8,7 +8,7 @@
     "parameters": {
       "field": {
         "default": "",
-        "description": "Field is a reference to the target field. Note that it is not allowed to\nbase64 encode the `.Position` field.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Field is a reference to the target field. Note that it is not allowed to\nbase64 encode the `.Position` field.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/pkg/plugin/processor/builtin/internal/exampleutil/specs/clone.json
+++ b/pkg/plugin/processor/builtin/internal/exampleutil/specs/clone.json
@@ -2,7 +2,7 @@
   "specification": {
     "name": "clone",
     "summary": "Clone records.",
-    "description": "Clone all records N times. For each input record, the processor\noutputs the original record plus N clones (for a total of N+1 records). Each clone\nis identical to the original, except the metadata field `clone.index` is\nset to the clone's index (0 for the original, 1 to N for the clones).\n\n**Important:** Add a [condition](https://conduit.io/docs/using/processors/conditions)\nto this processor if you only want to clone some records.\n\n**Important:** This processor currently only works using the pipeline architecture\nv2, which can be enabled using the flag `--preview.pipeline-arch-v2`.\nUsing it without the flag will result in an error.",
+    "description": "Clone all records N times. For each input record, the processor\noutputs the original record plus N clones (for a total of N+1 records). Each clone\nis identical to the original, except the metadata field `clone.index` is\nset to the clone's index (0 for the original, 1 to N for the clones).\n\n**Important:** Add a [condition](https://conduitdata.io/docs/using/processors/conditions)\nto this processor if you only want to clone some records.\n\n**Important:** This processor currently only works using the pipeline architecture\nv2, which can be enabled using the flag `--preview.pipeline-arch-v2`.\nUsing it without the flag will result in an error.",
     "version": "v0.1.0",
     "author": "Meroxa, Inc.",
     "parameters": {

--- a/pkg/plugin/processor/builtin/internal/exampleutil/specs/error.json
+++ b/pkg/plugin/processor/builtin/internal/exampleutil/specs/error.json
@@ -2,7 +2,7 @@
   "specification": {
     "name": "error",
     "summary": "Returns an error for all records that get passed to the processor.",
-    "description": "Any time a record is passed to this processor it returns an error,\nwhich results in the record being sent to the DLQ if it's configured, or the pipeline stopping.\n\n**Important:** Make sure to add a [condition](https://conduit.io/docs/using/processors/conditions)\nto this processor, otherwise all records will trigger an error.",
+    "description": "Any time a record is passed to this processor it returns an error,\nwhich results in the record being sent to the DLQ if it's configured, or the pipeline stopping.\n\n**Important:** Make sure to add a [condition](https://conduitdata.io/docs/using/processors/conditions)\nto this processor, otherwise all records will trigger an error.",
     "version": "v0.1.0",
     "author": "Meroxa, Inc.",
     "parameters": {

--- a/pkg/plugin/processor/builtin/internal/exampleutil/specs/field.convert.json
+++ b/pkg/plugin/processor/builtin/internal/exampleutil/specs/field.convert.json
@@ -8,7 +8,7 @@
     "parameters": {
       "field": {
         "default": "",
-        "description": "Field is the target field that should be converted.\nNote that you can only convert fields in structured data under `.Key` and\n`.Payload`.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Field is the target field that should be converted.\nNote that you can only convert fields in structured data under `.Key` and\n`.Payload`.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/pkg/plugin/processor/builtin/internal/exampleutil/specs/field.exclude.json
+++ b/pkg/plugin/processor/builtin/internal/exampleutil/specs/field.exclude.json
@@ -8,7 +8,7 @@
     "parameters": {
       "fields": {
         "default": "",
-        "description": "Fields is a comma separated list of target fields which should be excluded.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Fields is a comma separated list of target fields which should be excluded.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/pkg/plugin/processor/builtin/internal/exampleutil/specs/field.rename.json
+++ b/pkg/plugin/processor/builtin/internal/exampleutil/specs/field.rename.json
@@ -8,7 +8,7 @@
     "parameters": {
       "mapping": {
         "default": "",
-        "description": "Mapping is a comma separated list of keys and values for fields and their\nnew names (keys and values are separated by colons \":\").\n\nFor example: `.Metadata.key:id,.Payload.After.foo:bar`.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Mapping is a comma separated list of keys and values for fields and their\nnew names (keys and values are separated by colons \":\").\n\nFor example: `.Metadata.key:id,.Payload.After.foo:bar`.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/pkg/plugin/processor/builtin/internal/exampleutil/specs/field.set.json
+++ b/pkg/plugin/processor/builtin/internal/exampleutil/specs/field.set.json
@@ -8,7 +8,7 @@
     "parameters": {
       "field": {
         "default": "",
-        "description": "Field is the target field that will be set. Note that it is not allowed\nto set the `.Position` field.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Field is the target field that will be set. Note that it is not allowed\nto set the `.Position` field.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/pkg/plugin/processor/builtin/internal/exampleutil/specs/filter.json
+++ b/pkg/plugin/processor/builtin/internal/exampleutil/specs/filter.json
@@ -2,7 +2,7 @@
   "specification": {
     "name": "filter",
     "summary": "Acknowledges all records that get passed to the filter.",
-    "description": "Acknowledges all records that get passed to the filter, so\nthe records will be filtered out if the condition provided to the processor is\nevaluated to `true`.\n\n**Important:** Make sure to add a [condition](https://conduit.io/docs/using/processors/conditions)\nto this processor, otherwise all records will be filtered out.",
+    "description": "Acknowledges all records that get passed to the filter, so\nthe records will be filtered out if the condition provided to the processor is\nevaluated to `true`.\n\n**Important:** Make sure to add a [condition](https://conduitdata.io/docs/using/processors/conditions)\nto this processor, otherwise all records will be filtered out.",
     "version": "v0.1.0",
     "author": "Meroxa, Inc.",
     "parameters": {

--- a/pkg/plugin/processor/builtin/internal/exampleutil/specs/json.decode.json
+++ b/pkg/plugin/processor/builtin/internal/exampleutil/specs/json.decode.json
@@ -8,7 +8,7 @@
     "parameters": {
       "field": {
         "default": "",
-        "description": "Field is a reference to the target field. Only fields that are under\n`.Key` and `.Payload` can be decoded.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Field is a reference to the target field. Only fields that are under\n`.Key` and `.Payload` can be decoded.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/pkg/plugin/processor/builtin/internal/exampleutil/specs/json.encode.json
+++ b/pkg/plugin/processor/builtin/internal/exampleutil/specs/json.encode.json
@@ -8,7 +8,7 @@
     "parameters": {
       "field": {
         "default": "",
-        "description": "Field is a reference to the target field. Only fields that are under\n`.Key` and `.Payload` can be encoded.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Field is a reference to the target field. Only fields that are under\n`.Key` and `.Payload` can be encoded.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/pkg/plugin/processor/builtin/internal/exampleutil/specs/split.json
+++ b/pkg/plugin/processor/builtin/internal/exampleutil/specs/split.json
@@ -8,7 +8,7 @@
     "parameters": {
       "field": {
         "default": "",
-        "description": "Field is the target field that should be split. Note that the target\nfield has to contain an array so it can be split, otherwise the processor\nreturns an error. This also means you can only split on fields in\nstructured data under `.Key` and `.Payload`.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Field is the target field that should be split. Note that the target\nfield has to contain an array so it can be split, otherwise the processor\nreturns an error. This also means you can only split on fields in\nstructured data under `.Key` and `.Payload`.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/pkg/plugin/processor/builtin/internal/exampleutil/specs/unwrap.debezium.json
+++ b/pkg/plugin/processor/builtin/internal/exampleutil/specs/unwrap.debezium.json
@@ -1,14 +1,14 @@
 {
   "specification": {
     "name": "unwrap.debezium",
-    "summary": "Unwraps a Debezium record from the input [OpenCDC record](https://conduit.io/docs/using/opencdc-record).",
-    "description": "In this processor, the wrapped (Debezium) record replaces the wrapping record (being processed) \ncompletely, except for the position.\n\nThe Debezium record's metadata and the wrapping record's metadata is merged, with the Debezium metadata having precedence.\n\nThis is useful in cases where Conduit acts as an intermediary between a Debezium source and a Debezium destination. \nIn such cases, the Debezium record is set as the [OpenCDC record](https://conduit.io/docs/using/opencdc-record)'s payload,and needs to be unwrapped for further usage.",
+    "summary": "Unwraps a Debezium record from the input [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record).",
+    "description": "In this processor, the wrapped (Debezium) record replaces the wrapping record (being processed) \ncompletely, except for the position.\n\nThe Debezium record's metadata and the wrapping record's metadata is merged, with the Debezium metadata having precedence.\n\nThis is useful in cases where Conduit acts as an intermediary between a Debezium source and a Debezium destination. \nIn such cases, the Debezium record is set as the [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record)'s payload,and needs to be unwrapped for further usage.",
     "version": "v0.1.0",
     "author": "Meroxa, Inc.",
     "parameters": {
       "field": {
         "default": ".Payload.After",
-        "description": "Field is a reference to the field that contains the Debezium record.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Field is a reference to the field that contains the Debezium record.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/pkg/plugin/processor/builtin/internal/exampleutil/specs/unwrap.kafkaconnect.json
+++ b/pkg/plugin/processor/builtin/internal/exampleutil/specs/unwrap.kafkaconnect.json
@@ -1,14 +1,14 @@
 {
   "specification": {
     "name": "unwrap.kafkaconnect",
-    "summary": "Unwraps a Kafka Connect record from an [OpenCDC record](https://conduit.io/docs/using/opencdc-record).",
-    "description": "This processor unwraps a Kafka Connect record from the input [OpenCDC record](https://conduit.io/docs/using/opencdc-record).\n\nThe input record's payload is replaced with the Kafka Connect record.\n\nThis is useful in cases where Conduit acts as an intermediary between a Debezium source and a Debezium destination. \nIn such cases, the Debezium record is set as the [OpenCDC record](https://conduit.io/docs/using/opencdc-record)'s payload, and needs to be unwrapped for further usage.",
+    "summary": "Unwraps a Kafka Connect record from an [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record).",
+    "description": "This processor unwraps a Kafka Connect record from the input [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record).\n\nThe input record's payload is replaced with the Kafka Connect record.\n\nThis is useful in cases where Conduit acts as an intermediary between a Debezium source and a Debezium destination. \nIn such cases, the Debezium record is set as the [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record)'s payload, and needs to be unwrapped for further usage.",
     "version": "v0.1.0",
     "author": "Meroxa, Inc.",
     "parameters": {
       "field": {
         "default": ".Payload.After",
-        "description": "Field is a reference to the field that contains the Kafka Connect record.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Field is a reference to the field that contains the Kafka Connect record.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": [
           {

--- a/pkg/plugin/processor/builtin/internal/exampleutil/specs/unwrap.opencdc.json
+++ b/pkg/plugin/processor/builtin/internal/exampleutil/specs/unwrap.opencdc.json
@@ -1,14 +1,14 @@
 {
   "specification": {
     "name": "unwrap.opencdc",
-    "summary": "Unwraps an [OpenCDC record](https://conduit.io/docs/using/opencdc-record) saved in one of the record's fields.",
-    "description": "The `unwrap.opencdc` processor is useful in situations where a record goes through intermediate\nsystems before being written to a final destination. In these cases, the original [OpenCDC record](https://conduit.io/docs/using/opencdc-record) is part of the payload\nread from the intermediate system and needs to be unwrapped before being written.\n\nNote: if the wrapped [OpenCDC record](https://conduit.io/docs/using/opencdc-record) is not in a structured data field, then it's assumed that it's stored in JSON format.",
+    "summary": "Unwraps an [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record) saved in one of the record's fields.",
+    "description": "The `unwrap.opencdc` processor is useful in situations where a record goes through intermediate\nsystems before being written to a final destination. In these cases, the original [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record) is part of the payload\nread from the intermediate system and needs to be unwrapped before being written.\n\nNote: if the wrapped [OpenCDC record](https://conduitdata.io/docs/using/opencdc-record) is not in a structured data field, then it's assumed that it's stored in JSON format.",
     "version": "v0.1.0",
     "author": "Meroxa, Inc.",
     "parameters": {
       "field": {
         "default": ".Payload.After",
-        "description": "Field is a reference to the field that contains the OpenCDC record.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Field is a reference to the field that contains the OpenCDC record.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": []
       },

--- a/pkg/plugin/processor/builtin/internal/exampleutil/specs/webhook.http.json
+++ b/pkg/plugin/processor/builtin/internal/exampleutil/specs/webhook.http.json
@@ -77,13 +77,13 @@
       },
       "response.body": {
         "default": ".Payload.After",
-        "description": "Specifies in which field should the response body be saved.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Specifies in which field should the response body be saved.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": []
       },
       "response.status": {
         "default": "",
-        "description": "Specifies in which field should the response status be saved. If no value\nis set, then the response status will NOT be saved.\n\nFor more information about the format, see [Referencing fields](https://conduit.io/docs/using/processors/referencing-fields).",
+        "description": "Specifies in which field should the response status be saved. If no value\nis set, then the response status will NOT be saved.\n\nFor more information about the format, see [Referencing fields](https://conduitdata.io/docs/using/processors/referencing-fields).",
         "type": "string",
         "validations": []
       },

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,7 +18,7 @@ sonar.test.exclusions=**/vendor/**
 #   Metadata for the project
 # =====================================================
 
-sonar.links.homepage=https://conduit.io/
+sonar.links.homepage=https://conduitdata.io/
 sonar.links.scm=https://github.com/ConduitIO/conduit
 sonar.links.issue=https://github.com/ConduitIO/conduit/issues
 


### PR DESCRIPTION
`ConduitDocsURL` was `https://conduit.io/docs` — a domain the project no longer controls (docs are on conduitdata.io), so `conduit open docs` opened a dead page. Corrected to `https://conduitdata.io/docs`. Found while fixing stale conduit.io references in the docs. Tier-3.