### PR TITLE
fix(cli): pipelines init refuses to silently overwrite, adds --force/--dry-run/--json

### DIFF
--- a/cmd/conduit/internal/llmsgen/allcodes/allcodes.go
+++ b/cmd/conduit/internal/llmsgen/allcodes/allcodes.go
@@ -57,6 +57,7 @@ import (
 	// equivalently named file) in the engine — TestAllCodesComplete in
 	// ../llmsgen fails the build if it drifts.
 	_ "github.com/conduitio/conduit/cmd/conduit/internal/deploy"
+	_ "github.com/conduitio/conduit/cmd/conduit/root/pipelines"
 	_ "github.com/conduitio/conduit/pkg/connector"
 	_ "github.com/conduitio/conduit/pkg/lifecycle-poc"
 	_ "github.com/conduitio/conduit/pkg/orchestrator"

--- a/cmd/conduit/root/pipelines/init.go
+++ b/cmd/conduit/root/pipelines/init.go
@@ -253,38 +253,6 @@ func (c *InitCommand) buildTemplatePipeline() (pipelineTemplate, error) {
 	}, nil
 }
 
-// checkDestination is the fix for this command's former silent-overwrite
-// bug: writeFile used to open with os.O_CREATE|os.O_WRONLY|os.O_TRUNC with no
-// existence check at all, so a second `pipelines init` into the same path
-// silently clobbered a hand-edited pipeline file. This refuses with a coded,
-// actionable error unless --force is set.
-//
-// --dry-run never reaches writeFile (ExecuteWithResult skips it), so it has
-// nothing destructive to guard against; it is exempt from this check
-// entirely so it can preview a pipeline even when a file already sits at the
-// destination.
-func (c *InitCommand) checkDestination() error {
-	if c.flags.Force || c.flags.DryRun {
-		return nil
-	}
-
-	_, err := os.Stat(c.configFilePath)
-	switch {
-	case err == nil:
-		ce := conduiterr.New(CodeDestinationExists, fmt.Sprintf("pipeline file %q already exists", c.configFilePath))
-		ce.ConfigPath = c.configFilePath
-		ce.Suggestion = fmt.Sprintf(
-			"pass --force to overwrite %q, choose a different pipeline name, or a different --pipelines.path",
-			c.configFilePath,
-		)
-		return ce
-	case os.IsNotExist(err):
-		return nil
-	default:
-		return conduiterr.Wrap(conduiterr.CodeInternal, fmt.Sprintf("could not check destination %q", c.configFilePath), err)
-	}
-}
-
 // renderPipeline executes the embedded pipeline.tmpl against pipeline and
 // returns the rendered YAML as a string, without touching the filesystem —
 // the shared rendering path for both a real write (writeFile) and --dry-run
@@ -304,18 +272,42 @@ func (c *InitCommand) renderPipeline(pipeline pipelineTemplate) (string, error) 
 }
 
 // writeFile writes the already-rendered pipeline config to c.configFilePath.
-// checkDestination is the sole existence gate; by the time writeFile runs,
-// either the destination didn't exist, or --force explicitly authorized the
-// overwrite, so O_TRUNC here is safe.
+//
+// Invariant: never silently overwrite an existing pipeline file — this
+// command's original bug was os.OpenFile with O_CREATE|O_WRONLY|O_TRUNC and
+// no existence check at all, so a second `pipelines init` into the same path
+// silently clobbered a hand-edited pipeline. Without --force, the file is
+// opened with O_EXCL instead of O_TRUNC: the existence check and the write
+// are a single atomic syscall, so there is no TOCTOU window between "check
+// if it exists" and "write" the way a separate os.Stat followed by an open
+// would have (e.g. another `pipelines init` run, or anything else, creating
+// the file in between). --force switches to O_TRUNC, explicitly authorizing
+// the overwrite. Only called when !DryRun (see ExecuteWithResult) — --dry-run
+// never reaches here, so it has nothing to protect and never hits this
+// check at all.
 func (c *InitCommand) writeFile(renderedConfig string) error {
-	output, err := os.OpenFile(c.configFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	flags := os.O_CREATE | os.O_WRONLY | os.O_EXCL
+	if c.flags.Force {
+		flags = os.O_CREATE | os.O_WRONLY | os.O_TRUNC
+	}
+
+	output, err := os.OpenFile(c.configFilePath, flags, 0o600)
 	if err != nil {
-		return cerrors.Errorf("failed to open %q: %w", c.configFilePath, err)
+		if !c.flags.Force && os.IsExist(err) {
+			ce := conduiterr.New(CodeDestinationExists, fmt.Sprintf("pipeline file %q already exists", c.configFilePath))
+			ce.ConfigPath = c.configFilePath
+			ce.Suggestion = fmt.Sprintf(
+				"pass --force to overwrite %q, choose a different pipeline name, or a different --pipelines.path",
+				c.configFilePath,
+			)
+			return ce
+		}
+		return conduiterr.Wrap(conduiterr.CodeInternal, fmt.Sprintf("could not open %q", c.configFilePath), err)
 	}
 	defer output.Close()
 
 	if _, err := output.WriteString(renderedConfig); err != nil {
-		return cerrors.Errorf("failed writing pipeline config: %w", err)
+		return conduiterr.Wrap(conduiterr.CodeInternal, "failed writing pipeline config", err)
 	}
 	return nil
 }
@@ -368,23 +360,17 @@ func (c *InitCommand) setSourceAndDestinationConnector() {
 	}
 }
 
-// ExecuteWithResult resolves the pipeline's source/destination/name, refuses
-// (via checkDestination) rather than silently clobbering an existing
-// pipeline file, then renders and — unless --dry-run — writes the pipeline
-// config. A non-nil error here is always a HARD command failure (unknown
-// connector, destination-exists-without-force, an I/O failure); this
-// command has no "domain finding" outcome distinct from success, so OK is
-// always true when err is nil.
+// ExecuteWithResult resolves the pipeline's source/destination/name, renders
+// the pipeline config, and — unless --dry-run — writes it, refusing (via
+// writeFile) rather than silently clobbering an existing pipeline file. A
+// non-nil error here is always a HARD command failure (unknown connector,
+// destination-exists-without-force, an I/O failure); this command has no
+// "domain finding" outcome distinct from success, so OK is always true when
+// err is nil.
 func (c *InitCommand) ExecuteWithResult(_ context.Context) (cecdysis.Outcome, error) {
 	c.setSourceAndDestinationConnector()
 	c.pipelineName = c.getPipelineName()
 	c.configFilePath = filepath.Join(c.flags.PipelinesPath, fmt.Sprintf("%s.yaml", c.pipelineName))
-
-	// Invariant: never silently overwrite an existing pipeline file (this
-	// command's original bug). See checkDestination's doc.
-	if err := c.checkDestination(); err != nil {
-		return cecdysis.Outcome{}, err
-	}
 
 	pipeline, err := c.buildTemplatePipeline()
 	if err != nil {
@@ -400,9 +386,11 @@ func (c *InitCommand) ExecuteWithResult(_ context.Context) (cecdysis.Outcome, er
 
 	written := false
 	if !c.flags.DryRun {
+		// Invariant: never silently overwrite an existing pipeline file
+		// (this command's original bug) — see writeFile's doc for the
+		// atomic, TOCTOU-safe existence check.
 		if err := c.writeFile(rendered); err != nil {
-			return cecdysis.Outcome{}, conduiterr.Wrap(conduiterr.CodeInternal,
-				fmt.Sprintf("could not write pipeline file %q", c.configFilePath), err)
+			return cecdysis.Outcome{}, err
 		}
 		written = true
 	}

--- a/cmd/conduit/root/pipelines/init.go
+++ b/cmd/conduit/root/pipelines/init.go
@@ -15,26 +15,28 @@
 package pipelines
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"text/template"
 
 	"github.com/conduitio/conduit-commons/config"
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/plugin"
 	"github.com/conduitio/conduit/pkg/plugin/connector/builtin"
 	"github.com/conduitio/ecdysis"
 )
 
 var (
+	_ cecdysis.CommandWithResult = (*InitCommand)(nil)
 	_ ecdysis.CommandWithDocs    = (*InitCommand)(nil)
 	_ ecdysis.CommandWithFlags   = (*InitCommand)(nil)
 	_ ecdysis.CommandWithArgs    = (*InitCommand)(nil)
-	_ ecdysis.CommandWithExecute = (*InitCommand)(nil)
 
 	//go:embed pipeline.tmpl
 	pipelineCfgTmpl string
@@ -54,6 +56,35 @@ type InitFlags struct {
 	Source        string `long:"source" usage:"Source connector (any of the built-in connectors)." default:"generator"`
 	Destination   string `long:"destination" usage:"Destination connector (any of the built-in connectors)." default:"log"`
 	PipelinesPath string `long:"pipelines.path" usage:"Path where the pipeline will be saved." default:"./pipelines"`
+	Force         bool   `long:"force" usage:"Overwrite the pipeline file if one already exists at the destination path."`
+	DryRun        bool   `long:"dry-run" usage:"Print the pipeline configuration that would be written, without writing it."`
+}
+
+// InitResult is `pipelines init`'s --json result payload (cecdysis.Outcome.Result).
+type InitResult struct {
+	// Path is the pipeline YAML file's resolved destination path.
+	Path string `json:"path"`
+	// PipelineName is the resolved pipeline name (from the positional
+	// argument, or derived from Source/Destination, or the demo name).
+	PipelineName string `json:"pipelineName"`
+	Source       string `json:"source"`
+	Destination  string `json:"destination"`
+	// DryRun reports whether this run wrote nothing (--dry-run).
+	DryRun bool `json:"dryRun"`
+	// Forced reports whether --force was set (informational; true even if
+	// no existing file needed overwriting).
+	Forced bool `json:"forced"`
+	// Config is the rendered pipeline YAML — the literal bytes written to
+	// Path, or (under --dry-run) the bytes that would have been written.
+	Config string `json:"config"`
+}
+
+// InitSummary is `pipelines init`'s --json summary payload
+// (cecdysis.Outcome.Summary).
+type InitSummary struct {
+	// Written reports whether a file was actually written to disk. False
+	// only under --dry-run.
+	Written bool `json:"written"`
 }
 
 type InitCommand struct {
@@ -92,15 +123,23 @@ func (c *InitCommand) Usage() string { return "init [PIPELINE_NAME]" }
 func (c *InitCommand) Docs() ecdysis.Docs {
 	return ecdysis.Docs{
 		Short: "Initialize a pipeline with the chosen connectors via flags, or a demo pipeline if no flags are specified.",
-		Long: `Initialize a pipeline configuration file, with all of parameters for source and destination connectors 
+		Long: `Initialize a pipeline configuration file, with all of parameters for source and destination connectors
 initialized and described. The source and destination connector can be chosen via flags. If no connectors are chosen, then
-a simple and runnable demo-pipeline is fully configured.`,
+a simple and runnable demo-pipeline is fully configured.
+
+Refuses to overwrite an existing pipeline file at the destination path unless --force is set.
+--dry-run prints the pipeline configuration that would be written without touching the filesystem
+(and is exempt from the --force check, since it never writes).`,
 		Example: "conduit pipelines init\n" +
 			"conduit pipelines init --source generator --destination s3 \n" +
 			"conduit pipelines init awesome-pipeline-name --source postgres --destination kafka \n" +
-			"conduit pipelines init file-to-pg --source file --destination postgres --pipelines.path ./my-pipelines",
+			"conduit pipelines init file-to-pg --source file --destination postgres --pipelines.path ./my-pipelines\n" +
+			"conduit pipelines init --force\n" +
+			"conduit pipelines init --dry-run --json",
 	}
 }
+
+func (c *InitCommand) ResultCommand() string { return "pipelines.init" }
 
 func (c *InitCommand) getSourceSpec() (connectorSpec, error) {
 	src := c.flags.Source
@@ -214,29 +253,70 @@ func (c *InitCommand) buildTemplatePipeline() (pipelineTemplate, error) {
 	}, nil
 }
 
-func (c *InitCommand) getOutput() *os.File {
-	output, err := os.OpenFile(c.configFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-	if err != nil {
-		log.Fatalf("error: failed to open %s: %v", c.configFilePath, err)
+// checkDestination is the fix for this command's former silent-overwrite
+// bug: writeFile used to open with os.O_CREATE|os.O_WRONLY|os.O_TRUNC with no
+// existence check at all, so a second `pipelines init` into the same path
+// silently clobbered a hand-edited pipeline file. This refuses with a coded,
+// actionable error unless --force is set.
+//
+// --dry-run never reaches writeFile (ExecuteWithResult skips it), so it has
+// nothing destructive to guard against; it is exempt from this check
+// entirely so it can preview a pipeline even when a file already sits at the
+// destination.
+func (c *InitCommand) checkDestination() error {
+	if c.flags.Force || c.flags.DryRun {
+		return nil
 	}
 
-	return output
+	_, err := os.Stat(c.configFilePath)
+	switch {
+	case err == nil:
+		ce := conduiterr.New(CodeDestinationExists, fmt.Sprintf("pipeline file %q already exists", c.configFilePath))
+		ce.ConfigPath = c.configFilePath
+		ce.Suggestion = fmt.Sprintf(
+			"pass --force to overwrite %q, choose a different pipeline name, or a different --pipelines.path",
+			c.configFilePath,
+		)
+		return ce
+	case os.IsNotExist(err):
+		return nil
+	default:
+		return conduiterr.Wrap(conduiterr.CodeInternal, fmt.Sprintf("could not check destination %q", c.configFilePath), err)
+	}
 }
 
-func (c *InitCommand) write(pipeline pipelineTemplate) error {
+// renderPipeline executes the embedded pipeline.tmpl against pipeline and
+// returns the rendered YAML as a string, without touching the filesystem —
+// the shared rendering path for both a real write (writeFile) and --dry-run
+// (which renders but never writes).
+func (c *InitCommand) renderPipeline(pipeline pipelineTemplate) (string, error) {
 	t, err := template.New("").Funcs(funcMap).Option("missingkey=zero").Parse(pipelineCfgTmpl)
 	if err != nil {
-		return cerrors.Errorf("failed parsing template: %w", err)
+		return "", cerrors.Errorf("failed parsing template: %w", err)
 	}
 
-	output := c.getOutput()
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, pipeline); err != nil {
+		return "", cerrors.Errorf("failed executing template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// writeFile writes the already-rendered pipeline config to c.configFilePath.
+// checkDestination is the sole existence gate; by the time writeFile runs,
+// either the destination didn't exist, or --force explicitly authorized the
+// overwrite, so O_TRUNC here is safe.
+func (c *InitCommand) writeFile(renderedConfig string) error {
+	output, err := os.OpenFile(c.configFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return cerrors.Errorf("failed to open %q: %w", c.configFilePath, err)
+	}
 	defer output.Close()
 
-	err = t.Execute(output, pipeline)
-	if err != nil {
-		return cerrors.Errorf("failed executing template: %w", err)
+	if _, err := output.WriteString(renderedConfig); err != nil {
+		return cerrors.Errorf("failed writing pipeline config: %w", err)
 	}
-
 	return nil
 }
 
@@ -288,22 +368,72 @@ func (c *InitCommand) setSourceAndDestinationConnector() {
 	}
 }
 
-func (c *InitCommand) Execute(_ context.Context) error {
+// ExecuteWithResult resolves the pipeline's source/destination/name, refuses
+// (via checkDestination) rather than silently clobbering an existing
+// pipeline file, then renders and — unless --dry-run — writes the pipeline
+// config. A non-nil error here is always a HARD command failure (unknown
+// connector, destination-exists-without-force, an I/O failure); this
+// command has no "domain finding" outcome distinct from success, so OK is
+// always true when err is nil.
+func (c *InitCommand) ExecuteWithResult(_ context.Context) (cecdysis.Outcome, error) {
 	c.setSourceAndDestinationConnector()
 	c.pipelineName = c.getPipelineName()
 	c.configFilePath = filepath.Join(c.flags.PipelinesPath, fmt.Sprintf("%s.yaml", c.pipelineName))
 
+	// Invariant: never silently overwrite an existing pipeline file (this
+	// command's original bug). See checkDestination's doc.
+	if err := c.checkDestination(); err != nil {
+		return cecdysis.Outcome{}, err
+	}
+
 	pipeline, err := c.buildTemplatePipeline()
 	if err != nil {
-		return err
+		return cecdysis.Outcome{}, conduiterr.Wrap(conduiterr.CodeInvalidArgument,
+			"could not build the pipeline configuration", err)
 	}
 
-	if err := c.write(pipeline); err != nil {
-		return cerrors.Errorf("could not write pipeline: %w", err)
+	rendered, err := c.renderPipeline(pipeline)
+	if err != nil {
+		return cecdysis.Outcome{}, conduiterr.Wrap(conduiterr.CodeInternal,
+			"could not render the pipeline configuration", err)
 	}
 
-	fmt.Printf("Your pipeline has been initialized and created at %q.\n"+
-		"To run the pipeline, simply run `conduit run`.\n", c.configFilePath)
+	written := false
+	if !c.flags.DryRun {
+		if err := c.writeFile(rendered); err != nil {
+			return cecdysis.Outcome{}, conduiterr.Wrap(conduiterr.CodeInternal,
+				fmt.Sprintf("could not write pipeline file %q", c.configFilePath), err)
+		}
+		written = true
+	}
 
-	return nil
+	return cecdysis.Outcome{
+		OK:      true,
+		Summary: InitSummary{Written: written},
+		Result: InitResult{
+			Path:         c.configFilePath,
+			PipelineName: c.pipelineName,
+			Source:       c.sourceConnector,
+			Destination:  c.destinationConnector,
+			DryRun:       c.flags.DryRun,
+			Forced:       c.flags.Force,
+			Config:       rendered,
+		},
+	}, nil
+}
+
+// Render returns the human-readable rendering of a successful init run: the
+// original "your pipeline has been initialized" message when a file was
+// written, or the rendered config plus a "nothing was written" notice under
+// --dry-run.
+func (c *InitCommand) Render(outcome cecdysis.Outcome) string {
+	result, _ := outcome.Result.(InitResult)
+
+	if result.DryRun {
+		return fmt.Sprintf("Dry run: the following pipeline configuration would be written to %q "+
+			"(nothing was written):\n\n%s", result.Path, result.Config)
+	}
+
+	return fmt.Sprintf("Your pipeline has been initialized and created at %q.\n"+
+		"To run the pipeline, simply run `conduit run`.\n", result.Path)
 }

--- a/cmd/conduit/root/pipelines/init_codes.go
+++ b/cmd/conduit/root/pipelines/init_codes.go
@@ -1,0 +1,33 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelines
+
+import (
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"google.golang.org/grpc/codes"
+)
+
+// CodeDestinationExists is raised by `pipelines init` when the resolved
+// pipeline file already exists and --force was not passed. This is the fix
+// for the command's previous behavior: os.OpenFile with O_TRUNC and no
+// existence check, which silently overwrote an existing pipeline
+// configuration. --force opts into the overwrite; --dry-run never touches
+// the filesystem and is exempt from this check entirely (see
+// InitCommand.checkDestination).
+//
+// codes.AlreadyExists classifies to exitcode.Validation (2) via
+// pkg/conduit/exitcode, the same bucket as pkg/scaffold's analogous
+// CodeDestinationExists for connector/processor scaffolding.
+var CodeDestinationExists = conduiterr.Register("pipelines.init_destination_exists", codes.AlreadyExists)

--- a/cmd/conduit/root/pipelines/init_command_test.go
+++ b/cmd/conduit/root/pipelines/init_command_test.go
@@ -1,0 +1,245 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// These are full-stack tests for `conduit pipelines init`, built the same
+// way cmd/conduit/root/pipelines/validate_test.go and
+// cmd/conduit/root/doctor/doctor_test.go build theirs: a real cobra command
+// wired through the same cecdysis.CommandWithResultDecorator cmd/conduit/cli
+// uses, driven through cmd.Execute()/ExecuteC(), asserting on both rendered
+// output and the process-level exit code classification.
+//
+// TestInitCommand_ExistingFile_RefusesWithoutForce is the regression test for
+// the bug this command shipped with: writeFile used to open with
+// os.O_CREATE|os.O_WRONLY|os.O_TRUNC and no existence check at all, silently
+// clobbering a second `pipelines init` into the same path. It fails without
+// the fix (the second init would succeed and overwrite silently) and passes
+// with it (coded refusal, original content intact).
+package pipelines
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/pkg/conduit/exitcode"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/ecdysis"
+	json "github.com/goccy/go-json"
+	"github.com/matryer/is"
+)
+
+func newInitEcdysis() *ecdysis.Ecdysis {
+	return ecdysis.New(ecdysis.WithDecorators(cecdysis.CommandWithResultDecorator{}))
+}
+
+// TestInitCommand_ExistingFile_RefusesWithoutForce is the regression test:
+// a second `pipelines init` into an already-populated --pipelines.path must
+// refuse with a coded error, exit Validation (2), and must not touch the
+// existing file's content.
+func TestInitCommand_ExistingFile_RefusesWithoutForce(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+
+	// First init: succeeds, creates demo-pipeline.yaml.
+	cmd := newInitEcdysis().MustBuildCobraCommand(&InitCommand{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--pipelines.path=" + dir})
+	is.NoErr(cmd.Execute())
+
+	path := filepath.Join(dir, "demo-pipeline.yaml")
+	original, err := os.ReadFile(path)
+	is.NoErr(err)
+	is.True(len(original) > 0)
+
+	// Second init into the same path, no --force: must refuse, not
+	// overwrite.
+	cmd2 := newInitEcdysis().MustBuildCobraCommand(&InitCommand{})
+	var out2 bytes.Buffer
+	cmd2.SetOut(&out2)
+	cmd2.SetErr(&out2)
+	cmd2.SetArgs([]string{"--pipelines.path=" + dir, "--json"})
+
+	err2 := cmd2.Execute()
+	is.True(err2 != nil)
+	is.Equal(exitcode.ExitCode(err2), exitcode.Validation)
+
+	var got cecdysis.Result
+	is.NoErr(json.Unmarshal(out2.Bytes(), &got))
+	is.Equal(got.Command, "pipelines.init")
+	is.True(!got.OK)
+	is.True(got.Error != nil)
+	is.Equal(got.Error.Code, CodeDestinationExists.Reason())
+	is.True(strings.Contains(got.Error.Suggestion, "--force"))
+	is.Equal(got.Error.ConfigPath, path)
+
+	// The file on disk must be untouched — this is the actual bug: prove
+	// content identity, not just that an error was returned.
+	after, err := os.ReadFile(path)
+	is.NoErr(err)
+	is.Equal(string(original), string(after))
+}
+
+// TestInitCommand_ExistingFile_ForceOverwrites covers the opt-in overwrite
+// path: --force must succeed and actually replace the file's content.
+func TestInitCommand_ExistingFile_ForceOverwrites(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+
+	cmd := newInitEcdysis().MustBuildCobraCommand(&InitCommand{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--pipelines.path=" + dir, "--source=generator", "--destination=log"})
+	is.NoErr(cmd.Execute())
+
+	path := filepath.Join(dir, "generator-to-log.yaml")
+	is.NoErr(os.WriteFile(path, []byte("hand-edited: true\n"), 0o600))
+
+	cmd2 := newInitEcdysis().MustBuildCobraCommand(&InitCommand{})
+	var out2 bytes.Buffer
+	cmd2.SetOut(&out2)
+	cmd2.SetArgs([]string{"--pipelines.path=" + dir, "--source=generator", "--destination=log", "--force", "--json"})
+	is.NoErr(cmd2.Execute())
+
+	var got cecdysis.Result
+	is.NoErr(json.Unmarshal(out2.Bytes(), &got))
+	is.Equal(got.Command, "pipelines.init")
+	is.True(got.OK)
+	is.True(got.Error == nil)
+
+	after, err := os.ReadFile(path)
+	is.NoErr(err)
+	is.True(!strings.Contains(string(after), "hand-edited"))
+	is.True(strings.Contains(string(after), "generator-source"))
+}
+
+// TestInitCommand_DryRun_WritesNothing covers --dry-run: the command must
+// print the rendered config but must not create any file.
+func TestInitCommand_DryRun_WritesNothing(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+
+	cmd := newInitEcdysis().MustBuildCobraCommand(&InitCommand{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--pipelines.path=" + dir, "--dry-run"})
+	is.NoErr(cmd.Execute())
+
+	path := filepath.Join(dir, "demo-pipeline.yaml")
+	_, statErr := os.Stat(path)
+	is.True(os.IsNotExist(statErr)) // nothing written
+
+	got := out.String()
+	is.True(strings.Contains(got, "Dry run"))
+	is.True(strings.Contains(got, "generator-source")) // the rendered config content
+	is.True(!strings.Contains(got, "has been initialized"))
+}
+
+// TestInitCommand_DryRun_JSON covers --dry-run combined with --json: the
+// envelope must report written:false in the summary and carry the rendered
+// config in the result, with nothing written to disk.
+func TestInitCommand_DryRun_JSON(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+
+	cmd := newInitEcdysis().MustBuildCobraCommand(&InitCommand{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--pipelines.path=" + dir, "--dry-run", "--json"})
+	is.NoErr(cmd.Execute())
+
+	path := filepath.Join(dir, "demo-pipeline.yaml")
+	_, statErr := os.Stat(path)
+	is.True(os.IsNotExist(statErr))
+
+	var got cecdysis.Result
+	is.NoErr(json.Unmarshal(out.Bytes(), &got))
+	is.Equal(got.Command, "pipelines.init")
+	is.True(got.OK)
+	is.True(got.Error == nil)
+
+	summaryBytes, err := json.Marshal(got.Summary)
+	is.NoErr(err)
+	var summary InitSummary
+	is.NoErr(json.Unmarshal(summaryBytes, &summary))
+	is.True(!summary.Written)
+
+	resultBytes, err := json.Marshal(got.Result)
+	is.NoErr(err)
+	var result InitResult
+	is.NoErr(json.Unmarshal(resultBytes, &result))
+	is.True(result.DryRun)
+	is.Equal(result.Path, path)
+	is.True(strings.Contains(result.Config, "generator-source"))
+}
+
+// TestInitCommand_ValidJSON_EnvelopeShape covers the Family A envelope
+// conformance requirement (CLI output conventions §1 / Workstream 8): a
+// successful --json run has command/ok/error present and error null.
+func TestInitCommand_ValidJSON_EnvelopeShape(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+
+	cmd := newInitEcdysis().MustBuildCobraCommand(&InitCommand{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--pipelines.path=" + dir, "--json"})
+	is.NoErr(cmd.Execute())
+	is.Equal(exitcode.ExitCode(nil), exitcode.OK)
+
+	var raw map[string]any
+	is.NoErr(json.Unmarshal(out.Bytes(), &raw))
+	for _, key := range []string{"command", "ok", "summary", "result", "error"} {
+		_, ok := raw[key]
+		is.True(ok)
+	}
+	is.Equal(raw["command"], "pipelines.init")
+	is.Equal(raw["ok"], true)
+	is.True(raw["error"] == nil)
+}
+
+// TestInitCommand_UnknownConnector_HardFailure covers a HARD command failure
+// (unresolvable connector) rendering through the envelope's error field with
+// a registered code, exit Validation (2).
+func TestInitCommand_UnknownConnector_HardFailure(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+
+	cmd := newInitEcdysis().MustBuildCobraCommand(&InitCommand{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--pipelines.path=" + dir, "--source=does-not-exist", "--json"})
+
+	err := cmd.Execute()
+	is.True(err != nil)
+	is.Equal(exitcode.ExitCode(err), exitcode.Validation)
+
+	var got cecdysis.Result
+	is.NoErr(json.Unmarshal(out.Bytes(), &got))
+	is.True(!got.OK)
+	is.True(got.Error != nil)
+}
+
+// TestCodeDestinationExists_Registered proves CodeDestinationExists is a
+// real, registered conduiterr code (agents/docs can look it up), not just a
+// local sentinel.
+func TestCodeDestinationExists_Registered(t *testing.T) {
+	is := is.New(t)
+	_, ok := conduiterr.LookupCode(CodeDestinationExists.Reason())
+	is.True(ok)
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -614,7 +614,7 @@ Author: Meroxa, Inc.
 | `sdk.schema.extract.key.enabled` | bool | true | no | Whether to extract and decode the record key with a schema. |  |
 | `sdk.schema.extract.payload.enabled` | bool | true | no | Whether to extract and decode the record payload with a schema. |  |
 
-## 3. Error codes (77)
+## 3. Error codes (78)
 
 | Reason | gRPC status | Description |
 | --- | --- | --- |
@@ -644,6 +644,7 @@ Author: Meroxa, Inc.
 | `pipeline.name_missing` | InvalidArgument | CodePipelineNameMissing is raised when a pipeline config is missing the required name field. |
 | `pipeline.not_running` | FailedPrecondition | CodePipelineNotRunning is raised when an operation requires the pipeline to be running, but it is currently stopped. |
 | `pipeline.running` | FailedPrecondition | CodePipelineRunning is raised when an operation requires the pipeline to be stopped, but it is currently running. |
+| `pipelines.init_destination_exists` | AlreadyExists | pipelines: init destination exists |
 | `processor.instance_not_found` | NotFound | CodeProcessorNotFound is raised when a referenced processor instance cannot be located. |
 | `processor.plugin_not_found` | NotFound | CodeProcessorPluginNotFound is raised when a referenced processor plugin cannot be located. |
 | `provisioning.live_apply_unauthorized` | FailedPrecondition | provisioning: live apply unauthorized |

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@
 (6 built-in connectors; full parameters in llms-full.txt)
 
 ## Error codes
-- 77 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
+- 78 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
 
 ## MCP tools
 - Read: deploy, doctor, dry_run, inspect, lint, repair, validate


### PR DESCRIPTION
## Summary

Fixes `conduit pipelines init`'s silent-overwrite bug and migrates it onto the `cecdysis`
enveloped-output path (`--json`, `--force`, `--dry-run`) — the "lands first" prerequisite
identified in the v0.19 Workstream 3 (templates gallery) plan, `templates.md` §4/§8: the
`--template` flag Workstream 3 will add needs an envelope to report against, and the
silent-overwrite bug would otherwise carry unfixed into the new template-scaffolding path.

**Roadmap item:** v0.19 Workstream 3 prerequisite (templates gallery), per
`conduit-v019-plans/workstreams/templates.md` §4 ("Corrected precedent for the non-empty-destination
/ overwrite behavior") and §11 task 1.

**The bug (verified in review):** `getOutput()` opened the destination with
`os.O_CREATE|os.O_WRONLY|os.O_TRUNC` and no existence check at all — a second `pipelines init`
into the same `--pipelines.path` silently clobbered a hand-edited pipeline file.

**What shipped:**

- Migrated `InitCommand` from `ecdysis.CommandWithExecute` onto `cecdysis.CommandWithResult`
  (Family A envelope: `command`/`ok`/`summary`/`result`/`error`), matching every other
  `pipelines <verb>` command (`validate`/`lint`/`dry-run`/`repair`/`apply`/`deploy`).
- `--force` (default false): refuses with a new registered error code
  (`pipelines.init_destination_exists`, `codes.AlreadyExists` → exit 2) when the destination
  file already exists, carrying `configPath` and a `suggestion` naming `--force`. `--force`
  opts into the overwrite.
- `--dry-run`: renders and prints the pipeline config without writing; exempt from the
  `--force` check entirely since it never touches the filesystem.
- `--json`: full envelope output, `result` carries `path`/`pipelineName`/`source`/`destination`/
  `dryRun`/`forced`/`config` (the literal rendered YAML), `summary` carries `written: bool`.

## Self-review findings (adversarial pass)

- **Found and fixed:** the first implementation used a separate `os.Stat` existence check
  followed later by `os.OpenFile(O_TRUNC)` — a TOCTOU race (anything creating the file between
  the two calls, e.g. a concurrent `pipelines init`, would still get silently overwritten despite
  the guard). Fixed by collapsing into one atomic `os.OpenFile` call: `O_EXCL` without `--force`
  (fails atomically if the file exists), `O_TRUNC` with `--force` (explicit overwrite). See the
  second commit.
- Checked error paths: unknown connector name, destination-exists, and I/O failure during write
  all return a coded `*conduiterr.ConduitError` with `configPath`/`suggestion` populated, per
  "errors are API."
- Checked resource cleanup: `output.Close()` is deferred; its error is not separately checked
  (matches this command's pre-existing behavior — not a regression, flagging for visibility).
- No concurrency beyond the single-process file open above — this is a one-shot CLI command, no
  goroutines.
- Verified manually end-to-end via `go run ./cmd/conduit pipelines init` (dry-run writes nothing,
  first init succeeds, second init without `--force` refuses with unchanged file content
  byte-for-byte, `--force` overwrites) — see gate results below.

## Gate results

- `go build ./...` — clean.
- `make generate && git diff --exit-code` — no drift.
- `golangci-lint run ./cmd/conduit/root/pipelines/...` — 0 issues.
- `go test -race ./cmd/conduit/root/pipelines/...` — all pass (existing `init_test.go` unmodified
  and green, plus new `init_command_test.go`: double-init refusal + untouched file content,
  `--force` overwrite, `--dry-run` no-write, `--dry-run --json`, envelope shape, unknown-connector
  hard failure, registered-code lookup).

## Test plan

- [x] `TestInitCommand_ExistingFile_RefusesWithoutForce` — the regression test for the bug: second
      init without `--force` returns the coded error, exit 2, and the original file's bytes are
      unchanged.
- [x] `TestInitCommand_ExistingFile_ForceOverwrites` — `--force` succeeds and actually replaces
      content.
- [x] `TestInitCommand_DryRun_WritesNothing` / `_DryRun_JSON` — no file created, config printed
      (human and `--json`).
- [x] `TestInitCommand_ValidJSON_EnvelopeShape` — envelope has all five keys, `error` null on
      success.
- [x] `TestInitCommand_UnknownConnector_HardFailure` — hard failure still classifies exit 2.

## Open question for DeVaris

None blocking. Note for later: `templates.md` §8 flags this same fix as a possible companion
to backport onto `pipelines init`'s generic (non-template) path — this PR *is* that backport,
landing ahead of the `--template` flag itself per the plan's task-1 ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD
