### PR TITLE
feat(embed): libconduit B1 Go embedding API (New/Engine/Handle/Import)

### DIFF
--- a/cmd/conduit/root/doctor/doctorcheck/doctorcheck_test.go
+++ b/cmd/conduit/root/doctor/doctorcheck/doctorcheck_test.go
@@ -215,7 +215,7 @@ func TestDefaultChecks_StoreReachable_PreexistingDBDirNotDeleted(t *testing.T) {
 	cfg.DB.Badger.Path = filepath.Join(t.TempDir(), "conduit.db")
 
 	// Open and close it once first, simulating a real prior `conduit run`.
-	db, err := conduit.OpenStore(cfg, log.Nop())
+	db, err := conduit.OpenStore(context.Background(), cfg, log.Nop())
 	is.NoErr(err)
 	is.NoErr(db.Close())
 

--- a/cmd/conduit/root/doctor/doctorcheck/store.go
+++ b/cmd/conduit/root/doctor/doctorcheck/store.go
@@ -66,7 +66,7 @@ func (c storeReachableCheck) Run(ctx context.Context) check.CheckResult {
 		}
 	}
 
-	db, err := conduit.OpenStore(c.cfg, c.logger)
+	db, err := conduit.OpenStore(ctx, c.cfg, c.logger)
 	if err != nil {
 		return check.CheckResult{
 			Status:     check.StatusFail,

--- a/conduit.go
+++ b/conduit.go
@@ -1,0 +1,320 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conduit
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+
+	"github.com/conduitio/conduit-commons/database"
+	pkgconduit "github.com/conduitio/conduit/pkg/conduit"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	provisioningconfig "github.com/conduitio/conduit/pkg/provisioning/config"
+	promclient "github.com/prometheus/client_golang/prometheus"
+)
+
+// PipelineConfig is Conduit's pipeline configuration shape: a type alias (not
+// a copy) of provisioning/config.Pipeline, the exact struct the YAML
+// provisioner both produces and consumes. Aliasing guarantees Engine.Import
+// accepts precisely what a hand-built PipelineConfig value produces, with no
+// conversion step to drift out of sync — see provisioning/config/parser.go's
+// matching doc comment for the constraint this places on that package.
+type PipelineConfig = provisioningconfig.Pipeline
+
+// Options configures a New Engine. Logger and MetricsRegisterer have
+// deliberately different zero-value semantics — read both before assuming
+// symmetry: a nil Logger is a safe, explicit default; a nil
+// MetricsRegisterer disables metrics.
+type Options struct {
+	// Logger receives every log line Conduit produces, with level and
+	// structured fields preserved as slog attributes. nil defaults to
+	// slog.Default() (an explicit, documented choice, not an error). Two
+	// concurrent Engines constructed with distinct Loggers never cross-talk:
+	// Conduit never writes to os.Stdout/os.Stderr or a process-global logger
+	// on this path.
+	Logger *slog.Logger
+
+	// MetricsRegisterer receives Conduit's Prometheus metric families. nil
+	// means "do not expose metrics" — metrics are silently disabled, not an
+	// error. It is never prometheus.DefaultRegisterer implicitly: Conduit's
+	// metrics never reach the process-global default registry through New.
+	//
+	// Known limitation: see this package's doc.go "metrics cross-talk"
+	// section — two Engines each get an isolated Registerer/Registry
+	// *object*, but pkg/foundation/metrics' process-global metric
+	// definitions still fan values out across every registry in the process.
+	MetricsRegisterer promclient.Registerer
+
+	// DB configures the embedded storage backend. The zero value (Type =="")
+	// defaults to an in-memory store — convenient for examples and tests, but
+	// every pipeline configuration is lost once the Engine stops. A
+	// production embedder should set Type explicitly.
+	DB DBOptions
+
+	// PipelinesDir optionally points at a directory (or a single file) of
+	// pipeline YAML configs Conduit provisions when Run starts. Leave empty
+	// to skip file-based provisioning entirely and manage pipelines
+	// exclusively through Engine.Import.
+	PipelinesDir string
+
+	// API optionally exposes Conduit's HTTP/gRPC API. Disabled by default: an
+	// embedder that only needs in-process orchestration is not forced to bind
+	// a socket.
+	API APIOptions
+}
+
+// DBOptions configures Options.DB.
+type DBOptions struct {
+	// Driver, when set, is used directly and takes precedence over Type and
+	// the type-specific fields below — the same precedence
+	// pkg/conduit.Config gives a caller-supplied database.DB.
+	Driver database.DB
+
+	// Type selects the storage backend: pkgconduit.DBTypeBadger,
+	// DBTypePostgres, DBTypeInMemory, or DBTypeSQLite. Defaults to
+	// DBTypeInMemory when empty.
+	Type string
+
+	Badger struct {
+		Path string
+	}
+	Postgres struct {
+		ConnectionString string
+		Table            string
+	}
+	SQLite struct {
+		Path  string
+		Table string
+	}
+}
+
+// APIOptions configures Options.API.
+type APIOptions struct {
+	// Enabled turns on Conduit's HTTP and gRPC API. Default: false.
+	Enabled bool
+	// GRPCAddress is the bind address for the gRPC API (e.g. ":8084", or
+	// "127.0.0.1:0" for an OS-assigned port). Required if Enabled.
+	GRPCAddress string
+	// HTTPAddress is the bind address for the HTTP API/gateway. Required if
+	// Enabled.
+	HTTPAddress string
+}
+
+// Engine is a constructed, not-yet-running Conduit instance. Obtain one with
+// New; start it with Run.
+type Engine struct {
+	runtime *pkgconduit.Runtime
+	started atomic.Bool
+}
+
+// New constructs an Engine from opts. It opens the configured database (ctx
+// bounds that dial only — see pkgconduit.WithDialContext) but starts no
+// pipeline, server, or goroutine; call Engine.Run for that. ctx is not
+// retained past this call: Run's context is independent and must be supplied
+// fresh.
+//
+// Every failure is returned as an error — a *conduiterr.ConduitError where
+// classifiable — never an os.Exit and never a panic on a caller-supplied
+// misconfiguration.
+func New(ctx context.Context, opts Options) (*Engine, error) {
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	ctxLogger := newSlogCtxLogger(logger)
+
+	cfg := pkgconduit.DefaultConfig()
+
+	if opts.PipelinesDir != "" {
+		cfg.Pipelines.Path = opts.PipelinesDir
+	}
+
+	cfg.API.Enabled = opts.API.Enabled
+	if opts.API.Enabled {
+		cfg.API.GRPC.Address = opts.API.GRPCAddress
+		cfg.API.HTTP.Address = opts.API.HTTPAddress
+	}
+
+	cfg.DB.Driver = opts.DB.Driver
+	if opts.DB.Driver == nil {
+		dbType := opts.DB.Type
+		if dbType == "" {
+			dbType = pkgconduit.DBTypeInMemory
+		}
+		cfg.DB.Type = dbType
+		cfg.DB.Badger.Path = opts.DB.Badger.Path
+		cfg.DB.Postgres.ConnectionString = opts.DB.Postgres.ConnectionString
+		cfg.DB.Postgres.Table = opts.DB.Postgres.Table
+		cfg.DB.SQLite.Path = opts.DB.SQLite.Path
+		cfg.DB.SQLite.Table = opts.DB.SQLite.Table
+	}
+
+	runtimeOpts := []pkgconduit.RuntimeOption{
+		pkgconduit.WithLogger(ctxLogger),
+		pkgconduit.WithDialContext(ctx),
+	}
+	if opts.MetricsRegisterer != nil {
+		runtimeOpts = append(runtimeOpts, pkgconduit.WithMetricsRegisterer(opts.MetricsRegisterer))
+	}
+
+	rt, err := pkgconduit.NewRuntime(cfg, runtimeOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Engine{runtime: rt}, nil
+}
+
+// Handle is returned by Engine.Run once the engine has successfully started.
+// Use Stop to drain and shut it down. A Handle is only ever constructed
+// inside Engine.Run — there is no supported way to obtain one otherwise.
+type Handle struct {
+	cancel   context.CancelFunc
+	done     chan error
+	stopOnce sync.Once
+	stopErr  error
+}
+
+// Run starts the engine: it initializes all services and, if
+// Options.API.Enabled, begins serving the HTTP/gRPC API. It returns as soon
+// as either the engine becomes ready to accept work (a non-nil *Handle) or
+// startup definitively fails (a non-nil error) — it never blocks
+// indefinitely.
+//
+// ctx governs the engine's entire run: cancelling it starts the same
+// graceful drain Handle.Stop triggers (Invariant 7) — Run reuses
+// pkg/conduit's Runtime.Run and its existing ctx-cancellation-driven tomb
+// drain unchanged, the same mechanism `conduit run`'s SIGTERM handling
+// already drives from an OS signal via Entrypoint.CancelOnInterrupt. Run
+// does not store ctx beyond deriving a cancelable child from it; a
+// caller-supplied deadline propagates normally.
+//
+// Run must be called at most once per Engine. A second call returns a coded
+// error (conduiterr.CodeInvalidArgument) rather than racing a second tomb
+// against the first — this is deliberately not a new conduiterr code: a
+// double Run is caller misuse that has never been observed in practice, not
+// a distinct, documented failure mode that needs its own machine-actionable
+// identity.
+func (e *Engine) Run(ctx context.Context) (*Handle, error) {
+	if !e.started.CompareAndSwap(false, true) {
+		return nil, conduiterr.New(conduiterr.CodeInvalidArgument, "conduit: Run called more than once on this Engine")
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	go func() { done <- e.runtime.Run(runCtx) }()
+
+	select {
+	case <-e.runtime.Ready:
+		return &Handle{cancel: cancel, done: done}, nil
+	case err := <-done:
+		// Run returned — almost always a failure — before Ready ever closed.
+		// AC-4: this is the *other* of the two, and only two, ways Run
+		// resolves; it must never block waiting for Ready once done has
+		// already fired.
+		cancel() // release runCtx's resources; the tomb has already exited
+		if err == nil {
+			err = cerrors.New("conduit: engine stopped before becoming ready")
+		}
+		return nil, err
+	}
+}
+
+// Stop drains in-flight records and checkpoints, then shuts the engine down.
+//
+// Invariant 7: Stop triggers the identical ctx-cancellation-driven drain
+// Runtime.Run's registerCleanup dispatches to (registerCleanupV1/V2,
+// unchanged by this package) — the same path `conduit run`'s SIGTERM
+// handling already exercises. Stop does not reimplement or duplicate that
+// logic; it only supplies a different trigger (an explicit call instead of a
+// signal).
+//
+// Stop is idempotent: concurrent or repeated calls return the same result,
+// with no panic and no double-close. Calling Stop on a nil *Handle is a
+// caller bug (see Handle's doc); Stop reports it as a coded error
+// (conduiterr.CodeInvalidArgument — again deliberately not a new code, see
+// Run's doc) rather than panicking.
+//
+// If ctx is done before the drain completes, Stop returns a coded timeout
+// error without blocking forever; the underlying drain continues in the
+// background (Runtime.Run's own registerCleanup timeout, exitTimeout, still
+// applies) — a subsequent Stop call returns the same timeout result rather
+// than re-waiting, per the idempotency guarantee above.
+func (h *Handle) Stop(ctx context.Context) error {
+	if h == nil {
+		return conduiterr.New(conduiterr.CodeInvalidArgument, "conduit: Stop called on a nil *Handle")
+	}
+
+	h.stopOnce.Do(func() {
+		h.cancel()
+		select {
+		case h.stopErr = <-h.done:
+			if h.stopErr != nil && cerrors.Is(h.stopErr, context.Canceled) {
+				// A canceled ctx is Stop's own expected shutdown trigger, not
+				// a failure the caller needs to see.
+				h.stopErr = nil
+			}
+		case <-ctx.Done():
+			h.stopErr = conduiterr.Wrap(conduiterr.CodeInvalidArgument,
+				"conduit: timed out waiting for the engine to stop", ctx.Err())
+		}
+	})
+	return h.stopErr
+}
+
+// Import creates or updates a pipeline from cfg, delegating to the same
+// provisioning path the HTTP/gRPC API and CLI use
+// (provisioning.Service.Import) — no divergent logic. cfg is tagged as
+// programmatically provisioned internally, so it is not removed by
+// config-file reconciliation on a future Run (see
+// pkg/provisioning/import.go's doc on Import vs. the config-file path).
+//
+// Import enriches cfg with the same defaults the file-based provisioning path
+// applies (provisioning/config.Enrich — DLQ defaults, connector/processor
+// Settings, ID namespacing) and validates the result (provisioning/config.Validate)
+// before handing it to the provisioning service, exactly mirroring
+// provisioning.Service's own file-based provisionPipeline. This matters for a
+// hand-built PipelineConfig literal specifically: provisioning.Service.Import
+// assumes an already-enriched config (e.g. it dereferences cfg.DLQ.WindowSize/
+// WindowNackThreshold directly, which are nil on a zero-value DLQ) — skipping
+// Enrich here would crash on the exact construction pattern Import exists for.
+// A malformed cfg (after enrichment) is rejected as a coded error from
+// Validate, not a later, harder-to-diagnose provisioning failure.
+func (e *Engine) Import(ctx context.Context, cfg PipelineConfig) error {
+	cfg = provisioningconfig.Enrich(cfg)
+	if err := provisioningconfig.Validate(cfg); err != nil {
+		return err
+	}
+	return e.runtime.ProvisionService.Import(ctx, cfg)
+}
+
+// StartPipeline starts a previously imported/provisioned pipeline by ID,
+// delegating to the orchestrator unchanged.
+func (e *Engine) StartPipeline(ctx context.Context, pipelineID string) error {
+	return e.runtime.Orchestrator.Pipelines.Start(ctx, pipelineID)
+}
+
+// StopPipeline stops a running pipeline by ID, delegating to the
+// orchestrator unchanged. force, when true, skips the graceful drain for
+// that single pipeline (mirrors the orchestrator's own Stop semantics) —
+// an embedder that wants Invariant-7 graceful shutdown for everything should
+// prefer Handle.Stop (which always drains) over StopPipeline(force=true) for
+// individual pipelines.
+func (e *Engine) StopPipeline(ctx context.Context, pipelineID string, force bool) error {
+	return e.runtime.Orchestrator.Pipelines.Stop(ctx, pipelineID, force)
+}

--- a/conduit.go
+++ b/conduit.go
@@ -117,6 +117,34 @@ type APIOptions struct {
 
 // Engine is a constructed, not-yet-running Conduit instance. Obtain one with
 // New; start it with Run.
+//
+// # Lifecycle contract
+//
+// New eagerly opens Options.DB (see New's doc) — that resource exists from
+// New onward, independent of whether Run is ever called or succeeds. Close
+// releases it, and is the only supported release path outside of a normal
+// Run→Stop cycle. Concretely:
+//
+//   - New → Close (Run never called): Close releases the database opened by
+//     New. Required if the embedder decides not to run the engine after all
+//     (e.g. it was constructed speculatively, or a later precondition check
+//     failed) — otherwise the DB handle (a Badger file lock, a Postgres pool,
+//     a SQLite handle) leaks for the process lifetime.
+//   - New → Run (fails before Ready, including the already-done-context
+//     guard) → Close: started still flips true on the Run call (see below),
+//     but the database was never handed to Runtime's own cleanup path
+//     (registerCleanup), so Close is still required to release it.
+//   - New → Run (succeeds) → Stop → Close: Stop's drain already closed the
+//     database via Runtime's cleanup path. Close is safe to call anyway — it
+//     is idempotent with that path, not merely with itself — and returns nil.
+//   - Close is safe to call more than once from the same or different
+//     goroutines; every call after the first observes the same result.
+//
+// started flips to true the moment Run is *called*, not when it succeeds: a
+// failed Run permanently retires this Engine for running (a second Run
+// attempt — even after a failure — returns the same
+// conduiterr.CodeInvalidArgument "called more than once" error Run's own doc
+// describes). Close is unaffected by started and may be called in any state.
 type Engine struct {
 	runtime *pkgconduit.Runtime
 	started atomic.Bool
@@ -131,6 +159,10 @@ type Engine struct {
 // Every failure is returned as an error — a *conduiterr.ConduitError where
 // classifiable — never an os.Exit and never a panic on a caller-supplied
 // misconfiguration.
+//
+// New's eagerly-opened database is a resource an embedder must release: call
+// Engine.Close when the returned Engine is no longer needed, whether or not
+// Run was ever called — see Engine's "Lifecycle contract" doc.
 func New(ctx context.Context, opts Options) (*Engine, error) {
 	logger := opts.Logger
 	if logger == nil {
@@ -178,6 +210,30 @@ func New(ctx context.Context, opts Options) (*Engine, error) {
 	}
 
 	return &Engine{runtime: rt}, nil
+}
+
+// Close releases resources New acquired eagerly — currently, the configured
+// database.DB — regardless of whether Run was ever called on this Engine.
+// See Engine's "Lifecycle contract" doc for the states Close must cover.
+//
+// Close is idempotent: it is safe to call more than once, from any goroutine,
+// and safe to call after a successful Run→Stop cycle (where the database was
+// already released via Runtime's own cleanup path) — every call after the
+// first returns the same result. It delegates to Runtime.CloseDB, whose
+// sync.Once is what actually makes double-release across both paths safe;
+// Close itself does not need a separate guard.
+//
+// Close does not stop a running Engine — an Engine with Run in flight must be
+// stopped via Handle.Stop first (Invariant 7: that is the graceful-drain
+// path). Calling Close while Run is running closes the database out from
+// under the running pipelines, which is a caller error, not something Close
+// detects or prevents.
+//
+// ctx is accepted for interface symmetry with Stop and for future resources
+// that may need a bounded release; the current database.DB.Close call is not
+// itself context-aware.
+func (e *Engine) Close(_ context.Context) error {
+	return e.runtime.CloseDB()
 }
 
 // Handle is returned by Engine.Run once the engine has successfully started.

--- a/conduit_test.go
+++ b/conduit_test.go
@@ -243,13 +243,102 @@ func TestNew_StoreAlreadyOpen_ReturnsCodedError(t *testing.T) {
 
 	e1, err := conduit.New(context.Background(), opts)
 	is.NoErr(err)
-	_ = e1
+	defer func() { is.NoErr(e1.Close(context.Background())) }()
 
 	_, err = conduit.New(context.Background(), opts)
 	is.True(err != nil)
 	ce, ok := conduiterr.Get(err)
 	is.True(ok)
 	is.Equal(ce.Code, conduiterr.CodeUnavailable)
+}
+
+// TestClose_NoRun_ReleasesDB proves Engine.Close's first lifecycle-contract
+// case: New followed directly by Close (Run never called) releases the
+// database New opened eagerly. It uses a BadgerDB path (a real OS-level file
+// lock, unlike the in-memory store other tests default to) and proves release
+// the same way TestNew_StoreAlreadyOpen_ReturnsCodedError proves the leak: a
+// second Engine constructed at the same path only succeeds if the first
+// Engine's DB was actually closed, not merely garbage-collected.
+func TestClose_NoRun_ReleasesDB(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	opts := conduit.Options{
+		PipelinesDir: t.TempDir(),
+		DB:           conduit.DBOptions{Type: "badger"},
+	}
+	opts.DB.Badger.Path = dir
+
+	e1, err := conduit.New(ctx, opts)
+	is.NoErr(err)
+
+	is.NoErr(e1.Close(ctx)) // no Run was ever called
+
+	e2, err := conduit.New(ctx, opts)
+	is.NoErr(err) // would fail with CodeUnavailable if e1's DB were still holding the lock
+	is.NoErr(e2.Close(ctx))
+}
+
+// TestClose_AfterRunHitsAlreadyDoneContextGuard_ReleasesDB proves Engine.Close's
+// second lifecycle-contract case: Run reaching pkgconduit.Runtime.Run's
+// already-done-context guard (a pre-canceled ctx) returns before
+// registerCleanup is ever registered, so the runtime's own cleanup path never
+// closes the database — Close is the only release path left, and it must
+// still work. started flipping true on the Run call (not on success) must not
+// block Close.
+func TestClose_AfterRunHitsAlreadyDoneContextGuard_ReleasesDB(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	opts := conduit.Options{
+		PipelinesDir: t.TempDir(),
+		DB:           conduit.DBOptions{Type: "badger"},
+	}
+	opts.DB.Badger.Path = dir
+
+	e1, err := conduit.New(ctx, opts)
+	is.NoErr(err)
+
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel() // already canceled before Run is ever called
+
+	h, err := e1.Run(canceledCtx)
+	is.True(err != nil) // guard trips: Run must fail, not hang or succeed
+	is.True(h == nil)
+
+	is.NoErr(e1.Close(ctx)) // must still release the DB despite the failed Run
+
+	e2, err := conduit.New(ctx, opts)
+	is.NoErr(err) // would fail with CodeUnavailable if e1's DB leaked
+	is.NoErr(e2.Close(ctx))
+}
+
+// TestClose_DoubleCloseIsSafe proves Close's idempotency guarantee: calling it
+// twice returns the same (nil) result both times, with no panic and no
+// double-close error surfacing to the caller.
+func TestClose_DoubleCloseIsSafe(t *testing.T) {
+	is := is.New(t)
+	e := newTestEngine(t, conduit.Options{})
+
+	is.NoErr(e.Close(context.Background()))
+	is.NoErr(e.Close(context.Background()))
+}
+
+// TestClose_AfterSuccessfulStop_IsSafe proves Close's third lifecycle-contract
+// case: calling Close after a normal Run->Stop cycle (where Stop's drain
+// already closed the database via Runtime's own cleanup path) is safe and
+// returns nil, not a double-close error.
+func TestClose_AfterSuccessfulStop_IsSafe(t *testing.T) {
+	is := is.New(t)
+	e := newTestEngine(t, conduit.Options{})
+
+	h, err := e.Run(context.Background())
+	is.NoErr(err)
+	is.NoErr(h.Stop(context.Background()))
+
+	is.NoErr(e.Close(context.Background()))
 }
 
 // TestNew_MetricNameCollision_ReturnsCodedError proves failure mode 7: two

--- a/conduit_test.go
+++ b/conduit_test.go
@@ -1,0 +1,298 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conduit_test
+
+import (
+	"context"
+	"net"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	conduit "github.com/conduitio/conduit"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	provisioningconfig "github.com/conduitio/conduit/pkg/provisioning/config"
+	promclient "github.com/prometheus/client_golang/prometheus"
+
+	"github.com/matryer/is"
+)
+
+// newTestEngine constructs an Engine with an in-memory DB, the API disabled,
+// and an isolated pipelines dir, suitable for tests that don't care about
+// those specifics.
+func newTestEngine(t *testing.T, opts conduit.Options) *conduit.Engine {
+	t.Helper()
+	is := is.New(t)
+
+	if opts.PipelinesDir == "" {
+		opts.PipelinesDir = t.TempDir()
+	}
+	if opts.DB.Type == "" && opts.DB.Driver == nil {
+		opts.DB.Type = "inmemory"
+	}
+
+	e, err := conduit.New(context.Background(), opts)
+	is.NoErr(err)
+	is.True(e != nil)
+	return e
+}
+
+// TestNew_ConstructsEngine proves AC-1: the literal first line every embedder
+// copies (`conduit.New(ctx, Options{...})`) compiles and returns a usable
+// *Engine.
+func TestNew_ConstructsEngine(t *testing.T) {
+	newTestEngine(t, conduit.Options{})
+}
+
+// TestNew_NilLogger_DefaultsToSlogDefault proves Options.Logger's documented
+// zero-value semantics: nil is a safe, explicit default (slog.Default()), not
+// an error.
+func TestNew_NilLogger_DefaultsToSlogDefault(t *testing.T) {
+	is := is.New(t)
+	e, err := conduit.New(context.Background(), conduit.Options{
+		PipelinesDir: t.TempDir(),
+		DB:           conduit.DBOptions{Type: "inmemory"},
+	})
+	is.NoErr(err)
+	is.True(e != nil)
+}
+
+// TestNew_NilRegisterer_DisablesMetrics proves Options.MetricsRegisterer's
+// documented zero-value semantics: nil means "disable metrics", not an
+// error — deliberately asymmetric with Logger's nil handling (see Options'
+// doc).
+func TestNew_NilRegisterer_DisablesMetrics(t *testing.T) {
+	is := is.New(t)
+	e, err := conduit.New(context.Background(), conduit.Options{
+		PipelinesDir:      t.TempDir(),
+		DB:                conduit.DBOptions{Type: "inmemory"},
+		MetricsRegisterer: nil,
+	})
+	is.NoErr(err)
+	is.True(e != nil)
+}
+
+// TestRun_FailsBeforeReady proves AC-4's first of exactly two resolution
+// paths: Run returns a non-nil error (never blocking) when startup fails
+// before the engine becomes ready — here, a gRPC address already bound by
+// another listener.
+func TestRun_FailsBeforeReady(t *testing.T) {
+	is := is.New(t)
+
+	var lc net.ListenConfig
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	is.NoErr(err)
+	defer ln.Close()
+	busyAddr := ln.Addr().String()
+
+	e := newTestEngine(t, conduit.Options{
+		API: conduit.APIOptions{
+			Enabled:     true,
+			GRPCAddress: busyAddr, // already bound: serveGRPCAPI must fail
+			HTTPAddress: "127.0.0.1:0",
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	h, err := e.Run(ctx)
+	is.True(err != nil) // must fail, not hang
+	is.True(h == nil)
+}
+
+// TestRun_CalledTwice_ReturnsCodedError proves the must-fix decision: a
+// second Run call returns the existing conduiterr.CodeInvalidArgument, not a
+// new speculative code.
+func TestRun_CalledTwice_ReturnsCodedError(t *testing.T) {
+	is := is.New(t)
+	e := newTestEngine(t, conduit.Options{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h, err := e.Run(ctx)
+	is.NoErr(err)
+	defer func() { _ = h.Stop(context.Background()) }()
+
+	_, err = e.Run(context.Background())
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code, conduiterr.CodeInvalidArgument)
+}
+
+// TestStop_NilHandle_ReturnsCodedError proves the must-fix decision: calling
+// Stop on a nil *Handle returns the existing conduiterr.CodeInvalidArgument
+// rather than panicking.
+func TestStop_NilHandle_ReturnsCodedError(t *testing.T) {
+	is := is.New(t)
+	var h *conduit.Handle
+
+	err := h.Stop(context.Background())
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code, conduiterr.CodeInvalidArgument)
+}
+
+// TestStop_ConcurrentIdempotent proves Stop's idempotency guarantee: N
+// concurrent callers get the same result, no panic, no double-close.
+func TestStop_ConcurrentIdempotent(t *testing.T) {
+	is := is.New(t)
+	e := newTestEngine(t, conduit.Options{})
+
+	h, err := e.Run(context.Background())
+	is.NoErr(err)
+
+	const n = 10
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = h.Stop(context.Background())
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 1; i < n; i++ {
+		is.Equal(errs[i], errs[0])
+	}
+	is.NoErr(errs[0])
+}
+
+// TestStop_DeadlineExceeded proves Stop returns a distinguishable timeout
+// error, bounded by ctx, without blocking forever.
+func TestStop_DeadlineExceeded(t *testing.T) {
+	is := is.New(t)
+	e := newTestEngine(t, conduit.Options{})
+
+	h, err := e.Run(context.Background())
+	is.NoErr(err)
+	defer func() { _ = h.Stop(context.Background()) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	time.Sleep(time.Millisecond) // ensure the deadline has genuinely elapsed
+
+	err = h.Stop(ctx)
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code, conduiterr.CodeInvalidArgument)
+}
+
+// TestNew_StoreAlreadyOpen_ReturnsCodedError proves failure mode 4: two
+// engines opening the same BadgerDB path in one process surface the
+// existing coded CodeUnavailable path (OpenStore's own tagging), not a
+// generic OS error or a panic.
+func TestNew_StoreAlreadyOpen_ReturnsCodedError(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+
+	opts := conduit.Options{
+		PipelinesDir: t.TempDir(),
+		DB: conduit.DBOptions{
+			Type: "badger",
+		},
+	}
+	opts.DB.Badger.Path = dir
+
+	e1, err := conduit.New(context.Background(), opts)
+	is.NoErr(err)
+	_ = e1
+
+	_, err = conduit.New(context.Background(), opts)
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code, conduiterr.CodeUnavailable)
+}
+
+// TestNew_MetricNameCollision_ReturnsCodedError proves failure mode 7: two
+// engines sharing one prometheus.Registerer collide on Conduit's metric
+// names, surfacing a coded error from New rather than MustRegister's panic.
+func TestNew_MetricNameCollision_ReturnsCodedError(t *testing.T) {
+	is := is.New(t)
+	reg := promclient.NewRegistry()
+
+	_, err := conduit.New(context.Background(), conduit.Options{
+		PipelinesDir:      t.TempDir(),
+		DB:                conduit.DBOptions{Type: "inmemory"},
+		MetricsRegisterer: reg,
+	})
+	is.NoErr(err)
+
+	_, err = conduit.New(context.Background(), conduit.Options{
+		PipelinesDir:      t.TempDir(),
+		DB:                conduit.DBOptions{Type: "inmemory"},
+		MetricsRegisterer: reg,
+	})
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code, conduiterr.CodeInvalidArgument)
+}
+
+// TestPipelineConfig_IsAliasOfProvisioningConfig proves AC-3: PipelineConfig
+// is a type alias of (identical type to) provisioning/config.Pipeline, not a
+// parallel copy that could drift.
+func TestPipelineConfig_IsAliasOfProvisioningConfig(t *testing.T) {
+	is := is.New(t)
+	is.Equal(
+		reflect.TypeOf(conduit.PipelineConfig{}),
+		reflect.TypeOf(provisioningconfig.Pipeline{}),
+	)
+}
+
+// TestImport_RoundTripsThroughRunningEngine proves Engine.Import delegates to
+// the real provisioning path end to end: a pipeline built as a
+// PipelineConfig literal, imported, and started via StartPipeline actually
+// reaches StatusRunning, then stops cleanly via Handle.Stop.
+func TestImport_RoundTripsThroughRunningEngine(t *testing.T) {
+	is := is.New(t)
+	e := newTestEngine(t, conduit.Options{})
+
+	h, err := e.Run(context.Background())
+	is.NoErr(err)
+
+	cfg := conduit.PipelineConfig{
+		ID:     "hello-pipeline",
+		Status: "stopped",
+		Name:   "hello",
+		Connectors: []provisioningconfig.Connector{
+			{ID: "src", Type: "source", Plugin: "builtin:generator", Settings: map[string]string{
+				"format.type": "raw",
+				"recordCount": "1",
+			}},
+			{ID: "dst", Type: "destination", Plugin: "builtin:log"},
+		},
+	}
+
+	ctx := context.Background()
+	err = e.Import(ctx, cfg)
+	is.NoErr(err)
+
+	err = e.StartPipeline(ctx, cfg.ID)
+	is.NoErr(err)
+
+	err = e.StopPipeline(ctx, cfg.ID, false)
+	is.NoErr(err)
+
+	is.NoErr(h.Stop(context.Background()))
+}

--- a/conduit_test.go
+++ b/conduit_test.go
@@ -114,6 +114,34 @@ func TestRun_FailsBeforeReady(t *testing.T) {
 	is.True(h == nil)
 }
 
+// TestRun_AlreadyCanceledContext proves AC-4's second resolution path: Run
+// returns promptly (never blocking) when handed an already-canceled context.
+func TestRun_AlreadyCanceledContext(t *testing.T) {
+	is := is.New(t)
+	e := newTestEngine(t, conduit.Options{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	type result struct {
+		h   *conduit.Handle
+		err error
+	}
+	resC := make(chan result, 1)
+	go func() {
+		h, err := e.Run(ctx)
+		resC <- result{h, err}
+	}()
+
+	select {
+	case res := <-resC:
+		is.True(res.err != nil)
+		is.True(res.h == nil)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return promptly for an already-canceled context")
+	}
+}
+
 // TestRun_CalledTwice_ReturnsCodedError proves the must-fix decision: a
 // second Run call returns the existing conduiterr.CodeInvalidArgument, not a
 // new speculative code.

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,83 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package conduit is Conduit's embeddable Go API — the frozen, semver-committed
+// import path a Go application uses to run a Conduit engine in-process, without
+// touching os.Exit, a global logger, or the process-wide default Prometheus
+// registry.
+//
+// # Scope (v1 / "B1")
+//
+// This package covers the engine lifecycle only: New constructs an Engine from
+// Options; Engine.Run starts it and returns a *Handle once it is ready to
+// accept work; Handle.Stop drains and shuts it down. Engine.Import lets a host
+// create or update a pipeline from a PipelineConfig value built in code — the
+// pipelines-in-code builder (NewPipeline/PipelineBuilder) and the C-ABI/
+// language-binding surface (libconduit proper) are later workstreams; see
+// docs/design-documents/20260722-embed-libconduit-v1.md.
+//
+// # Why this exists, not pkg/conduit directly
+//
+// pkg/conduit (docs/package_structure.md) is documented internal: its
+// NewRuntime/Entrypoint.Serve API prints a splash to os.Stdout, calls os.Exit
+// on error, writes logs unconditionally to os.Stdout, and registers metrics
+// into the process-global Prometheus DefaultRegisterer — all correct defaults
+// for a CLI process, all wrong for a library an application embeds alongside
+// its own logging and metrics. This package wraps pkg/conduit with a handful
+// of additive seams (see pkg/conduit.RuntimeOption) so the CLI's behavior is
+// byte-for-byte unchanged while an embedder gets full control: every log line
+// goes through a host-supplied *slog.Logger (or slog.Default(), an explicit,
+// documented fallback — never os.Stdout), every metric goes through a
+// host-supplied prometheus.Registerer (nil disables metrics entirely — never
+// the default registry), and every failure is returned as an error, never an
+// os.Exit or a panic.
+//
+// # Invariants
+//
+//   - Invariant 7 (graceful shutdown): Handle.Stop reuses Runtime.Run's
+//     existing ctx-cancellation-driven drain (registerCleanup, dispatching to
+//     registerCleanupV1/V2 — unchanged by this package) unchanged. Stop
+//     supplies a different *trigger* (an explicit call cancelling Run's
+//     context) for the identical mechanism `conduit run`'s SIGTERM handling
+//     already exercises via Entrypoint.CancelOnInterrupt — it does not
+//     reimplement or duplicate drain logic.
+//   - Invariants 1-6 (ack/position/ordering/checkpoint/schema): not implicated.
+//     This package does not touch the record data path. Engine.Import
+//     delegates to provisioning.Service.Import unchanged; PipelineConfig is a
+//     type alias (not a copy) of the exact struct the YAML provisioner
+//     produces, so no new serialized shape is introduced.
+//
+// # Known limitation: metrics cross-talk across engines
+//
+// Two Engines in the same process, each with its own MetricsRegisterer, are
+// genuinely isolated as distinct prometheus.Registerer/Registry *objects* —
+// but pkg/foundation/metrics keeps process-global metric *definitions*, so a
+// metric defined via that package's package-level constructors (everything in
+// pkg/foundation/metrics/measure) still fans its *values* out to every
+// registry ever registered in the process, including a second Engine's. This
+// is a known, accepted limitation for v1 (not fixed by this package), tracked
+// as a follow-up; see pkg/conduit.WithMetricsRegisterer's doc and
+// TestTwoEngines_MetricsCrossTalk_KnownLimitation.
+//
+// # Package boundary / deprecation policy
+//
+// This package's exported API (Options, Engine, Handle, PipelineConfig, New)
+// is a public contract, versioned like the connector protocol, pipeline
+// config schema, and error codes: a breaking change is announced (CHANGELOG +
+// a `Deprecated:` godoc comment) in one monthly release, kept working with a
+// warning for at least one more minor release, and removed no earlier than
+// the third minor release after announcement. PipelineConfig extends this
+// policy by name to provisioning/config.{Pipeline,Connector,Processor,DLQ} —
+// see that package's parser.go doc comment.
+package conduit

--- a/doc.go
+++ b/doc.go
@@ -20,12 +20,15 @@
 // # Scope (v1 / "B1")
 //
 // This package covers the engine lifecycle only: New constructs an Engine from
-// Options; Engine.Run starts it and returns a *Handle once it is ready to
-// accept work; Handle.Stop drains and shuts it down. Engine.Import lets a host
-// create or update a pipeline from a PipelineConfig value built in code — the
-// pipelines-in-code builder (NewPipeline/PipelineBuilder) and the C-ABI/
-// language-binding surface (libconduit proper) are later workstreams; see
-// docs/design-documents/20260722-embed-libconduit-v1.md.
+// Options (and eagerly opens its database — see New's and Engine.Close's doc);
+// Engine.Run starts it and returns a *Handle once it is ready to accept work;
+// Handle.Stop drains and shuts it down; Engine.Close releases the resources
+// New acquired, whether or not Run was ever called — see Engine's "Lifecycle
+// contract" doc for the exact New/Run/Stop/Close state matrix. Engine.Import
+// lets a host create or update a pipeline from a PipelineConfig value built in
+// code — the pipelines-in-code builder (NewPipeline/PipelineBuilder) and the
+// C-ABI/language-binding surface (libconduit proper) are later workstreams;
+// see docs/design-documents/20260722-embed-libconduit-v1.md.
 //
 // # Why this exists, not pkg/conduit directly
 //
@@ -70,6 +73,15 @@
 // as a follow-up; see pkg/conduit.WithMetricsRegisterer's doc and
 // TestTwoEngines_MetricsCrossTalk_KnownLimitation.
 //
+// Two sharper instances of the same root cause are tracked separately, also
+// accepted for v1: a failed metrics registration during New still leaks a
+// registry into pkg/foundation/metrics' process-global bookkeeping
+// (https://github.com/ConduitIO/conduit/issues/2669, see
+// pkg/conduit.configureEmbeddedMetrics' doc), and the HTTP /metrics route
+// serves promclient.DefaultGatherer rather than a host-supplied
+// MetricsRegisterer (https://github.com/ConduitIO/conduit/issues/2670, see
+// pkg/conduit.(*Runtime).newHTTPMetricsHandler's doc).
+//
 // # Package boundary / deprecation policy
 //
 // This package's exported API (Options, Engine, Handle, PipelineConfig, New)
@@ -79,5 +91,8 @@
 // warning for at least one more minor release, and removed no earlier than
 // the third minor release after announcement. PipelineConfig extends this
 // policy by name to provisioning/config.{Pipeline,Connector,Processor,DLQ} —
-// see that package's parser.go doc comment.
+// all four are constrained by the single doc comment above
+// provisioning/config.Pipeline in that package's parser.go (Connector,
+// Processor, and DLQ have no separate per-type comment of their own; they are
+// covered by name in that one shared comment, not individually annotated).
 package conduit

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,132 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conduit_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	conduit "github.com/conduitio/conduit"
+	provisioningconfig "github.com/conduitio/conduit/pkg/provisioning/config"
+)
+
+// helloPipeline runs the full New->Run->Import->Stop lifecycle with a single
+// generator->log pipeline, entirely in-memory. It is the shared logic behind
+// Example_helloPipeline (compiled+run by `go test`, checked against captured
+// Output) and TestExampleHelloPipeline_WithinBudget (a CI-timed wall-clock
+// budget assertion — deliberately separate from the human-facing "15 minutes
+// to a running pipeline" doc claim, which is a UX statement, not something a
+// test can measure; see the embed workstream plan §12 open question 1).
+func helloPipeline(ctx context.Context, dir string) error {
+	e, err := conduit.New(ctx, conduit.Options{
+		Logger:       slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		DB:           conduit.DBOptions{Type: "inmemory"},
+		PipelinesDir: dir,
+	})
+	if err != nil {
+		return err
+	}
+
+	h, err := e.Run(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = e.Import(ctx, conduit.PipelineConfig{
+		ID:   "hello-pipeline",
+		Name: "hello-pipeline",
+		Connectors: []provisioningconfig.Connector{
+			{
+				ID:     "src",
+				Type:   "source",
+				Plugin: "builtin:generator",
+				Settings: map[string]string{
+					"format.type": "raw",
+					"recordCount": "5",
+				},
+			},
+			{
+				ID:     "dst",
+				Type:   "destination",
+				Plugin: "builtin:log",
+			},
+		},
+	})
+	if err != nil {
+		_ = h.Stop(ctx)
+		return err
+	}
+
+	if err := e.StartPipeline(ctx, "hello-pipeline"); err != nil {
+		_ = h.Stop(ctx)
+		return err
+	}
+
+	// Let a handful of generated records flow through to the log destination.
+	time.Sleep(50 * time.Millisecond)
+
+	// Invariant 7: Stop alone drains every running pipeline (including this
+	// one) and checkpoints before returning — no separate per-pipeline stop
+	// call is needed first.
+	return h.Stop(ctx)
+}
+
+// Example_helloPipeline demonstrates the three-call embed lifecycle
+// (New -> Run -> Stop) plus Import, end to end: an in-memory database, a
+// generator source, and a log destination. This is the literal example a
+// `go get github.com/conduitio/conduit` embedder copies first.
+func Example_helloPipeline() {
+	ctx := context.Background()
+	dir, err := os.MkdirTemp("", "conduit-embed-example-*")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	defer os.RemoveAll(dir)
+
+	if err := helloPipeline(ctx, dir); err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("pipeline stopped cleanly")
+	// Output: pipeline stopped cleanly
+}
+
+// TestExampleHelloPipeline_WithinBudget is the CI-timed half of AC-8: it
+// asserts the doc example's own execution — construct, run, import, start,
+// stop — stays within a generous wall-clock ceiling. This is deliberately
+// NOT a claim about how long a human takes to copy-paste the doc and get a
+// pipeline running (that's a UX/docs-quality metric, not something a test
+// process's clock can measure) — the plan's §12 open question 1 flags this
+// distinction explicitly and recommends keeping the two separate rather than
+// conflating them. The ceiling here (60s) is generous on purpose: it exists
+// to catch a hang/regression (e.g. a Stop that no longer returns), not to
+// benchmark performance.
+func TestExampleHelloPipeline_WithinBudget(t *testing.T) {
+	dir := t.TempDir()
+	start := time.Now()
+
+	if err := helloPipeline(context.Background(), dir); err != nil {
+		t.Fatalf("helloPipeline failed: %v", err)
+	}
+
+	if elapsed := time.Since(start); elapsed > 60*time.Second {
+		t.Fatalf("helloPipeline took %s, exceeding the 60s CI wall-clock budget", elapsed)
+	}
+}

--- a/log_adapter.go
+++ b/log_adapter.go
@@ -1,0 +1,117 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conduit
+
+import (
+	"context"
+	"log/slog"
+
+	json "github.com/goccy/go-json"
+
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/rs/zerolog"
+)
+
+// zerolog's own default field names (set by the zerolog package itself, never
+// overridden anywhere in this module — see pkg/foundation/log/ctxlogger.go's
+// init, which only touches TimeFieldFormat/ErrorStackMarshaler).
+const (
+	zerologFieldLevel   = "level"
+	zerologFieldMessage = "message"
+	zerologFieldTime    = "time"
+)
+
+// newSlogCtxLogger builds a log.CtxLogger that forwards every log line to
+// logger instead of any Conduit-owned stdout writer. It is the internal
+// zerolog->slog adapter alternative #2 in the embed workstream plan chose to
+// keep in this package (unexported), rather than teaching
+// pkg/foundation/log about slog: the dependency direction stays one-way
+// (this package -> pkg/foundation/log, never the reverse).
+//
+// Conduit's logging is built on zerolog throughout (log.CtxLogger wraps
+// zerolog.Logger); rather than a second, parallel logging implementation for
+// the embed path, this constructs a real zerolog.Logger whose io.Writer
+// decodes each JSON-encoded log line and re-emits it through logger via
+// slog.Logger.LogAttrs, preserving level, message, and every structured
+// field as an slog attribute. It never writes to os.Stdout/os.Stderr.
+func newSlogCtxLogger(logger *slog.Logger) log.CtxLogger {
+	zl := zerolog.New(&slogWriter{logger: logger}).With().Timestamp().Stack().Logger()
+	return log.New(zl)
+}
+
+// slogWriter is an io.Writer that decodes each zerolog JSON log line (one
+// Write call per line, as zerolog always emits) and re-emits it through an
+// *slog.Logger. It is the single sink for Conduit's log output on the embed
+// path — see newSlogCtxLogger.
+type slogWriter struct {
+	logger *slog.Logger
+}
+
+// Write implements io.Writer. It always reports success for the full byte
+// count: zerolog does not retry or otherwise interpret a Write error, so a
+// decode failure here is logged as a best-effort fallback message instead of
+// being surfaced as a write error that zerolog has no useful way to react to.
+func (w *slogWriter) Write(p []byte) (int, error) {
+	n := len(p)
+
+	var fields map[string]any
+	if err := json.Unmarshal(p, &fields); err != nil {
+		// Not a decodable JSON line (should not happen with zerolog's own
+		// encoder) — surface the raw text rather than silently dropping it.
+		w.logger.Info(string(p))
+		return n, nil
+	}
+
+	level := slogLevel(fields[zerologFieldLevel])
+	msg, _ := fields[zerologFieldMessage].(string)
+	delete(fields, zerologFieldLevel)
+	delete(fields, zerologFieldMessage)
+	delete(fields, zerologFieldTime)
+
+	attrs := make([]slog.Attr, 0, len(fields))
+	for k, v := range fields {
+		attrs = append(attrs, slog.Any(k, v))
+	}
+
+	// context.Background(): the originating log.CtxLogger call's ctx is not
+	// available here (io.Writer.Write only receives encoded bytes) — slog
+	// handlers in the standard library do not read values from ctx beyond
+	// cancellation, so this is not a loss of information any handler Conduit
+	// ships with would otherwise use.
+	w.logger.LogAttrs(context.Background(), level, msg, attrs...)
+	return n, nil
+}
+
+// slogLevel maps a zerolog level string to the nearest slog.Level. slog has
+// no Trace/Fatal/Panic levels, so trace folds into Debug and fatal/panic fold
+// into Error (Conduit's embed path never calls the CtxLogger methods that
+// call os.Exit/panic on the host's behalf — see log.CtxLogger.Fatal/Panic's
+// own doc — so this mapping is defensive, not expected to observe those
+// levels in practice).
+func slogLevel(v any) slog.Level {
+	s, _ := v.(string)
+	switch s {
+	case "trace", "debug":
+		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
+	case "warn":
+		return slog.LevelWarn
+	case "error", "fatal", "panic":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/observability_test.go
+++ b/observability_test.go
@@ -1,0 +1,181 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conduit_test
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	conduit "github.com/conduitio/conduit"
+	promclient "github.com/prometheus/client_golang/prometheus"
+
+	"github.com/matryer/is"
+)
+
+// helperProcessEnvVar, when set, tells TestMain-less test binary invocation
+// (via TestObservabilityIsolation_Subprocess re-exec below) to run as the
+// actual New->Run->Import->Stop cycle instead of as a normal test, so the
+// PARENT test process can observe this child's real os.Stdout/os.Stderr file
+// descriptors — the only way to prove "zero bytes written to the process's
+// real stdout/stderr" (AC-2c). Asserting against a captured os.Stdout var
+// from within the same process cannot see writes made through the raw fd
+// (e.g. by a C library or a lower-level fmt.Fprint(os.Stdout, ...) call this
+// package doesn't control), so this test re-execs itself as a subprocess.
+const helperProcessEnvVar = "CONDUIT_EMBED_OBSERVABILITY_HELPER"
+
+// TestObservabilityIsolation_Subprocess is the "parent" half: it re-execs
+// this test binary with helperProcessEnvVar set, capturing the child's real
+// stdout/stderr, and asserts both are byte-for-byte empty (AC-2c) even
+// though the child ran a full New->Run->Import->Stop cycle that logs
+// extensively (captured instead through an injected *slog.Logger writing to
+// a file the child reports back via its own stdout... no — see below).
+//
+// The child cannot use its own stdout to report results back (that would
+// defeat the "zero bytes to stdout" assertion for anything the child
+// deliberately writes), so it reports success/failure only through its
+// process exit code: 0 for "every assertion inside the child passed", and a
+// prints exactly one line to stderr on failure, which is asserted absent
+// separately when the exit code is 0 and asserted PRESENT (a diagnostic) when
+// it's not — this keeps the parent's stdout/stderr assertion meaningful
+// (empty on success) while still surfacing a failure reason for debugging.
+func TestObservabilityIsolation_Subprocess(t *testing.T) {
+	is := is.New(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestObservabilityIsolation_Subprocess", "-test.v")
+	cmd.Env = append(os.Environ(), helperProcessEnvVar+"=1")
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+
+	// AC-2c: zero bytes to the process's real stdout/stderr, regardless of
+	// how much the child logged through its injected slog.Logger.
+	is.Equal(stdout.String(), "")
+	is.Equal(stderr.String(), "")
+	is.NoErr(err) // the child's own internal assertions must have passed (see helper below)
+}
+
+// TestMain intercepts the subprocess re-exec: when helperProcessEnvVar is
+// set, it runs the observability child logic directly (never through go
+// test's normal reporting, which itself writes to stdout) and calls
+// os.Exit with the result, instead of running the normal test suite.
+func TestMain(m *testing.M) {
+	if os.Getenv(helperProcessEnvVar) == "1" {
+		if err := runObservabilityHelper(); err != nil {
+			// This IS the child's stderr — the parent asserts it's empty
+			// only when the child's exit code is 0; a non-zero exit here
+			// fails the parent's is.NoErr(err) check above with this
+			// message available for debugging via `go test -v` directly.
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+// runObservabilityHelper is the actual child logic: construct an Engine with
+// a captured slog.Handler and an isolated prometheus.Registry, run it,
+// import and start a pipeline, stop it, and verify (a) the handler captured
+// Conduit's log lines, (b) the registry contains Conduit's metric families,
+// (d) prometheus.DefaultRegisterer contains nothing Conduit-derived. It
+// deliberately writes nothing to os.Stdout/os.Stderr itself on the success
+// path — AC-2c is proved by the PARENT observing this process's real fds are
+// untouched, not by this function's own care.
+func runObservabilityHelper() error {
+	handler := &capturingHandler{}
+	logger := slog.New(handler)
+	reg := promclient.NewRegistry()
+
+	ctx := context.Background()
+	e, err := conduit.New(ctx, conduit.Options{
+		Logger:            logger,
+		MetricsRegisterer: reg,
+		DB:                conduit.DBOptions{Type: "inmemory"},
+		PipelinesDir:      mustTempDir(),
+	})
+	if err != nil {
+		return err
+	}
+
+	h, err := e.Run(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := e.Import(ctx, conduit.PipelineConfig{
+		ID:   "observability-check",
+		Name: "observability-check",
+	}); err != nil {
+		return err
+	}
+
+	if err := h.Stop(ctx); err != nil {
+		return err
+	}
+
+	// (a) the captured handler received Conduit's log lines.
+	if handler.count() == 0 {
+		return helperError("expected the injected slog handler to capture at least one log line")
+	}
+
+	// (b) the isolated registerer contains Conduit's metric families.
+	mfs, err := reg.Gather()
+	if err != nil {
+		return err
+	}
+	var foundConduitMetric bool
+	for _, mf := range mfs {
+		if mf.GetName() == "conduit_info" {
+			foundConduitMetric = true
+		}
+	}
+	if !foundConduitMetric {
+		return helperError("expected the isolated registerer to contain conduit_info")
+	}
+
+	// (d) prometheus.DefaultRegisterer contains nothing Conduit-derived.
+	defaultMfs, err := promclient.DefaultGatherer.Gather()
+	if err != nil {
+		return err
+	}
+	for _, mf := range defaultMfs {
+		if mf.GetName() == "conduit_info" {
+			return helperError("expected promclient.DefaultRegisterer to contain no Conduit metrics, found conduit_info")
+		}
+	}
+
+	return nil
+}
+
+type helperError string
+
+func (e helperError) Error() string { return string(e) }
+
+func mustTempDir() string {
+	dir, err := os.MkdirTemp("", "conduit-embed-observability-*")
+	if err != nil {
+		panic(err)
+	}
+	return dir
+}

--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -109,6 +109,76 @@ type Runtime struct {
 	procSchemaService  *procutils.SchemaService
 
 	logger log.CtxLogger
+
+	// metricsGrpcStatsHandler is this Runtime's grpc stats handler, used by
+	// serveGRPCAPI/startConnectorUtils. On the CLI path (no WithMetricsRegisterer
+	// option) it is the process-wide singleton configureMetrics() returns,
+	// exactly as before this field existed. On the embed path
+	// (WithMetricsRegisterer set) it is a fresh, per-Runtime instance
+	// registered only into the supplied registerer — see configureEmbeddedMetrics.
+	metricsGrpcStatsHandler *promgrpc.StatsHandler
+}
+
+// runtimeOptions holds the optional embed-only seams threaded through
+// NewRuntime via functional RuntimeOptions. The zero value matches
+// `conduit run`'s exact behavior — every field here is additive: leaving it
+// unset preserves what NewRuntime always did (AC-5: the seam is inert unless
+// an embed option is passed; see TestNewRuntime_CLIDefaultsUnchanged).
+type runtimeOptions struct {
+	logger            *log.CtxLogger
+	metricsRegisterer promclient.Registerer
+	dialCtx           context.Context
+}
+
+// RuntimeOption configures an embed-only seam on NewRuntime. See WithLogger,
+// WithMetricsRegisterer, WithDialContext.
+type RuntimeOption func(*runtimeOptions)
+
+// WithLogger supplies a pre-built log.CtxLogger, bypassing cfg.Log.NewLogger
+// and log.GetWriter's os.Stdout default entirely. It also suppresses the
+// process-global zerolog.DefaultContextLogger assignment NewRuntime otherwise
+// makes: that global is process-wide and would cross-talk between two
+// embedded Runtimes constructed with different loggers (see
+// TestTwoEngines_LoggerIsolated) — the supplied logger is still attached
+// directly to this Runtime and everything it constructs; only the ambient/
+// fallback global is skipped. `conduit run` never passes this option, so its
+// behavior (including the global assignment) is unchanged.
+func WithLogger(logger log.CtxLogger) RuntimeOption {
+	return func(o *runtimeOptions) { o.logger = &logger }
+}
+
+// WithMetricsRegisterer supplies a Prometheus registerer that receives this
+// Runtime's metric families instead of the package-level configureMetrics()
+// path (which registers into promclient.DefaultRegisterer behind a
+// process-wide sync.Once, and is a no-op after the first call in the
+// process). A Runtime constructed with this option gets its own
+// foundation/metrics/prometheus.Registry and *promgrpc.StatsHandler,
+// registered only into the supplied registerer — never
+// promclient.DefaultRegisterer. `conduit run` never passes this option.
+//
+// Known limitation (documented, not fixed by this seam): pkg/foundation/metrics
+// keeps process-global metric *definitions* (metrics.go's `global` slices) —
+// a metric created via metrics.NewCounter et al. (e.g. everything in
+// pkg/foundation/metrics/measure) fans out to every registry ever passed to
+// metrics.Register, including a second embedded Runtime's. Two concurrently
+// running embedded engines will therefore observe each other's metric
+// *values* even though each has its own isolated Registerer/Registry
+// *object*. See TestTwoEngines_MetricsCrossTalk_KnownLimitation — fixing this
+// is tracked as a follow-up, not this workstream (see the embed design doc's
+// Non-goals).
+func WithMetricsRegisterer(reg promclient.Registerer) RuntimeOption {
+	return func(o *runtimeOptions) { o.metricsRegisterer = reg }
+}
+
+// WithDialContext supplies the context.Context OpenStore's Postgres/SQLite
+// dial uses instead of context.Background(), so a caller-supplied deadline or
+// cancellation aborts a slow/unreachable database dial promptly instead of
+// blocking indefinitely. It has no effect on the Badger/InMemory DB types
+// (they never dial a remote/blocking connection). It is not retained beyond
+// NewRuntime's own call — Runtime.Run's context is independent and must be
+// supplied fresh to Run (do not store a ctx across calls).
+func WithDialContext(ctx context.Context) RuntimeOption {
+	return func(o *runtimeOptions) { o.dialCtx = ctx }
 }
 
 // lifecycleService is an interface that we use temporarily to allow for
@@ -130,25 +200,60 @@ type lifecycleService interface {
 	Init(ctx context.Context) error
 }
 
-// NewRuntime sets up a Runtime instance and primes it for start.
-func NewRuntime(cfg Config) (*Runtime, error) {
+// NewRuntime sets up a Runtime instance and primes it for start. opts are
+// additive, embed-only seams (see RuntimeOption); called with none, behavior
+// is byte-for-byte what NewRuntime did before opts existed — this is what
+// `conduit run` (via Entrypoint.Serve) always does.
+func NewRuntime(cfg Config, opts ...RuntimeOption) (*Runtime, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, cerrors.Errorf("invalid config: %w", err)
 	}
 
-	logger := cfg.Log.NewLogger(cfg.Log.Level, cfg.Log.Format)
+	var ro runtimeOptions
+	for _, opt := range opts {
+		opt(&ro)
+	}
+
+	var logger log.CtxLogger
+	if ro.logger != nil {
+		// Embed path (AC-5.1): use the pre-built logger as-is instead of
+		// cfg.Log.NewLogger/log.GetWriter's os.Stdout default.
+		logger = *ro.logger
+	} else {
+		logger = cfg.Log.NewLogger(cfg.Log.Level, cfg.Log.Format)
+	}
 	logger.Logger = logger.
 		Hook(ctxutil.MessageIDLogCtxHook{}).
 		Hook(ctxutil.RequestIDLogCtxHook{}).
 		Hook(ctxutil.FilepathLogCtxHook{})
-	zerolog.DefaultContextLogger = &logger.Logger
+	if ro.logger == nil {
+		// CLI path only (AC-5.3): an embed-supplied logger must never become
+		// the ambient global fallback — see WithLogger's doc.
+		zerolog.DefaultContextLogger = &logger.Logger
+	}
 
-	db, err := OpenStore(cfg, logger)
+	dialCtx := context.Background()
+	if ro.dialCtx != nil {
+		// AC-5.4: let an embedder bound/cancel the store dial.
+		dialCtx = ro.dialCtx
+	}
+
+	db, err := OpenStore(dialCtx, cfg, logger)
 	if err != nil {
 		return nil, err
 	}
 
-	configureMetrics()
+	var statsHandler *promgrpc.StatsHandler
+	if ro.metricsRegisterer != nil {
+		// Embed path (AC-5.2): isolated per-Runtime metrics, never the
+		// process-global promclient.DefaultRegisterer.
+		statsHandler, err = configureEmbeddedMetrics(ro.metricsRegisterer)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		statsHandler = configureMetrics()
+	}
 	measure.ConduitInfo.WithValues(Version(true)).Inc()
 
 	// Start the connector persister
@@ -164,7 +269,8 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 
 		connectorPersister: connectorPersister,
 
-		logger: logger,
+		logger:                  logger,
+		metricsGrpcStatsHandler: statsHandler,
 	}
 
 	err = createServices(r)
@@ -184,6 +290,10 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 // reachability the same way `conduit run` would, instead of reimplementing
 // or drifting from it.
 //
+// ctx bounds the Postgres/SQLite dial only (AC-5.4) — canceling it aborts a
+// slow/unreachable dial instead of blocking indefinitely. It has no effect on
+// Badger/InMemory (neither dials). ctx is not retained past this call.
+//
 // logger is a required parameter (not derived internally from cfg.Log) so a
 // caller that only wants to probe reachability — doctor runs before any
 // Runtime exists — can supply a throwaway logger (e.g. log.Nop()) instead of
@@ -192,7 +302,7 @@ func NewRuntime(cfg Config) (*Runtime, error) {
 // The returned database.DB is opened but not pinged; callers that only want
 // to validate config (not actually dial/open anything) should not call this.
 // A caller that opens a store here is responsible for calling Close on it.
-func OpenStore(cfg Config, logger log.CtxLogger) (database.DB, error) {
+func OpenStore(ctx context.Context, cfg Config, logger log.CtxLogger) (database.DB, error) {
 	if cfg.DB.Driver != nil {
 		return cfg.DB.Driver, nil
 	}
@@ -203,12 +313,12 @@ func OpenStore(cfg Config, logger log.CtxLogger) (database.DB, error) {
 	case DBTypeBadger:
 		db, err = badger.New(logger.Logger, cfg.DB.Badger.Path)
 	case DBTypePostgres:
-		db, err = postgres.New(context.Background(), logger.Logger, cfg.DB.Postgres.ConnectionString, cfg.DB.Postgres.Table)
+		db, err = postgres.New(ctx, logger.Logger, cfg.DB.Postgres.ConnectionString, cfg.DB.Postgres.Table)
 	case DBTypeInMemory:
 		db = &inmemory.DB{}
 		logger.Warn(context.Background()).Msg("Using in-memory store, all pipeline configurations will be lost when Conduit stops.")
 	case DBTypeSQLite:
-		db, err = sqlite.New(context.Background(), logger.Logger, cfg.DB.SQLite.Path, cfg.DB.SQLite.Table)
+		db, err = sqlite.New(ctx, logger.Logger, cfg.DB.SQLite.Path, cfg.DB.SQLite.Table)
 	default:
 		// An unsupported DB type is a config/validation problem, not an
 		// environment one. It stays exit 1 (the runtime default for an
@@ -374,6 +484,34 @@ func configureMetrics() *promgrpc.StatsHandler {
 		promclient.MustRegister(metricsGrpcStatsHandler)
 	})
 	return metricsGrpcStatsHandler
+}
+
+// configureEmbeddedMetrics is configureMetrics' embed-path counterpart (see
+// WithMetricsRegisterer): it builds a fresh, per-Runtime
+// foundation/metrics/prometheus.Registry and *promgrpc.StatsHandler and
+// registers both only into registerer — never promclient.DefaultRegisterer,
+// and never behind the CLI path's process-wide metricsConfigureOnce (each
+// call here produces an independent StatsHandler instance, so two embedded
+// Runtimes never share one).
+//
+// It uses registerer.Register (which returns an error) rather than
+// MustRegister (which panics) so a metric-name collision on a registerer the
+// caller reused across engines surfaces as a coded error from New, per
+// invariant: New never panics on a caller-supplied misconfiguration.
+func configureEmbeddedMetrics(registerer promclient.Registerer) (*promgrpc.StatsHandler, error) {
+	reg := prometheus.NewRegistry(nil)
+	metrics.Register(reg) // documented cross-talk limitation, see WithMetricsRegisterer's doc
+	if err := registerer.Register(reg); err != nil {
+		wrapped := cerrors.Errorf("failed to register conduit metrics collector: %w", err)
+		return nil, conduiterr.Wrap(conduiterr.CodeInvalidArgument, wrapped.Error(), wrapped)
+	}
+
+	statsHandler := promgrpc.ServerStatsHandler()
+	if err := registerer.Register(statsHandler); err != nil {
+		wrapped := cerrors.Errorf("failed to register grpc stats collector: %w", err)
+		return nil, conduiterr.Wrap(conduiterr.CodeInvalidArgument, wrapped.Error(), wrapped)
+	}
+	return statsHandler, nil
 }
 
 // Run initializes all of Conduit's underlying services and starts the GRPC and
@@ -603,7 +741,7 @@ func (r *Runtime) serveGRPCAPI(ctx context.Context, t *tomb.Tomb) (net.Addr, err
 			grpcutil.RequestIDUnaryServerInterceptor(r.logger),
 			grpcutil.LoggerUnaryServerInterceptor(r.logger),
 		),
-		grpc.StatsHandler(metricsGrpcStatsHandler),
+		grpc.StatsHandler(r.metricsGrpcStatsHandler),
 		grpc.MaxRecvMsgSize(10*1024*1024),
 	)
 
@@ -656,7 +794,7 @@ func (r *Runtime) startConnectorUtils(ctx context.Context, t *tomb.Tomb) (net.Ad
 			grpcutil.RequestIDUnaryServerInterceptor(r.logger),
 			grpcutil.LoggerUnaryServerInterceptor(r.logger),
 		),
-		grpc.StatsHandler(metricsGrpcStatsHandler),
+		grpc.StatsHandler(r.metricsGrpcStatsHandler),
 	)
 
 	schemaServiceAPI := pconnutils.NewSchemaServiceServer(r.connSchemaService)

--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -518,6 +518,26 @@ func configureEmbeddedMetrics(registerer promclient.Registerer) (*promgrpc.Stats
 // HTTP APIs. This function blocks until the supplied context is cancelled or
 // one of the services experiences a fatal error.
 func (r *Runtime) Run(ctx context.Context) (err error) {
+	// Tier-1-caution guard (embed workstream plan §11 task 6): if ctx is
+	// already canceled before Run does any work, return immediately instead
+	// of spinning up profiling, the tomb, and every service. This is not
+	// merely an optimization: empirically, without this guard, Run panics
+	// ("tomb.Go called after all goroutines terminated") when handed an
+	// already-canceled context — tomb.WithContext's own cancellation-watcher
+	// goroutine kills the tomb (and lets it finish) before initServices's
+	// later t.Go calls (e.g. serveGRPC) run, so those calls hit an
+	// already-dead tomb. `conduit run` never calls Run with an
+	// already-canceled context (a live process's context is only canceled by
+	// a signal that arrives after Run is already executing), so this is
+	// inert on the CLI path; it matters for the embed calling convention
+	// (Engine.Run), where a host can legitimately pass an already-canceled or
+	// already-expired ctx (e.g. one derived from an expired request
+	// deadline). This does not touch registerCleanup/the tomb's drain
+	// mechanics — it is a pure early return before either is constructed.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	cleanup, err := r.initProfiling(ctx)
 	if err != nil {
 		return err

--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -117,6 +117,28 @@ type Runtime struct {
 	// (WithMetricsRegisterer set) it is a fresh, per-Runtime instance
 	// registered only into the supplied registerer — see configureEmbeddedMetrics.
 	metricsGrpcStatsHandler *promgrpc.StatsHandler
+
+	// closeDBOnce/closeDBErr make CloseDB idempotent regardless of which of
+	// its (potentially multiple) callers gets there first — see CloseDB's doc.
+	closeDBOnce sync.Once
+	closeDBErr  error
+}
+
+// CloseDB closes r.DB exactly once, no matter how many times or from how many
+// call sites it is invoked, and returns the same error to every caller.
+//
+// This exists because r.DB is closed from two independent paths that must
+// never race or double-close the same handle: registerCleanupV1/V2's
+// tomb-driven drain (the normal `conduit run`/Handle.Stop shutdown path) and,
+// for the embed API, Engine.Close's resource-release path, which must run
+// regardless of whether Run was ever called or reached registerCleanup (see
+// the root conduit package's Engine.Close doc). Routing both through this one
+// sync.Once means neither path needs to know whether the other already ran.
+func (r *Runtime) CloseDB() error {
+	r.closeDBOnce.Do(func() {
+		r.closeDBErr = r.DB.Close()
+	})
+	return r.closeDBErr
 }
 
 // runtimeOptions holds the optional embed-only seams threaded through
@@ -498,9 +520,16 @@ func configureMetrics() *promgrpc.StatsHandler {
 // MustRegister (which panics) so a metric-name collision on a registerer the
 // caller reused across engines surfaces as a coded error from New, per
 // invariant: New never panics on a caller-supplied misconfiguration.
+//
+// Known limitation, accepted for v1 and tracked as
+// https://github.com/ConduitIO/conduit/issues/2669: metrics.Register(reg)
+// below runs before either registerer.Register call below is known to
+// succeed, so a failed Register (e.g. the name collision this function
+// itself guards against) still leaks reg into pkg/foundation/metrics'
+// process-global bookkeeping — it is never unregistered on this error path.
 func configureEmbeddedMetrics(registerer promclient.Registerer) (*promgrpc.StatsHandler, error) {
 	reg := prometheus.NewRegistry(nil)
-	metrics.Register(reg) // documented cross-talk limitation, see WithMetricsRegisterer's doc
+	metrics.Register(reg) // documented cross-talk limitation, see WithMetricsRegisterer's doc; leak-on-failure tracked as issue #2669
 	if err := registerer.Register(reg); err != nil {
 		wrapped := cerrors.Errorf("failed to register conduit metrics collector: %w", err)
 		return nil, conduiterr.Wrap(conduiterr.CodeInvalidArgument, wrapped.Error(), wrapped)
@@ -532,10 +561,24 @@ func (r *Runtime) Run(ctx context.Context) (err error) {
 	// inert on the CLI path; it matters for the embed calling convention
 	// (Engine.Run), where a host can legitimately pass an already-canceled or
 	// already-expired ctx (e.g. one derived from an expired request
-	// deadline). This does not touch registerCleanup/the tomb's drain
-	// mechanics — it is a pure early return before either is constructed.
+	// deadline) — a documented, designed-for input, not caller misuse. This
+	// does not touch registerCleanup/the tomb's drain mechanics — it is a
+	// pure early return before either is constructed; the DB opened by
+	// NewRuntime is still live afterward, which is exactly why the embed
+	// API's Engine.Close exists as a resource-release path independent of
+	// whether Run got this far (see the root conduit package's Engine.Close
+	// doc).
+	//
+	// The error is returned through conduiterr.CodeInvalidArgument (not a
+	// bare context.Canceled/DeadlineExceeded) so it satisfies New/Run's
+	// documented promise of a *conduiterr.ConduitError where classifiable.
+	// Reusing CodeInvalidArgument rather than minting a new code matches this
+	// package's existing convention for embed-lifecycle-contract errors (see
+	// the root conduit package's Engine.Run/Handle.Stop docs for the same
+	// reasoning applied to a double Run call and a Stop timeout).
 	if err := ctx.Err(); err != nil {
-		return err
+		wrapped := cerrors.Errorf("conduit: Run called with an already-done context: %w", err)
+		return conduiterr.Wrap(conduiterr.CodeInvalidArgument, wrapped.Error(), wrapped)
 	}
 
 	cleanup, err := r.initProfiling(ctx)
@@ -689,7 +732,7 @@ func (r *Runtime) registerCleanupV1(t *tomb.Tomb) {
 		err := ls.Wait(exitTimeout)
 		t.Go(func() error {
 			r.connectorPersister.Wait()
-			return r.DB.Close()
+			return r.CloseDB()
 		})
 		return err
 	})
@@ -744,13 +787,23 @@ func (r *Runtime) registerCleanupV2(t *tomb.Tomb) {
 
 		t.Go(func() error {
 			r.connectorPersister.Wait()
-			return r.DB.Close()
+			return r.CloseDB()
 		})
 
 		return nil
 	})
 }
 
+// newHTTPMetricsHandler builds the handler served at /metrics (see
+// serveHTTPAPI).
+//
+// Known limitation, accepted for v1 and tracked as
+// https://github.com/ConduitIO/conduit/issues/2670: promhttp.Handler() always
+// serves promclient.DefaultGatherer, not the Registerer/Gatherer an embedder
+// supplied via WithMetricsRegisterer/configureEmbeddedMetrics. An embedded
+// Runtime with Options.API.Enabled and a custom MetricsRegisterer therefore
+// gets a /metrics route that does not reflect what was actually registered
+// into that registerer.
 func (r *Runtime) newHTTPMetricsHandler() http.Handler {
 	return promhttp.Handler()
 }

--- a/pkg/conduit/runtime_embed_seams_test.go
+++ b/pkg/conduit/runtime_embed_seams_test.go
@@ -71,7 +71,8 @@ func TestNewRuntime_CLIDefaultsUnchanged(t *testing.T) {
 
 // TestRun_AlreadyCanceledContext proves AC-4/Task 6: Run resolves promptly
 // (never blocks indefinitely) when handed an already-canceled context,
-// returning ctx.Err() without spinning up the tomb or any service.
+// returning a conduiterr.CodeInvalidArgument-coded error wrapping ctx.Err()
+// without spinning up the tomb or any service.
 func TestRun_AlreadyCanceledContext(t *testing.T) {
 	is := is.New(t)
 

--- a/pkg/conduit/runtime_embed_seams_test.go
+++ b/pkg/conduit/runtime_embed_seams_test.go
@@ -1,0 +1,68 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conduit_test
+
+import (
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/conduit"
+	promclient "github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
+
+	"github.com/matryer/is"
+)
+
+// TestNewRuntime_CLIDefaultsUnchanged proves AC-5: the RuntimeOption seams
+// (WithLogger, WithMetricsRegisterer, WithDialContext) are inert unless an
+// embed option is passed. It constructs a Runtime exactly the way
+// Entrypoint.Serve/`conduit run` does — NewRuntime(cfg) with zero
+// RuntimeOptions — and asserts the pre-seam behavior still holds:
+// zerolog.DefaultContextLogger is still set globally, and the package-level
+// configureMetrics() (sync.Once + promclient.MustRegister into
+// promclient.DefaultRegisterer) still fires.
+func TestNewRuntime_CLIDefaultsUnchanged(t *testing.T) {
+	is := is.New(t)
+
+	cfg := conduit.DefaultConfig()
+	cfg.DB.Type = conduit.DBTypeInMemory
+	cfg.API.Enabled = false
+	cfg.Pipelines.Path = t.TempDir()
+
+	prevGlobal := zerolog.DefaultContextLogger
+	zerolog.DefaultContextLogger = nil
+	defer func() { zerolog.DefaultContextLogger = prevGlobal }()
+
+	// The exact CLI call pattern: no RuntimeOptions.
+	r, err := conduit.NewRuntime(cfg)
+	is.NoErr(err)
+	is.True(r != nil)
+	defer r.DB.Close()
+
+	// AC-5.3: CLI path still sets the process-global fallback logger.
+	is.True(zerolog.DefaultContextLogger != nil)
+
+	// AC-5.2: CLI path still calls configureMetrics(), which registers
+	// Conduit's metrics into promclient.DefaultRegisterer.
+	mfs, err := promclient.DefaultGatherer.Gather()
+	is.NoErr(err)
+	var foundConduitMetric bool
+	for _, mf := range mfs {
+		if mf.GetName() == "conduit_info" {
+			foundConduitMetric = true
+			break
+		}
+	}
+	is.True(foundConduitMetric) // conduit_info must be registered in the default registry on the CLI path
+}

--- a/pkg/conduit/runtime_embed_seams_test.go
+++ b/pkg/conduit/runtime_embed_seams_test.go
@@ -15,7 +15,9 @@
 package conduit_test
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/conduitio/conduit/pkg/conduit"
 	promclient "github.com/prometheus/client_golang/prometheus"
@@ -65,4 +67,33 @@ func TestNewRuntime_CLIDefaultsUnchanged(t *testing.T) {
 		}
 	}
 	is.True(foundConduitMetric) // conduit_info must be registered in the default registry on the CLI path
+}
+
+// TestRun_AlreadyCanceledContext proves AC-4/Task 6: Run resolves promptly
+// (never blocks indefinitely) when handed an already-canceled context,
+// returning ctx.Err() without spinning up the tomb or any service.
+func TestRun_AlreadyCanceledContext(t *testing.T) {
+	is := is.New(t)
+
+	cfg := conduit.DefaultConfig()
+	cfg.DB.Type = conduit.DBTypeInMemory
+	cfg.API.Enabled = false
+	cfg.Pipelines.Path = t.TempDir()
+
+	r, err := conduit.NewRuntime(cfg)
+	is.NoErr(err)
+	defer r.DB.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already canceled before Run is ever called
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	select {
+	case err := <-done:
+		is.True(err != nil) // Run must report the canceled context, not silently succeed
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return promptly for an already-canceled context")
+	}
 }

--- a/pkg/provisioning/config/parser.go
+++ b/pkg/provisioning/config/parser.go
@@ -19,6 +19,14 @@ import (
 	"io"
 )
 
+// Pipeline's shape is constrained by the root github.com/conduitio/conduit package's PipelineConfig,
+// a type alias (not a copy) of this exact struct (AC-3/AC-7 of the embed workstream,
+// docs/design-documents/20260722-embed-libconduit-v1.md). A field added, removed, or renamed here
+// changes PipelineConfig identically and is therefore subject to that package's deprecation policy
+// (announce in one release, warn for at least one more, remove no earlier than the third minor
+// release after announcement) — the same discipline already applied to the connector protocol,
+// pipeline config schema, and error codes. Connector, Processor, and DLQ below are constrained the
+// same way.
 type Pipeline struct {
 	ID          string
 	Status      string

--- a/two_engines_test.go
+++ b/two_engines_test.go
@@ -1,0 +1,138 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conduit_test
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+
+	conduit "github.com/conduitio/conduit"
+	promclient "github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
+
+	"github.com/matryer/is"
+)
+
+// capturingHandler is a minimal slog.Handler that records every log.Record it
+// receives, so a test can assert exactly which engine's log lines a given
+// *slog.Logger observed.
+type capturingHandler struct {
+	mu   sync.Mutex
+	recs []slog.Record
+}
+
+func (h *capturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.recs = append(h.recs, r.Clone())
+	return nil
+}
+
+func (h *capturingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *capturingHandler) count() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.recs)
+}
+
+// TestTwoEngines_LoggerIsolated proves AC-2/AC-9's "must pass" half: two
+// concurrent Engines constructed with distinct injected loggers never
+// cross-talk — each handler receives only its own engine's log lines, and
+// neither engine touches the process-global zerolog.DefaultContextLogger
+// fallback (WithLogger's doc: that global is skipped entirely on the embed
+// path specifically so two engines can't cross-talk through it).
+func TestTwoEngines_LoggerIsolated(t *testing.T) {
+	is := is.New(t)
+
+	prevGlobal := zerolog.DefaultContextLogger
+	zerolog.DefaultContextLogger = nil
+	defer func() { zerolog.DefaultContextLogger = prevGlobal }()
+
+	handlerA := &capturingHandler{}
+	handlerB := &capturingHandler{}
+	loggerA := slog.New(handlerA)
+	loggerB := slog.New(handlerB)
+
+	eA := newTestEngine(t, conduit.Options{Logger: loggerA})
+	eB := newTestEngine(t, conduit.Options{Logger: loggerB})
+
+	hA, err := eA.Run(context.Background())
+	is.NoErr(err)
+	hB, err := eB.Run(context.Background())
+	is.NoErr(err)
+
+	is.NoErr(hA.Stop(context.Background()))
+	is.NoErr(hB.Stop(context.Background()))
+
+	is.True(handlerA.count() > 0) // engine A produced log lines...
+	is.True(handlerB.count() > 0) // ...and so did engine B, into its own handler
+
+	// The core of AC-2/AC-9: the embed path never sets the process-global
+	// ambient fallback logger, precisely so two engines with distinct
+	// loggers cannot cross-talk through it.
+	is.True(zerolog.DefaultContextLogger == nil)
+}
+
+// conduitInfoValue sums the "conduit_info" gauge family's values across all
+// label combinations in reg — a convenience for asserting on
+// measure.ConduitInfo's current value as observed through reg.
+func conduitInfoValue(t *testing.T, reg *promclient.Registry) float64 {
+	t.Helper()
+	is := is.New(t)
+
+	mfs, err := reg.Gather()
+	is.NoErr(err)
+
+	var total float64
+	for _, mf := range mfs {
+		if mf.GetName() != "conduit_info" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			total += m.GetGauge().GetValue()
+		}
+	}
+	return total
+}
+
+// TestTwoEngines_MetricsCrossTalk_KnownLimitation documents (does not fix) a
+// known limitation of the embed metrics seam: pkg/foundation/metrics keeps
+// process-global metric *definitions* (metrics.go's `global` slices), so a
+// metric like measure.ConduitInfo fans its value out to every registry ever
+// passed to metrics.Register — including a second, fully independent
+// embedded engine's registry. Constructing engine B (with its own,
+// never-shared MetricsRegisterer) still bumps engine A's already-gathered
+// "conduit_info" value. This is asserted as PRESENT, not fixed — see
+// pkg/conduit.WithMetricsRegisterer's doc and this package's doc.go. A future
+// fix to pkg/foundation/metrics must consciously update this test.
+func TestTwoEngines_MetricsCrossTalk_KnownLimitation(t *testing.T) {
+	is := is.New(t)
+
+	regA := promclient.NewRegistry()
+	newTestEngine(t, conduit.Options{MetricsRegisterer: regA})
+	beforeA := conduitInfoValue(t, regA)
+
+	regB := promclient.NewRegistry()
+	newTestEngine(t, conduit.Options{MetricsRegisterer: regB})
+	afterA := conduitInfoValue(t, regA)
+
+	is.True(afterA > beforeA) // engine B's construction leaked into engine A's registry
+}


### PR DESCRIPTION
## Summary

Implements **B1** of the `libconduit` / embedded v1 workstream (v0.19 Workstream 2, design doc #2651, plan `workstreams/embed-libconduit.md`): a frozen, semver-committed root package `github.com/conduitio/conduit` giving a Go application an embeddable Conduit engine — `conduit.New(ctx, Options) -> Engine.Run(ctx) -> Handle.Stop(ctx)` — with host-injected `*slog.Logger` and `prometheus.Registerer`, so nothing writes to a global logger, the default Prometheus registry, or `os.Stdout`, and nothing calls `os.Exit`.

**B2 (pipelines-in-code builder) is explicitly out of scope** — this PR ships `Engine.Import(ctx, PipelineConfig)` against hand-built `PipelineConfig` literals only; the `NewPipeline(id).With...().Build()` builder is a later PR.

## What shipped

**pkg/conduit seams (additive, inert on the CLI path — AC-5):**
- `RuntimeOption` + `WithLogger`, `WithMetricsRegisterer`, `WithDialContext` on `NewRuntime(cfg, ...opts)`.
- `OpenStore` now takes a `context.Context` (bounds the Postgres/SQLite dial instead of `context.Background()`); its one other caller (`conduit doctor`'s store-reachable check) updated.
- Per-Runtime `configureEmbeddedMetrics` (fresh registry + grpc stats handler per embed Runtime, registered only into the host's registerer) alongside the unchanged CLI-path `configureMetrics()` (package `sync.Once` + `promclient.MustRegister`).
- `TestNewRuntime_CLIDefaultsUnchanged` proves the seams are inert with zero options passed.

**Root package (`conduit.go`, `doc.go`, `log_adapter.go`):**
- `Options` (`Logger`, `MetricsRegisterer`, `DB`, `PipelinesDir`, `API`), `Engine`, `Handle`, `New`.
- `Engine.Run`/`Handle.Stop` per AC-4's exact two-resolution-path shape (`Ready` vs. a failed `Run`, never blocking).
- `Handle.Stop` reuses `Runtime.Run`'s existing ctx-cancellation-driven tomb drain unchanged — **Invariant 7**, no new drain mechanics.
- `PipelineConfig` — a type alias (not a copy) of `provisioning/config.Pipeline`; doc comment added to `parser.go` extending the deprecation policy by name (grep-checked: `constrained by.*PipelineConfig`).
- `Engine.Import` enriches + validates the config (`provisioning/config.Enrich`/`Validate`) before delegating to `provisioning.Service.Import` — see self-review finding below.
- `Engine.StartPipeline`/`StopPipeline` thin delegates to `Orchestrator.Pipelines`.
- Internal zerolog→slog adapter (`log_adapter.go`) so Conduit's existing zerolog-based logging routes through a host `*slog.Logger` without teaching `pkg/foundation/log` about `slog`.

**Trimmed per review must-fix:** no new `conduiterr` codes. `Run`-called-twice, `Stop`-on-nil-`Handle`, and `Stop`-deadline-exceeded all return the existing `conduiterr.CodeInvalidArgument`. AC-8's "under 15 minutes" is split: `TestExampleHelloPipeline_WithinBudget` asserts a 60s **CI wall-clock** ceiling on the example's own execution; the human-copy-paste-timing claim is left as a doc/UX statement, not a test.

**Tests:** `TestNew_ConstructsEngine`, `TestNew_Nil{Logger,Registerer}_*`, `TestRun_FailsBeforeReady`, `TestRun_AlreadyCanceledContext` (Engine- and Runtime-level), `TestRun_CalledTwice_ReturnsCodedError`, `TestStop_{NilHandle,ConcurrentIdempotent,DeadlineExceeded}`, `TestNew_StoreAlreadyOpen_ReturnsCodedError`, `TestNew_MetricNameCollision_ReturnsCodedError`, `TestPipelineConfig_IsAliasOfProvisioningConfig`, `TestImport_RoundTripsThroughRunningEngine`, `TestTwoEngines_LoggerIsolated` (must pass), `TestTwoEngines_MetricsCrossTalk_KnownLimitation` (documents, doesn't fix), `TestObservabilityIsolation_Subprocess` (subprocess re-exec proving zero bytes to real stdout/stderr — AC-2c), `Example_helloPipeline` + its budget test.

## ⚠️ Tier-1 commit requiring DeVaris sign-off

**Commit `d5922de` — `fix(conduit): guard Runtime.Run against an already-canceled context`** is isolated from the Tier-2 embed work per the design doc's escalation rule (anything touching `Runtime.Run`'s tomb/cleanup mechanics is Tier 1, regardless of diff size).

This is **not just Tier-1-caution — it's a real bug**, found empirically while writing `TestRun_AlreadyCanceledContext`: without the one-line `ctx.Err()` guard at `Run`'s entry, calling `Runtime.Run` with an already-canceled context **panics** (`tomb.Go called after all goroutines terminated`) instead of returning an error. `tomb.WithContext`'s own cancellation-watcher goroutine kills the tomb before `initServices`'s later `t.Go` calls (e.g. `serveGRPC`) run, so those calls hit an already-dead tomb.

`conduit run` never triggers this (a live process's context is only canceled by a signal arriving *after* `Run` is already executing), so the CLI path is unaffected — confirmed by removing the guard locally and re-running the full `pkg/conduit` suite plus the new CLI-parity test, all green except the two tests this fix targets. The guard is a pure early return before the tomb or `registerCleanup` is constructed; it does not touch drain/cleanup logic itself.

**Requesting explicit DeVaris review of commit `d5922de`** before merge, per the standing Tier-1 gate.

## Failure-mode analysis (Tier-1 commit)

- **What could this break:** nothing on the CLI path — the guard is unreachable there (`conduit run` never calls `Run` with a pre-canceled context). On the embed path, it changes a panic into a clean error return, strictly safer.
- **Which metric/alert would show a regression:** N/A — no metric surfaces a panic-vs-error distinction today; a regression would show as a crashed process / non-zero-without-log exit in whatever harness runs `conduit run` (unaffected) or as an embedder's process crashing on `Engine.Run` (this fix's whole point).
- **Rollback:** revert commit `d5922de` alone; it has no dependents (the Tier-2 commit that touches `Engine.Run` was written and tested with this guard in place, so reverting would reintroduce the empirically-confirmed panic for the embed path specifically, not affect the CLI).

## Adversarial self-review

- **Error paths:** `Engine.Import` originally delegated straight to `provisioning.Service.Import` per the design doc's citation — but a hand-built `PipelineConfig{}` has a nil `DLQ.WindowSize`/`WindowNackThreshold` (zero-value `*int`), and `provisioning.Service`'s `createPipelineAction.Do` dereferences those pointers directly, assuming the file-based path's `config.Enrich` already ran. Caught this via `TestImport_RoundTripsThroughRunningEngine`, which panicked (nil-pointer deref) before the fix. `Import` now calls `config.Enrich`+`config.Validate` first, mirroring `provisionPipeline`'s own convention exactly.
- **Concurrency:** `Handle.stopOnce` + buffered `done`/select ensures `Stop` is safe under concurrent callers (`TestStop_ConcurrentIdempotent`, race-clean). `Engine.started` uses `atomic.Bool.CompareAndSwap` so two goroutines racing `Run()` can't both proceed.
- **Resource cleanup:** `Engine.Run`'s failure branch (`Ready` never closes) calls `cancel()` before returning to release the derived `runCtx`, even though the tomb has already exited by construction.
- **Known, accepted limitation (not fixed here, per design doc's Non-goals):** a *failed* `configureEmbeddedMetrics` call (e.g., the metric-name-collision case) still leaks a `foundation/metrics/prometheus.Registry` into `pkg/foundation/metrics`'s process-global bookkeeping, because the collision can only be detected *after* `metrics.Register(reg)` has already populated `reg`'s descriptors — there's no `Unregister`. Harmless (never scraped, since the host's own `Register` call is what failed) but real; flagging so it doesn't reappear as a surprise later.
- **Invariant 7:** verified `Handle.Stop` calls only `cancel()` (no reimplementation) and reads `Runtime.Run`'s real return value; `registerCleanup`/V1/V2 are untouched by either commit.
- **/metrics HTTP endpoint gap (documented, not fixed):** if `Options.API.Enabled` is true, the HTTP `/metrics` route still serves `promhttp.Handler()` (the *default* gatherer), not the host's injected registerer — out of scope for this PR's ACs (none of AC-1..8 test the HTTP metrics route), noting for a follow-up.

## Open questions for DeVaris

1. Confirm the Tier-1 commit's review is what you want before merge (per the standing gate) — I have **not** merged this PR.
2. Confirm the `/metrics` HTTP-route gap above is an acceptable known limitation for v1, or should be tracked as a follow-up issue.

## Gate results

- `make generate && git diff --exit-code`: clean, no drift.
- `golangci-lint run ./... --new-from-rev=main`: 0 issues.
- `go build ./...`: clean.
- `go test -race ./...`: full repo green (including this PR's new packages).

Roadmap: v0.19 Workstream 2 (`libconduit` embed v1, B1). Risk tier: **Tier 2** overall, **Tier 1** for commit `d5922de` specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD