### PR TITLE
feat(generate): eval harness + benchmark corpus (design-only path)

### DIFF
--- a/cmd/conduit/internal/generate/capability.go
+++ b/cmd/conduit/internal/generate/capability.go
@@ -1,0 +1,72 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import "github.com/conduitio/conduit/pkg/provisioning/config"
+
+// capabilityProcessors maps a required-capability tag (as used in a
+// Request's Expect.RequiredCapabilities) to the set of builtin processor
+// plugin names that satisfy it. Sourced by hand from
+// pkg/plugin/processor/builtin.DefaultBuiltinProcessors's keys at the time
+// this package was written — never a second, independently-maintained
+// processor list; if a builtin processor is renamed or removed, this map
+// needs a matching update (there is no structural link enforcing it, since
+// importing the builtin processor registry here would pull plugin runtime
+// dependencies into a package that only ever handles YAML text — a cost not
+// worth paying for a compile-time guarantee testdata already exercises).
+//
+// A capability tag NOT present in this map is intentionally
+// unsatisfiable (hasCapability returns false for it) rather than matching
+// everything or nothing gracefully — an eval fixture typo'ing a capability
+// name should show up as a permanent semantic-match failure, not silently
+// pass.
+var capabilityProcessors = map[string]map[string]bool{
+	"filter":              {"filter": true},
+	"mask":                {"field.exclude": true},
+	"rename":              {"field.rename": true},
+	"set":                 {"field.set": true},
+	"convert":             {"field.convert": true},
+	"json-encode":         {"json.encode": true},
+	"json-decode":         {"json.decode": true},
+	"avro-encode":         {"avro.encode": true},
+	"avro-decode":         {"avro.decode": true},
+	"base64-encode":       {"base64.encode": true},
+	"base64-decode":       {"base64.decode": true},
+	"unwrap-debezium":     {"unwrap.debezium": true},
+	"unwrap-kafkaconnect": {"unwrap.kafkaconnect": true},
+	"unwrap-opencdc":      {"unwrap.opencdc": true},
+	"split":               {"split": true},
+	"clone":               {"clone": true},
+	"webhook":             {"webhook.http": true},
+	"embed":               {"openai.embed": true, "cohere.embed": true},
+	"textgen":             {"openai.textgen": true, "cohere.command": true, "ollama.request": true},
+}
+
+// hasCapability reports whether any processor in procs (pipeline-level or
+// attached to a connector — allProcessors flattens both) is one of the
+// builtin plugins capabilityProcessors registers for tag. An unknown tag
+// (see the map's doc comment) always returns false.
+func hasCapability(procs []config.Processor, tag string) bool {
+	plugins, ok := capabilityProcessors[tag]
+	if !ok {
+		return false
+	}
+	for _, p := range procs {
+		if plugins[p.Plugin] {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/conduit/internal/generate/doc.go
+++ b/cmd/conduit/internal/generate/doc.go
@@ -1,0 +1,71 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package generate is the eval-harness half of `conduit generate`
+// (docs/design-documents/20260722-conduit-generate.md). It contains no CLI
+// command, no MCP tool, and no LLM provider client — those are the v0.20
+// implementation, deferred per that design doc's Status section (the v0.19
+// build slot went to the Python connector SDK). No new external dependency
+// ships with this package.
+//
+// What v0.19 ships here is the eval harness the future `generate` command's
+// acceptance bar (design doc §10) is measured against, plus the committed
+// benchmark corpus it's measured over:
+//
+//   - The corpus: testdata/eval_requests.yaml, >= 25 canonical natural-
+//     language pipeline requests, each grounded in one of Conduit's real
+//     built-in connectors (file, generator, kafka, log, postgres, s3) and
+//     carrying its expected semantic intent (source/destination category,
+//     required processor capabilities) — see Request/Expect in fixture.go.
+//     docs/generate-benchmark.md is the human-readable rendering of this
+//     same file; the YAML is the source of truth.
+//
+//   - The scorer: given a Request->candidate-pipeline-YAML mapping (however
+//     produced — a live provider call in v0.20, or a fixture in this
+//     package's own tests today), ScoreRun/ScoreMedian report TWO separate
+//     numbers, never collapsed into one:
+//
+//     1. Validate-pass rate — does the candidate pass the exact
+//     cmd/conduit/internal/validate engine `conduit pipelines validate`
+//     uses. Because that engine only exposes a path-based Run (there is no
+//     RunBytes/RunReader in-memory seam yet — the design doc's Decision §3
+//     names this exact gap and its two resolutions), this package uses the
+//     documented fallback: a private (0600) temp file, validated, then
+//     removed (validateCandidate in validate_score.go). The day RunBytes
+//     lands, this is the only function that needs to change.
+//
+//     2. Semantic-intent-match rate — does the candidate's actual source/
+//     destination connector category and processor set match the
+//     Request's Expect, even when it validates cleanly. A pipeline can be
+//     schema-valid and still point at the wrong connector or drop a
+//     requested filter; this is the DX-review failure mode the design doc
+//     names as the reason a validate-pass rate alone isn't a sufficient
+//     bar (semantic_score.go).
+//
+// # Invariants this package holds
+//
+//   - A Request.ID with no entry in the candidates map counts as a FAIL on
+//     BOTH metrics (Result.Missing), never silently excluded from the
+//     denominator — a shrunk denominator would hide the worst failure (no
+//     candidate produced at all) behind a better-looking rate.
+//   - Medians, never best-of, across repeated runs (ScoreMedian) — the same
+//     discipline CLAUDE.md requires of benchi results, applied here because
+//     an eval harness that could be gamed by cherry-picking its best run is
+//     not a release gate, it's theater.
+//   - The scorer never calls an LLM provider and never makes a network
+//     call — it is pure, deterministic (given a fixed candidates map), and
+//     proven correct with fixture-only tests (fixture_test.go): known-good
+//     candidates score true on both axes, known-bad ones score false on the
+//     specific axis they're wrong on, with no live model in the loop.
+package generate

--- a/cmd/conduit/internal/generate/fixture.go
+++ b/cmd/conduit/internal/generate/fixture.go
@@ -1,0 +1,97 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"os"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/yaml/v3"
+)
+
+// Request is one committed benchmark fixture: a canonical natural-language
+// pipeline request paired with its expected semantic intent. This is the
+// eval corpus's unit — see docs/design-documents/20260722-conduit-generate.md
+// §10 and docs/generate-benchmark.md for the rendered corpus.
+type Request struct {
+	// ID is a stable, unique fixture identifier (kebab-case), used as the
+	// key into a Candidates map and in test/report output. Renaming an ID
+	// is a corpus-breaking change for anyone tracking scores over time —
+	// treat it like the connector protocol's naming discipline.
+	ID string `yaml:"id"`
+	// Prompt is the exact natural-language request text a future `generate`
+	// invocation (or a human reviewer of this corpus) would see verbatim.
+	Prompt string `yaml:"prompt"`
+	// Expect is the ground-truth semantic intent this request should
+	// produce, judged by the deterministic heuristics in
+	// semantic_score.go — never re-derived from Prompt by this package
+	// (that NL-extraction heuristic is design doc §9's job, owned by the
+	// future `generate` command itself, not by this scorer).
+	Expect Expect `yaml:"expect"`
+	// Notes is free-text context for a human reviewing the corpus (why this
+	// fixture exists, what failure mode it targets). Never consumed by the
+	// scorer.
+	Notes string `yaml:"notes,omitempty"`
+}
+
+// Expect is a Request's ground-truth semantic intent: which built-in
+// connector category (file, generator, kafka, log, postgres, or s3) should
+// occupy the source and destination roles, and which processor
+// capabilities (capability.go) the candidate must demonstrably include.
+// SourceCategory/DestinationCategory are left empty only when a request
+// deliberately doesn't pin one side down; every fixture in the committed
+// corpus sets both, since "grounded in real built-in connectors" is the
+// corpus's stated bar (task brief) and an unpinned side can't be scored as
+// a mismatch.
+type Expect struct {
+	SourceCategory       string   `yaml:"sourceCategory"`
+	DestinationCategory  string   `yaml:"destinationCategory"`
+	RequiredCapabilities []string `yaml:"requiredCapabilities,omitempty"`
+}
+
+// LoadRequests reads and validates a committed eval corpus file (the shape
+// testdata/eval_requests.yaml uses): every Request must carry a non-empty,
+// unique ID and a non-empty Prompt. It never silently drops a malformed
+// entry — a corpus fixture with a typo'd or duplicate ID is exactly the
+// kind of silent drift that would make the reported rates measure a
+// smaller (and differently-shaped) corpus than the one committed to the
+// repo, so this is a hard error, not a skip.
+func LoadRequests(path string) ([]Request, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, cerrors.Errorf("reading eval requests %q: %w", path, err)
+	}
+
+	var reqs []Request
+	if err := yaml.Unmarshal(data, &reqs); err != nil {
+		return nil, cerrors.Errorf("parsing eval requests %q: %w", path, err)
+	}
+
+	seen := make(map[string]bool, len(reqs))
+	for i, r := range reqs {
+		if r.ID == "" {
+			return nil, cerrors.Errorf("eval requests %q: entry %d has no id", path, i)
+		}
+		if seen[r.ID] {
+			return nil, cerrors.Errorf("eval requests %q: duplicate id %q", path, r.ID)
+		}
+		seen[r.ID] = true
+		if r.Prompt == "" {
+			return nil, cerrors.Errorf("eval requests %q: entry %q has no prompt", path, r.ID)
+		}
+	}
+
+	return reqs, nil
+}

--- a/cmd/conduit/internal/generate/score.go
+++ b/cmd/conduit/internal/generate/score.go
@@ -1,0 +1,154 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"context"
+	"sort"
+
+	"github.com/conduitio/conduit/cmd/conduit/internal/validate"
+)
+
+// Candidates maps a Request.ID to the full pipeline-config YAML text
+// produced for it — by a live provider call once `generate` is built
+// (v0.20), or by a fixture in this package's own tests today. This harness
+// never produces a Candidates value itself; it only scores one.
+type Candidates map[string]string
+
+// Result is one Request's outcome within a single ScoreRun pass.
+type Result struct {
+	RequestID string
+
+	// Missing is true when the Candidates map this Result came from had no
+	// entry for RequestID. A missing candidate counts as a FAIL on both
+	// metrics (see ScoreRun) — it is never excluded from the denominator.
+	Missing bool
+
+	ValidatePass   bool
+	ValidateReport validate.Report
+	// ValidateErr is non-nil only when validateCandidate itself could not
+	// run (e.g. a temp-file I/O failure) — distinct from the candidate
+	// simply failing validation, which shows up as findings inside
+	// ValidateReport with ValidatePass false and ValidateErr nil.
+	ValidateErr error
+
+	SemanticMatch  bool
+	SemanticIssues []string
+}
+
+// RunScore is the result of scoring every Request in a corpus against one
+// Candidates mapping ("one run" — see ScoreMedian for repeats).
+type RunScore struct {
+	Total              int
+	ValidatePassCount  int
+	SemanticMatchCount int
+	ValidatePassRate   float64
+	SemanticMatchRate  float64
+	Results            []Result
+}
+
+// ScoreRun scores one full pass: every request in requests is looked up in
+// candidates and scored on both axes independently. A request.ID absent
+// from candidates is recorded as Result.Missing and counts as a fail on
+// BOTH metrics — never silently dropped from the denominator (see doc.go's
+// invariants). requests order is preserved in RunScore.Results.
+func ScoreRun(ctx context.Context, requests []Request, candidates Candidates) RunScore {
+	rs := RunScore{Total: len(requests), Results: make([]Result, 0, len(requests))}
+
+	for _, req := range requests {
+		res := Result{RequestID: req.ID}
+
+		candidate, ok := candidates[req.ID]
+		if !ok {
+			res.Missing = true
+			res.SemanticIssues = []string{"no candidate provided for this request"}
+		} else {
+			report, err := validateCandidate(ctx, candidate)
+			res.ValidateReport = report
+			res.ValidateErr = err
+			res.ValidatePass = err == nil && report.OK()
+
+			sem := scoreSemantic(ctx, req.Expect, candidate)
+			res.SemanticMatch = sem.Match
+			res.SemanticIssues = sem.Issues
+		}
+
+		if res.ValidatePass {
+			rs.ValidatePassCount++
+		}
+		if res.SemanticMatch {
+			rs.SemanticMatchCount++
+		}
+		rs.Results = append(rs.Results, res)
+	}
+
+	if rs.Total > 0 {
+		rs.ValidatePassRate = float64(rs.ValidatePassCount) / float64(rs.Total)
+		rs.SemanticMatchRate = float64(rs.SemanticMatchCount) / float64(rs.Total)
+	}
+	return rs
+}
+
+// MedianScore is the result of scoring N repeated runs over the same
+// requests (e.g. N separate generations against a live provider, per
+// design doc §10's "re-run >= 3x each") and reporting the MEDIAN — never
+// the best-of, per CLAUDE.md's benchmarking discipline ("report medians
+// with variance, not best runs") applied here to model-output scoring
+// instead of throughput numbers.
+type MedianScore struct {
+	Runs              []RunScore
+	ValidatePassRate  float64
+	SemanticMatchRate float64
+}
+
+// ScoreMedian calls ScoreRun once per element of runs and reduces the two
+// rates to their median across runs. Every individual RunScore is kept in
+// MedianScore.Runs for detail (e.g. rendering into docs/generate-benchmark.md
+// or a scheduled-CI artifact) — the median alone is not enough context to
+// debug a regression.
+func ScoreMedian(ctx context.Context, requests []Request, runs []Candidates) MedianScore {
+	ms := MedianScore{Runs: make([]RunScore, len(runs))}
+	validateRates := make([]float64, len(runs))
+	semanticRates := make([]float64, len(runs))
+
+	for i, c := range runs {
+		rs := ScoreRun(ctx, requests, c)
+		ms.Runs[i] = rs
+		validateRates[i] = rs.ValidatePassRate
+		semanticRates[i] = rs.SemanticMatchRate
+	}
+
+	ms.ValidatePassRate = median(validateRates)
+	ms.SemanticMatchRate = median(semanticRates)
+	return ms
+}
+
+// median returns the middle value of vals (average of the two middle
+// values for an even-length input), without mutating the caller's slice.
+// median(nil) is 0 — ScoreMedian never calls it with an empty runs slice
+// from its own tests, but a defensive zero is safer than a panic for a
+// function that will eventually be fed live, possibly-empty data.
+func median(vals []float64) float64 {
+	if len(vals) == 0 {
+		return 0
+	}
+	sorted := append([]float64(nil), vals...)
+	sort.Float64s(sorted)
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		return sorted[mid]
+	}
+	return (sorted[mid-1] + sorted[mid]) / 2
+}

--- a/cmd/conduit/internal/generate/score_test.go
+++ b/cmd/conduit/internal/generate/score_test.go
@@ -1,0 +1,400 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+// This file proves the scorer is correct WITHOUT a live LLM: every case
+// feeds a known-good or known-bad candidate pipeline YAML (committed under
+// testdata/candidates) and asserts the exact score, never invoking a
+// provider. See doc.go's invariants.
+
+// mustReadCandidate loads a fixture candidate YAML by filename (relative to
+// testdata/candidates/) as a string, failing the test on any read error.
+func mustReadCandidate(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile("testdata/candidates/" + name)
+	if err != nil {
+		t.Fatalf("reading fixture candidate %q: %v", name, err)
+	}
+	return string(data)
+}
+
+// findRequest returns the Request with the given id from requests, failing
+// the test if it's not found — keeps every test below anchored to the real
+// committed corpus (testdata/eval_requests.yaml) instead of a hand-rolled
+// duplicate Expect that could silently drift from it.
+func findRequest(t *testing.T, requests []Request, id string) Request {
+	t.Helper()
+	for _, r := range requests {
+		if r.ID == id {
+			return r
+		}
+	}
+	t.Fatalf("no fixture request with id %q in the committed corpus", id)
+	return Request{}
+}
+
+func TestLoadRequests_CommittedCorpus(t *testing.T) {
+	is := is.New(t)
+
+	requests, err := LoadRequests("testdata/eval_requests.yaml")
+	is.NoErr(err)
+
+	// Task brief AC: >= 25 canonical requests.
+	is.True(len(requests) >= 25)
+
+	seen := make(map[string]bool, len(requests))
+	for _, r := range requests {
+		is.True(r.ID != "")
+		is.True(r.Prompt != "")
+		is.True(r.Expect.SourceCategory != "")      // every committed fixture pins a source...
+		is.True(r.Expect.DestinationCategory != "") // ...and a destination (task brief: "grounded in real built-in connectors")
+		is.True(!seen[r.ID])                        // no duplicate ids
+		seen[r.ID] = true
+
+		// Every category used must be one of the six real built-in
+		// connectors named in doc.go — never a hypothetical one.
+		is.True(builtinConnectorCategories[r.Expect.SourceCategory])
+		is.True(builtinConnectorCategories[r.Expect.DestinationCategory])
+	}
+}
+
+func TestLoadRequests_RejectsDuplicateID(t *testing.T) {
+	is := is.New(t)
+
+	dir := t.TempDir()
+	path := dir + "/dup.yaml"
+	is.NoErr(os.WriteFile(path, []byte(`
+- id: same-id
+  prompt: "a"
+  expect: {sourceCategory: file, destinationCategory: log}
+- id: same-id
+  prompt: "b"
+  expect: {sourceCategory: file, destinationCategory: log}
+`), 0o600))
+
+	_, err := LoadRequests(path)
+	is.True(err != nil)
+}
+
+func TestLoadRequests_RejectsMissingID(t *testing.T) {
+	is := is.New(t)
+
+	dir := t.TempDir()
+	path := dir + "/missing-id.yaml"
+	is.NoErr(os.WriteFile(path, []byte(`
+- prompt: "no id here"
+  expect: {sourceCategory: file, destinationCategory: log}
+`), 0o600))
+
+	_, err := LoadRequests(path)
+	is.True(err != nil)
+}
+
+// builtinConnectorCategories is the test's own independent list of the six
+// real built-in connectors (Context, task brief) — deliberately NOT
+// imported from capability.go/semantic_score.go, so this test would catch
+// the corpus drifting to reference a category neither this list nor the
+// production code recognizes.
+var builtinConnectorCategories = map[string]bool{
+	"file": true, "generator": true, "kafka": true,
+	"log": true, "postgres": true, "s3": true,
+}
+
+// --- validate-pass axis ---
+
+func TestValidateCandidate_GoodCandidate_Passes(t *testing.T) {
+	is := is.New(t)
+
+	candidate := mustReadCandidate(t, "postgres-cdc-to-kafka-filtered-good.yaml")
+	report, err := validateCandidate(context.Background(), candidate)
+	is.NoErr(err)
+	is.True(report.OK())
+}
+
+func TestValidateCandidate_BadSchema_Fails(t *testing.T) {
+	is := is.New(t)
+
+	candidate := mustReadCandidate(t, "postgres-cdc-to-kafka-filtered-bad-schema.yaml")
+	report, err := validateCandidate(context.Background(), candidate)
+	is.NoErr(err) // validateCandidate itself succeeds; the CANDIDATE fails validation
+	is.True(!report.OK())
+	is.True(report.Summary.Errors > 0)
+}
+
+// A schema-valid-but-semantically-wrong candidate still passes validate —
+// this is exactly the DX-review failure mode (design doc: "a pipeline can
+// validate and confidently do the wrong thing") the semantic axis below
+// exists to catch.
+func TestValidateCandidate_WrongConnectorButValid_Passes(t *testing.T) {
+	is := is.New(t)
+
+	candidate := mustReadCandidate(t, "kafka-to-postgres-sync-bad-wrong-connector.yaml")
+	report, err := validateCandidate(context.Background(), candidate)
+	is.NoErr(err)
+	is.True(report.OK())
+}
+
+// --- semantic-intent axis ---
+
+func TestScoreSemantic_GoodCandidate_Matches(t *testing.T) {
+	is := is.New(t)
+
+	requests, err := LoadRequests("testdata/eval_requests.yaml")
+	is.NoErr(err)
+	req := findRequest(t, requests, "postgres-cdc-to-kafka-filtered")
+
+	candidate := mustReadCandidate(t, "postgres-cdc-to-kafka-filtered-good.yaml")
+	res := scoreSemantic(context.Background(), req.Expect, candidate)
+	is.True(res.Match)
+	is.Equal(len(res.Issues), 0)
+}
+
+func TestScoreSemantic_NoCapabilitiesNeeded_Matches(t *testing.T) {
+	is := is.New(t)
+
+	requests, err := LoadRequests("testdata/eval_requests.yaml")
+	is.NoErr(err)
+	req := findRequest(t, requests, "generator-to-log-smoketest")
+
+	candidate := mustReadCandidate(t, "generator-to-log-smoketest-good.yaml")
+	res := scoreSemantic(context.Background(), req.Expect, candidate)
+	is.True(res.Match)
+}
+
+func TestScoreSemantic_WrongConnector_FailsEvenThoughValid(t *testing.T) {
+	is := is.New(t)
+
+	requests, err := LoadRequests("testdata/eval_requests.yaml")
+	is.NoErr(err)
+	req := findRequest(t, requests, "kafka-to-postgres-sync")
+
+	candidate := mustReadCandidate(t, "kafka-to-postgres-sync-bad-wrong-connector.yaml")
+
+	// Confirm the premise: this candidate DOES pass validate.
+	report, verr := validateCandidate(context.Background(), candidate)
+	is.NoErr(verr)
+	is.True(report.OK())
+
+	// But it must fail the semantic check: wrong source AND destination.
+	res := scoreSemantic(context.Background(), req.Expect, candidate)
+	is.True(!res.Match)
+	is.True(len(res.Issues) >= 2)
+}
+
+// A candidate with two connectors in the same role is malformed input the
+// checker must never resolve by guessing which one "the" source was — it
+// should report an unresolvable (empty) category for that role, which
+// mismatches any non-empty Expect.
+func TestScoreSemantic_MultipleSourceConnectors_NeverGuessesACategory(t *testing.T) {
+	is := is.New(t)
+
+	candidate := `
+version: "2.2"
+pipelines:
+  - id: two-sources
+    status: running
+    connectors:
+      - id: src1
+        type: source
+        plugin: builtin:postgres
+      - id: src2
+        type: source
+        plugin: builtin:kafka
+      - id: dst
+        type: destination
+        plugin: builtin:s3
+`
+	res := scoreSemantic(context.Background(), Expect{SourceCategory: "postgres", DestinationCategory: "s3"}, candidate)
+	is.True(!res.Match)
+}
+
+func TestScoreSemantic_DroppedFilter_Fails(t *testing.T) {
+	is := is.New(t)
+
+	requests, err := LoadRequests("testdata/eval_requests.yaml")
+	is.NoErr(err)
+	req := findRequest(t, requests, "postgres-cdc-to-kafka-filtered")
+
+	candidate := mustReadCandidate(t, "postgres-cdc-to-kafka-filtered-bad-dropped-filter.yaml")
+
+	report, verr := validateCandidate(context.Background(), candidate)
+	is.NoErr(verr)
+	is.True(report.OK()) // still schema-valid
+
+	res := scoreSemantic(context.Background(), req.Expect, candidate)
+	is.True(!res.Match)
+	is.Equal(len(res.Issues), 1)
+}
+
+func TestScoreSemantic_SwappedDirection_Fails(t *testing.T) {
+	is := is.New(t)
+
+	requests, err := LoadRequests("testdata/eval_requests.yaml")
+	is.NoErr(err)
+	req := findRequest(t, requests, "postgres-cdc-to-kafka-filtered")
+
+	candidate := mustReadCandidate(t, "postgres-cdc-to-kafka-filtered-bad-swapped-direction.yaml")
+
+	report, verr := validateCandidate(context.Background(), candidate)
+	is.NoErr(verr)
+	is.True(report.OK())
+
+	res := scoreSemantic(context.Background(), req.Expect, candidate)
+	is.True(!res.Match) // source/destination categories are swapped relative to Expect
+}
+
+func TestScoreSemantic_UnknownPlugin_NeverFabricatesAMatch(t *testing.T) {
+	is := is.New(t)
+
+	requests, err := LoadRequests("testdata/eval_requests.yaml")
+	is.NoErr(err)
+	req := findRequest(t, requests, "postgres-cdc-to-kafka-filtered")
+
+	candidate := mustReadCandidate(t, "postgres-cdc-to-kafka-filtered-bad-unknown-plugin.yaml")
+
+	// A non-builtin plugin reference is schema-valid (validate doesn't
+	// resolve plugin registries without ResolvePlugins).
+	report, verr := validateCandidate(context.Background(), candidate)
+	is.NoErr(verr)
+	is.True(report.OK())
+
+	res := scoreSemantic(context.Background(), req.Expect, candidate)
+	is.True(!res.Match) // an unresolvable source category never counts as a match
+}
+
+func TestScoreSemantic_MalformedYAML_NeverPanicsNeverMatches(t *testing.T) {
+	is := is.New(t)
+
+	res := scoreSemantic(context.Background(), Expect{SourceCategory: "postgres", DestinationCategory: "kafka"}, "not: [valid: yaml: at all")
+	is.True(!res.Match)
+	is.True(len(res.Issues) >= 1)
+}
+
+// --- capability.go ---
+
+func TestHasCapability_UnknownTag_NeverMatches(t *testing.T) {
+	is := is.New(t)
+	is.True(!hasCapability(nil, "this-tag-does-not-exist"))
+}
+
+// --- ScoreRun / ScoreMedian ---
+
+func TestScoreRun_MissingCandidate_FailsBothMetrics(t *testing.T) {
+	is := is.New(t)
+
+	requests := []Request{
+		{ID: "a", Prompt: "x", Expect: Expect{SourceCategory: "file", DestinationCategory: "log"}},
+	}
+	rs := ScoreRun(context.Background(), requests, Candidates{}) // no entry for "a"
+
+	is.Equal(rs.Total, 1)
+	is.Equal(rs.ValidatePassCount, 0)
+	is.Equal(rs.SemanticMatchCount, 0)
+	is.True(rs.Results[0].Missing)
+	is.Equal(rs.ValidatePassRate, 0.0)
+	is.Equal(rs.SemanticMatchRate, 0.0)
+}
+
+func TestScoreRun_MixedResults_ComputesRatesOverFullDenominator(t *testing.T) {
+	is := is.New(t)
+
+	requests, err := LoadRequests("testdata/eval_requests.yaml")
+	is.NoErr(err)
+	good := findRequest(t, requests, "postgres-cdc-to-kafka-filtered")
+	other := findRequest(t, requests, "kafka-to-postgres-sync")
+
+	candidates := Candidates{
+		good.ID: mustReadCandidate(t, "postgres-cdc-to-kafka-filtered-good.yaml"),
+		// other.ID deliberately has no candidate: Missing, counts against
+		// the denominator instead of shrinking it.
+	}
+	rs := ScoreRun(context.Background(), []Request{good, other}, candidates)
+
+	is.Equal(rs.Total, 2)
+	is.Equal(rs.ValidatePassCount, 1)
+	is.Equal(rs.SemanticMatchCount, 1)
+	is.Equal(rs.ValidatePassRate, 0.5)
+	is.Equal(rs.SemanticMatchRate, 0.5)
+}
+
+func TestMedian_OddAndEvenLengths(t *testing.T) {
+	is := is.New(t)
+
+	// Values chosen to be exact in binary floating point (eighths), so the
+	// assertion isn't sensitive to floating-point rounding.
+	is.Equal(median([]float64{0.5, 1.0, 0.25}), 0.5)         // odd: sorted middle
+	is.Equal(median([]float64{0.5, 1.0, 0.25, 0.75}), 0.625) // even: average of the two middles
+	is.Equal(median(nil), 0.0)
+}
+
+// ScoreMedian must report the MEDIAN across runs, never the best run — a
+// harness that could be gamed by cherry-picking its best attempt would not
+// be a trustworthy release gate (CLAUDE.md's benchi discipline, applied to
+// model-output scoring).
+func TestScoreMedian_ReportsMedianNotBestOf(t *testing.T) {
+	is := is.New(t)
+
+	requests, err := LoadRequests("testdata/eval_requests.yaml")
+	is.NoErr(err)
+	req := findRequest(t, requests, "postgres-cdc-to-kafka-filtered")
+
+	good := mustReadCandidate(t, "postgres-cdc-to-kafka-filtered-good.yaml")
+	badSchema := mustReadCandidate(t, "postgres-cdc-to-kafka-filtered-bad-schema.yaml")
+
+	oneReq := []Request{req}
+	runs := []Candidates{
+		{req.ID: good},      // run 1: pass (rate 1.0)
+		{req.ID: good},      // run 2: pass (rate 1.0)
+		{req.ID: badSchema}, // run 3: fail (rate 0.0)
+	}
+
+	ms := ScoreMedian(context.Background(), oneReq, runs)
+	// Sorted rates: [0.0, 1.0, 1.0] -> median 1.0. The single failing run
+	// must not drag the reported number below what the median actually is,
+	// and a best-of reduction would trivially also read 1.0 here — the real
+	// assertion is in the NEXT test, which forces median != best-of.
+	is.Equal(ms.ValidatePassRate, 1.0)
+	is.Equal(len(ms.Runs), 3)
+}
+
+func TestScoreMedian_DiffersFromBestOfWhenMajorityFails(t *testing.T) {
+	is := is.New(t)
+
+	requests, err := LoadRequests("testdata/eval_requests.yaml")
+	is.NoErr(err)
+	req := findRequest(t, requests, "postgres-cdc-to-kafka-filtered")
+
+	good := mustReadCandidate(t, "postgres-cdc-to-kafka-filtered-good.yaml")
+	badSchema := mustReadCandidate(t, "postgres-cdc-to-kafka-filtered-bad-schema.yaml")
+
+	oneReq := []Request{req}
+	runs := []Candidates{
+		{req.ID: badSchema}, // fail (0.0)
+		{req.ID: badSchema}, // fail (0.0)
+		{req.ID: good},      // pass (1.0) -- the best run
+	}
+
+	ms := ScoreMedian(context.Background(), oneReq, runs)
+	// Best-of would report 1.0; the median of [0.0, 0.0, 1.0] is 0.0.
+	is.Equal(ms.ValidatePassRate, 0.0)
+}

--- a/cmd/conduit/internal/generate/semantic_score.go
+++ b/cmd/conduit/internal/generate/semantic_score.go
@@ -1,0 +1,173 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/plugin"
+	"github.com/conduitio/conduit/pkg/provisioning/config"
+	yamlparser "github.com/conduitio/conduit/pkg/provisioning/config/yaml"
+)
+
+// SemanticResult is one candidate's outcome against a Request's Expect: did
+// the actual source/destination connector category and processor set match
+// what the request asked for, independent of whether the candidate also
+// passed validate.Run. A candidate can validate cleanly and still fail
+// here — wrong connector, swapped direction, or a dropped filter are all
+// schema-valid mistakes (the DX-review failure mode design doc
+// 20260722-conduit-generate.md exists to answer).
+type SemanticResult struct {
+	Match bool
+	// Issues names every mismatch found, in Conduit's own vocabulary
+	// (expected vs. found category, or a named missing capability) — never
+	// a bare "no match", so a human (or a future retry-feedback loop, per
+	// the design doc §3) has something concrete to act on.
+	Issues []string
+}
+
+// scoreSemantic parses candidate with the SAME YAML parser validate.Run
+// uses (never a second, hand-rolled parser) and checks it against expect:
+//
+//   - source/destination connector category (the builtin plugin's bare
+//     name, e.g. "postgres" out of "builtin:postgres") matches, when expect
+//     names one;
+//   - every tag in expect.RequiredCapabilities resolves to at least one
+//     matching processor (pipeline-level or attached to either connector) —
+//     capability.go's hasCapability.
+//
+// A parse failure or an empty pipeline document is reported as a
+// SemanticResult with Match false and a descriptive Issue, not a fatal
+// error — the caller (ScoreRun) always gets a judgeable result for every
+// candidate that was actually provided.
+func scoreSemantic(ctx context.Context, expect Expect, candidate string) SemanticResult {
+	pipelines, err := yamlparser.NewParser(log.Nop()).Parse(ctx, strings.NewReader(candidate))
+	if len(pipelines) == 0 {
+		return SemanticResult{
+			Match:  false,
+			Issues: []string{fmt.Sprintf("candidate did not parse into a judgeable pipeline: %v", errOrNoPipelines(err))},
+		}
+	}
+
+	// generate's own non-goal (design doc, Goals/Non-goals: "one NL string
+	// in, one pipeline candidate out") means a candidate is exactly one
+	// pipeline; a document with more than one is judged on the first, and
+	// that itself is flagged as an issue since it's not what a well-formed
+	// candidate should ever produce. A partial parse (pipelines recovered
+	// alongside a non-nil err, per yaml.Parser's "return whatever parsed
+	// successfully" contract) is still judged on what did parse, with the
+	// error surfaced as an additional issue rather than discarded.
+	p := pipelines[0]
+	var issues []string
+	if err != nil {
+		issues = append(issues, fmt.Sprintf("candidate had parse errors: %v", err))
+	}
+	if len(pipelines) > 1 {
+		issues = append(issues, fmt.Sprintf("candidate contains %d pipelines, expected exactly 1", len(pipelines)))
+	}
+
+	sourceCat, destCat := connectorCategories(p)
+	if expect.SourceCategory != "" && sourceCat != expect.SourceCategory {
+		issues = append(issues, fmt.Sprintf("expected source category %q, found %q", expect.SourceCategory, orNone(sourceCat)))
+	}
+	if expect.DestinationCategory != "" && destCat != expect.DestinationCategory {
+		issues = append(issues, fmt.Sprintf("expected destination category %q, found %q", expect.DestinationCategory, orNone(destCat)))
+	}
+
+	procs := allProcessors(p)
+	for _, tag := range expect.RequiredCapabilities {
+		if !hasCapability(procs, tag) {
+			issues = append(issues, fmt.Sprintf("missing required capability %q (no matching processor present)", tag))
+		}
+	}
+
+	return SemanticResult{Match: len(issues) == 0, Issues: issues}
+}
+
+// connectorCategories returns the builtin category (bare plugin name) of
+// p's source and destination connector. A pipeline with more than one
+// connector in the same role, or a non-builtin/unresolvable plugin
+// reference, yields an empty category for that role — a mismatch against
+// any non-empty Expect, and never a fabricated category by guessing which
+// of several same-role connectors was "the" one the request meant.
+func connectorCategories(p config.Pipeline) (source, destination string) {
+	var sourceSeen, destSeen bool
+	for _, c := range p.Connectors {
+		cat := builtinCategory(c.Plugin)
+		switch c.Type {
+		case config.TypeSource:
+			source, sourceSeen = foldRoleCategory(sourceSeen, cat)
+		case config.TypeDestination:
+			destination, destSeen = foldRoleCategory(destSeen, cat)
+		}
+	}
+	return source, destination
+}
+
+// foldRoleCategory folds one more same-role connector's category into the
+// running result for that role: the first one sets it, a second (or later)
+// one makes it permanently ambiguous ("") rather than silently keeping
+// whichever was seen first — a candidate with two sources (or two
+// destinations) is malformed input the checker should never paper over
+// with a guess at which one "the" connector was.
+func foldRoleCategory(seenBefore bool, cat string) (string, bool) {
+	if seenBefore {
+		return "", true
+	}
+	return cat, true
+}
+
+// builtinCategory returns the bare plugin name of a builtin plugin
+// reference (e.g. "postgres" for "builtin:postgres"), or "" for any
+// standalone/"any"-typed reference — this package only ever judges against
+// the corpus's grounding, the built-in connector set, per the task brief's
+// "grounded in real built-in connectors" requirement.
+func builtinCategory(pluginRef string) string {
+	fn := plugin.FullName(pluginRef)
+	if fn.PluginType() != plugin.PluginTypeBuiltin {
+		return ""
+	}
+	return fn.PluginName()
+}
+
+// allProcessors flattens a pipeline's own processors and every connector's
+// attached processors into one slice — a required capability may be
+// satisfied at either level, and the semantic checker does not care which.
+func allProcessors(p config.Pipeline) []config.Processor {
+	out := make([]config.Processor, 0, len(p.Processors))
+	out = append(out, p.Processors...)
+	for _, c := range p.Connectors {
+		out = append(out, c.Processors...)
+	}
+	return out
+}
+
+func orNone(s string) string {
+	if s == "" {
+		return "(none)"
+	}
+	return s
+}
+
+func errOrNoPipelines(err error) error {
+	if err != nil {
+		return err
+	}
+	return cerrors.New("no pipelines in document")
+}

--- a/cmd/conduit/internal/generate/testdata/candidates/generator-to-log-smoketest-good.yaml
+++ b/cmd/conduit/internal/generate/testdata/candidates/generator-to-log-smoketest-good.yaml
@@ -1,0 +1,12 @@
+version: "2.2"
+pipelines:
+  - id: smoketest
+    status: running
+    name: smoketest
+    connectors:
+      - id: gen-source
+        type: source
+        plugin: builtin:generator
+      - id: log-dest
+        type: destination
+        plugin: builtin:log

--- a/cmd/conduit/internal/generate/testdata/candidates/kafka-to-postgres-sync-bad-wrong-connector.yaml
+++ b/cmd/conduit/internal/generate/testdata/candidates/kafka-to-postgres-sync-bad-wrong-connector.yaml
@@ -1,0 +1,11 @@
+version: "2.2"
+pipelines:
+  - id: wrong-connectors
+    status: running
+    connectors:
+      - id: gen-source
+        type: source
+        plugin: builtin:generator
+      - id: log-dest
+        type: destination
+        plugin: builtin:log

--- a/cmd/conduit/internal/generate/testdata/candidates/postgres-cdc-to-kafka-filtered-bad-dropped-filter.yaml
+++ b/cmd/conduit/internal/generate/testdata/candidates/postgres-cdc-to-kafka-filtered-bad-dropped-filter.yaml
@@ -1,0 +1,15 @@
+version: "2.2"
+pipelines:
+  - id: orders-to-kafka-no-filter
+    status: running
+    connectors:
+      - id: pg-source
+        type: source
+        plugin: builtin:postgres
+        settings:
+          table: orders
+      - id: kafka-dest
+        type: destination
+        plugin: builtin:kafka
+        settings:
+          topic: orders

--- a/cmd/conduit/internal/generate/testdata/candidates/postgres-cdc-to-kafka-filtered-bad-schema.yaml
+++ b/cmd/conduit/internal/generate/testdata/candidates/postgres-cdc-to-kafka-filtered-bad-schema.yaml
@@ -1,0 +1,16 @@
+version: "2.2"
+pipelines:
+  - id: orders-to-kafka
+    status: bogus-status
+    connectors:
+      - id: pg-source
+        type: bogus-type
+        plugin: builtin:postgres
+      - id: kafka-dest
+        type: destination
+        plugin: builtin:kafka
+        processors:
+          - id: amount-filter
+            plugin: filter
+            settings:
+              expression: "amount > 100"

--- a/cmd/conduit/internal/generate/testdata/candidates/postgres-cdc-to-kafka-filtered-bad-swapped-direction.yaml
+++ b/cmd/conduit/internal/generate/testdata/candidates/postgres-cdc-to-kafka-filtered-bad-swapped-direction.yaml
@@ -1,0 +1,20 @@
+version: "2.2"
+pipelines:
+  - id: orders-swapped
+    status: running
+    connectors:
+      - id: kafka-source
+        type: source
+        plugin: builtin:kafka
+        settings:
+          topic: orders
+      - id: pg-dest
+        type: destination
+        plugin: builtin:postgres
+        settings:
+          table: orders
+        processors:
+          - id: amount-filter
+            plugin: filter
+            settings:
+              expression: "amount > 100"

--- a/cmd/conduit/internal/generate/testdata/candidates/postgres-cdc-to-kafka-filtered-bad-unknown-plugin.yaml
+++ b/cmd/conduit/internal/generate/testdata/candidates/postgres-cdc-to-kafka-filtered-bad-unknown-plugin.yaml
@@ -1,0 +1,18 @@
+version: "2.2"
+pipelines:
+  - id: orders-unknown-plugin
+    status: running
+    connectors:
+      - id: mystery-source
+        type: source
+        plugin: standalone:some-custom-plugin
+      - id: kafka-dest
+        type: destination
+        plugin: builtin:kafka
+        settings:
+          topic: orders
+        processors:
+          - id: amount-filter
+            plugin: filter
+            settings:
+              expression: "amount > 100"

--- a/cmd/conduit/internal/generate/testdata/candidates/postgres-cdc-to-kafka-filtered-good.yaml
+++ b/cmd/conduit/internal/generate/testdata/candidates/postgres-cdc-to-kafka-filtered-good.yaml
@@ -1,0 +1,21 @@
+version: "2.2"
+pipelines:
+  - id: orders-to-kafka
+    status: running
+    name: orders-to-kafka
+    connectors:
+      - id: pg-source
+        type: source
+        plugin: builtin:postgres
+        settings:
+          table: orders
+      - id: kafka-dest
+        type: destination
+        plugin: builtin:kafka
+        settings:
+          topic: orders
+        processors:
+          - id: amount-filter
+            plugin: filter
+            settings:
+              expression: "amount > 100"

--- a/cmd/conduit/internal/generate/testdata/eval_requests.yaml
+++ b/cmd/conduit/internal/generate/testdata/eval_requests.yaml
@@ -1,0 +1,205 @@
+# Committed eval-harness benchmark corpus for `conduit generate`
+# (docs/design-documents/20260722-conduit-generate.md §10).
+#
+# This is the SOURCE OF TRUTH for the corpus; docs/generate-benchmark.md is
+# its human-readable rendering. Every request here is grounded in one of
+# Conduit's six real built-in connectors (file, generator, kafka, log,
+# postgres, s3) — never an invented or hypothetical one — and every
+# `expect` reflects what those connectors actually support:
+#   - `generator` is source-only (no Destination in its SDK build).
+#   - `log` is destination-only (no Source in its SDK build).
+#   - `file`, `kafka`, `postgres`, `s3` support both roles.
+#
+# Loaded by generate.LoadRequests (fixture.go), which enforces unique,
+# non-empty ids and non-empty prompts. Do not rename an id casually — it is
+# the join key a scored run's report keys on.
+#
+# requiredCapabilities values name a tag in capability.go's
+# capabilityProcessors map, each backed by a real builtin processor plugin
+# (pkg/plugin/processor/builtin.DefaultBuiltinProcessors). A request with no
+# meaningful transform intent omits requiredCapabilities entirely rather
+# than listing an empty list.
+
+- id: postgres-cdc-to-kafka-filtered
+  prompt: "stream new orders from postgres into a kafka topic, only orders over $100"
+  expect:
+    sourceCategory: postgres
+    destinationCategory: kafka
+    requiredCapabilities: [filter]
+  notes: "the canonical direction + filter case named in the design doc's DX review (§1)"
+
+- id: postgres-to-s3-json-export
+  prompt: "export all customer records from postgres to an s3 bucket as json"
+  expect:
+    sourceCategory: postgres
+    destinationCategory: s3
+    requiredCapabilities: [json-encode]
+
+- id: kafka-to-postgres-sync
+  prompt: "sync messages from the kafka topic 'events' into a postgres table"
+  expect:
+    sourceCategory: kafka
+    destinationCategory: postgres
+
+- id: kafka-to-s3-archive
+  prompt: "archive every message from kafka into an s3 bucket as json files"
+  expect:
+    sourceCategory: kafka
+    destinationCategory: s3
+    requiredCapabilities: [json-encode]
+
+- id: file-to-kafka-ingest
+  prompt: "read lines from a local file and publish each one to a kafka topic"
+  expect:
+    sourceCategory: file
+    destinationCategory: kafka
+
+- id: s3-to-postgres-load
+  prompt: "load objects from an s3 bucket into a postgres table"
+  expect:
+    sourceCategory: s3
+    destinationCategory: postgres
+
+- id: generator-to-log-smoketest
+  prompt: "generate some fake test records and print them to the log, just to check the pipeline runs"
+  expect:
+    sourceCategory: generator
+    destinationCategory: log
+  notes: "the zero-key, no-real-system-required smoke-test shape"
+
+- id: postgres-to-log-debug-tap
+  prompt: "tap postgres change events and print them to the log for debugging, don't write them anywhere else"
+  expect:
+    sourceCategory: postgres
+    destinationCategory: log
+
+- id: kafka-to-kafka-retopic
+  prompt: "copy every record from the kafka topic 'raw-events' into a different kafka topic 'processed-events'"
+  expect:
+    sourceCategory: kafka
+    destinationCategory: kafka
+  notes: "same connector category on both sides — tests direction detection isn't confused by a same-category pair"
+
+- id: file-to-s3-upload
+  prompt: "upload files from a local directory to an s3 bucket"
+  expect:
+    sourceCategory: file
+    destinationCategory: s3
+
+- id: s3-to-file-backup
+  prompt: "download objects from an s3 bucket and save them as local files for backup"
+  expect:
+    sourceCategory: s3
+    destinationCategory: file
+
+- id: postgres-cdc-debezium-unwrap-to-kafka
+  prompt: "capture postgres change data and publish it to kafka, unwrapping the debezium envelope so the topic only has the actual row data"
+  expect:
+    sourceCategory: postgres
+    destinationCategory: kafka
+    requiredCapabilities: [unwrap-debezium]
+
+- id: kafka-connect-unwrap-to-postgres
+  prompt: "consume kafka connect formatted messages from a topic and upsert them into postgres, unwrapping the kafka connect envelope first"
+  expect:
+    sourceCategory: kafka
+    destinationCategory: postgres
+    requiredCapabilities: [unwrap-kafkaconnect]
+
+- id: postgres-to-s3-mask-pii
+  prompt: "export postgres customer records to s3, but remove the ssn field before writing"
+  expect:
+    sourceCategory: postgres
+    destinationCategory: s3
+    requiredCapabilities: [mask]
+
+- id: kafka-to-s3-rename-field
+  prompt: "archive kafka messages to s3, renaming the 'ts' field to 'timestamp' before writing"
+  expect:
+    sourceCategory: kafka
+    destinationCategory: s3
+    requiredCapabilities: [rename]
+
+- id: file-to-log-tail
+  prompt: "tail a log file and print each new line to the console"
+  expect:
+    sourceCategory: file
+    destinationCategory: log
+
+- id: generator-to-kafka-loadtest
+  prompt: "generate synthetic load-test records and publish them to a kafka topic"
+  expect:
+    sourceCategory: generator
+    destinationCategory: kafka
+
+- id: postgres-to-postgres-replicate
+  prompt: "replicate a table from one postgres database to another postgres database"
+  expect:
+    sourceCategory: postgres
+    destinationCategory: postgres
+
+- id: kafka-to-file-export
+  prompt: "export all messages from a kafka topic to a local file"
+  expect:
+    sourceCategory: kafka
+    destinationCategory: file
+
+- id: s3-to-kafka-load
+  prompt: "load objects from an s3 bucket and publish each one to a kafka topic"
+  expect:
+    sourceCategory: s3
+    destinationCategory: kafka
+
+- id: postgres-to-kafka-filter-and-encode
+  prompt: "stream postgres orders to kafka as json, only include orders that are still pending"
+  expect:
+    sourceCategory: postgres
+    destinationCategory: kafka
+    requiredCapabilities: [filter, json-encode]
+
+- id: file-to-file-base64-decode
+  prompt: "read a file of base64-encoded records and write the decoded content to another file"
+  expect:
+    sourceCategory: file
+    destinationCategory: file
+    requiredCapabilities: [base64-decode]
+
+- id: kafka-to-s3-split-batches
+  prompt: "archive kafka messages to s3, splitting any batched records into individual records first"
+  expect:
+    sourceCategory: kafka
+    destinationCategory: s3
+    requiredCapabilities: [split]
+
+- id: postgres-to-kafka-convert-types
+  prompt: "stream postgres orders to kafka, converting the amount field to a floating point number before publishing"
+  expect:
+    sourceCategory: postgres
+    destinationCategory: kafka
+    requiredCapabilities: [convert]
+
+- id: generator-to-s3-loadtest
+  prompt: "generate synthetic test data and write it to an s3 bucket for load testing"
+  expect:
+    sourceCategory: generator
+    destinationCategory: s3
+
+- id: kafka-to-postgres-filter-before-upsert
+  prompt: "consume kafka events and upsert them into postgres, but skip any event marked as a test event"
+  expect:
+    sourceCategory: kafka
+    destinationCategory: postgres
+    requiredCapabilities: [filter]
+
+- id: s3-to-log-audit
+  prompt: "read new objects from an s3 bucket and print an audit line to the log for each one, don't store them anywhere"
+  expect:
+    sourceCategory: s3
+    destinationCategory: log
+
+- id: postgres-to-kafka-set-derived-field
+  prompt: "stream postgres orders to kafka, adding a derived 'processed_at' field with the current timestamp before publishing"
+  expect:
+    sourceCategory: postgres
+    destinationCategory: kafka
+    requiredCapabilities: [set]

--- a/cmd/conduit/internal/generate/validate_score.go
+++ b/cmd/conduit/internal/generate/validate_score.go
@@ -1,0 +1,66 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"context"
+	"os"
+
+	"github.com/conduitio/conduit/cmd/conduit/internal/validate"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+)
+
+// validateCandidate runs the exact engine `conduit pipelines validate` uses
+// (validate.Run) against a candidate pipeline-config YAML document held only
+// in memory.
+//
+// validate.Run/RunWithOptions take a file path and read the config from
+// disk — there is no in-memory (RunBytes/RunReader) entry point today (see
+// docs/design-documents/20260722-conduit-generate.md, Decision §3, "the
+// disk seam"). That design doc names the in-memory seam as the PREFERRED
+// resolution and a temp-file+cleanup shim as the fallback if the seam
+// proves infeasible at generate's build time. This eval harness needs an
+// answer now, before that command is built, so it takes the fallback:
+// write the candidate to a private (0600) temp file, run validate.Run
+// against it, and remove the file before returning — win or lose, on every
+// return path (defer, not a final explicit call, so a panic mid-Run still
+// cleans up).
+//
+// This is deliberately the ONLY place in this package that touches disk.
+// If/when validate gains RunBytes, this function's body is the only thing
+// that needs to change — every caller (ScoreRun) is unaffected.
+func validateCandidate(ctx context.Context, candidate string) (validate.Report, error) {
+	f, err := os.CreateTemp("", "conduit-generate-eval-*.yaml")
+	if err != nil {
+		return validate.Report{}, cerrors.Errorf("creating temp file for candidate validation: %w", err)
+	}
+	path := f.Name()
+	// Best-effort cleanup of a private scratch file; nothing downstream
+	// depends on the removal succeeding (a leaked temp file in the OS temp
+	// dir is a cleanup nuisance, never a correctness or security issue,
+	// since it was never a user-visible candidate — see doc.go's "the ONLY
+	// place in this package that touches disk").
+	defer func() { _ = os.Remove(path) }()
+
+	if _, err := f.WriteString(candidate); err != nil {
+		_ = f.Close()
+		return validate.Report{}, cerrors.Errorf("writing candidate to temp file %q: %w", path, err)
+	}
+	if err := f.Close(); err != nil {
+		return validate.Report{}, cerrors.Errorf("closing temp file %q: %w", path, err)
+	}
+
+	return validate.Run(ctx, path)
+}

--- a/docs/generate-benchmark.md
+++ b/docs/generate-benchmark.md
@@ -1,0 +1,144 @@
+# `conduit generate` benchmark corpus and eval harness
+
+**Status: design-only path deliverable for v0.19.** `conduit generate` itself is not implemented
+in v0.19 — the command build is deferred to v0.20+ (the v0.19 build slot went to the Python
+connector SDK; see `docs/design-documents/20260722-conduit-generate.md`'s Status section). What
+ships now is this document, the committed benchmark corpus, and a scoring harness proven correct
+against fixture data — so that when `generate` is built, the acceptance bar it must clear is
+already frozen and reviewable, not invented mid-implementation.
+
+No LLM provider client ships with this harness. It scores whatever candidate pipeline YAML it's
+given; it never calls a model itself.
+
+## Where things live
+
+| Artifact | Path |
+| --- | --- |
+| Corpus (source of truth) | `cmd/conduit/internal/generate/testdata/eval_requests.yaml` |
+| Scoring harness (Go) | `cmd/conduit/internal/generate/*.go` |
+| Fixture tests proving the harness is correct | `cmd/conduit/internal/generate/score_test.go` |
+| Fixture candidate pipelines (good and bad, by hand) | `cmd/conduit/internal/generate/testdata/candidates/` |
+
+This file is a rendering of the corpus for human review. If the two ever disagree, the YAML file
+is correct — it's what `generate.LoadRequests` and the future CI/scheduled eval job actually read.
+
+## The two metrics — always reported separately
+
+Per the design doc's §10, a schema-valid pipeline is not the same thing as a _correct_ one, so the
+harness reports two independent numbers, never collapsed into one:
+
+1. **Validate-pass rate** — does the candidate pass `cmd/conduit/internal/validate`'s `Run`, the
+   exact engine `conduit pipelines validate` uses. Committed floor: **>= 90%** of the corpus.
+2. **Semantic-intent-match rate** — does the candidate's actual source/destination connector
+   category and processor set match the request's stated intent (`Expect`), even when it
+   validates cleanly. A pipeline can be schema-valid and still point at the wrong connector, swap
+   source/destination, or silently drop a requested filter — this is the failure mode a
+   validate-pass number alone cannot see. Committed v1 floor: **>= 70%** (deliberately lower than
+   the validate-pass floor — it measures a strictly harder, coarser property; see the design doc
+   §10 for what it does and does not catch).
+
+Both numbers are **medians over >= 3 repeated runs**, never best-of — the same discipline
+CLAUDE.md requires of `benchi` throughput claims, applied here to model-output scoring
+(`ScoreMedian` in `score.go`).
+
+**This PR reports no live scores.** There is no provider integration yet, so there is nothing to
+run the harness against in production. What's proven here is that the harness itself is correct:
+given a known-good candidate it scores both metrics true, and given each specific way a candidate
+can go wrong (bad schema, wrong connector, dropped filter, swapped direction, a fabricated/unknown
+plugin) it scores false on exactly the axis that's wrong — see `score_test.go`. When v0.20 wires up
+a provider, running it against this same corpus and reporting the resulting medians into this file
+is the first real eval run.
+
+## How a request is scored
+
+Each corpus entry pairs a natural-language `prompt` with an `expect` block — the ground truth this
+harness checks a candidate against, **not** re-derived from the prompt text by the scorer itself
+(that NL-extraction heuristic is the future `generate` command's own semantic checker, design doc
+§9 — a separate, harder problem this harness doesn't attempt):
+
+```yaml
+- id: postgres-cdc-to-kafka-filtered
+  prompt: "stream new orders from postgres into a kafka topic, only orders over $100"
+  expect:
+    sourceCategory: postgres
+    destinationCategory: kafka
+    requiredCapabilities: [filter]
+  notes: "the canonical direction + filter case named in the design doc's DX review (§1)"
+```
+
+Given a candidate pipeline YAML for this request, the scorer:
+
+- Runs `validate.Run` against it (via a private temp-file shim — `validate.Run` has no in-memory
+  entry point yet; see `validate_score.go`'s doc comment and the design doc's "disk seam"
+  discussion, Decision §3).
+- Parses it with the same YAML parser `validate` uses, and checks: does the source connector's
+  plugin resolve to the `postgres` builtin category? The destination to `kafka`? Is there a
+  processor (anywhere in the pipeline) matching each tag in `requiredCapabilities` — here,
+  `filter`, which maps to the builtin `filter` processor plugin (`capability.go`)?
+
+A candidate that validates but uses the wrong connector, swaps source and destination, drops a
+required capability, or references a non-builtin/fabricated plugin name scores **fail** on the
+semantic-intent axis even though it may score **pass** on validate — exactly the gap the two
+separate numbers exist to expose.
+
+A request with no candidate provided at all (e.g. a provider call that errored out every retry)
+counts as a **fail on both metrics** — never silently excluded from the denominator, which would
+otherwise hide the worst failure (no output at all) behind an artificially better rate.
+
+## The corpus
+
+28 requests (>= 25 required), every one grounded in one of Conduit's six real built-in connectors
+— `file`, `generator`, `kafka`, `log`, `postgres`, `s3` — respecting what each connector actually
+supports: `generator` is source-only, `log` is destination-only; the other four support both
+roles. Coverage spans every connector in both a source and a destination role where that role is
+real, plus nine processor capabilities (filter, mask, rename, set, convert, json-encode,
+unwrap-debezium, unwrap-kafkaconnect, split, base64-decode).
+
+| id | prompt | source | destination | required capabilities |
+| --- | --- | --- | --- | --- |
+| postgres-cdc-to-kafka-filtered | stream new orders from postgres into a kafka topic, only orders over $100 | postgres | kafka | filter |
+| postgres-to-s3-json-export | export all customer records from postgres to an s3 bucket as json | postgres | s3 | json-encode |
+| kafka-to-postgres-sync | sync messages from the kafka topic 'events' into a postgres table | kafka | postgres | — |
+| kafka-to-s3-archive | archive every message from kafka into an s3 bucket as json files | kafka | s3 | json-encode |
+| file-to-kafka-ingest | read lines from a local file and publish each one to a kafka topic | file | kafka | — |
+| s3-to-postgres-load | load objects from an s3 bucket into a postgres table | s3 | postgres | — |
+| generator-to-log-smoketest | generate some fake test records and print them to the log, just to check the pipeline runs | generator | log | — |
+| postgres-to-log-debug-tap | tap postgres change events and print them to the log for debugging, don't write them anywhere else | postgres | log | — |
+| kafka-to-kafka-retopic | copy every record from the kafka topic 'raw-events' into a different kafka topic 'processed-events' | kafka | kafka | — |
+| file-to-s3-upload | upload files from a local directory to an s3 bucket | file | s3 | — |
+| s3-to-file-backup | download objects from an s3 bucket and save them as local files for backup | s3 | file | — |
+| postgres-cdc-debezium-unwrap-to-kafka | capture postgres change data and publish it to kafka, unwrapping the debezium envelope so the topic only has the actual row data | postgres | kafka | unwrap-debezium |
+| kafka-connect-unwrap-to-postgres | consume kafka connect formatted messages from a topic and upsert them into postgres, unwrapping the kafka connect envelope first | kafka | postgres | unwrap-kafkaconnect |
+| postgres-to-s3-mask-pii | export postgres customer records to s3, but remove the ssn field before writing | postgres | s3 | mask |
+| kafka-to-s3-rename-field | archive kafka messages to s3, renaming the 'ts' field to 'timestamp' before writing | kafka | s3 | rename |
+| file-to-log-tail | tail a log file and print each new line to the console | file | log | — |
+| generator-to-kafka-loadtest | generate synthetic load-test records and publish them to a kafka topic | generator | kafka | — |
+| postgres-to-postgres-replicate | replicate a table from one postgres database to another postgres database | postgres | postgres | — |
+| kafka-to-file-export | export all messages from a kafka topic to a local file | kafka | file | — |
+| s3-to-kafka-load | load objects from an s3 bucket and publish each one to a kafka topic | s3 | kafka | — |
+| postgres-to-kafka-filter-and-encode | stream postgres orders to kafka as json, only include orders that are still pending | postgres | kafka | filter, json-encode |
+| file-to-file-base64-decode | read a file of base64-encoded records and write the decoded content to another file | file | file | base64-decode |
+| kafka-to-s3-split-batches | archive kafka messages to s3, splitting any batched records into individual records first | kafka | s3 | split |
+| postgres-to-kafka-convert-types | stream postgres orders to kafka, converting the amount field to a floating point number before publishing | postgres | kafka | convert |
+| generator-to-s3-loadtest | generate synthetic test data and write it to an s3 bucket for load testing | generator | s3 | — |
+| kafka-to-postgres-filter-before-upsert | consume kafka events and upsert them into postgres, but skip any event marked as a test event | kafka | postgres | filter |
+| s3-to-log-audit | read new objects from an s3 bucket and print an audit line to the log for each one, don't store them anywhere | s3 | log | — |
+| postgres-to-kafka-set-derived-field | stream postgres orders to kafka, adding a derived 'processed_at' field with the current timestamp before publishing | postgres | kafka | set |
+
+## Growing the corpus
+
+Per the design doc §10, the fixture set is the spec of "what `generate` is for" — growing it (more
+connector combinations, deliberately ambiguous prompts that should refuse, adversarial prompts
+embedding an injected instruction) is high-leverage work, the same way expanding the SDK acceptance
+suite is. Add an entry to `testdata/eval_requests.yaml`, keep this table in sync, and make sure
+`generate.LoadRequests`' invariants still hold: unique, non-empty `id`, non-empty `prompt`, and (for
+the committed corpus specifically) both `sourceCategory` and `destinationCategory` set to one of
+the six real built-in connectors.
+
+## Related
+
+- `docs/design-documents/20260722-conduit-generate.md` — the full design (provider model, the
+  never-auto-apply boundary, the disk-seam decision this harness's temp-file shim implements the
+  fallback for).
+- ROADMAP.md, Agent-native section — the v0.19 Workstream 1 item this PR advances (eval-harness
+  path only; the command implementation is v0.20+).


### PR DESCRIPTION
## Summary

Ships v0.19 Workstream 1's committed deliverable for `conduit generate` — per
`docs/design-documents/20260722-conduit-generate.md`'s Status section, the command
implementation itself is deferred to v0.20 (the v0.19 build slot went to the Python
connector SDK). **No `generate` command, MCP tool, or LLM provider client ships in
this PR.** What ships is the frozen acceptance bar the future command must clear:

- **Benchmark corpus** (`cmd/conduit/internal/generate/testdata/eval_requests.yaml`,
  rendered for humans in `docs/generate-benchmark.md`): 28 canonical natural-language
  pipeline requests (≥ 25 required), each grounded in a real built-in connector (file,
  generator, kafka, log, postgres, s3 — respecting that `generator` is source-only and
  `log` is destination-only) with its expected semantic intent (source/destination
  category, required processor capabilities).
- **Scoring harness** (`ScoreRun`/`ScoreMedian` in `score.go`) reporting two
  independent numbers, never collapsed into one:
  1. **Validate-pass rate** — runs the exact `cmd/conduit/internal/validate` engine
     `conduit pipelines validate` uses. Since `validate.Run` has no in-memory
     (`RunBytes`/`RunReader`) seam yet (confirmed absent from the tree), this uses the
     design doc's documented fallback: a private (0600) temp file, validated, then
     removed (`validate_score.go`) — the one place in the package that touches disk.
  2. **Semantic-intent-match rate** — parses the candidate with the same YAML parser
     `validate` uses and checks the actual source/destination connector category and
     processor set against the request's `Expect`, even when the candidate validates
     cleanly (`semantic_score.go`). A missing candidate fails **both** metrics rather
     than shrinking the denominator; repeated runs reduce by **median**, never
     best-of (CLAUDE.md's benchi discipline, applied to model-output scoring).
- **Fixture tests prove the scorer correct without a live LLM** (`score_test.go`, 19
  tests): known-good candidates score true on both axes; known-bad ones — bad schema,
  wrong connector (still validates), dropped filter, swapped direction, an unknown/
  fabricated plugin, malformed YAML, ambiguous multi-source — each score false on
  exactly the axis they're wrong on.

## Adversarial self-review

Re-read the diff hunting specifically for the classes CLAUDE.md flags:

- **Resource cleanup**: `validateCandidate`'s temp file is removed via `defer` on
  every return path, including the write/close error paths (verified each early
  return happens after `os.CreateTemp` and before returning, so the defer is always
  registered first).
- **Silent wrong answers** (the risk class this whole feature exists to prevent, one
  level down): initially, `connectorCategories` silently kept the *first* connector
  found in a role and ignored a second one in the same role — i.e. it would have
  guessed instead of flagging ambiguity. Caught in self-review and fixed: a second
  same-role connector now makes that role's category permanently ambiguous (`""`),
  which always mismatches a non-empty `Expect`. Added
  `TestScoreSemantic_MultipleSourceConnectors_NeverGuessesACategory` to lock this in.
- **Error paths**: a parse failure that still recovers partial pipelines (the parser's
  documented "return whatever parsed successfully" contract) is judged on what did
  parse, with the error surfaced as an additional issue rather than discarded or
  treated as an unconditional hard failure.
- **Concurrency**: no shared mutable state; `os.CreateTemp`'s per-call random suffix
  means concurrent scoring (not currently done, but not precluded) wouldn't collide.
- **Data-path invariants (1–7)**: none apply — this package never touches a running
  pipeline, ack/position/checkpoint logic, or any serialized format; it only reads
  YAML text it's given and writes/removes its own private temp file.

## Gates run (this PR only — see Process maturity table for what's not live)

- `go build ./...` — clean.
- `golangci-lint run ./cmd/conduit/internal/generate/...` — 0 issues.
- `go test -race ./cmd/conduit/internal/generate/...` — 19/19 pass.
- `make generate && git diff --exit-code` — clean (no generated-file drift; this PR
  adds no `//go:generate` directive).
- `npx markdownlint-cli2 docs/generate-benchmark.md` — 0 errors.
- No `--json` CLI surface added (no CLI command ships) — Family-A/golden-fixture gate
  N/A.
- No error code added — `allcodes.go` registration N/A (those are `generate.*` codes
  owned by the v0.20 command build).
- Full-repo `golangci-lint run ./...` was attempted but returned findings entirely
  inside a *different* concurrent worktree's vendored-Go-authors code
  (`internal/diff`, unrelated to this change) — a sandbox artifact of this
  multi-agent environment, not a finding against this diff. Only the scoped run above
  is claimed as verified.

## Tier

Tier 2 (docs/testdata + a self-contained internal package, no CLI/MCP surface, no
data-path code).

## Test plan

- [x] `go build ./...`
- [x] `golangci-lint run ./cmd/conduit/internal/generate/...`
- [x] `go test -race ./cmd/conduit/internal/generate/...`
- [x] `make generate && git diff --exit-code`
- [x] `npx markdownlint-cli2 docs/generate-benchmark.md`

## Open questions for DeVaris

- Corpus size/mix: 28 requests across 6 connectors × ~9 processor capabilities. Worth
  adding adversarial/prompt-injection-shaped fixtures now, or defer to the v0.20 PR
  that actually wires up retries and can exercise them live?
- `capability.go`'s tag→processor map is hand-maintained (not structurally linked to
  `builtin.DefaultBuiltinProcessors`, to avoid pulling plugin-runtime deps into a
  YAML-only package) — acceptable for a design-only PR, but flagging so it doesn't
  silently drift if builtin processors are renamed before v0.20 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD