### PR TITLE
fix(embed): lazy DB open + skip file provisioning on empty PipelinesDir (B1 DX hardening)

### DIFF
--- a/conduit.go
+++ b/conduit.go
@@ -17,6 +17,7 @@ package conduit
 import (
 	"context"
 	"log/slog"
+	goruntime "runtime"
 	"sync"
 	"sync/atomic"
 
@@ -46,7 +47,8 @@ type Options struct {
 	// slog.Default() (an explicit, documented choice, not an error). Two
 	// concurrent Engines constructed with distinct Loggers never cross-talk:
 	// Conduit never writes to os.Stdout/os.Stderr or a process-global logger
-	// on this path.
+	// on this path. The resolved logger also backs the leak-check finalizer
+	// (see Engine's "Lifecycle contract" doc) if Close is never called.
 	Logger *slog.Logger
 
 	// MetricsRegisterer receives Conduit's Prometheus metric families. nil
@@ -67,9 +69,17 @@ type Options struct {
 	DB DBOptions
 
 	// PipelinesDir optionally points at a directory (or a single file) of
-	// pipeline YAML configs Conduit provisions when Run starts. Leave empty
-	// to skip file-based provisioning entirely and manage pipelines
-	// exclusively through Engine.Import.
+	// pipeline YAML configs Conduit provisions on Run. Leave empty to skip
+	// file-based provisioning entirely and manage pipelines exclusively
+	// through Engine.Import — New never falls back to a CLI-style
+	// cwd/pipelines default in that case (B1 DX hardening fix: an earlier
+	// version of this package fell back to scanning the working directory
+	// anyway, and — because that directory usually doesn't exist for a
+	// pure-embed caller — provisioning then failed silently, as a swallowed
+	// ERROR log, while Run still returned a healthy Handle). When
+	// PipelinesDir is set and provisioning genuinely fails (a missing
+	// directory, malformed YAML, ...), Run returns that failure as an error
+	// instead of only logging it — see Run's doc.
 	PipelinesDir string
 
 	// API optionally exposes Conduit's HTTP/gRPC API. Disabled by default: an
@@ -120,25 +130,42 @@ type APIOptions struct {
 //
 // # Lifecycle contract
 //
-// New eagerly opens Options.DB (see New's doc) — that resource exists from
-// New onward, independent of whether Run is ever called or succeeds. Close
-// releases it, and is the only supported release path outside of a normal
-// Run→Stop cycle. Concretely:
+// New only validates Options — it does not open Options.DB, dial anything, or
+// construct pkg/conduit's Runtime. That happens lazily, in ensureRuntime, the
+// first time either Run or Import is called (B1 DX hardening fix: v1 opened
+// the database eagerly in New, so a New'd-and-discarded Engine — constructed
+// speculatively, or abandoned after a later precondition check failed — leaked
+// a Badger file lock or a Postgres/SQLite pool for the rest of the process's
+// life unless Close was called). Concretely:
 //
-//   - New → Close (Run never called): Close releases the database opened by
-//     New. Required if the embedder decides not to run the engine after all
-//     (e.g. it was constructed speculatively, or a later precondition check
-//     failed) — otherwise the DB handle (a Badger file lock, a Postgres pool,
-//     a SQLite handle) leaks for the process lifetime.
+//   - New → discard (Run and Import never called): nothing was ever opened.
+//     Calling Close is still safe but no longer required to avoid a leak —
+//     there is nothing to release.
+//   - New → Close (Run/Import never called): same as above; Close observes
+//     that ensureRuntime never ran and returns nil without touching anything.
+//   - New → Run or Import (opens the database) → Close: Close releases the
+//     database ensureRuntime opened.
 //   - New → Run (fails before Ready, including the already-done-context
-//     guard) → Close: started still flips true on the Run call (see below),
-//     but the database was never handed to Runtime's own cleanup path
-//     (registerCleanup), so Close is still required to release it.
+//     guard) → Close: ensureRuntime already opened the database before
+//     Runtime.Run's guard trips (started still flips true on the Run call,
+//     see below), and it was never handed to Runtime's own cleanup path
+//     (registerCleanup) — Close is still required to release it.
 //   - New → Run (succeeds) → Stop → Close: Stop's drain already closed the
 //     database via Runtime's cleanup path. Close is safe to call anyway — it
 //     is idempotent with that path, not merely with itself — and returns nil.
 //   - Close is safe to call more than once from the same or different
 //     goroutines; every call after the first observes the same result.
+//
+// Safety net: if an Engine that DID open resources (Run or Import actually
+// ran) is garbage-collected without Close ever being called, a
+// runtime.SetFinalizer hook logs a leak warning through Options.Logger (or
+// slog.Default() if none was supplied) instead of leaking silently — see
+// engineLeakCheckFinalizer. This is belt-and-suspenders, not a substitute for
+// Close: a finalizer's timing is unpredictable (GC-dependent, and finalizers
+// are not guaranteed to run at all before process exit), and it deliberately
+// only logs — it never closes the database itself, since running arbitrary
+// cleanup from a finalizer goroutine with no ordering guarantee relative to
+// the rest of the program is its own footgun.
 //
 // started flips to true the moment Run is *called*, not when it succeeds: a
 // failed Run permanently retires this Engine for running (a second Run
@@ -146,24 +173,119 @@ type APIOptions struct {
 // conduiterr.CodeInvalidArgument "called more than once" error Run's own doc
 // describes). Close is unaffected by started and may be called in any state.
 type Engine struct {
-	runtime *pkgconduit.Runtime
+	cfg         pkgconduit.Config
+	runtimeOpts []pkgconduit.RuntimeOption
+	logger      *slog.Logger // resolved, never nil; used only by the leak-check finalizer
+
 	started atomic.Bool
+
+	// mu guards every field below it: the lazy-open state (initDone, runtime,
+	// initErr, opened) and closed. A plain Mutex — not sync.Once/atomics —
+	// specifically so Close can block until any in-flight ensureRuntime call
+	// (from a concurrent Run or Import) has finished, rather than racing to
+	// observe "nothing opened yet" and returning early while a database open
+	// completes moments later with nothing left to release it. Engine
+	// construction and shutdown are not a hot path, so a mutex held across
+	// NewRuntime's dial is an acceptable, simple trade for that correctness.
+	mu       sync.Mutex
+	initDone bool
+	runtime  *pkgconduit.Runtime
+	initErr  error
+	// opened is true once ensureRuntime has successfully constructed runtime
+	// (i.e. Options.DB was actually opened). Close and the leak-check
+	// finalizer both read it to decide whether there is anything to release
+	// or warn about.
+	opened bool
+	// closed is true once Close has been called.
+	closed bool
 }
 
-// New constructs an Engine from opts. It opens the configured database (ctx
-// bounds that dial only — see pkgconduit.WithDialContext) but starts no
-// pipeline, server, or goroutine; call Engine.Run for that. ctx is not
-// retained past this call: Run's context is independent and must be supplied
-// fresh.
+// ensureRuntime lazily constructs the real pkg/conduit Runtime — opening
+// Options.DB and every service built on top of it — the first time it is
+// called, from whichever of Run or Import gets there first; every later or
+// concurrent caller blocks until that first call finishes and then observes
+// the same (*pkgconduit.Runtime, error) pair, without reopening anything.
+// This is the mechanism behind Engine's lazy-DB lifecycle contract (see
+// Engine's doc) — New itself never calls this.
+//
+// Only the very first caller's ctx bounds the Postgres/SQLite dial (via
+// pkgconduit.WithDialContext); once the runtime exists (or has permanently
+// failed to), a later call's ctx has no effect. ctx is not retained beyond
+// this call in either case.
+func (e *Engine) ensureRuntime(ctx context.Context) (*pkgconduit.Runtime, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.initDone {
+		return e.runtime, e.initErr
+	}
+	e.initDone = true
+
+	opts := make([]pkgconduit.RuntimeOption, len(e.runtimeOpts), len(e.runtimeOpts)+1)
+	copy(opts, e.runtimeOpts)
+	opts = append(opts, pkgconduit.WithDialContext(ctx))
+
+	rt, err := pkgconduit.NewRuntime(e.cfg, opts...)
+	if err != nil {
+		e.initErr = err
+		return nil, err
+	}
+
+	e.runtime = rt
+	e.opened = true
+	// Leak-check safety net (see engineLeakCheckFinalizer's doc): only armed
+	// once resources actually exist to leak. Close clears it again.
+	goruntime.SetFinalizer(e, engineLeakCheckFinalizer)
+
+	return rt, nil
+}
+
+// engineLeakCheckFinalizer is Engine's GC safety net (see Engine's "Lifecycle
+// contract" doc): if an Engine that actually opened resources is
+// garbage-collected without Close ever being called, this logs a leak
+// warning instead of letting the database handle leak silently for the rest
+// of the process's life. Close clears the finalizer (via
+// runtime.SetFinalizer(e, nil)) on every real call, so a well-behaved caller
+// never sees this fire.
+//
+// It deliberately does not call Close itself: a finalizer runs on a
+// runtime-managed goroutine with no ordering guarantee relative to the rest
+// of the program (and, per the runtime.SetFinalizer doc, is not guaranteed to
+// run at all before the process exits) — auto-releasing the database from
+// here would trade the leak footgun for an even harder-to-debug
+// use-after-close footgun. Logging is the safety net; it is not a substitute
+// for calling Close.
+func engineLeakCheckFinalizer(e *Engine) {
+	e.mu.Lock()
+	closed := e.closed
+	e.mu.Unlock()
+	if closed {
+		return
+	}
+
+	logger := e.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	logger.Warn(
+		"conduit: Engine garbage-collected without Close being called; its database resources "+
+			"(a Badger file lock, or a Postgres/SQLite connection pool) were never released — "+
+			"call Engine.Close once an Engine that has run or imported a pipeline is no longer needed",
+		"component", "conduit.Engine",
+	)
+}
+
+// New validates opts and returns a not-yet-running Engine. It does not open
+// Options.DB, dial anything, or construct pkg/conduit's Runtime — that is
+// deferred to the first call to Run or Import (see ensureRuntime and Engine's
+// "Lifecycle contract" doc). ctx is not used beyond this call (there is
+// nothing left to bound: validation does no I/O); Run's and Import's own ctx
+// bounds the later database dial.
 //
 // Every failure is returned as an error — a *conduiterr.ConduitError where
 // classifiable — never an os.Exit and never a panic on a caller-supplied
 // misconfiguration.
-//
-// New's eagerly-opened database is a resource an embedder must release: call
-// Engine.Close when the returned Engine is no longer needed, whether or not
-// Run was ever called — see Engine's "Lifecycle contract" doc.
-func New(ctx context.Context, opts Options) (*Engine, error) {
+func New(_ context.Context, opts Options) (*Engine, error) {
 	logger := opts.Logger
 	if logger == nil {
 		logger = slog.Default()
@@ -172,7 +294,19 @@ func New(ctx context.Context, opts Options) (*Engine, error) {
 
 	cfg := pkgconduit.DefaultConfig()
 
-	if opts.PipelinesDir != "" {
+	if opts.PipelinesDir == "" {
+		// B1 DX hardening fix: an embed caller who leaves PipelinesDir unset
+		// must never have Conduit silently scan DefaultConfig's CLI-oriented
+		// cwd/pipelines default — that directory usually doesn't exist for a
+		// pure-embed caller, and the resulting provisioning failure used to
+		// surface only as a swallowed ERROR log while Run still returned a
+		// healthy Handle. Disabled short-circuits file provisioning entirely
+		// (see pkgconduit.Config.Pipelines.Disabled's doc and initServices);
+		// cfg.Pipelines.Path is deliberately left at its DefaultConfig value
+		// (unused while Disabled) rather than "", which would instead fail
+		// cfg.Validate()'s required-field check just below.
+		cfg.Pipelines.Disabled = true
+	} else {
 		cfg.Pipelines.Path = opts.PipelinesDir
 	}
 
@@ -196,44 +330,76 @@ func New(ctx context.Context, opts Options) (*Engine, error) {
 		cfg.DB.SQLite.Table = opts.DB.SQLite.Table
 	}
 
+	// pkgconduit.NewRuntime (deferred to ensureRuntime, on first Run/Import)
+	// validates cfg again before opening anything; validating here too gives
+	// New its documented fail-fast behavior without needing to open the
+	// database — cfg.Validate() does no I/O of its own.
+	if err := cfg.Validate(); err != nil {
+		return nil, cerrors.Errorf("invalid config: %w", err)
+	}
+
 	runtimeOpts := []pkgconduit.RuntimeOption{
 		pkgconduit.WithLogger(ctxLogger),
-		pkgconduit.WithDialContext(ctx),
 	}
 	if opts.MetricsRegisterer != nil {
 		runtimeOpts = append(runtimeOpts, pkgconduit.WithMetricsRegisterer(opts.MetricsRegisterer))
 	}
 
-	rt, err := pkgconduit.NewRuntime(cfg, runtimeOpts...)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Engine{runtime: rt}, nil
+	return &Engine{
+		cfg:         cfg,
+		runtimeOpts: runtimeOpts,
+		logger:      logger,
+	}, nil
 }
 
-// Close releases resources New acquired eagerly — currently, the configured
-// database.DB — regardless of whether Run was ever called on this Engine.
-// See Engine's "Lifecycle contract" doc for the states Close must cover.
+// Close releases whatever ensureRuntime actually opened — currently, the
+// configured database.DB — regardless of whether Run was ever called on this
+// Engine. See Engine's "Lifecycle contract" doc for the states Close must
+// cover.
+//
+// Close is a safe no-op if nothing was ever opened: an Engine that never had
+// Run or Import called on it holds no resources at all (Options.DB opens
+// lazily — see New's and ensureRuntime's doc), so there is nothing to release
+// and Close returns nil without touching anything.
 //
 // Close is idempotent: it is safe to call more than once, from any goroutine,
 // and safe to call after a successful Run→Stop cycle (where the database was
 // already released via Runtime's own cleanup path) — every call after the
-// first returns the same result. It delegates to Runtime.CloseDB, whose
-// sync.Once is what actually makes double-release across both paths safe;
-// Close itself does not need a separate guard.
+// first returns the same result. When resources were opened, it delegates to
+// Runtime.CloseDB, whose sync.Once is what actually makes double-release
+// across both paths safe; Close itself does not need a separate guard for
+// that.
 //
 // Close does not stop a running Engine — an Engine with Run in flight must be
 // stopped via Handle.Stop first (Invariant 7: that is the graceful-drain
 // path). Calling Close while Run is running closes the database out from
 // under the running pipelines, which is a caller error, not something Close
-// detects or prevents.
+// detects or prevents. Likewise, calling Close concurrently with the very
+// first Run or Import call on this Engine (i.e. while ensureRuntime is still
+// opening the database for the first time) blocks until that open attempt
+// finishes (Close and ensureRuntime share the same mutex) and then releases
+// whatever it produced — but starting that race at all is caller-orchestrated
+// concurrency this method does not otherwise guard against.
 //
 // ctx is accepted for interface symmetry with Stop and for future resources
 // that may need a bounded release; the current database.DB.Close call is not
 // itself context-aware.
 func (e *Engine) Close(_ context.Context) error {
-	return e.runtime.CloseDB()
+	e.mu.Lock()
+	e.closed = true
+	opened := e.opened
+	rt := e.runtime
+	e.mu.Unlock()
+
+	// A real Close means the leak-check finalizer no longer applies, whether
+	// or not it was ever armed (SetFinalizer on an object with none set is a
+	// harmless no-op).
+	goruntime.SetFinalizer(e, nil)
+
+	if !opened {
+		return nil
+	}
+	return rt.CloseDB()
 }
 
 // Handle is returned by Engine.Run once the engine has successfully started.
@@ -246,19 +412,21 @@ type Handle struct {
 	stopErr  error
 }
 
-// Run starts the engine: it initializes all services and, if
-// Options.API.Enabled, begins serving the HTTP/gRPC API. It returns as soon
-// as either the engine becomes ready to accept work (a non-nil *Handle) or
-// startup definitively fails (a non-nil error) — it never blocks
-// indefinitely.
+// Run starts the engine: on first call, it lazily opens Options.DB and
+// constructs every service (ensureRuntime — a no-op if Import already did
+// this), then initializes all services and, if Options.API.Enabled, begins
+// serving the HTTP/gRPC API. It returns as soon as either the engine becomes
+// ready to accept work (a non-nil *Handle) or startup definitively fails (a
+// non-nil error) — it never blocks indefinitely.
 //
-// ctx governs the engine's entire run: cancelling it starts the same
-// graceful drain Handle.Stop triggers (Invariant 7) — Run reuses
-// pkg/conduit's Runtime.Run and its existing ctx-cancellation-driven tomb
-// drain unchanged, the same mechanism `conduit run`'s SIGTERM handling
-// already drives from an OS signal via Entrypoint.CancelOnInterrupt. Run
-// does not store ctx beyond deriving a cancelable child from it; a
-// caller-supplied deadline propagates normally.
+// ctx bounds the database dial if this is the first Run or Import call on
+// this Engine (see ensureRuntime), and then governs the engine's entire run:
+// cancelling it starts the same graceful drain Handle.Stop triggers
+// (Invariant 7) — Run reuses pkg/conduit's Runtime.Run and its existing
+// ctx-cancellation-driven tomb drain unchanged, the same mechanism `conduit
+// run`'s SIGTERM handling already drives from an OS signal via
+// Entrypoint.CancelOnInterrupt. Run does not store ctx beyond deriving a
+// cancelable child from it; a caller-supplied deadline propagates normally.
 //
 // Run must be called at most once per Engine. A second call returns a coded
 // error (conduiterr.CodeInvalidArgument) rather than racing a second tomb
@@ -266,17 +434,49 @@ type Handle struct {
 // double Run is caller misuse that has never been observed in practice, not
 // a distinct, documented failure mode that needs its own machine-actionable
 // identity.
+//
+// A caller-configured Options.PipelinesDir that fails to provision (a missing
+// directory, malformed pipeline YAML, ...) is a startup failure Run surfaces
+// as a returned error — not merely a log line, unlike `conduit run`'s own
+// default behavior for the identical failure (see
+// pkgconduit.Runtime.ProvisioningErr's doc, which this reads: that field is
+// purely additive and `conduit run` never consults it). B1 DX hardening: the
+// CLI's swallow-unless-exit-on-degraded default, reused unchanged on the
+// embed path, violated New's "every failure returned as an error" promise.
+// Run detects this right after Ready fires (the same point
+// ProvisionService.Init has already run), gracefully stops what it just
+// started (Invariant 7 — the identical drain Handle.Stop would trigger), and
+// returns the provisioning error instead of a Handle. This never fires when
+// Options.PipelinesDir is empty: file provisioning is Disabled entirely in
+// that case (see New's doc), not attempted against a possibly-nonexistent
+// path.
 func (e *Engine) Run(ctx context.Context) (*Handle, error) {
 	if !e.started.CompareAndSwap(false, true) {
 		return nil, conduiterr.New(conduiterr.CodeInvalidArgument, "conduit: Run called more than once on this Engine")
 	}
 
+	rt, err := e.ensureRuntime(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	runCtx, cancel := context.WithCancel(ctx)
 	done := make(chan error, 1)
-	go func() { done <- e.runtime.Run(runCtx) }()
+	go func() { done <- rt.Run(runCtx) }()
 
 	select {
-	case <-e.runtime.Ready:
+	case <-rt.Ready:
+		if provErr := rt.ProvisioningErr; provErr != nil {
+			// Fix (B1 DX hardening): declare this Run a failure instead of
+			// handing back a Handle that looks healthy over broken file
+			// provisioning. cancel+drain first (Invariant 7's graceful
+			// shutdown), exactly what Handle.Stop would do, since no Handle
+			// is being returned for the caller to Stop later.
+			cancel()
+			<-done
+			wrapped := cerrors.Errorf("conduit: pipeline provisioning failed for pipelines dir %q: %w", e.cfg.Pipelines.Path, provErr)
+			return nil, conduiterr.Wrap(conduiterr.CodeInvalidArgument, wrapped.Error(), wrapped)
+		}
 		return &Handle{cancel: cancel, done: done}, nil
 	case err := <-done:
 		// Run returned — almost always a failure — before Ready ever closed.
@@ -351,18 +551,35 @@ func (h *Handle) Stop(ctx context.Context) error {
 // Enrich here would crash on the exact construction pattern Import exists for.
 // A malformed cfg (after enrichment) is rejected as a coded error from
 // Validate, not a later, harder-to-diagnose provisioning failure.
+//
+// Import may be called before Run — a pure-embed, Import-driven caller that
+// never needs a Handle need not call Run at all. It is (with Run) one of the
+// two calls that can trigger ensureRuntime and lazily open Options.DB, if
+// neither has run yet on this Engine — see Engine's "Lifecycle contract" doc.
 func (e *Engine) Import(ctx context.Context, cfg PipelineConfig) error {
+	rt, err := e.ensureRuntime(ctx)
+	if err != nil {
+		return err
+	}
+
 	cfg = provisioningconfig.Enrich(cfg)
 	if err := provisioningconfig.Validate(cfg); err != nil {
 		return err
 	}
-	return e.runtime.ProvisionService.Import(ctx, cfg)
+	return rt.ProvisionService.Import(ctx, cfg)
 }
 
 // StartPipeline starts a previously imported/provisioned pipeline by ID,
-// delegating to the orchestrator unchanged.
+// delegating to the orchestrator unchanged. Calling it before Run or Import
+// has ever run on this Engine still lazily opens Options.DB (ensureRuntime)
+// so this returns the orchestrator's own not-found error rather than a
+// nil-pointer panic — though no pipeline could exist yet on such an Engine.
 func (e *Engine) StartPipeline(ctx context.Context, pipelineID string) error {
-	return e.runtime.Orchestrator.Pipelines.Start(ctx, pipelineID)
+	rt, err := e.ensureRuntime(ctx)
+	if err != nil {
+		return err
+	}
+	return rt.Orchestrator.Pipelines.Start(ctx, pipelineID)
 }
 
 // StopPipeline stops a running pipeline by ID, delegating to the
@@ -370,7 +587,12 @@ func (e *Engine) StartPipeline(ctx context.Context, pipelineID string) error {
 // that single pipeline (mirrors the orchestrator's own Stop semantics) —
 // an embedder that wants Invariant-7 graceful shutdown for everything should
 // prefer Handle.Stop (which always drains) over StopPipeline(force=true) for
-// individual pipelines.
+// individual pipelines. See StartPipeline's doc on why this also routes
+// through ensureRuntime.
 func (e *Engine) StopPipeline(ctx context.Context, pipelineID string, force bool) error {
-	return e.runtime.Orchestrator.Pipelines.Stop(ctx, pipelineID, force)
+	rt, err := e.ensureRuntime(ctx)
+	if err != nil {
+		return err
+	}
+	return rt.Orchestrator.Pipelines.Stop(ctx, pipelineID, force)
 }

--- a/conduit.go
+++ b/conduit.go
@@ -155,6 +155,11 @@ type APIOptions struct {
 //     is idempotent with that path, not merely with itself — and returns nil.
 //   - Close is safe to call more than once from the same or different
 //     goroutines; every call after the first observes the same result.
+//   - New → Close → Run or Import (no prior Run/Import call — ensureRuntime
+//     never ran before Close): ensureRuntime checks the closed flag before
+//     ever opening anything, so this never silently opens a fresh runtime the
+//     caller believed was already released. It returns a coded error
+//     (conduiterr.CodeInvalidArgument) instead.
 //
 // Safety net: if an Engine that DID open resources (Run or Import actually
 // ran) is garbage-collected without Close ever being called, a
@@ -212,9 +217,35 @@ type Engine struct {
 // pkgconduit.WithDialContext); once the runtime exists (or has permanently
 // failed to), a later call's ctx has no effect. ctx is not retained beyond
 // this call in either case.
+//
+// Known limitation: only the first caller's ctx bounds the dial — a
+// concurrent second caller (e.g. Import racing Run) has no independent
+// timeout of its own. If that first caller's ctx is short-lived and gets
+// canceled, the second caller's dial observes that same cancellation even
+// though its own ctx may still have time left. This is accepted for v1: the
+// alternative (bounding the dial by whichever caller's ctx is most
+// permissive, or racing the dial per caller) adds real complexity for a
+// narrow window that only matters when two callers race the very first
+// Run/Import on an Engine.
+//
+// Once Close has been called, ensureRuntime never opens a runtime — even if
+// Run or Import is called for the first time afterward, with no prior open —
+// so a caller cannot resurrect resources it already believed were released.
+// It returns the same conduiterr.CodeInvalidArgument used elsewhere in this
+// package for caller-misuse states (double Run, nil-Handle Stop) rather than
+// minting a new code for this one.
 func (e *Engine) ensureRuntime(ctx context.Context) (*pkgconduit.Runtime, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+
+	if e.closed {
+		// Guards against Run/Import being called after Close with no prior
+		// ensureRuntime call: without this check, a caller that already
+		// believes its Engine's resources are released would silently open a
+		// brand new runtime (and database) here instead of getting an error.
+		return nil, conduiterr.New(conduiterr.CodeInvalidArgument,
+			"conduit: Run/Import called on an Engine after Close")
+	}
 
 	if e.initDone {
 		return e.runtime, e.initErr

--- a/conduit_test.go
+++ b/conduit_test.go
@@ -17,6 +17,8 @@ package conduit_test
 import (
 	"context"
 	"net"
+	"os"
+	"path/filepath"
 	"reflect"
 	"sync"
 	"testing"
@@ -229,9 +231,15 @@ func TestStop_DeadlineExceeded(t *testing.T) {
 // engines opening the same BadgerDB path in one process surface the
 // existing coded CodeUnavailable path (OpenStore's own tagging), not a
 // generic OS error or a panic.
+//
+// B1 DX-hardening (lazy DB open): New no longer opens anything, so the
+// contention has to be forced by actually running e1 first — the store only
+// opens (and the lock is only held) once ensureRuntime runs, on Run or
+// Import, not on New. See Engine's "Lifecycle contract" doc.
 func TestNew_StoreAlreadyOpen_ReturnsCodedError(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
+	ctx := context.Background()
 
 	opts := conduit.Options{
 		PipelinesDir: t.TempDir(),
@@ -241,25 +249,33 @@ func TestNew_StoreAlreadyOpen_ReturnsCodedError(t *testing.T) {
 	}
 	opts.DB.Badger.Path = dir
 
-	e1, err := conduit.New(context.Background(), opts)
+	e1, err := conduit.New(ctx, opts)
 	is.NoErr(err)
-	defer func() { is.NoErr(e1.Close(context.Background())) }()
+	h1, err := e1.Run(ctx) // actually opens the Badger store, holding its file lock
+	is.NoErr(err)
+	defer func() {
+		is.NoErr(h1.Stop(ctx))
+		is.NoErr(e1.Close(ctx))
+	}()
 
-	_, err = conduit.New(context.Background(), opts)
+	e2, err := conduit.New(ctx, opts)
+	is.NoErr(err) // New only validates Options; still opens nothing
+
+	_, err = e2.Run(ctx)
 	is.True(err != nil)
 	ce, ok := conduiterr.Get(err)
 	is.True(ok)
 	is.Equal(ce.Code, conduiterr.CodeUnavailable)
 }
 
-// TestClose_NoRun_ReleasesDB proves Engine.Close's first lifecycle-contract
-// case: New followed directly by Close (Run never called) releases the
-// database New opened eagerly. It uses a BadgerDB path (a real OS-level file
-// lock, unlike the in-memory store other tests default to) and proves release
-// the same way TestNew_StoreAlreadyOpen_ReturnsCodedError proves the leak: a
-// second Engine constructed at the same path only succeeds if the first
-// Engine's DB was actually closed, not merely garbage-collected.
-func TestClose_NoRun_ReleasesDB(t *testing.T) {
+// TestClose_NoRun_IsNoOp proves Engine.Close's first lifecycle-contract case
+// under lazy DB open: New alone opens nothing, so Close on a never-Run,
+// never-Imported Engine is a safe no-op — proven here the same way
+// TestNew_StoreAlreadyOpen_ReturnsCodedError proves contention: a second
+// Engine at the same BadgerDB path opens (via Run) without contention, which
+// would fail with CodeUnavailable if e1 had actually opened (and leaked) the
+// store instead.
+func TestClose_NoRun_IsNoOp(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	ctx := context.Background()
@@ -273,20 +289,23 @@ func TestClose_NoRun_ReleasesDB(t *testing.T) {
 	e1, err := conduit.New(ctx, opts)
 	is.NoErr(err)
 
-	is.NoErr(e1.Close(ctx)) // no Run was ever called
+	is.NoErr(e1.Close(ctx)) // no Run/Import was ever called; nothing to release
 
 	e2, err := conduit.New(ctx, opts)
-	is.NoErr(err) // would fail with CodeUnavailable if e1's DB were still holding the lock
+	is.NoErr(err)
+	h2, err := e2.Run(ctx) // would fail with CodeUnavailable if e1 had opened (and leaked) the store
+	is.NoErr(err)
+	is.NoErr(h2.Stop(ctx))
 	is.NoErr(e2.Close(ctx))
 }
 
 // TestClose_AfterRunHitsAlreadyDoneContextGuard_ReleasesDB proves Engine.Close's
-// second lifecycle-contract case: Run reaching pkgconduit.Runtime.Run's
-// already-done-context guard (a pre-canceled ctx) returns before
-// registerCleanup is ever registered, so the runtime's own cleanup path never
-// closes the database — Close is the only release path left, and it must
-// still work. started flipping true on the Run call (not on success) must not
-// block Close.
+// second lifecycle-contract case: Run's ensureRuntime call opens the database
+// before pkgconduit.Runtime.Run's already-done-context guard (a pre-canceled
+// ctx) trips and returns, before registerCleanup is ever registered — so the
+// runtime's own cleanup path never closes the database. Close is the only
+// release path left, and it must still work. started flipping true on the Run
+// call (not on success) must not block Close.
 func TestClose_AfterRunHitsAlreadyDoneContextGuard_ReleasesDB(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
@@ -315,12 +334,30 @@ func TestClose_AfterRunHitsAlreadyDoneContextGuard_ReleasesDB(t *testing.T) {
 	is.NoErr(e2.Close(ctx))
 }
 
-// TestClose_DoubleCloseIsSafe proves Close's idempotency guarantee: calling it
-// twice returns the same (nil) result both times, with no panic and no
-// double-close error surfacing to the caller.
+// TestClose_DoubleCloseIsSafe proves Close's idempotency guarantee on an
+// Engine that never opened anything (lazy DB open: New/Close alone, no
+// Run/Import — see Engine's "Lifecycle contract" doc): calling it twice
+// returns the same (nil) no-op result both times, with no panic.
 func TestClose_DoubleCloseIsSafe(t *testing.T) {
 	is := is.New(t)
 	e := newTestEngine(t, conduit.Options{})
+
+	is.NoErr(e.Close(context.Background()))
+	is.NoErr(e.Close(context.Background()))
+}
+
+// TestClose_DoubleCloseAfterRunIsSafe proves the same idempotency guarantee
+// on the path that actually exercises #2667's Runtime.CloseDB double-release
+// safety: an Engine that did open a database (via Run) and already released
+// it once (via Stop's own cleanup path) still returns the same nil result on
+// a second, third, ... Close call, rather than a double-close error.
+func TestClose_DoubleCloseAfterRunIsSafe(t *testing.T) {
+	is := is.New(t)
+	e := newTestEngine(t, conduit.Options{})
+
+	h, err := e.Run(context.Background())
+	is.NoErr(err)
+	is.NoErr(h.Stop(context.Background()))
 
 	is.NoErr(e.Close(context.Background()))
 	is.NoErr(e.Close(context.Background()))
@@ -341,25 +378,26 @@ func TestClose_AfterSuccessfulStop_IsSafe(t *testing.T) {
 	is.NoErr(e.Close(context.Background()))
 }
 
-// TestNew_MetricNameCollision_ReturnsCodedError proves failure mode 7: two
+// TestRun_MetricNameCollision_ReturnsCodedError proves failure mode 7: two
 // engines sharing one prometheus.Registerer collide on Conduit's metric
-// names, surfacing a coded error from New rather than MustRegister's panic.
-func TestNew_MetricNameCollision_ReturnsCodedError(t *testing.T) {
+// names, surfacing a coded error rather than MustRegister's panic.
+//
+// B1 DX-hardening (lazy DB open): metrics registration happens inside
+// ensureRuntime, which New no longer calls — so the collision only manifests
+// once the second engine actually runs, not at New. This was
+// TestNew_MetricNameCollision_ReturnsCodedError before the lazy-open change;
+// renamed to match where the failure now surfaces.
+func TestRun_MetricNameCollision_ReturnsCodedError(t *testing.T) {
 	is := is.New(t)
 	reg := promclient.NewRegistry()
 
-	_, err := conduit.New(context.Background(), conduit.Options{
-		PipelinesDir:      t.TempDir(),
-		DB:                conduit.DBOptions{Type: "inmemory"},
-		MetricsRegisterer: reg,
-	})
+	e1 := newTestEngine(t, conduit.Options{MetricsRegisterer: reg})
+	h1, err := e1.Run(context.Background())
 	is.NoErr(err)
+	defer func() { _ = h1.Stop(context.Background()) }()
 
-	_, err = conduit.New(context.Background(), conduit.Options{
-		PipelinesDir:      t.TempDir(),
-		DB:                conduit.DBOptions{Type: "inmemory"},
-		MetricsRegisterer: reg,
-	})
+	e2 := newTestEngine(t, conduit.Options{MetricsRegisterer: reg})
+	_, err = e2.Run(context.Background())
 	is.True(err != nil)
 	ce, ok := conduiterr.Get(err)
 	is.True(ok)
@@ -412,4 +450,104 @@ func TestImport_RoundTripsThroughRunningEngine(t *testing.T) {
 	is.NoErr(err)
 
 	is.NoErr(h.Stop(context.Background()))
+}
+
+// TestNew_EmptyPipelinesDir_NeverScansCWD is the regression test for the B1
+// DX-hardening bug: leaving Options.PipelinesDir empty used to fall through
+// to pkgconduit.DefaultConfig's CLI-oriented cwd/pipelines default, so an
+// embed caller who never asked for file provisioning could still have
+// whatever happened to be sitting in its process's working directory
+// provisioned. This plants a real, valid pipeline YAML at cwd/pipelines and
+// proves Run with an empty PipelinesDir never provisions it — StartPipeline
+// on its ID must return a not-found error, not succeed.
+func TestNew_EmptyPipelinesDir_NeverScansCWD(t *testing.T) {
+	is := is.New(t)
+
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	pipelinesDir := filepath.Join(cwd, "pipelines")
+	is.NoErr(os.MkdirAll(pipelinesDir, 0o755))
+	pipelineYAML := `
+version: 2.2
+pipelines:
+  - id: should-not-be-provisioned
+    status: stopped
+    connectors:
+      - id: src
+        type: source
+        plugin: builtin:generator
+        settings:
+          format.type: raw
+          recordCount: "1"
+      - id: dst
+        type: destination
+        plugin: builtin:log
+`
+	is.NoErr(os.WriteFile(filepath.Join(pipelinesDir, "test.yaml"), []byte(pipelineYAML), 0o600))
+
+	ctx := context.Background()
+	// conduit.New directly, not newTestEngine: that helper backfills an empty
+	// PipelinesDir with t.TempDir(), which would defeat the exact case this
+	// test exists to cover.
+	e, err := conduit.New(ctx, conduit.Options{
+		DB: conduit.DBOptions{Type: "inmemory"},
+		// PipelinesDir deliberately left empty.
+	})
+	is.NoErr(err)
+
+	h, err := e.Run(ctx)
+	is.NoErr(err) // Disabled provisioning must not fail Run, and must not surface even a swallowed log as an error
+	defer func() { _ = h.Stop(ctx) }()
+
+	err = e.StartPipeline(ctx, "should-not-be-provisioned")
+	is.True(err != nil) // the pipeline sitting in cwd/pipelines must never have been provisioned
+}
+
+// TestNew_NonexistentCustomPipelinesDir_FailsFast proves a side effect of
+// this fix worth pinning down explicitly: unlike an empty PipelinesDir (fully
+// Disabled, see TestNew_EmptyPipelinesDir_NeverScansCWD), a *configured*
+// PipelinesDir that doesn't exist at all fails Config.Validate() — and
+// therefore New itself — immediately, rather than deferring to Run. New's
+// own doc promises "every failure returned as an error"; a missing directory
+// is exactly the kind of caller-supplied misconfiguration that should never
+// need a Run round-trip to discover. (This particular Validate error is a
+// plain wrapped error, not a *conduiterr.ConduitError — pkg/conduit.Config's
+// requiredConfigFieldErr/invalidConfigFieldErr predate the conduiterr
+// convention — so this only asserts non-nil, not a code.)
+func TestNew_NonexistentCustomPipelinesDir_FailsFast(t *testing.T) {
+	is := is.New(t)
+
+	_, err := conduit.New(context.Background(), conduit.Options{
+		DB:           conduit.DBOptions{Type: "inmemory"},
+		PipelinesDir: filepath.Join(t.TempDir(), "does-not-exist"),
+	})
+	is.True(err != nil)
+}
+
+// TestRun_MalformedPipelinesDir_ReturnsError is the regression test for the
+// other half of the B1 DX-hardening bug: when Options.PipelinesDir IS
+// configured, exists (so Config.Validate() passes — see
+// TestNew_NonexistentCustomPipelinesDir_FailsFast for the case it doesn't),
+// but genuinely fails to *provision* (here, a syntactically invalid pipeline
+// YAML file, discovered only once ProvisionService.Init actually parses it),
+// Run must surface that failure as a returned error — not only the swallowed
+// ERROR log `conduit run`'s own default (Config.Pipelines.ExitOnDegraded ==
+// false) produces for the identical failure.
+func TestRun_MalformedPipelinesDir_ReturnsError(t *testing.T) {
+	is := is.New(t)
+
+	dir := t.TempDir()
+	malformedYAML := "pipelines:\n  - id: pipeline1\n                      status: running\n"
+	is.NoErr(os.WriteFile(filepath.Join(dir, "bad.yaml"), []byte(malformedYAML), 0o600))
+
+	e := newTestEngine(t, conduit.Options{PipelinesDir: dir})
+
+	h, err := e.Run(context.Background())
+	is.True(err != nil) // must fail, not return a healthy Handle over a swallowed log
+	is.True(h == nil)
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code, conduiterr.CodeInvalidArgument)
 }

--- a/conduit_test.go
+++ b/conduit_test.go
@@ -299,6 +299,57 @@ func TestClose_NoRun_IsNoOp(t *testing.T) {
 	is.NoErr(e2.Close(ctx))
 }
 
+// TestRun_AfterClose_WithNoPriorOpen_ReturnsCodedError is the regression test
+// for the review-flagged use-after-close gap: ensureRuntime never checked the
+// closed flag, so calling Run or Import for the first time on an Engine after
+// Close had already been called (with no prior Run/Import) silently opened a
+// fresh runtime — and a fresh database — that the caller believed was already
+// released. Proves both that the call fails with the existing
+// conduiterr.CodeInvalidArgument (see ensureRuntime's doc: deliberately not a
+// new code) and, via the same no-leak proof TestClose_NoRun_IsNoOp uses, that
+// no database was actually opened: a second Engine at the same BadgerDB path
+// opens without contention, which would fail with CodeUnavailable if Run had
+// gone ahead and opened (and held the file lock on) e1's store.
+func TestRun_AfterClose_WithNoPriorOpen_ReturnsCodedError(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	opts := conduit.Options{
+		PipelinesDir: t.TempDir(),
+		DB:           conduit.DBOptions{Type: "badger"},
+	}
+	opts.DB.Badger.Path = dir
+
+	e1, err := conduit.New(ctx, opts)
+	is.NoErr(err)
+
+	is.NoErr(e1.Close(ctx)) // Close before Run/Import ever ran: nothing to release yet
+
+	_, err = e1.Run(ctx)
+	is.True(err != nil) // must not silently open a fresh runtime after Close
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code, conduiterr.CodeInvalidArgument)
+
+	err = e1.Import(ctx, conduit.PipelineConfig{})
+	is.True(err != nil) // Import must be guarded identically to Run
+	ce, ok = conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code, conduiterr.CodeInvalidArgument)
+
+	// No-leak proof: a second Engine at the identical BadgerDB path must open
+	// without contention. If Run (or Import) above had gone ahead and opened
+	// e1's database despite Close, this would instead fail with
+	// conduiterr.CodeUnavailable (see TestNew_StoreAlreadyOpen_ReturnsCodedError).
+	e2, err := conduit.New(ctx, opts)
+	is.NoErr(err)
+	h2, err := e2.Run(ctx)
+	is.NoErr(err)
+	is.NoErr(h2.Stop(ctx))
+	is.NoErr(e2.Close(ctx))
+}
+
 // TestClose_AfterRunHitsAlreadyDoneContextGuard_ReleasesDB proves Engine.Close's
 // second lifecycle-contract case: Run's ensureRuntime call opens the database
 // before pkgconduit.Runtime.Run's already-done-context guard (a pre-canceled

--- a/doc.go
+++ b/doc.go
@@ -17,18 +17,29 @@
 // touching os.Exit, a global logger, or the process-wide default Prometheus
 // registry.
 //
-// # Scope (v1 / "B1")
+// # Scope (v1 / "B1", DX-hardened)
 //
-// This package covers the engine lifecycle only: New constructs an Engine from
-// Options (and eagerly opens its database — see New's and Engine.Close's doc);
-// Engine.Run starts it and returns a *Handle once it is ready to accept work;
-// Handle.Stop drains and shuts it down; Engine.Close releases the resources
-// New acquired, whether or not Run was ever called — see Engine's "Lifecycle
-// contract" doc for the exact New/Run/Stop/Close state matrix. Engine.Import
-// lets a host create or update a pipeline from a PipelineConfig value built in
-// code — the pipelines-in-code builder (NewPipeline/PipelineBuilder) and the
+// This package covers the engine lifecycle only: New validates Options and
+// constructs an Engine, but opens nothing — the database (and every service
+// built on it) is opened lazily, on whichever of Engine.Run or Engine.Import
+// is called first (see ensureRuntime, and Engine's "Lifecycle contract" doc).
+// Run starts the engine and returns a *Handle once it is ready to accept
+// work; Handle.Stop drains and shuts it down; Engine.Close releases whatever
+// was actually opened, whether or not Run was ever called, and is a safe
+// no-op if nothing was — see Engine's "Lifecycle contract" doc for the exact
+// New/Run/Import/Stop/Close state matrix. Engine.Import lets a host create or
+// update a pipeline from a PipelineConfig value built in code — the
+// pipelines-in-code builder (NewPipeline/PipelineBuilder) and the
 // C-ABI/language-binding surface (libconduit proper) are later workstreams;
 // see docs/design-documents/20260722-embed-libconduit-v1.md.
+//
+// The database open was eager in the original B1 merge; a DX audit (zero
+// external adoption yet, so the right time to fix a frozen-contract mistake)
+// found this made a New'd-and-discarded Engine leak a Badger file lock or a
+// Postgres/SQLite pool unless Close was called even when the caller never ran
+// anything. It is lazy as of this fast-follow — see New's doc and
+// engineLeakCheckFinalizer for the GC-time safety net that remains for any
+// discard-without-Close path this doesn't otherwise catch.
 //
 // # Why this exists, not pkg/conduit directly
 //
@@ -74,8 +85,10 @@
 // TestTwoEngines_MetricsCrossTalk_KnownLimitation.
 //
 // Two sharper instances of the same root cause are tracked separately, also
-// accepted for v1: a failed metrics registration during New still leaks a
-// registry into pkg/foundation/metrics' process-global bookkeeping
+// accepted for v1: a failed metrics registration during ensureRuntime (first
+// Run or Import, not New — see this package's lazy-open fast-follow above)
+// still leaks a registry into pkg/foundation/metrics' process-global
+// bookkeeping
 // (https://github.com/ConduitIO/conduit/issues/2669, see
 // pkg/conduit.configureEmbeddedMetrics' doc), and the HTTP /metrics route
 // serves promclient.DefaultGatherer rather than a host-supplied

--- a/example_test.go
+++ b/example_test.go
@@ -33,6 +33,13 @@ import (
 // budget assertion — deliberately separate from the human-facing "15 minutes
 // to a running pipeline" doc claim, which is a UX statement, not something a
 // test can measure; see the embed workstream plan §12 open question 1).
+//
+// New below does not open anything (B1 DX-hardening fix: the database opens
+// lazily, on this very Run call — see New's and Engine's "Lifecycle contract"
+// doc); Run's own success-then-Stop path already releases it via Runtime's
+// cleanup, which is why this example never calls Engine.Close explicitly —
+// see Close's doc for when it would still be needed (e.g. if Run below had
+// failed, or if the engine were discarded before ever being run).
 func helloPipeline(ctx context.Context, dir string) error {
 	e, err := conduit.New(ctx, conduit.Options{
 		Logger:       slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),

--- a/pkg/conduit/config.go
+++ b/pkg/conduit/config.go
@@ -172,7 +172,23 @@ type Config struct {
 	Pipelines struct {
 		Path           string `long:"pipelines.path" usage:"path to a pipelines' directory or a pipeline configuration file"`
 		ExitOnDegraded bool   `long:"pipelines.exit-on-degraded" mapstructure:"exit-on-degraded" usage:"exit Conduit if a pipeline is degraded"`
-		ErrorRecovery  struct {
+
+		// Disabled turns off file-based pipeline provisioning entirely:
+		// initServices never calls ProvisionService.Init, so Path is never
+		// stat'd or scanned. It deliberately has no `long`/`mapstructure`
+		// tag — it is not a CLI flag, `conduit run` never sets it, and
+		// DefaultConfig leaves it at its zero value (false) — so this field
+		// cannot regress the CLI's cwd/pipelines default-scanning behavior.
+		// It exists only for the root embed package
+		// (github.com/conduitio/conduit), whose New sets it when
+		// Options.PipelinesDir is left empty: an embed-only "no file
+		// provisioning" intent that must not be expressible by silently
+		// inheriting this Config's DefaultConfig-populated Path
+		// (cwd/pipelines) — that default is CLI-oriented, not something a
+		// pure-embed/Import-driven caller ever asked for. See initServices.
+		Disabled bool
+
+		ErrorRecovery struct {
 			// MinDelay is the minimum delay before restart: Default: 1 second
 			MinDelay time.Duration `long:"pipelines.error-recovery.min-delay" mapstructure:"min-delay" usage:"minimum delay before restart"`
 			// MaxDelay is the maximum delay before restart: Default: 10 minutes

--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -96,6 +96,20 @@ type Runtime struct {
 	// Ready will be closed when Runtime has successfully started
 	Ready chan struct{}
 
+	// ProvisioningErr is set (once, before Ready closes) if
+	// ProvisionService.Init returned a non-nil error during initServices —
+	// regardless of Config.Pipelines.ExitOnDegraded. It is purely additive:
+	// `conduit run`'s own behavior (log the error via cerrors.ForEach, and
+	// only fail startup when ExitOnDegraded is set) is completely unchanged
+	// and never reads this field. It exists so the root embed package
+	// (github.com/conduitio/conduit) can tell a genuine file-provisioning
+	// failure apart from a healthy Ready and surface it as a returned error
+	// from Engine.Run, instead of the CLI's swallowed-log default — see that
+	// package's Run doc and the B1 DX-hardening fix it documents. nil means
+	// either provisioning is Config.Pipelines.Disabled, or it ran and found
+	// no errors.
+	ProvisioningErr error
+
 	pipelineService  *pipeline.Service
 	connectorService *connector.Service
 	processorService *processor.Service
@@ -1324,17 +1338,32 @@ func (r *Runtime) initServices(ctx context.Context, t *tomb.Tomb) error {
 		return cerrors.Errorf("failed to init pipeline service: %w", err)
 	}
 
-	err = r.ProvisionService.Init(ctx)
-	if err != nil {
-		cerrors.ForEach(err, func(err error) {
-			r.logger.Err(ctx, err).Msg("provisioning failed")
-		})
-		if r.Config.Pipelines.ExitOnDegraded {
-			r.logger.Warn(ctx).
-				Err(err).
-				Msg("Conduit will shut down due to a pipeline provisioning failure and 'exit on error' enabled")
-			err = cerrors.Errorf("shut down due to 'exit on error' enabled: %w", err)
-			return err
+	if r.Config.Pipelines.Disabled {
+		// Embed-only: Options.PipelinesDir was left empty (see the root
+		// conduit package's New doc) — file provisioning is off, not merely
+		// pointed at an empty/missing path, so Path is never stat'd or
+		// scanned. `conduit run` never sets Disabled (see its field doc), so
+		// this branch is unreachable on the CLI path.
+		r.logger.Debug(ctx).Msg("file-based pipeline provisioning is disabled, skipping")
+	} else {
+		err = r.ProvisionService.Init(ctx)
+		if err != nil {
+			// Additive (see ProvisioningErr's doc): recorded regardless of
+			// ExitOnDegraded, purely for the embed API to read after Ready
+			// closes. Does not change what's logged or when initServices
+			// itself fails below — that remains exactly `conduit run`'s
+			// existing behavior.
+			r.ProvisioningErr = err
+			cerrors.ForEach(err, func(err error) {
+				r.logger.Err(ctx, err).Msg("provisioning failed")
+			})
+			if r.Config.Pipelines.ExitOnDegraded {
+				r.logger.Warn(ctx).
+					Err(err).
+					Msg("Conduit will shut down due to a pipeline provisioning failure and 'exit on error' enabled")
+				err = cerrors.Errorf("shut down due to 'exit on error' enabled: %w", err)
+				return err
+			}
 		}
 	}
 

--- a/two_engines_test.go
+++ b/two_engines_test.go
@@ -118,21 +118,34 @@ func conduitInfoValue(t *testing.T, reg *promclient.Registry) float64 {
 // process-global metric *definitions* (metrics.go's `global` slices), so a
 // metric like measure.ConduitInfo fans its value out to every registry ever
 // passed to metrics.Register — including a second, fully independent
-// embedded engine's registry. Constructing engine B (with its own,
-// never-shared MetricsRegisterer) still bumps engine A's already-gathered
-// "conduit_info" value. This is asserted as PRESENT, not fixed — see
+// embedded engine's registry. Running engine B (with its own, never-shared
+// MetricsRegisterer) still bumps engine A's already-gathered "conduit_info"
+// value. This is asserted as PRESENT, not fixed — see
 // pkg/conduit.WithMetricsRegisterer's doc and this package's doc.go. A future
 // fix to pkg/foundation/metrics must consciously update this test.
+//
+// B1 DX-hardening (lazy DB open): metrics registration happens inside
+// ensureRuntime (first Run or Import), which New no longer triggers — so both
+// engines below must actually Run for the cross-talk to manifest; merely
+// constructing them (as this test did before the lazy-open change) no longer
+// registers or increments anything.
 func TestTwoEngines_MetricsCrossTalk_KnownLimitation(t *testing.T) {
 	is := is.New(t)
+	ctx := context.Background()
 
 	regA := promclient.NewRegistry()
-	newTestEngine(t, conduit.Options{MetricsRegisterer: regA})
+	eA := newTestEngine(t, conduit.Options{MetricsRegisterer: regA})
+	hA, err := eA.Run(ctx)
+	is.NoErr(err)
+	defer func() { _ = hA.Stop(ctx) }()
 	beforeA := conduitInfoValue(t, regA)
 
 	regB := promclient.NewRegistry()
-	newTestEngine(t, conduit.Options{MetricsRegisterer: regB})
+	eB := newTestEngine(t, conduit.Options{MetricsRegisterer: regB})
+	hB, err := eB.Run(ctx)
+	is.NoErr(err)
+	defer func() { _ = hB.Stop(ctx) }()
 	afterA := conduitInfoValue(t, regA)
 
-	is.True(afterA > beforeA) // engine B's construction leaked into engine A's registry
+	is.True(afterA > beforeA) // engine B's Run leaked into engine A's registry
 }


### PR DESCRIPTION
## Summary

DX audit fast-follow on the merged libconduit B1 embed API (#2667). Adoption is zero, so now is the right time to fix two frozen-`Options`-contract issues rather than carry them forward.

**Fix 1 — silent provisioning failure on empty `Options.PipelinesDir`.** Leaving `PipelinesDir` empty fell through to `pkg/conduit`'s CLI-oriented `cwd/pipelines` default. That directory usually doesn't exist for a pure-embed caller, so provisioning failed as a swallowed ERROR log while `Run` still returned a healthy `Handle` — contradicting `New`'s doc promise that every failure is returned as an error.

- Added `pkgconduit.Config.Pipelines.Disabled` (no `long`/`mapstructure` tag — not a CLI flag, zero value `false`, `conduit run` never sets it). The embed layer's `New` sets it whenever `Options.PipelinesDir == ""`, which short-circuits `initServices`'s call to `ProvisionService.Init` entirely instead of falling back to a scan.
- Added `pkgconduit.Runtime.ProvisioningErr` — purely additive, set regardless of `ExitOnDegraded`, never read by the CLI. `Engine.Run` reads it right after `Ready` fires; if set, it cancels + drains (Invariant 7) and returns the error instead of a `Handle`. A genuine failure with a *configured* `PipelinesDir` (missing dir, malformed YAML) now surfaces as a returned error, matching `conduit run`'s own log-and-continue default being intentionally NOT reused on the embed path.
- CLI behavior is untouched: `Disabled` is always `false` on that path, and `ProvisioningErr` is never consulted there.

**Fix 2 — eager DB open / mandatory Close footgun.** `New` opened the database eagerly, so a constructed-but-never-`Run` `Engine` leaked a Badger file lock or Postgres pool, and `Close` was mandatory even without `Run`.

- `New` now only validates `Options` (including calling `cfg.Validate()` directly, so a bad config still fails fast). Constructing `pkg/conduit`'s `Runtime` — which is where the DB actually opens — is deferred to `ensureRuntime`, called lazily on the first `Run` or `Import` (also wired into `StartPipeline`/`StopPipeline` so a runtime-never-built Engine can't nil-pointer-panic on those either).
- `Close` reads whether anything was actually opened and is a safe no-op otherwise; when something was opened it still delegates to `Runtime.CloseDB` (#2667's idempotent double-release path, unchanged).
- Added a `runtime.SetFinalizer` safety net on `Engine`: if an Engine that DID open resources is GC'd without `Close`, it logs a leak warning through the injected logger (else `slog.Default()`). Verified working end-to-end with a standalone smoke test (construct → Run → Stop → drop the reference → GC → warning observed in the log). Close clears the finalizer.
- `TestNew_StoreAlreadyOpen_ReturnsCodedError` is preserved but the contention now has to be forced via `Run` (both engines), since `New` alone opens nothing — same for the metrics-collision and metrics-cross-talk tests, which also moved their trigger from `New` to `Run`.

## Store-already-open timing change

Documented explicitly in `Engine`'s "Lifecycle contract" doc and in the updated test: the coded `CodeUnavailable` collision now surfaces "when the DB actually opens (on Run/Import)," not at `New`.

## Failure-mode analysis (Tier-1-adjacent: frozen `Options` semantics + DB lifecycle + provisioning behavior)

- **What could this break:** any caller relying on `New` eagerly failing on a bad `PipelinesDir`/DB config would now see that surface at `Run`/`Import` instead — mitigated by keeping `cfg.Validate()` synchronous in `New` (a nonexistent custom `PipelinesDir` still fails fast at `New`, proven by `TestNew_NonexistentCustomPipelinesDir_FailsFast`). A caller relying on metrics being registered immediately after `New` (before `Run`) would see a behavior change — there is no such use case in the codebase (adoption is zero) and it's the described intent of this fix.
- **Which metric/alert would show it:** none live yet for this package (it's a library, not a running service); the example (`Example_helloPipeline`) and its CI wall-clock budget test are the closest thing to a canary and both still pass.
- **How to roll back:** revert this commit; #2667's eager-open behavior returns immediately, no state/format migration involved (nothing here touches serialized data).
- **Concurrency:** `ensureRuntime`/`Close` share one `sync.Mutex` (not `sync.Once`+atomics) specifically so a `Close` racing the very first `Run`/`Import` blocks until that open attempt resolves, rather than observing "nothing opened yet" and returning early while an open completes moments later with nothing left to release it — documented in `Close`'s own doc as the one remaining caller-orchestrated race (calling `Close` concurrently with the *first* `Run`/`Import`, as opposed to a later one, which just reuses the cached result).
- **Uncertainty surfaced, not assumed away:** the leak-check finalizer is explicitly documented as best-effort — GC timing is unpredictable and finalizers aren't guaranteed to run before process exit. It's a safety net, not a substitute for `Close`.

## Adversarial self-review

- Re-checked that `Config.Pipelines.Disabled` has no CLI flag tag and defaults `false`, so `conduit run` is provably unaffected (`initServices`' new branch is unreachable from the CLI).
- Re-checked `Runtime.ProvisioningErr` doesn't change what's logged or when `conduit run` itself fails — it's an added field next to unchanged control flow, not a rewrite of it.
- Traced the `opened`/`closed` mutex-guarded reads in `Close` and the finalizer to confirm no data race (ran the full suite under `-race`).
- Found and fixed a test-writing mistake myself: my first draft of `TestRun_BadPipelinesDir_ReturnsError` assumed a nonexistent `PipelinesDir` would fail at `Run` — it actually fails at `New` (`cfg.Validate()`'s existing non-default-path stat check), which is a *better* outcome than the bug report implied for that specific sub-case. Split it into two tests: `TestNew_NonexistentCustomPipelinesDir_FailsFast` (New-time) and `TestRun_MalformedPipelinesDir_ReturnsError` (an existing directory with unparseable YAML — the case that genuinely can only be discovered at Run/Init time).
- `StartPipeline`/`StopPipeline` now also call `ensureRuntime` — not strictly requested, but necessary to avoid a new nil-pointer-panic footgun these lazy semantics would otherwise introduce for a caller that invokes them before any `Run`/`Import`.

## B2 conflict — sequencing note for DeVaris

This will conflict with the in-flight B2 builder PR **#2673** (`feat/embed-b2-pipeline-builder`, currently open) on `conduit.go` — confirmed via `git diff main origin/feat/embed-b2-pipeline-builder -- conduit.go`, which touches the same file (adds `ImportPipeline` near `Import`). Recommend merging whichever lands first, then rebasing the other before merge — I have not attempted to resolve that conflict here.

## Test plan

- [x] `make generate && git diff --exit-code` — clean, no drift
- [x] `golangci-lint run ./... --new-from-rev=851c406` — 0 issues
- [x] `go build ./...`
- [x] `go test -race ./ ./pkg/conduit/... ./pkg/provisioning/...` — all green, including #2667's Close tests (updated for lazy semantics) and new regression tests for both fixes
- [x] Manual smoke test of the GC finalizer (outside the repo, in a throwaway module) confirming the leak warning actually fires

**DO NOT MERGE** — flagging for DeVaris awareness per frozen-contract-semantic changes and the B2 sequencing conflict above.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD