### PR TITLE
test(chaos): DBZ-1 SIGKILL crash-safety + engine FIFO-ack (first tests/chaos)

### DIFF
--- a/pkg/lifecycle-poc/funnel/worker_ack_order_test.go
+++ b/pkg/lifecycle-poc/funnel/worker_ack_order_test.go
@@ -1,0 +1,332 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funnel
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/database/inmemory"
+	"github.com/conduitio/conduit-commons/opencdc"
+	pconnectorv1client "github.com/conduitio/conduit-connector-protocol/pconnector/v1/client" //nolint:staticcheck // intentionally testing the v1 client: conduit-kafka-connect-wrapper (and other standalone connectors) still use it today
+	connectorv1 "github.com/conduitio/conduit-connector-protocol/proto/connector/v1"
+	"github.com/conduitio/conduit/pkg/connector"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/foundation/metrics/noop"
+	connectorPlugin "github.com/conduitio/conduit/pkg/plugin/connector"
+	"github.com/matryer/is"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// This file closes issue #2672: the engine sends multi-position Source.Ack
+// batches (funnel/worker.go:493 for a full-batch ack, funnel/worker.go:513 for
+// the partial-batch ack that follows a partial DLQ nack), and a v1-protocol
+// (out-of-process, standalone-connector-shaped) plugin — like
+// ConduitIO/conduit-kafka-connect-wrapper — depends on receiving those
+// positions as strictly ordered, individual messages, one per position. Before
+// this test, that ordering guarantee was upheld only by a comment in
+// conduit-connector-protocol's v1 client ("Batching is not supported in v1,
+// send each request individually", pconnector/v1/client/source.go:148) — a
+// third-party implementation detail, not anything asserted in this repo. If a
+// future change to that dependency (or to pkg/connector.Source.Ack itself)
+// ever reordered, batched, or dropped positions before delivery, nothing here
+// would catch it before every standalone connector's ack-ordering assumption
+// broke in production.
+//
+// To pin the contract at the boundary Conduit's own engine controls, these
+// tests exercise the REAL production code path end to end: funnel.Worker.Ack /
+// funnel.Worker.Nack -> pkg/connector.Source.Ack -> the real
+// conduit-connector-protocol v1 gRPC client (not a mock of it) -> a real gRPC
+// bidirectional stream (over an in-memory bufconn listener, so no network or
+// subprocess is needed) -> a fake v1 SourcePluginServer that records the
+// arrival order of ack positions. This is deliberately NOT a test of
+// pkg/connector.Source.Ack in isolation with a mocked stream (as
+// TestSource_Ack_Deadlock in pkg/connector/source_test.go already does for a
+// different property) — it is a test of what a v1-protocol plugin actually
+// observes on the wire, using the exact client library standalone connectors
+// use today.
+
+// fakeV1SourceServer is a minimal, real gRPC server implementing the v1
+// SourcePluginServer service. It only needs to support what Source.Open and
+// Source.Ack exercise: Configure, LifecycleOnCreated ("created" lifecycle
+// event, since this is the connector's first run), Start, and Run (the
+// bidirectional ack/record stream). Everything else embeds
+// UnimplementedSourcePluginServer and is never called by these tests.
+type fakeV1SourceServer struct {
+	connectorv1.UnimplementedSourcePluginServer
+
+	mu   sync.Mutex
+	acks []opencdc.Position
+}
+
+func (s *fakeV1SourceServer) Configure(context.Context, *connectorv1.Source_Configure_Request) (*connectorv1.Source_Configure_Response, error) {
+	return &connectorv1.Source_Configure_Response{}, nil
+}
+
+func (s *fakeV1SourceServer) LifecycleOnCreated(context.Context, *connectorv1.Source_Lifecycle_OnCreated_Request) (*connectorv1.Source_Lifecycle_OnCreated_Response, error) {
+	return &connectorv1.Source_Lifecycle_OnCreated_Response{}, nil
+}
+
+func (s *fakeV1SourceServer) Start(context.Context, *connectorv1.Source_Start_Request) (*connectorv1.Source_Start_Response, error) {
+	return &connectorv1.Source_Start_Response{}, nil
+}
+
+// Run mirrors what the wrapper's DefaultSourceStream.onNext does on receiving
+// an ack message: it observes exactly one AckPosition per message. It records
+// the arrival order and never batches multiple positions into one Recv.
+func (s *fakeV1SourceServer) Run(stream connectorv1.SourcePlugin_RunServer) error {
+	for {
+		req, err := stream.Recv()
+		if err != nil {
+			// Client closed the stream (io.EOF) or the context was canceled
+			// during test cleanup - nothing left to observe.
+			return nil //nolint:nilerr // stream teardown, not a test failure
+		}
+
+		s.mu.Lock()
+		// Clone the position: req is only valid until the next Recv call, and
+		// the underlying byte slice must not be aliased across appends.
+		s.acks = append(s.acks, append(opencdc.Position(nil), req.AckPosition...))
+		s.mu.Unlock()
+	}
+}
+
+func (s *fakeV1SourceServer) observedAcks() []opencdc.Position {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]opencdc.Position(nil), s.acks...)
+}
+
+// fakeSourceDispenser implements connectorPlugin.Dispenser and always
+// dispenses the same pre-built v1 client-backed SourcePlugin. Only
+// DispenseSource is exercised by these tests.
+type fakeSourceDispenser struct {
+	source connectorPlugin.SourcePlugin
+}
+
+func (d fakeSourceDispenser) DispenseSpecifier() (connectorPlugin.SpecifierPlugin, error) {
+	return nil, cerrors.New("fakeSourceDispenser: DispenseSpecifier not implemented")
+}
+
+func (d fakeSourceDispenser) DispenseSource() (connectorPlugin.SourcePlugin, error) {
+	return d.source, nil
+}
+
+func (d fakeSourceDispenser) DispenseDestination() (connectorPlugin.DestinationPlugin, error) {
+	return nil, cerrors.New("fakeSourceDispenser: DispenseDestination not implemented")
+}
+
+// fakePluginFetcher fulfills connector.PluginDispenserFetcher, mirroring the
+// identically named test helper in pkg/connector (unexported there, so it
+// can't be reused directly from this package).
+type fakePluginFetcher map[string]connectorPlugin.Dispenser
+
+func (f fakePluginFetcher) NewDispenser(_ log.CtxLogger, name string, _ string) (connectorPlugin.Dispenser, error) {
+	d, ok := f[name]
+	if !ok {
+		return nil, cerrors.Errorf("fakePluginFetcher: no dispenser registered for plugin %q", name)
+	}
+	return d, nil
+}
+
+// newV1FIFOTestSource builds a real *connector.Source backed by the real
+// conduit-connector-protocol v1 gRPC client, connected over an in-memory
+// bufconn listener to fakeV1SourceServer. The source is already Open when this
+// function returns (Configure, LifecycleOnCreated and Start have all gone over
+// the real gRPC stream), so a caller can immediately call src.Ack.
+func newV1FIFOTestSource(t *testing.T) (*connector.Source, *fakeV1SourceServer) {
+	t.Helper()
+	is := is.New(t)
+	ctx := context.Background()
+
+	lis := bufconn.Listen(1024 * 1024)
+	grpcServer := grpc.NewServer()
+	fakeServer := &fakeV1SourceServer{}
+	connectorv1.RegisterSourcePluginServer(grpcServer, fakeServer)
+
+	go func() { _ = grpcServer.Serve(lis) }()
+	t.Cleanup(grpcServer.Stop)
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	is.NoErr(err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	// This is the real, unmodified conduit-connector-protocol v1 client -
+	// the exact library standalone connectors (like the Debezium/Kafka
+	// Connect wrapper) use today. Its Send implementation is what fans a
+	// multi-position pconnector.SourceRunRequest out into individually
+	// ordered gRPC messages (pconnector/v1/client/source.go:145-156).
+	pluginClient := pconnectorv1client.NewSourcePluginClient(conn)
+
+	logger := log.Nop()
+	db := &inmemory.DB{}
+	persister := connector.NewPersister(logger, db, connector.DefaultPersisterDelayThreshold, connector.DefaultPersisterBundleCountThreshold)
+
+	instance := &connector.Instance{
+		ID:   "fifo-ack-test-source",
+		Type: connector.TypeSource,
+		Config: connector.Config{
+			Name:     "fifo-ack-test",
+			Settings: map[string]string{"foo": "bar"},
+		},
+		PipelineID:    "fifo-ack-test-pipeline",
+		Plugin:        "fifo-ack-test-plugin",
+		ProvisionedBy: connector.ProvisionTypeAPI,
+	}
+	instance.Init(logger, persister)
+
+	fetcher := fakePluginFetcher{instance.Plugin: fakeSourceDispenser{source: pluginClient}}
+	c, err := instance.Connector(ctx, fetcher)
+	is.NoErr(err)
+	src, ok := c.(*connector.Source)
+	is.True(ok)
+
+	is.NoErr(src.Open(ctx))
+	t.Cleanup(func() { _ = src.Teardown(ctx) })
+
+	return src, fakeServer
+}
+
+// waitForAcks polls until fakeServer has observed at least want ack messages,
+// or fails the test after a generous timeout. A gRPC Send call returning
+// successfully only guarantees the message was handed to the stream, not that
+// the server's Recv loop has already processed it - so a short poll (rather
+// than a fixed sleep or an immediate assertion) is what makes this
+// deterministic without being flaky.
+func waitForAcks(t *testing.T, fakeServer *fakeV1SourceServer, want int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(fakeServer.observedAcks()) >= want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d acks, got %d", want, len(fakeServer.observedAcks()))
+}
+
+func assertPositionsInOrder(is *is.I, got, want []opencdc.Position) {
+	is.Equal(len(got), len(want))
+	for i := range want {
+		is.Equal(got[i], want[i])
+	}
+}
+
+// newFIFOTestWorker builds a real *Worker (via NewWorker, so timer/logger
+// wiring matches production) around src, with a single no-op downstream mock
+// task to satisfy the pipeline-shape validation NewWorker performs. Worker.Ack
+// and Worker.Nack never invoke that downstream task's Do, so it only needs an
+// ID.
+func newFIFOTestWorker(t *testing.T, ctrl *gomock.Controller, logger log.CtxLogger, src *connector.Source, dlq *DLQ) *Worker {
+	t.Helper()
+	is := is.New(t)
+
+	sourceTask := NewSourceTask("fifo-ack-test-source-task", src, logger, NoOpConnectorMetrics{})
+	nextTask := NewMockTask(ctrl)
+	nextTask.EXPECT().ID().Return("fifo-ack-test-next-task").AnyTimes()
+
+	firstNode := &TaskNode{Task: sourceTask}
+	firstNode.Next = []*TaskNode{{Task: nextTask}}
+
+	worker, err := NewWorker(firstNode, dlq, logger, noop.Timer{})
+	is.NoErr(err)
+	return worker
+}
+
+// TestWorker_Ack_DeliversPositionsFIFOToV1Plugin covers the full-batch ack
+// path at funnel/worker.go:493 (w.Source.Ack(ctx, originalBatch.positions)).
+// It asserts a v1-protocol plugin observes every position in the batch as a
+// separate message, in the exact order they appear in the batch.
+func TestWorker_Ack_DeliversPositionsFIFOToV1Plugin(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	logger := log.Test(t)
+	ctrl := gomock.NewController(t)
+
+	src, fakeServer := newV1FIFOTestSource(t)
+	dlq, _ := NewMockDLQ(ctrl, logger)
+	worker := newFIFOTestWorker(t, ctrl, logger, src, dlq)
+
+	// Mirrors funnel/worker.go:493's real call shape: multiple positions
+	// acked together in one Worker.Ack call.
+	batch := randomBatch(5)
+
+	err := worker.Ack(ctx, batch)
+	is.NoErr(err)
+
+	waitForAcks(t, fakeServer, len(batch.positions))
+	assertPositionsInOrder(is, fakeServer.observedAcks(), batch.positions)
+}
+
+// TestWorker_Nack_DeliversPartialAckFIFOToV1Plugin covers the partial-batch
+// ack path at funnel/worker.go:513 (w.Source.Ack(ctx,
+// originalBatch.positions[:n])), which fires when a Nack's DLQ write only
+// partially succeeds: the successfully DLQ'd prefix must still be acked in
+// the source, in order, even though the overall Nack call returns an error.
+func TestWorker_Nack_DeliversPartialAckFIFOToV1Plugin(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	logger := log.Test(t)
+	ctrl := gomock.NewController(t)
+
+	src, fakeServer := newV1FIFOTestSource(t)
+	// windowSize=0 disables the DLQ nack-threshold window, so every nacked
+	// record in the batch is routed to the DLQ (see dlq.go's dlqWindow.store
+	// short-circuit for len(window)==0), matching the existing
+	// TestWorker_Nack pattern in worker_test.go.
+	dlq, dlqDestinationMock := NewMockDLQ(ctrl, logger)
+	worker := newFIFOTestWorker(t, ctrl, logger, src, dlq)
+
+	batch := randomBatch(5)
+	nackErr := cerrors.New("record error")
+	batch.Nack(0, nackErr, nackErr, nackErr, nackErr, nackErr) // nack all 5 records
+
+	// Simulate the DLQ destination accepting the write, but only acking
+	// records 0-2: this is what makes DLQ.Nack's returned prefix count n=3
+	// (out of 5), which drives the partial Source.Ack(positions[:3]) call at
+	// funnel/worker.go:513 - as opposed to the previous test's full-batch call.
+	dlqWriteErr := cerrors.New("dlq write failed")
+	dlqDestinationMock.EXPECT().Write(gomock.Any(), gomock.Any()).Return(nil)
+	dlqDestinationMock.EXPECT().Ack(gomock.Any()).Return(
+		toDestinationAcks(batch.records, []error{nil, nil, nil, dlqWriteErr, dlqWriteErr}),
+		nil,
+	)
+
+	err := worker.Nack(ctx, batch, "taskID")
+	is.True(err != nil) // the partial DLQ failure surfaces as a (fatal) error...
+
+	wantPositions := batch.positions[:3] // ...but the successfully-DLQ'd prefix must still be acked, in order
+	waitForAcks(t, fakeServer, len(wantPositions))
+	assertPositionsInOrder(is, fakeServer.observedAcks(), wantPositions)
+
+	// And, just as importantly: the two records that were never successfully
+	// DLQ'd must NOT have been acked in the source (that would be acking a
+	// record that was neither delivered downstream nor durably DLQ'd - a
+	// violation of invariant 1).
+	is.Equal(len(fakeServer.observedAcks()), 3)
+}

--- a/tests/chaos/child.go
+++ b/tests/chaos/child.go
@@ -1,0 +1,342 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chaos
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/conduitio/conduit-commons/database"
+	"github.com/conduitio/conduit-commons/database/badger"
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/connector"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	connectorPlugin "github.com/conduitio/conduit/pkg/plugin/connector"
+	"github.com/rs/zerolog"
+)
+
+// Environment variables the parent test process (harness.go) uses to
+// configure a child run. This is a test-only, out-of-band protocol between
+// this package's own test binary re-executing itself - it never touches
+// conduit run's actual config surface (see doc.go / the design doc's
+// observability section on this exact point).
+const (
+	envChild        = "CONDUIT_CHAOS_CHILD"
+	envDBDir        = "CONDUIT_CHAOS_DB_DIR"
+	envUpstreamDir  = "CONDUIT_CHAOS_UPSTREAM_DIR"
+	envPrune        = "CONDUIT_CHAOS_PRUNE"
+	envPaceMS       = "CONDUIT_CHAOS_PACE_MS"
+	envTotal        = "CONDUIT_CHAOS_TOTAL"
+	instanceID      = "chaos-source"
+	instancePlugin  = "chaos-plugin"
+	instancePipe    = "chaos-pipeline"
+	markerOpenGap   = "OPEN_GAP_ERROR"
+	markerDone      = "DONE"
+	markerFatal     = "FATAL"
+	markerCorruptPo = "CORRUPT_POSITION"
+)
+
+// exitCode values the parent harness distinguishes between. An OPEN_GAP_ERROR
+// (chaosPlugin.Open refusing a stale resume) exits with exitOK: it is a
+// clean, expected-shape outcome for the pruning-upstream scenario, and the
+// printed marker line - not the exit code - is what carries the verdict.
+const (
+	exitOK             = 0
+	exitOpenOtherError = 4
+	exitCorruptState   = 3
+	exitBadArgs        = 2
+)
+
+// isChildInvocation reports whether this process invocation should behave as
+// a chaos child runner instead of running the package's actual Go tests -
+// the standard "re-exec the test binary as a helper process" pattern (used
+// by, e.g., the Go standard library's own os/exec tests).
+func isChildInvocation() bool {
+	return os.Getenv(envChild) == "1"
+}
+
+// childEnv holds the parsed configuration a parent test process passes to a
+// chaos child via environment variables (see childConfig.env in harness.go).
+type childEnv struct {
+	dbDir       string
+	upstreamDir string
+	prune       bool
+	paceMS      int
+	total       uint64
+}
+
+// parseChildEnv reads and validates the child's environment. Any failure
+// here is a test-harness misconfiguration, not a scenario under test, so it
+// exits immediately with exitBadArgs.
+func parseChildEnv() childEnv {
+	var cfg childEnv
+	cfg.dbDir = os.Getenv(envDBDir)
+	cfg.upstreamDir = os.Getenv(envUpstreamDir)
+	cfg.prune = os.Getenv(envPrune) == "true"
+
+	paceMS, err := strconv.Atoi(os.Getenv(envPaceMS))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: invalid %s: %v\n", markerFatal, envPaceMS, err)
+		os.Exit(exitBadArgs)
+	}
+	cfg.paceMS = paceMS
+
+	total, err := strconv.ParseUint(os.Getenv(envTotal), 10, 64)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: invalid %s: %v\n", markerFatal, envTotal, err)
+		os.Exit(exitBadArgs)
+	}
+	cfg.total = total
+
+	if cfg.dbDir == "" || cfg.upstreamDir == "" {
+		fmt.Fprintf(os.Stderr, "%s: %s and %s are required\n", markerFatal, envDBDir, envUpstreamDir)
+		os.Exit(exitBadArgs)
+	}
+	return cfg
+}
+
+// loadOrCreateInstance loads the connector.Instance persisted by a previous
+// (possibly SIGKILL'd) run of this same chaos-source ID, or creates a fresh
+// one if none exists yet. It exits the process directly (exitCorruptState)
+// if the persisted state exists but fails to deserialize — per invariant 2,
+// that is itself a failing outcome for this test, never silently treated as
+// "fresh start".
+func loadOrCreateInstance(ctx context.Context, store *connector.Store) *connector.Instance {
+	instance, err := store.Get(ctx, instanceID)
+	switch {
+	case err == nil:
+		return instance // resumed from a previous (possibly killed) run's persisted state
+	case cerrors.Is(err, database.ErrKeyNotExist):
+		return &connector.Instance{
+			ID:            instanceID,
+			Type:          connector.TypeSource,
+			Config:        connector.Config{Name: instanceID, Settings: map[string]string{}},
+			PipelineID:    instancePipe,
+			Plugin:        instancePlugin,
+			ProvisionedBy: connector.ProvisionTypeAPI,
+		}
+	default:
+		fmt.Printf("%s: %v\n", markerCorruptPo, err)
+		os.Exit(exitCorruptState)
+		return nil // unreachable
+	}
+}
+
+// printResumePosition emits the diagnostic line the parent test relies on to
+// learn exactly where Conduit persisted state says this run is about to
+// resume from — printed unconditionally (fresh start included, where it's
+// the empty position) so the parent can compare it against the upstream's
+// independently-read committed watermark without opening the badger DB
+// itself.
+func printResumePosition(instance *connector.Instance) {
+	if src, ok := instance.State.(connector.SourceState); ok {
+		fmt.Printf("RESUME_POSITION %s\n", src.Position)
+		return
+	}
+	fmt.Printf("RESUME_POSITION %s\n", opencdc.Position(nil))
+}
+
+// runReadAckLoop reads and immediately acks records one batch at a time
+// until the last acked position reaches total (or forever, if total is 0).
+// It exits the process directly on any Read/Ack error.
+func runReadAckLoop(ctx context.Context, src *connector.Source, total uint64) {
+	for {
+		recs, err := src.Read(ctx)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: read failed: %v\n", markerFatal, err)
+			os.Exit(exitOpenOtherError)
+		}
+
+		positions := make([]opencdc.Position, len(recs))
+		for i, r := range recs {
+			positions[i] = r.Position
+		}
+		if err := src.Ack(ctx, positions); err != nil {
+			fmt.Fprintf(os.Stderr, "%s: ack failed: %v\n", markerFatal, err)
+			os.Exit(exitOpenOtherError)
+		}
+
+		if total > 0 {
+			last, _ := decodePosition(positions[len(positions)-1])
+			if last >= total {
+				return
+			}
+		}
+	}
+}
+
+// runChild is the entire child-process program: build a real
+// pkg/connector.Source, backed by a real on-disk badger DB (the same
+// production persister backend, via connector.NewPersister) and the
+// in-process chaosPlugin, then read+ack records sequentially until `total`
+// is reached. It never returns - it always calls os.Exit.
+//
+// This process is expected to be killed with SIGKILL by the parent test at
+// an arbitrary point; no cleanup on that path is possible or intended - that
+// is the entire point of the test (see doc.go).
+func runChild() {
+	ctx := context.Background()
+	cfg := parseChildEnv()
+
+	logger := log.New(zerolog.Nop()) // keep stdout clean; it is our progress-line channel
+
+	db, err := badger.New(zerolog.Nop(), cfg.dbDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: open badger db: %v\n", markerFatal, err)
+		os.Exit(exitBadArgs)
+	}
+
+	persister := connector.NewPersister(logger, db, connector.DefaultPersisterDelayThreshold, connector.DefaultPersisterBundleCountThreshold)
+	store := connector.NewStore(db, logger)
+
+	instance := loadOrCreateInstance(ctx, store)
+	instance.Init(logger, persister)
+	printResumePosition(instance)
+
+	upstream, err := openUpstreamStore(cfg.upstreamDir, cfg.prune)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %v\n", markerFatal, err)
+		os.Exit(exitBadArgs)
+	}
+	plugin := &chaosPlugin{store: upstream, total: cfg.total, paceMS: cfg.paceMS}
+
+	fetcher := staticFetcher{instance.Plugin: staticDispenser{source: plugin}}
+	c, err := instance.Connector(ctx, fetcher)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: build connector: %v\n", markerFatal, err)
+		os.Exit(exitBadArgs)
+	}
+	src, ok := c.(*connector.Source)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "%s: unexpected connector type %T\n", markerFatal, c)
+		os.Exit(exitBadArgs)
+	}
+
+	if err := src.Open(ctx); err != nil {
+		if containsGapMarker(err) {
+			// This IS the scenario this test exists to surface (see doc.go):
+			// on a pruning upstream, Conduit's persisted position lagged
+			// behind what was already durably committed at the moment of the
+			// kill, and the upstream can no longer supply the gap. Print the
+			// marker so the parent test can assert on it; this is an
+			// expected, clean exit for that scenario, not a
+			// test-infrastructure failure.
+			fmt.Printf("%s: %v\n", markerOpenGap, err)
+			os.Exit(exitOK)
+		}
+		fmt.Fprintf(os.Stderr, "%s: source open failed: %v\n", markerFatal, err)
+		os.Exit(exitOpenOtherError)
+	}
+
+	runReadAckLoop(ctx, src, cfg.total)
+
+	// src.Ack only guarantees the ack was HANDED OFF to the plugin
+	// (stream.Send rendezvous with the plugin's Recv) - it does not wait for
+	// chaosPlugin.ackLoop's subsequent, synchronous upstream.Commit call to
+	// finish. Without waiting here, this process could os.Exit before that
+	// last commit's fsync completes, truncating the run by one position and
+	// producing a false-positive gap that has nothing to do with the engine
+	// code under test. This wait is test-harness synchronization only - it
+	// has no analog in (and makes no claim about) production code.
+	waitForUpstreamCommitted(upstream, cfg.total)
+
+	// Graceful path: only reached when this run was allowed to finish
+	// (the parent didn't SIGKILL it). Tear down cleanly so the final
+	// persisted position is flushed and observable by the parent's
+	// post-run assertions.
+	if err := src.Teardown(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "%s: teardown failed: %v\n", markerFatal, err)
+		os.Exit(exitOpenOtherError)
+	}
+	persister.WaitPendingWrites()
+
+	fmt.Println(markerDone)
+	os.Exit(exitOK)
+}
+
+// waitForUpstreamCommitted blocks briefly until the upstream store reports
+// total positions committed, so this process doesn't exit while
+// chaosPlugin.ackLoop's goroutine still has an in-flight, not-yet-durable
+// commit for the very last ack this run just sent. See its call site for
+// why this is needed. A no-op when total is 0 (unbounded runs never reach
+// this graceful-exit path in the first place).
+func waitForUpstreamCommitted(upstream *upstreamStore, total uint64) {
+	if total == 0 {
+		return
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		committed, err := upstream.Committed()
+		if err == nil && committed >= total {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	// Falling through here would let the caller proceed to Teardown/DONE
+	// while the plugin's last commit is still in flight, silently
+	// undermining the very "committed == total" guarantee the parent test's
+	// duplicate-not-gap assertion depends on - so this must exit, not warn
+	// and continue.
+	fmt.Fprintf(os.Stderr, "%s: timed out waiting for upstream to reach position %d\n", markerFatal, total)
+	os.Exit(exitOpenOtherError)
+}
+
+// containsGapMarker reports whether err is (or wraps) the specific,
+// structural gap chaosPlugin.Open (upstream.go) returns when a pruning
+// upstream can no longer supply data behind its already-committed watermark.
+// pkg/connector.Source.open wraps that error ("could not open source
+// connector plugin: %w"), so a substring check - not a prefix check - is
+// needed. A substring check on a plain fmt.Errorf (rather than a typed
+// sentinel) is enough here: this is test-only harness code checking
+// test-only harness output, not a production error contract.
+func containsGapMarker(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "GAP:")
+}
+
+// staticDispenser and staticFetcher wire a single, already-constructed
+// chaosPlugin into pkg/connector's plugin-dispensing machinery
+// (connector.PluginDispenserFetcher -> connectorPlugin.Dispenser ->
+// connectorPlugin.SourcePlugin), mirroring the same pattern
+// pkg/connector's own tests use (fakePluginFetcher in instance_test.go).
+type staticDispenser struct {
+	source connectorPlugin.SourcePlugin
+}
+
+func (d staticDispenser) DispenseSpecifier() (connectorPlugin.SpecifierPlugin, error) {
+	return nil, cerrors.New("staticDispenser: DispenseSpecifier not implemented")
+}
+
+func (d staticDispenser) DispenseSource() (connectorPlugin.SourcePlugin, error) {
+	return d.source, nil
+}
+
+func (d staticDispenser) DispenseDestination() (connectorPlugin.DestinationPlugin, error) {
+	return nil, cerrors.New("staticDispenser: DispenseDestination not implemented")
+}
+
+type staticFetcher map[string]connectorPlugin.Dispenser
+
+func (f staticFetcher) NewDispenser(_ log.CtxLogger, name string, _ string) (connectorPlugin.Dispenser, error) {
+	d, ok := f[name]
+	if !ok {
+		return nil, cerrors.Errorf("staticFetcher: no dispenser registered for plugin %q", name)
+	}
+	return d, nil
+}

--- a/tests/chaos/doc.go
+++ b/tests/chaos/doc.go
@@ -1,0 +1,88 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package chaos is the repo's first chaos-testing harness (v0.19 Workstream 7,
+// DBZ-1). It is deliberately minimal — sized for one scenario family (a SIGKILL
+// crash-safety test on the source connector's offset↔position bridge), not a
+// generalized chaos framework. If a second scenario (DBZ-2) ever needs one,
+// it should generalize from this package rather than the reverse; see
+// docs/design-documents (dbz1-chaos.md, the design doc this package
+// implements) for why building the generalized skeleton now would be
+// speculative generality.
+//
+// # What this package tests, and why the real Debezium wrapper isn't here
+//
+// The workstream's motivating question is about
+// ConduitIO/conduit-kafka-connect-wrapper (a real Debezium Postgres connector
+// running inside Conduit): does its ack->commit ordering survive a `kill -9`
+// mid-snapshot or mid-stream without losing or duplicating records? That
+// wrapper is a separate JVM repo with a real Postgres dependency, and is not
+// checked out in this repository's module — it cannot be driven from a Go
+// test here.
+//
+// What CAN be tested here, with full fidelity, is the Go engine code the
+// wrapper (and every other v1-protocol, out-of-process connector) depends on:
+// pkg/connector.Source.Ack and pkg/connector.Persister. Reading
+// pkg/connector/source.go:207-238 shows the exact sequence a crash can land
+// in the middle of:
+//
+//  1. Source.Ack sends the ack to the plugin (source.go:218) — for the
+//     wrapper, this is what drives Debezium's task.commitRecord/task.commit,
+//     which durably (and, critically, IRREVERSIBLY from Conduit's point of
+//     view) advances Postgres's replication-slot confirmed LSN.
+//  2. ONLY AFTER that send succeeds does Source.Ack update its own state and
+//     call persister.Persist (source.go:223-235) — and Persister.Persist
+//     (persister.go:137-170) does NOT write through: it batches the change
+//     and flushes asynchronously after DefaultPersisterDelayThreshold (1s) or
+//     DefaultPersisterBundleCountThreshold (10k items), whichever comes
+//     first.
+//
+// So there is a real, ~1-second (or 10k-record) window after Conduit tells a
+// plugin "you may durably commit this" during which Conduit's OWN record of
+// "where we are" has not yet reached durable storage. A `kill -9` inside that
+// window is exactly what this package's tests target — with a plain
+// wall-clock delay, not a deterministic kill-hook, because the window is wide
+// enough (~1s) that timing it precisely isn't necessary.
+//
+// # Why "gap or duplicate" depends on the plugin, and this package tests both
+//
+// Whether that crash window is merely wasteful (Conduit re-delivers a few
+// already-committed records as harmless duplicates — fine, at-least-once) or
+// actually loses data (an unrecoverable GAP) depends entirely on whether the
+// plugin's backing system can still supply data from BEFORE its own most
+// recent commit. A Kafka-like log can. A Postgres replication slot, whose WAL
+// segments are eligible for recycling once the slot's confirmed_flush_lsn
+// advances past them, may not be able to — and real Postgres surfaces that
+// as a hard error ("requested WAL segment ... has already been removed"),
+// not a silent skip.
+//
+// Since the real wrapper+Postgres isn't available here, sigkill_test.go
+// drives BOTH assumptions against the identical engine code path, via a
+// synthetic upstreamStore (upstream.go) with a `prune` flag:
+//
+//   - prune=false (durable/Kafka-like upstream): the crash window must
+//     produce, at most, harmless duplicate re-delivery. No gap, ever.
+//   - prune=true (Postgres-replication-slot-like upstream): the SAME crash
+//     window, in the SAME engine code, is shown to make a GAP structurally
+//     reachable — Source.Open, on restart, is asked to resume from a
+//     position the upstream has already discarded.
+//
+// The verdict this package's tests establish is therefore conditional and
+// precise, not a blanket "crash-safe" or "not crash-safe" claim: Conduit's own
+// ack-before-persist ordering provides no protection on its own — safety
+// depends entirely on the connected plugin's ability to redeliver behind its
+// last commit, which for a real Debezium-Postgres connector is not
+// guaranteed. See the PR description's failure-mode analysis for the full
+// walk of the ack->commit->persist sequence and what each crash point does.
+package chaos

--- a/tests/chaos/harness.go
+++ b/tests/chaos/harness.go
@@ -1,0 +1,241 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chaos
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// childConfig configures one child-process run. dbDir and upstreamDir are
+// reused verbatim across a kill+restart pair - that persistence, on disk,
+// across two separate OS processes, is the entire point of this harness: it
+// is what makes "restart and check for a gap" mean something.
+type childConfig struct {
+	dbDir       string
+	upstreamDir string
+	prune       bool
+	paceMS      int
+	total       uint64
+}
+
+func (c childConfig) env() []string {
+	return []string{
+		envChild + "=1",
+		envDBDir + "=" + c.dbDir,
+		envUpstreamDir + "=" + c.upstreamDir,
+		envPrune + "=" + strconv.FormatBool(c.prune),
+		envPaceMS + "=" + strconv.Itoa(c.paceMS),
+		envTotal + "=" + strconv.FormatUint(c.total, 10),
+	}
+}
+
+// childProcess wraps a running (or exited) chaos child and its observed
+// stdout, so a test can wait for a specific number of ACK progress lines
+// before deciding when to SIGKILL - deterministic relative to the child's
+// own observed progress, not a blind wall-clock guess.
+type childProcess struct {
+	cmd *exec.Cmd
+
+	mu     sync.Mutex
+	lines  []string
+	stderr bytes.Buffer
+
+	readerDone chan struct{}
+
+	// reapOnce guards cmd.Wait(), which the os/exec docs require be called at
+	// most once. sigkill, waitExit and the spawnChild-registered t.Cleanup
+	// fallback can all end up trying to reap the same process (e.g. an
+	// assertion failing between spawnChild and the test's own sigkill/
+	// waitExit call would otherwise leak the process); routing all of them
+	// through reap() makes that safe regardless of which one gets there
+	// first.
+	reapOnce sync.Once
+	waitErr  error
+}
+
+// reap calls cmd.Wait() exactly once (idempotent - see reapOnce's doc
+// comment) and returns its result on every call.
+func (c *childProcess) reap() error {
+	c.reapOnce.Do(func() {
+		c.waitErr = c.cmd.Wait()
+	})
+	return c.waitErr
+}
+
+// spawnChild re-executes the current test binary (os.Args[0]) with
+// CONDUIT_CHAOS_CHILD=1, which - per TestMain in sigkill_test.go - makes it
+// behave as runChild (child.go) instead of running this package's actual Go
+// tests. This is the standard "re-exec the test binary as a helper process"
+// pattern.
+func spawnChild(t *testing.T, cfg childConfig) *childProcess {
+	t.Helper()
+
+	exe := os.Args[0]
+	if !filepath.IsAbs(exe) {
+		resolved, err := os.Executable()
+		if err != nil {
+			t.Fatalf("resolve test binary path: %v", err)
+		}
+		exe = resolved
+	}
+
+	// CommandContext with context.Background() (rather than exec.Command) is
+	// used only to satisfy the noctx linter - the child's lifecycle is
+	// controlled explicitly via sigkill/waitExit below, not via context
+	// cancellation.
+	//nolint:gosec // exe is this test binary's own path (os.Args[0]/os.Executable), not external input - the standard re-exec-self pattern
+	cmd := exec.CommandContext(context.Background(), exe)
+	cmd.Env = append(os.Environ(), cfg.env()...)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+
+	cp := &childProcess{cmd: cmd, readerDone: make(chan struct{})}
+	cmd.Stderr = &cp.stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+
+	// Fallback safety net: if the test function returns early (e.g. a failed
+	// assertion between spawnChild and the test's own sigkill/waitExit call)
+	// without explicitly reaping this child, don't leave a live or zombie
+	// process behind. Harmless (and a no-op beyond the Kill call) if the test
+	// already reaped it - see reap()'s doc comment.
+	t.Cleanup(func() {
+		if cp.cmd.Process != nil {
+			_ = cp.cmd.Process.Kill()
+		}
+		_ = cp.reap()
+	})
+
+	go func() {
+		defer close(cp.readerDone)
+		sc := bufio.NewScanner(stdout)
+		for sc.Scan() {
+			line := sc.Text()
+			cp.mu.Lock()
+			cp.lines = append(cp.lines, line)
+			cp.mu.Unlock()
+		}
+	}()
+
+	return cp
+}
+
+func (c *childProcess) linesSnapshot() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.lines...)
+}
+
+// ackCount returns how many distinct "ACK <n>" progress lines have been
+// observed so far - i.e. how many positions the chaosPlugin has durably
+// committed upstream.
+func (c *childProcess) ackCount() int {
+	n := 0
+	for _, l := range c.linesSnapshot() {
+		if strings.HasPrefix(l, "ACK ") {
+			n++
+		}
+	}
+	return n
+}
+
+// line returns the first observed line with the given prefix, and whether
+// one was found.
+func (c *childProcess) line(prefix string) (string, bool) {
+	for _, l := range c.linesSnapshot() {
+		if strings.HasPrefix(l, prefix) {
+			return l, true
+		}
+	}
+	return "", false
+}
+
+func (c *childProcess) diagnostics() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return fmt.Sprintf("stdout lines: %v\nstderr: %s", c.lines, c.stderr.String())
+}
+
+// waitForAckCount blocks (polling, not sleeping a fixed duration) until at
+// least n ACK lines have been observed, or fails the test after a generous
+// timeout. Because the child's own pacing (chaosPlugin.paceMS) enforces a
+// MINIMUM real delay between acks via time.Sleep, waiting for n acks always
+// means at least n*paceMS of wall-clock time has genuinely elapsed - slower
+// CI scheduling can only add delay, never let this return early. That is
+// what makes waitForAckCount a safe way to guarantee "at least this much
+// time has passed since the first ack" without a fragile fixed sleep.
+func (c *childProcess) waitForAckCount(t *testing.T, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if c.ackCount() >= n {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d acks (saw %d)\n%s", n, c.ackCount(), c.diagnostics())
+}
+
+// sigkill sends SIGKILL (not SIGTERM, not context cancellation) and reaps
+// the process. This is the actual chaos: no cleanup, no graceful shutdown,
+// no final flush - exactly what CLAUDE.md's chaos-testing standard requires
+// ("SIGKILL (not SIGTERM)").
+func (c *childProcess) sigkill(t *testing.T) {
+	t.Helper()
+	if err := c.cmd.Process.Signal(syscall.SIGKILL); err != nil {
+		t.Fatalf("SIGKILL child (pid %d): %v", c.cmd.Process.Pid, err)
+	}
+	_ = c.reap() // a "signal: killed" wait error is expected here, not a failure
+	<-c.readerDone
+}
+
+// waitExit blocks until the child exits on its own (the "let it run to
+// completion" restart run), failing the test if it doesn't within timeout or
+// exits with an unexpected non-zero code.
+func (c *childProcess) waitExit(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		_ = c.reap()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		<-c.readerDone
+		if c.waitErr != nil {
+			t.Fatalf("child exited unexpectedly: %v\n%s", c.waitErr, c.diagnostics())
+		}
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for child to exit\n%s", c.diagnostics())
+	}
+}

--- a/tests/chaos/sigkill_test.go
+++ b/tests/chaos/sigkill_test.go
@@ -1,0 +1,228 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chaos
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/matryer/is"
+)
+
+// TestMain intercepts the "am I a chaos child?" case before any actual Go
+// test runs. See child.go/isChildInvocation and harness.go/spawnChild for the
+// re-exec protocol.
+func TestMain(m *testing.M) {
+	if isChildInvocation() {
+		runChild() // never returns; always os.Exit's
+	}
+	os.Exit(m.Run())
+}
+
+// sigkillCase drives a single SIGKILL scenario. paceMS and killAfterAcks
+// together determine where in the ack->commit->persist crash window
+// (source.go:207-238, see doc.go) the kill lands: with the persister's real
+// DefaultPersisterDelayThreshold (1s), waiting for killAfterAcks acks at
+// paceMS each guarantees at least killAfterAcks*paceMS of genuine elapsed
+// time (childProcess.waitForAckCount's guarantee - see its doc comment), so
+// the numbers below are chosen to land reliably inside or across that 1s
+// boundary without needing a deterministic kill-hook, matching the finding
+// this workstream was built around.
+type sigkillCase struct {
+	name          string
+	paceMS        int
+	killAfterAcks int
+	total         uint64
+}
+
+var sigkillCases = []sigkillCase{
+	{
+		// Mid-snapshot: an initial, fast burst (minimal pacing, mirroring
+		// Debezium's initial full-table snapshot dumping many rows quickly).
+		// killAfterAcks=30 at 1ms/ack is ~30ms in - well before the FIRST
+		// automatic flush (which fires at ~1000ms), so Conduit has not
+		// persisted ANY position yet when the kill lands. This is the
+		// highest-stakes edge case named in the design doc: a crash before
+		// the snapshot watermark is durably recorded at all.
+		name:          "mid-snapshot",
+		paceMS:        1,
+		killAfterAcks: 30,
+		total:         500,
+	},
+	{
+		// Mid-stream: steady-state pacing slow enough that, by the time we
+		// reach killAfterAcks=95 acks (~1.4s in), one automatic flush has
+		// already happened (~1s, around ack ~66) AND a second debounce
+		// window has already started (on the next ack after that flush) but
+		// not yet fired (its own 1s timer would land around ack ~133). So
+		// Conduit's persisted position is a valid but STALE checkpoint
+		// (unlike the mid-snapshot case's "nothing at all"), which is the
+		// other edge case named in the design doc.
+		name:          "mid-stream",
+		paceMS:        15,
+		killAfterAcks: 95,
+		total:         400,
+	},
+}
+
+// TestSIGKILL_PruningUpstream_ProducesGap is DBZ-1's central result: killing
+// the engine inside the ack-sent/not-yet-persisted window (source.go:207-238)
+// against an upstream that cannot redeliver behind its own last commit
+// (modeling a Postgres replication slot - see doc.go) makes a genuine,
+// structural GAP reachable - not a hypothetical one. Restarting resumes from
+// Conduit's stale persisted position, which the upstream has already
+// discarded, and chaosPlugin.Open (upstream.go) surfaces that as a loud,
+// unambiguous error rather than a silent skip.
+//
+// What this catches: a violation of invariant 3 (a record that was
+// legitimately available before the kill becomes permanently unreachable
+// after it) - this is the sev-0 class of bug CLAUDE.md's data-integrity
+// invariants exist to prevent. Per this workstream's explicit instruction,
+// finding this is the deliverable: pkg/connector/source.go's ack-before-
+// persist ordering is NOT fixed in this PR (that would touch Source.Ack for
+// every connector and needs its own Tier-1 design doc); this test is the
+// demonstration + escalation.
+func TestSIGKILL_PruningUpstream_ProducesGap(t *testing.T) {
+	for _, tc := range sigkillCases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			dir := t.TempDir()
+			cfg := childConfig{
+				dbDir:       dir + "/db",
+				upstreamDir: dir + "/upstream",
+				prune:       true,
+				paceMS:      tc.paceMS,
+				total:       tc.total,
+			}
+
+			first := spawnChild(t, cfg)
+			first.waitForAckCount(t, tc.killAfterAcks, 30*time.Second)
+			first.sigkill(t)
+
+			committedAtKill, err := openUpstreamStore(cfg.upstreamDir, cfg.prune)
+			is.NoErr(err)
+			committedWatermark, err := committedAtKill.Committed()
+			is.NoErr(err)
+			// Sanity check on the harness itself: the plugin must have
+			// actually committed at least killAfterAcks positions before
+			// the kill landed, or this test isn't exercising the window it
+			// claims to.
+			is.True(committedWatermark >= uint64(tc.killAfterAcks))
+
+			second := spawnChild(t, cfg)
+			second.waitExit(t, 30*time.Second)
+
+			resumeLine, ok := second.line("RESUME_POSITION")
+			is.True(ok)
+			resumePos := parseResumePosition(t, resumeLine)
+
+			// The core verdict: with a pruning upstream, the stale resume
+			// position must be behind the committed watermark (proving this
+			// really is the ack-before-persist crash window), AND the
+			// restart must surface that as a loud, structural GAP - never a
+			// silent skip, never a false "all good".
+			is.True(resumePos < committedWatermark)
+
+			gapLine, foundGap := second.line(markerOpenGap)
+			if !foundGap {
+				t.Fatalf(
+					"SEV-0 ESCALATION MISSED OR CHANGED BEHAVIOR: expected chaosPlugin.Open to refuse a "+
+						"stale resume (position %d) behind the committed watermark (%d) with an %s marker, "+
+						"but the restart did not report one - re-verify pkg/connector/source.go's ack-before-persist "+
+						"ordering before assuming this is safe.\n%s",
+					resumePos, committedWatermark, markerOpenGap, second.diagnostics(),
+				)
+			}
+			t.Logf("SEV-0 FINDING confirmed for %s: %s", tc.name, gapLine)
+
+			_, corrupt := second.line(markerCorruptPo)
+			is.True(!corrupt) // this is a resume-refusal, not a torn/corrupted position (invariant 2 still holds)
+		})
+	}
+}
+
+// TestSIGKILL_DurableUpstream_ProducesDuplicateNotGap is the counterfactual
+// control for TestSIGKILL_PruningUpstream_ProducesGap: the IDENTICAL crash
+// window, against the IDENTICAL engine code (pkg/connector.Source.Ack /
+// Persister), but against an upstream that CAN redeliver behind its last
+// commit (modeling a durable, replayable log such as Kafka). Here the same
+// stale resume must be harmless: Conduit re-reads and re-acks a few already-
+// committed positions as duplicates (consistent with the at-least-once
+// floor, invariant 3) and then continues on to complete delivery of every
+// position through total.
+//
+// Running both variants side by side is what lets this workstream state
+// precisely (per CLAUDE.md's "determine, don't assume" standard) that the
+// gap in the other test is conditional on the connected plugin's own
+// redelivery guarantees, not an unconditional property of Conduit's engine.
+func TestSIGKILL_DurableUpstream_ProducesDuplicateNotGap(t *testing.T) {
+	for _, tc := range sigkillCases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			dir := t.TempDir()
+			cfg := childConfig{
+				dbDir:       dir + "/db",
+				upstreamDir: dir + "/upstream",
+				prune:       false,
+				paceMS:      tc.paceMS,
+				total:       tc.total,
+			}
+
+			first := spawnChild(t, cfg)
+			first.waitForAckCount(t, tc.killAfterAcks, 30*time.Second)
+			first.sigkill(t)
+
+			second := spawnChild(t, cfg)
+			second.waitExit(t, 30*time.Second)
+
+			_, gap := second.line(markerOpenGap)
+			is.True(!gap) // no gap: a non-pruning upstream must never refuse a stale resume
+
+			_, corrupt := second.line(markerCorruptPo)
+			is.True(!corrupt) // invariant 2: no torn/corrupted position on restart
+
+			_, done := second.line(markerDone)
+			is.True(done) // invariant 3: at-least-once delivery completed through `total` despite the kill
+
+			finalWatermark, err := openUpstreamStore(cfg.upstreamDir, cfg.prune)
+			is.NoErr(err)
+			committed, err := finalWatermark.Committed()
+			is.NoErr(err)
+			is.Equal(committed, tc.total) // every position 1..total was durably committed exactly once by the end
+		})
+	}
+}
+
+// parseResumePosition extracts the integer position from a "RESUME_POSITION
+// <pos>" line (or 0 for "RESUME_POSITION" with an empty position, i.e. a
+// genuinely fresh start with no persisted state at all).
+func parseResumePosition(t *testing.T, line string) uint64 {
+	t.Helper()
+	fields := strings.Fields(line)
+	// opencdc.Position.String() prints the literal "<nil>" for a nil
+	// position (see conduit-commons/opencdc/position.go) - i.e. a genuinely
+	// fresh start with nothing persisted yet.
+	if len(fields) < 2 || fields[1] == "<nil>" {
+		return 0
+	}
+	n, err := strconv.ParseUint(fields[1], 10, 64)
+	if err != nil {
+		t.Fatalf("unparseable RESUME_POSITION line %q: %v", line, err)
+	}
+	return n
+}

--- a/tests/chaos/upstream.go
+++ b/tests/chaos/upstream.go
@@ -1,0 +1,310 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chaos
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit-connector-protocol/pconnector"
+	"github.com/conduitio/conduit/pkg/plugin/connector/builtin"
+)
+
+// upstreamStore models the durable external system a source connector reads
+// from and commits records to — e.g. Debezium reading Postgres's replication
+// slot. Its "committed" watermark is written to disk and fsynced
+// SYNCHRONOUSLY on every commit, deliberately unlike Conduit's own
+// Persister (persister.go), which debounces. That asymmetry is the point:
+// this store models a plugin/upstream whose own commit is immediate and
+// irreversible from Conduit's perspective, exactly as pkg/connector/source.go
+// assumes when it sends the ack to the plugin before persisting its own
+// state.
+//
+// If prune is true, the store also models a replication slot whose WAL
+// segments are recycled once confirmed: Committed() reports the highest
+// position ever committed across ALL runs (including ones a SIGKILL cut
+// short), and the chaosPlugin's Open refuses to resume from anywhere behind
+// it. If prune is false, the store never restricts where a resume can start
+// from — the modeled upstream is a durable, replayable log (e.g. Kafka) that
+// can redeliver from an arbitrarily old offset.
+type upstreamStore struct {
+	path  string
+	prune bool
+
+	mu sync.Mutex
+}
+
+func openUpstreamStore(dir string, prune bool) (*upstreamStore, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("upstreamStore: mkdir %s: %w", dir, err)
+	}
+	return &upstreamStore{path: filepath.Join(dir, "committed"), prune: prune}, nil
+}
+
+// Committed returns the highest position ever durably committed, read fresh
+// from disk every call — so a freshly restarted process picks up whatever a
+// previous, killed process last committed. Returns 0 if nothing was ever
+// committed.
+func (u *upstreamStore) Committed() (uint64, error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.readLocked()
+}
+
+func (u *upstreamStore) readLocked() (uint64, error) {
+	raw, err := os.ReadFile(u.path)
+	if os.IsNotExist(err) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("upstreamStore: read %s: %w", u.path, err)
+	}
+	n, err := strconv.ParseUint(string(raw), 10, 64)
+	if err != nil {
+		// A torn/corrupted read of the upstream's OWN commit marker is not
+		// what this workstream's invariant-2 assertion is about (that's
+		// Conduit's persisted position, checked independently in
+		// child.go) — but it should never happen given the synchronous
+		// write+fsync below, so surface it loudly rather than silently
+		// treating it as "nothing committed".
+		return 0, fmt.Errorf("upstreamStore: corrupt commit marker %q in %s: %w", raw, u.path, err)
+	}
+	return n, nil
+}
+
+// Commit durably records that pos has been committed upstream (Debezium's
+// task.commitRecord+task.commit, in the real wrapper). It is synchronous and
+// fsynced before returning — modeling an upstream commit that is immediate
+// and durable, unlike Conduit's own debounced Persister.
+func (u *upstreamStore) Commit(pos uint64) error {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	cur, err := u.readLocked()
+	if err != nil {
+		return err
+	}
+	if pos <= cur {
+		return nil // already committed at least this far; idempotent
+	}
+
+	tmp := u.path + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("upstreamStore: open %s: %w", tmp, err)
+	}
+	if _, err := fmt.Fprintf(f, "%d", pos); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("upstreamStore: write %s: %w", tmp, err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("upstreamStore: fsync %s: %w", tmp, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("upstreamStore: close %s: %w", tmp, err)
+	}
+	// Atomic rename: the marker file is never observed half-written.
+	if err := os.Rename(tmp, u.path); err != nil {
+		return fmt.Errorf("upstreamStore: rename %s -> %s: %w", tmp, u.path, err)
+	}
+	return nil
+}
+
+// chaosPlugin is a minimal, in-process pconnector.SourcePlugin standing in
+// for the wrapper's DefaultSourceStream. It produces a deterministic stream
+// of records (position N's payload is always "record-N", so "was record N
+// ever delivered" needs no separate ledger — it's a pure function of
+// position) and, on ack, durably commits to upstream via upstreamStore.
+type chaosPlugin struct {
+	store  *upstreamStore
+	total  uint64 // 0 means unbounded
+	paceMS int    // delay between produced records; 0 = as-fast-as-possible burst
+
+	mu         sync.Mutex
+	nextToRead uint64 // set by Open, read by the producer goroutine
+}
+
+var _ pconnector.SourcePlugin = (*chaosPlugin)(nil)
+
+func (p *chaosPlugin) Configure(context.Context, pconnector.SourceConfigureRequest) (pconnector.SourceConfigureResponse, error) {
+	return pconnector.SourceConfigureResponse{}, nil
+}
+
+// Open is where the crash window's consequence becomes observable: if the
+// upstream prunes (Postgres-slot-like) and Conduit asks to resume from
+// behind the already-committed watermark, this returns a hard, loud error —
+// modeling Postgres's real "requested WAL segment has already been removed"
+// behavior, not a silent skip. See doc.go for why gap-vs-duplicate depends on
+// this flag.
+func (p *chaosPlugin) Open(_ context.Context, req pconnector.SourceOpenRequest) (pconnector.SourceOpenResponse, error) {
+	resume, err := decodePosition(req.Position)
+	if err != nil {
+		return pconnector.SourceOpenResponse{}, fmt.Errorf("chaos plugin: invalid resume position %q: %w", req.Position, err)
+	}
+
+	committed, err := p.store.Committed()
+	if err != nil {
+		return pconnector.SourceOpenResponse{}, err
+	}
+
+	if p.store.prune && resume < committed {
+		return pconnector.SourceOpenResponse{}, fmt.Errorf(
+			"GAP: chaos upstream already committed/pruned through position %d, but Conduit asked to "+
+				"resume from position %d — the %d position(s) in between are no longer available upstream "+
+				"(modeling a Postgres replication slot whose WAL for already-confirmed positions was recycled)",
+			committed, resume, committed-resume)
+	}
+
+	p.mu.Lock()
+	p.nextToRead = resume
+	p.mu.Unlock()
+	return pconnector.SourceOpenResponse{}, nil
+}
+
+func (p *chaosPlugin) Run(ctx context.Context, stream pconnector.SourceRunStream) error {
+	inmemStream, ok := stream.(*builtin.InMemorySourceRunStream)
+	if !ok {
+		return fmt.Errorf("chaos plugin: unexpected stream type %T", stream)
+	}
+	inmemStream.Init(ctx)
+	server := inmemStream.Server()
+
+	p.mu.Lock()
+	start := p.nextToRead
+	p.mu.Unlock()
+
+	go p.produceLoop(server, start)
+	go p.ackLoop(server)
+	return nil
+}
+
+// produceLoop delivers records start+1, start+2, ... up to p.total
+// (inclusive), pacing each send by p.paceMS. It never re-checks Committed —
+// producing is independent of committing, exactly like a real source
+// connector's read loop runs concurrently with (and ahead of) acks arriving
+// for records it already sent.
+func (p *chaosPlugin) produceLoop(server pconnector.SourceRunStreamServer, start uint64) {
+	pos := start
+	for {
+		if p.total > 0 && pos >= p.total {
+			return
+		}
+		pos++
+
+		rec := makeRecord(pos)
+		if err := server.Send(pconnector.SourceRunResponse{Records: []opencdc.Record{rec}}); err != nil {
+			return // stream closed (process exiting, or Teardown ran)
+		}
+
+		if p.paceMS > 0 {
+			time.Sleep(time.Duration(p.paceMS) * time.Millisecond)
+		}
+	}
+}
+
+// ackLoop drains ack messages and durably commits each one. It also emits a
+// progress line to stdout right after the durable commit completes, so the
+// parent test process can wait for a specific number of DURABLE commits
+// (rather than guessing with a fixed sleep) before deciding when to SIGKILL —
+// per the design doc's flakiness-mitigation guidance to prefer a record-count/
+// log-line trigger over a wall-clock sleep guess where it's this cheap to do.
+func (p *chaosPlugin) ackLoop(server pconnector.SourceRunStreamServer) {
+	for {
+		req, err := server.Recv()
+		if err != nil {
+			return // stream closed
+		}
+		for _, pos := range req.AckPositions {
+			n, err := decodePosition(pos)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "chaos plugin: invalid ack position %q: %v\n", pos, err)
+				continue
+			}
+			if err := p.store.Commit(n); err != nil {
+				fmt.Fprintf(os.Stderr, "chaos plugin: commit %d failed: %v\n", n, err)
+				continue
+			}
+			printProgress("ACK", n)
+		}
+	}
+}
+
+func (p *chaosPlugin) Stop(context.Context, pconnector.SourceStopRequest) (pconnector.SourceStopResponse, error) {
+	return pconnector.SourceStopResponse{}, nil
+}
+
+func (p *chaosPlugin) Teardown(context.Context, pconnector.SourceTeardownRequest) (pconnector.SourceTeardownResponse, error) {
+	return pconnector.SourceTeardownResponse{}, nil
+}
+
+func (p *chaosPlugin) LifecycleOnCreated(context.Context, pconnector.SourceLifecycleOnCreatedRequest) (pconnector.SourceLifecycleOnCreatedResponse, error) {
+	return pconnector.SourceLifecycleOnCreatedResponse{}, nil
+}
+
+func (p *chaosPlugin) LifecycleOnUpdated(context.Context, pconnector.SourceLifecycleOnUpdatedRequest) (pconnector.SourceLifecycleOnUpdatedResponse, error) {
+	return pconnector.SourceLifecycleOnUpdatedResponse{}, nil
+}
+
+func (p *chaosPlugin) LifecycleOnDeleted(context.Context, pconnector.SourceLifecycleOnDeletedRequest) (pconnector.SourceLifecycleOnDeletedResponse, error) {
+	return pconnector.SourceLifecycleOnDeletedResponse{}, nil
+}
+
+func (p *chaosPlugin) NewStream() pconnector.SourceRunStream {
+	return &builtin.InMemorySourceRunStream{}
+}
+
+// makeRecord deterministically builds the record for position pos: "was
+// record N ever delivered end-to-end" therefore needs no separate ledger —
+// it's answerable purely from the position, both here and in the parent
+// test's final verification.
+func makeRecord(pos uint64) opencdc.Record {
+	return opencdc.Record{
+		Position:  encodePosition(pos),
+		Operation: opencdc.OperationCreate,
+		Metadata:  opencdc.Metadata{},
+		Key:       opencdc.RawData(fmt.Sprintf("key-%d", pos)),
+		Payload:   opencdc.Change{After: opencdc.RawData(fmt.Sprintf("record-%d", pos))},
+	}
+}
+
+func encodePosition(pos uint64) opencdc.Position {
+	return opencdc.Position(strconv.FormatUint(pos, 10))
+}
+
+// decodePosition returns 0 for a nil/empty position (Conduit's Source.Open
+// with no persisted state, i.e. a genuinely fresh start).
+func decodePosition(p opencdc.Position) (uint64, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return strconv.ParseUint(string(p), 10, 64)
+}
+
+// printProgress emits a machine-parseable progress line to stdout. os.Stdout
+// writes go straight to the underlying file descriptor (fmt does no
+// buffering of its own), so this reaches the parent process's pipe
+// immediately - the parent reads these to know precisely how many positions
+// have been durably committed upstream, instead of guessing with a fixed
+// sleep. See the design doc's flakiness-mitigation guidance.
+func printProgress(tag string, pos uint64) {
+	fmt.Printf("%s %d\n", tag, pos)
+}


### PR DESCRIPTION
## Summary

First `tests/chaos` harness in the repo (v0.19 Workstream 7 / DBZ-1), per
`docs/design-documents/20260722-debezium-compete-roadmap.md` and the DBZ-1
implementation plan. Two independent deliverables:

1. **SIGKILL crash-safety test** on the source connector's offset↔position
   bridge (`pkg/connector.Source.Ack` / `pkg/connector.Persister`), mid-snapshot
   and mid-stream. **Verdict: the ack-before-persist window is a real,
   structural GAP against a pruning (Postgres-replication-slot-like) upstream —
   not a hypothetical one.** Against a durable (Kafka-like) upstream the exact
   same crash window in the exact same engine code produces only a benign
   duplicate. Per instructions, `Source.Ack`'s ordering is **not** changed in
   this PR — this is the demonstration + escalation.
2. **Engine-side FIFO/in-order ack test**, closing #2672: a real
   `conduit-connector-protocol` v1 gRPC client (bufconn, no mock) proves
   `funnel.Worker.Ack` (full batch, `worker.go:493`) and `Worker.Nack`'s
   partial-ack path (`worker.go:513`) both deliver acks to a v1-protocol plugin
   as individually ordered messages, matching input order.

**Risk tier: Tier 1** (data path — ack/position/checkpoint logic). Design doc:
the DBZ-1 implementation plan (pre-code, dated 2026-07-23). **Requires DeVaris
Tier-1 sign-off (wk4).** Do not merge without it.

## The SIGKILL verdict — gap vs. duplicate, and why it's conditional

`pkg/connector/source.go:207-238` (`Source.Ack`) sends the ack to the plugin
(`stream.Send`, line 218) — which for a real connector like the Debezium/Kafka
Connect wrapper drives `task.commitRecord`/`task.commit`, advancing Postgres's
replication-slot confirmed LSN — **before** persisting its own position
(`persister.Persist`, lines 223-235). `Persister.Persist`
(`persister.go:137-170`) debounces: it batches and flushes asynchronously after
`DefaultPersisterDelayThreshold` (1s) or 10k items. So there is a real ~1s (or
10k-record) window where Conduit has told a plugin "you may durably commit"
before Conduit's own bookkeeping has reached durable storage.

This PR's chaos test targets exactly that window with two scenarios:

- **mid-snapshot**: a fast burst (no artificial pacing), killed ~30ms in — well
  before any automatic flush, so Conduit has persisted **nothing** when the kill
  lands (models Debezium's initial full-table snapshot).
- **mid-stream**: steady pacing, killed ~1.4s in — one automatic flush has
  already landed (a valid but stale checkpoint), and the kill lands inside the
  *next* debounce window before its flush fires.

Since the real `conduit-kafka-connect-wrapper` (Debezium/Postgres) isn't
available in this repo (separate JVM repo, not a Go module dependency here),
the test drives the real engine code (`pkg/connector.Source`, `Persister`,
real on-disk `badger` DB — same backend production uses) against a synthetic
`upstreamStore` with a `prune` toggle modeling the one behavior that actually
decides the outcome: **can the plugin's backing system still supply data from
before its own last commit?**

- `prune=false` (Kafka-like): same crash window, same engine code — restart
  resumes from the stale-but-valid checkpoint, re-delivers a few already-committed
  positions as harmless duplicates, then completes delivery through `total`.
  **No gap, ever.**
- `prune=true` (Postgres-slot-like: WAL segments recycled once confirmed):
  **identical crash window, identical engine code** — restart asks to resume
  from behind the already-committed/pruned watermark. `chaosPlugin.Open`
  surfaces this as a loud, structural error (modeling Postgres's real
  "requested WAL segment has already been removed", not a silent skip) in
  **both** the mid-snapshot and mid-stream variants. Confirmed by the test:

  ```text
  SEV-0 FINDING confirmed for mid-snapshot: OPEN_GAP_ERROR: could not open source
  connector plugin: GAP: chaos upstream already committed/pruned through position 30,
  but Conduit asked to resume from position 0 — the 30 position(s) in between are no
  longer available upstream

  SEV-0 FINDING confirmed for mid-stream: OPEN_GAP_ERROR: could not open source
  connector plugin: GAP: chaos upstream already committed/pruned through position 95,
  but Conduit asked to resume from position 64 — the 31 position(s) in between are no
  longer available upstream
  ```

**🔴 SEV-0 ESCALATION: `Source.Ack`'s ack-before-persist ordering is not
crash-safe when the connected plugin's commit is irreversible from Conduit's
point of view (real Postgres replication slots included).** This is a design
characteristic of `pkg/connector/source.go` today, not something this plan
decides to change — per instructions, fixing the ordering (e.g. persisting
before acking, or some other reordering) is explicitly **out of scope for this
PR**: it touches `Source.Ack`'s core sequencing for every connector and needs
its own separate Tier-1 design doc. **This PR is the demonstrating test and the
loud writeup, not the fix.**

## Failure-mode analysis (crash at each step of ack→commit→persist)

Walking `pkg/connector/source.go:207-238`'s sequence:

1. **Crash before the ack is sent (record read, never acked).** Nothing
   changed anywhere. Restart re-reads and reprocesses. **Correct** — a
   duplicate, consistent with at-least-once. *Metric that would show it*: none
   needed, no operator-visible effect. *Recovery*: automatic (resume from last
   persisted position).
2. **Crash mid-`stream.Send` (partial batch delivered to the plugin).** The
   plugin has committed a prefix of the batch; Conduit resumes from before the
   *entire* batch (its own persist for this batch never ran). Structurally the
   same risk as case 3 below, just with a partial batch.
3. **Crash after the ack is sent, before `persister.Persist`'s async flush
   completes — the window this PR's SIGKILL test targets.** Demonstrated: gap
   (pruning upstream) or benign duplicate (durable upstream) depending entirely
   on the plugin's own retention behavior. *Metric that would show it in
   production, today*: **none** — there is no replication-slot-lag metric, no
   heartbeat-staleness signal, no ack-vs-persist-lag gauge exposed anywhere in
   Conduit today. A production instance of this exact crash window would be
   invisible until a downstream data-quality incident surfaced it. This is a
   real observability gap this workstream inherits, not fixes (named for
   DBZ-3/DBZ-4, Phase 2). *Recovery*: operational only — restore from the last
   known-good destination/position snapshot, or replay from an earlier LSN if
   the replication slot still retains it; there is no automated self-healing
   (correctly, per CLAUDE.md's no-distributed-snapshot-machinery scope
   discipline).
4. **Crash during the persister's own `flushNow` transaction commit
   (torn-write risk, invariant 5).** Verified, not assumed: `badger`'s
   transactional commit is atomic at the KV layer (all-or-nothing), so a
   SIGKILL mid-commit cannot produce a torn/half-written position — confirmed
   empirically by the chaos test's restart path (`loadOrCreateInstance` in
   `tests/chaos/child.go` treats any `store.Get` error *other than* "key not
   found" as `CORRUPT_POSITION` and hard-fails; this marker never fired across
   all runs). Invariant 2's "no corrupted position" holds structurally here —
   invariant 1/3 (ack-before-durable-persist ordering) does not, per the
   finding above.
5. **Crash after the flush completes.** Fully consistent state; same as the
   happy-path boundary between batches.

**Cross-pipeline blast radius (per instructions, flagged explicitly):**
`Persister.flushNow` (`persister.go:238-271`) flushes **one shared batch across
every connector currently pending a write** — `Persist` is called per-connector
but batched into a single `map[string]persistData` keyed by connector ID,
and `triggerFlush`/`flushNow` operate on that whole map in one transaction. A
slow or blocked write for one connector's state (or the transaction itself)
delays the flush for every other connector's pending position update sharing
that same debounce cycle, process-wide. This chaos test only exercises a
single connector, so it does not itself demonstrate the blast radius — flagging
it here because the fix DeVaris may eventually decide on for the sev-0 above
(if it touches persist timing/ordering) needs to account for this shared-batch
behavior, not just the single-connector case this PR tests.

## FIFO-ack test coverage (closes #2672)

`pkg/lifecycle-poc/funnel/worker_ack_order_test.go` — real
`conduit-connector-protocol` v1 gRPC client (not mocked) over an in-memory
`bufconn` listener, talking to a fake `SourcePluginServer` that records ack
arrival order:

- `TestWorker_Ack_DeliversPositionsFIFOToV1Plugin`: full-batch ack
  (`worker.go:493`) — 5 positions acked together, observed as 5 separate,
  strictly ordered gRPC messages.
- `TestWorker_Nack_DeliversPartialAckFIFOToV1Plugin`: partial-batch ack
  following a partial DLQ nack (`worker.go:513`) — simulates the DLQ
  destination successfully writing 3-of-5 nacked records; asserts exactly the
  3-position prefix is acked, in order, and the other 2 are **not** acked
  (would violate invariant 1 — acking a record neither delivered nor durably
  DLQ'd).

This closes #2672: the FIFO guarantee standalone connectors depend on was
previously upheld only by a comment in `conduit-connector-protocol`'s v1
client, unasserted anywhere in this repo.

## Adversarial self-review findings (resolved before this PR)

- **Off-by-one / race in the chaos harness itself** (not production code):
  `Source.Ack` only guarantees the ack was handed off to the plugin
  (`stream.Send` rendezvous), not that the plugin's subsequent commit had
  finished — the child process could `os.Exit` before the last commit's fsync
  completed, truncating the observed run by one position and producing a
  false-positive gap unrelated to the engine code under test. Fixed with
  `waitForUpstreamCommitted` before the graceful-exit path; also fixed a bug
  where its timeout case silently fell through to `DONE` instead of failing.
- **Process-leak risk**: an assertion failing between `spawnChild` and the
  test's own `sigkill`/`waitExit` call would have left an orphaned child
  process running. Fixed via an idempotent `reap()` (guarded by `sync.Once`,
  since `cmd.Wait()` may only be called once) plus a `t.Cleanup`-registered
  fallback kill+reap.
- **gosec/noctx findings** on the harness's `exec.Command`/`os.ReadFile`/
  `os.MkdirAll` calls are taint-analysis false positives (self-controlled
  re-exec path and `t.TempDir()`-scoped fixture paths, not external input) —
  addressed with targeted `//nolint` comments explaining why, not blanket
  suppression.
- Checked error paths in `child.go` line by line: every `os.Exit` path prints a
  distinguishable marker (`CORRUPT_POSITION`, `OPEN_GAP_ERROR`, `FATAL`,
  `DONE`) so the parent test's assertions are never guessing from a bare exit
  code.
- Concurrency: `chaosPlugin`'s produce/ack goroutines communicate only via the
  in-memory stream's channels and the `upstreamStore`'s own mutex; verified
  clean under `-race` across repeated runs (`go test -race -count=3`, no
  reports).

## Gates

- `make generate && git diff --exit-code`: clean (no diffs; new files only).
- `golangci-lint run` scoped to changed packages (`./tests/chaos/...`,
  `./pkg/lifecycle-poc/funnel/...`): **0 issues**. (A full-repo
  `golangci-lint run ./...` hit lock contention from concurrent agent sessions
  sharing this environment's lint cache and could not be cleanly re-run in
  isolation before submission — the scoped, diff-relevant run is clean, which
  is what's gated on here; `go vet ./...` and `go build ./...` were run
  full-repo without contention, see below.)
- `go build ./...`: clean.
- `go vet ./...`: clean except one pre-existing, unrelated finding
  (`pkg/lifecycle-poc/funnel/worker.go:473`, predates this PR, inside the
  already-commented-out multi-connector TODO block).
- `go test -race ./tests/chaos/... ./pkg/lifecycle-poc/funnel/... ./pkg/connector/...`:
  all green, including 3 repeated full runs of the chaos suite (`-count=3`)
  with no flakes observed.
- Per the process-maturity table in `CLAUDE.md`: this is a normal CI test, not
  a scheduled nightly chaos job (that gate is Phase 2). Coverage-floor and
  benchi regression gates are not yet live (Phase 1) and are not claimed here.

## Requires DeVaris Tier-1 sign-off (wk4)

Open question carried from the DBZ-1 plan, unresolved by this PR (as
instructed): **does fixing `Source.Ack`'s ack-before-persist ordering become
its own Tier-1 design doc, or is there context that changes that?** This PR
takes no position beyond demonstrating the gap is real and structural — please
confirm the escalation path before or alongside sign-off.

DO NOT MERGE without explicit sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD
