### PR TITLE
fix(engine): persist position before plugin ack — sev-0 Source.Ack ordering (Approach A)

### DIFF
--- a/benchi/ack-hot-path/README.md
+++ b/benchi/ack-hot-path/README.md
@@ -1,0 +1,95 @@
+# benchi: Source.Ack persist-ordering fix — ack hot-path throughput
+
+Reference-pipeline benchmark for the sev-0 fix
+(`fix(engine): persist position before plugin ack — Approach A`,
+`docs/design-documents/20260723-source-ack-persist-ordering-fix.md`). Compares
+record throughput between `origin/main` (ack-before-persist, the bug) and this
+branch (ack-follows-durable-flush, the fix) on a generator-source ->
+log-destination pipeline with no external infrastructure, isolating the
+engine's own record/ack hot path (`Source.Read` -> `Source.Ack` ->
+`Persister.Persist` -> the deferred plugin-ack) from any downstream I/O.
+
+## Status: config committed, not run in this sandbox
+
+Per `CLAUDE.md`'s performance discipline ("claims require benchi runs,
+committed configs, reproducible results" / "never assert numbers without a
+benchmark in the repo"), stating this plainly: **this benchi config was
+authored and committed, but the actual Docker-orchestrated run has not been
+executed** — the sandbox this fix was developed in has the `benchi` binary
+installable (`go install github.com/conduitio/benchi/cmd/benchi@latest`
+succeeds) but no reachable Docker daemon (`docker info` fails with "no such
+file or directory" on the daemon socket). Do not read the numbers below as a
+benchi result; they are not.
+
+## What was actually measured: a same-sandbox Go microbenchmark
+
+As a substitute, immediately-reproducible signal — not a replacement for the
+benchi run above, which is still required before this claim is considered
+benchi-backed — `pkg/connector/source_bench_test.go`'s
+`BenchmarkSource_Ack` measures `Source.Ack` in isolation (real
+`connector.Source`/`connector.Persister`, real in-memory store, production
+default thresholds), run three times at `-benchtime=20000x` on both this
+branch and a temporary revert of just the ordering change (`Source.Ack`
+sending the ack before `persister.Persist`, restored immediately after
+measuring — see the fix PR description's "fails-without-fix" section, which
+reuses the same revert):
+
+```text
+$ go test -run '^$' -bench '^BenchmarkSource_Ack$' -benchmem -benchtime=20000x -count=3 ./pkg/connector/...
+
+# this branch (fix: ack deferred to post-flush callback)
+BenchmarkSource_Ack-16    20000    642.0 ns/op    707 B/op    6 allocs/op
+BenchmarkSource_Ack-16    20000    637.0 ns/op    707 B/op    6 allocs/op
+BenchmarkSource_Ack-16    20000    739.0 ns/op    707 B/op    6 allocs/op
+
+# temporarily reverted (pre-fix: synchronous stream.Send before persist)
+BenchmarkSource_Ack-16    20000   1501.0 ns/op    743 B/op    8 allocs/op
+BenchmarkSource_Ack-16    20000   1184.0 ns/op    742 B/op    8 allocs/op
+BenchmarkSource_Ack-16    20000   1214.0 ns/op    742 B/op    8 allocs/op
+```
+
+**Direction, not magnitude, is the claim worth stating from this data:** the
+fix's `Ack` call is faster per call, not slower, in this microbenchmark —
+because the pre-fix code pays a synchronous stream `Send` (a channel
+rendezvous with the plugin-side reader) on every single call, while the fix
+only enqueues and registers with the already-existing debounced persister,
+deferring the actual `Send` to the batched flush callback. This is
+consistent with the design doc's own framing ("hot path unchanged, only ack
+timing moves") but is a microbenchmark of one function, on one machine
+(Apple M3 Max, `darwin/arm64`), against an in-memory store and an in-memory
+stream with no plugin-side processing cost — it does not establish an
+end-to-end pipeline throughput or latency number, and does not exercise the
+cross-connector shared-batch blast radius the design doc names as inherited,
+not introduced, by this fix. That end-to-end number is exactly what the
+benchi run above is for, and it is what a >10% regression check would
+actually gate on per `CLAUDE.md`'s benchmark-regression-gate discipline.
+
+## Reproducing the benchi run
+
+From the repo root, on a machine with a running Docker daemon:
+
+```sh
+# 1. Build the "main" (pre-fix) image from a clean checkout of origin/main.
+git fetch origin main
+git worktree add /tmp/conduit-bench-main origin/main
+docker build -t conduit-bench:main /tmp/conduit-bench-main
+git worktree remove /tmp/conduit-bench-main
+
+# 2. Build the "fix" (this branch) image from the current checkout.
+docker build -t conduit-bench:fix-source-ack .
+
+# 3. Install benchi if not already installed.
+go install github.com/conduitio/benchi/cmd/benchi@latest
+
+# 4. Run both tool variants against the same pipeline/test definition.
+benchi -config benchi/ack-hot-path/bench.yml
+
+# 5. Inspect results/<timestamp>/aggregated-results.csv for the
+#    conduit-main vs conduit-fix throughput comparison.
+```
+
+A >10% regression on `conduit-fix` vs `conduit-main` without a stated
+justification would fail the benchmark-regression-gate discipline in
+`CLAUDE.md` — given the microbenchmark direction above, none is expected, but
+this run has not confirmed that end-to-end, and this doc does not claim
+otherwise.

--- a/benchi/ack-hot-path/bench.yml
+++ b/benchi/ack-hot-path/bench.yml
@@ -1,0 +1,56 @@
+# benchi config for the Source.Ack persist-ordering sev-0 fix (Approach A,
+# docs/design-documents/20260723-source-ack-persist-ordering-fix.md).
+#
+# Compares record throughput between origin/main (ack-before-persist, the
+# bug) and this branch (ack-follows-durable-flush, the fix) on the same
+# reference pipeline: a generator source -> log destination with no external
+# infrastructure, isolating the engine's own record/ack hot path. See
+# ./README.md for why this run is committed but was NOT executed in the
+# session that authored it (no Docker daemon in that sandbox), and for the
+# exact commands to run it.
+#
+# No infrastructure section: this pipeline has no external dependency (the
+# generator source and log destination both run entirely inside the conduit
+# process), which is deliberate — it isolates the engine hot path this fix
+# touches from any downstream I/O latency.
+
+tools:
+  conduit-main:
+    compose: ./tools/compose-conduit-main.yml
+  conduit-fix:
+    compose: ./tools/compose-conduit-fix.yml
+
+metrics:
+  conduit:
+    collector: conduit
+    tools:
+      - conduit-main
+      - conduit-fix
+    settings:
+      url: http://localhost:8080/metrics
+      pipelines:
+        - "ack-hot-path"
+  docker:
+    collector: docker
+    settings:
+      containers:
+        - "benchi-conduit"
+
+tests:
+  - name: ack-hot-path
+    # 60s steady-state after the pipeline has had time to ramp up; benchi's
+    # aggregation already trims the first/last samples (see the top-level
+    # README.md's "trimmed mean" note), so this does not need its own
+    # separate warm-up step.
+    duration: 60s
+
+    steps:
+      pre-infrastructure:
+      post-infrastructure:
+      pre-tool:
+      post-tool:
+      pre-test:
+      during:
+      post-test:
+      pre-cleanup:
+      post-cleanup:

--- a/benchi/ack-hot-path/pipeline.yml
+++ b/benchi/ack-hot-path/pipeline.yml
@@ -1,0 +1,33 @@
+version: "2.2"
+pipelines:
+  - id: ack-hot-path
+    status: running
+    name: ack-hot-path
+    description: >
+      Reference pipeline for the Source.Ack persist-ordering fix (Approach A,
+      docs/design-documents/20260723-source-ack-persist-ordering-fix.md).
+      Generator source -> log destination, deliberately with no external
+      infrastructure in the loop, so the measured throughput isolates the
+      engine's own record/ack hot path (Source.Read -> Source.Ack ->
+      Persister.Persist -> deferred plugin-ack) rather than any downstream
+      I/O latency.
+    connectors:
+      - id: ack-hot-path:generator-src
+        type: source
+        plugin: builtin:generator
+        settings:
+          format.type: structured
+          format.options.id: int
+          format.options.name: string
+          operations: create
+          # No rate limit: the generator produces as fast as the pipeline can
+          # read+ack, so throughput is bounded by the engine's own hot path,
+          # not by an artificial pacing knob.
+      - id: ack-hot-path:log-dest
+        type: destination
+        plugin: builtin:log
+        settings:
+          # error, not a no-op level: the connector-log destination has no
+          # "off" setting, so this is the quietest valid level, minimizing
+          # (not eliminating) logging overhead in the measurement.
+          level: error

--- a/benchi/ack-hot-path/tools/compose-conduit-fix.yml
+++ b/benchi/ack-hot-path/tools/compose-conduit-fix.yml
@@ -1,0 +1,22 @@
+# Fix: conduit built from this branch (fix/source-ack-persist-ordering,
+# Approach A — ack-follows-durable-flush). Build with, from the repo root:
+#
+#   docker build -t conduit-bench:fix-source-ack .
+#
+# See ../README.md for the full reproduction steps.
+services:
+  conduit:
+    image: conduit-bench:fix-source-ack
+    container_name: benchi-conduit
+    networks:
+      - benchi
+    ports:
+      - '8080:8080'
+    environment:
+      CONDUIT_LOG_FORMAT: json
+    volumes:
+      - ../pipeline.yml:/app/pipelines/pipeline.yml
+
+networks:
+  benchi:
+    external: true

--- a/benchi/ack-hot-path/tools/compose-conduit-main.yml
+++ b/benchi/ack-hot-path/tools/compose-conduit-main.yml
@@ -1,0 +1,23 @@
+# Baseline: conduit built from origin/main (pre-fix ack-before-persist
+# ordering). Build with, from the repo root:
+#
+#   git worktree add /tmp/conduit-main origin/main
+#   docker build -t conduit-bench:main /tmp/conduit-main
+#
+# See ../README.md for the full reproduction steps.
+services:
+  conduit:
+    image: conduit-bench:main
+    container_name: benchi-conduit
+    networks:
+      - benchi
+    ports:
+      - '8080:8080'
+    environment:
+      CONDUIT_LOG_FORMAT: json
+    volumes:
+      - ../pipeline.yml:/app/pipelines/pipeline.yml
+
+networks:
+  benchi:
+    external: true

--- a/docs/design-documents/20260723-source-ack-persist-ordering-fix.md
+++ b/docs/design-documents/20260723-source-ack-persist-ordering-fix.md
@@ -1,0 +1,396 @@
+# Source.Ack persist-ordering fix
+
+## Summary
+
+**Confirmed sev-0, not hypothetical:** `Source.Ack` (`pkg/connector/source.go:207-238`) sends the
+ack to the plugin (`s.stream.Send`, line 218) **before** the resulting position reaches durable
+storage (`s.Instance.persister.Persist`, lines 223-235, which only enqueues into an in-memory batch
+— see `pkg/connector/persister.go:137-170`). The batch is flushed asynchronously by `flushNow`
+(`persister.go:238-271`) on a debounce: `DefaultPersisterDelayThreshold` (1s, `persister.go:28`) or
+`DefaultPersisterBundleCountThreshold` (10k items, `persister.go:29`), whichever comes first. Any
+crash inside that window loses the position write while the plugin has already been told "you may
+commit."
+
+For a plugin whose upstream commit is reversible/idempotent from Conduit's point of view (Kafka:
+retention-based, replay from an older offset just redelivers), the crash window degrades to a
+**benign duplicate** — consistent with the at-least-once floor (invariant 3). For a plugin whose
+upstream commit **prunes** data it considers committed (Postgres logical replication: acking a
+position drives `confirmed_flush_lsn` forward, and WAL segments behind that point can be recycled),
+the identical crash window produces a **structural gap**: Conduit resumes from the last _durably
+persisted_ position, which is now known to be behind data the upstream has already discarded.
+Confirmed empirically by the DBZ-1 chaos test (`gh pr diff 2677`, `tests/chaos/`) against a
+synthetic `upstreamStore` with a `prune` toggle — identical engine code, identical crash timing,
+`prune=false` → duplicate delivery, `prune=true` → `OPEN_GAP_ERROR` on restart.
+
+This violates invariants 1 (ack only after durable downstream handling), 2 (crash-safe, gap-free
+position resume), and 3 (at-least-once floor) for every source connector backed by a
+pruning/retention-limited upstream. It is **latent**: present in every shipped release since
+`Source.Ack`'s current form, not introduced by DBZ-1 — DBZ-1 is simply the repo's first test that
+looks at this window at all.
+
+**This PR is documentation only.** It records the bug, proposes and recommends a fix approach
+(**A: ack-follows-durable-flush**), and requests DeVaris's Tier-1 sign-off on the _approach_ before
+any code changes. The code fix is a separate, subsequent PR.
+
+## Context
+
+### The mechanism, traced end to end
+
+1. `funnel.Worker.Ack` (`pkg/lifecycle-poc/funnel/worker.go:491-496`) is called once a batch has
+   been acked by every downstream node (including the DLQ, for partial failures —
+   `worker.go:507-531`, `Nack`, acks the successfully-DLQ'd prefix). It calls
+   `w.Source.Ack(ctx, originalBatch.positions)`.
+2. `connector.Source.Ack` (`source.go:207-238`):
+   - Line 218: `s.stream.Send(pconnector.SourceRunRequest{AckPositions: p})` — sends the ack over
+     the plugin gRPC stream. For a real connector (e.g. the Debezium/Kafka-Connect wrapper,
+     `DefaultSourceStream.onNext`), this is what triggers the plugin's own upstream commit
+     (`task.commitRecord`/`task.commit`, which for Debezium-Postgres advances the replication
+     slot's confirmed LSN — an irreversible signal to Postgres that it may recycle WAL behind that
+     point).
+   - Lines 223-227: updates `s.Instance.State` in memory, under `s.Instance`'s lock.
+   - Lines 228-235: calls `s.Instance.persister.Persist(ctx, s.Instance, callback)` — this
+     **enqueues** the connector's new state into the persister's in-memory batch
+     (`Persister.batch`, keyed by connector ID) and returns immediately. It does not wait for a
+     flush.
+3. `Persister.Persist` (`persister.go:137-170`) arms a debounce timer
+   (`DefaultPersisterDelayThreshold` = 1s) the first time a batch starts accumulating, or triggers
+   an immediate flush if `bundleCount` hits `DefaultPersisterBundleCountThreshold` (10k). Either
+   path eventually calls `triggerFlush` → `flushNow` (`persister.go:214-271`), which opens one
+   `badger` transaction, writes every connector's queued state, and commits.
+4. **The gap:** step 2's plugin-ack (irreversible for pruning upstreams) can be observed by the
+   outside world microseconds after it happens. Step 3's durable write can lag it by up to ~1s (or
+   until 10k records accumulate across _all_ connectors sharing that debounce cycle — see "Blast
+   radius" below). A crash anywhere in that window loses step 3 while step 2 already happened.
+
+### Why this stayed hidden
+
+`Source.Ack`'s ordering predates any chaos test in this repo (`tests/chaos` did not exist before
+DBZ-1, PR #2677). The persister's debounce was designed for throughput (batch position writes
+instead of an fsync per record) and reviewed for the failure modes visible at the time — torn
+writes (invariant 5, upheld: `badger`'s transaction commit is atomic, confirmed by the chaos test's
+restart path never hitting its `CORRUPT_POSITION` marker) — but not for the ack-before-persist
+ordering itself, because no test exercised a plugin whose upstream _prunes_ on ack. Every existing
+integration/acceptance test targets connectors (Postgres native, Kafka, S3, generator, file) where
+either there is no comparable irreversible commit, or the test never runs a `kill -9` in the
+window. DBZ-1's synthetic `upstreamStore` with an explicit `prune` toggle is the first thing in
+this repo that isolates the one variable that actually decides gap-vs-duplicate.
+
+### Constraints this design is bound by (from `CLAUDE.md`)
+
+- No connector-protocol change without an explicit versioning discussion — a fix that requires
+  every connector plugin to adopt new protocol semantics is a last resort, not a first choice.
+- No trading ack-correctness/ordering/crash-safety for throughput without a design doc and
+  explicit approval — this doc is that approval request.
+- Position serialization is unchanged by any option below; no migration is needed.
+- Ordering guarantees are per-source-partition (invariant 4) — the fix must not introduce
+  cross-partition reordering of acks.
+- Shutdown is graceful by default (invariant 7) — `kill -9` at any instant must remain recoverable
+  without loss, and SIGTERM must still drain and checkpoint before exit.
+
+## Decision
+
+> **Implementation note — what actually shipped (PR #2680), pending DeVaris re-affirmation
+> at Tier-1 sign-off.** Approach A shipped, but the bullets immediately below describe the
+> **originally recommended** per-source-partition high-water-mark (HWM) design. The shipped
+> implementation uses a simpler **connector-level FIFO `seq`** instead: `Source.Ack`
+> (`pkg/connector/source.go`) unconditionally overwrites `Instance.State.Position` with the
+> position of the _last_ record in each `Ack` call
+> (`s.Instance.State = SourceState{Position: p[len(p)-1]}`, `source.go:394`) —
+> `SourceState.Position` is always the connector's full **cumulative** position, never a
+> per-partition offset map. Because of that, whichever flush lands durably necessarily
+> **subsumes** every earlier-queued `seq`: there is no per-partition dimension for a later
+> flush to fail to cover, so a purely engine-internal, monotonically increasing `seq` counter
+> (queued and drained FIFO by `onPersistFlushed`, see `source.go`'s `pendingAcks`) is
+> sufficient to preserve invariant 4 — no per-partition HWM state was needed, or built. The
+> "Per-source-partition high-water-mark tracking" bullet below and the "Per-partition ordering"
+> failure-mode entry further down are retained as-written for the historical record (they were
+> the basis for the original sign-off request) but do **not** describe the shipped code — see
+> `TestSource_OnPersistFlushed_OutOfOrderCompletionStillDeliversInOrder`
+> (`pkg/connector/source_test.go`) for the shipped ordering guarantee instead. This is a
+> simplification relative to what was asked approval for, not an equivalent restatement of it,
+> so it is flagged here explicitly rather than assumed to be silently covered by the original
+> sign-off.
+
+**Recommended: Approach A — ack-follows-durable-flush.**
+
+Move the plugin-ack (`s.stream.Send` in `Source.Ack`) from _before_ `persister.Persist` to a
+**post-flush callback**, so the plugin is only told "you may commit" once its position has actually
+reached durable storage. Concretely:
+
+- `Source.Ack` no longer sends `AckPositions` inline. Instead it enqueues `(position, ackFn)` where
+  `ackFn` is deferred until the flush that durably persists that position completes.
+- The persister already threads a `PersistCallback` through `flushNow` (`persister.go:261-264`,
+  currently used only to propagate flush errors back via `s.errs`). Approach A extends that
+  callback: on success, it invokes the plugin ack for every position that batch just made durable,
+  in the order those positions were originally acked.
+- **Per-source-partition high-water-mark tracking** is required to preserve invariant 4: the
+  callback must ack the highest **contiguous** durably-flushed position per partition, not just
+  "whatever flushed most recently," so a source with multiple partitions/keys never acks position
+  N on partition X before position N-1 on partition X has flushed, even if flush batches interleave
+  across partitions. This is new state the fix must add (it does not exist today because acking was
+  never gated on persistence).
+- The persister's debounce (1s / 10k items) is **unchanged** — this is the throughput mechanism the
+  fix deliberately keeps. What changes is _when the plugin finds out_, not _when Conduit decides to
+  write_.
+- **Cost:** the plugin (and therefore the upstream, for pruning connectors) learns about a
+  committable position up to one debounce interval later than today. For Postgres replication
+  slots, this means WAL is held roughly one flush-interval longer before being eligible for
+  pruning — bounded, tunable (via `delayThreshold`), and enormously preferable to occasional silent
+  gaps. This is the entire trade the fix makes, stated plainly.
+- **No protocol change, no connector change.** `AckPositions` still carries the same shape; only
+  the engine-side timing of when it's sent changes. Every connector, standalone or built-in,
+  benefits without a rebuild.
+- **Graceful shutdown (invariant 7):** `lifecycle.Service.StopAndWait`
+  (`pkg/lifecycle/service.go:475-490`) already forces a flush and blocks on it via
+  `s.connectors.WaitPersisted()` (`persister.go:202-204`, `WaitPendingWrites`) before returning.
+  Under Approach A, the drain path must additionally block on the deferred plugin-acks for that
+  final flush completing — i.e. `StopAndWait` returns only after the plugin has actually been told
+  about the last durable position, not merely after the write landed. This is a required, not
+  incidental, part of the fix: without it, a graceful shutdown could still tear down the connector
+  (and its stream) between "position flushed" and "plugin acked," silently dropping the final ack
+  and leaving the plugin holding a commit it was never told to make — reintroducing invariant 1
+  violation on the _graceful_ path even after fixing the crash path.
+  **Shipped refinement:** the fix PR (#2680) bounds this wait at `Source.Teardown` itself
+  (`DefaultTeardownFlushTimeout` = 10s, overridable via a test-only `teardownFlushTimeout`
+  field) rather than blocking on it indefinitely — `Teardown` forces the flush and waits via
+  `Persister.WaitPendingWritesContext`, and on timeout or ctx cancellation logs a warning and
+  proceeds with teardown anyway. See the new "Graceful shutdown racing a stuck/slow flush"
+  failure-mode entry below for why an unbounded wait here would itself have been a new
+  hang-on-shutdown exposure this fix did not have before it started touching the persister on
+  the shutdown path at all.
+- **Crash between flush-complete and plugin-ack:** on restart, the position is already durably
+  persisted (that's why the ack fired), so the resumed position is correct; the plugin simply never
+  received that specific ack message. Consequence: the plugin (re)commits data it would have
+  committed anyway on the next ack it does receive — a benign duplicate window, not a gap, because
+  durability now strictly precedes the ack signal instead of following it.
+
+### Alternatives considered
+
+**B — synchronous persist-then-ack.** Make `Source.Ack` flush the batch durably and only then send
+`AckPositions`, inline, removing (or drastically shortening) the debounce specifically on the code
+path that leads to an ack. Correct: it trivially satisfies invariant 1 by construction, no
+per-partition HWM tracking needed, simplest to reason about.
+
+_Why it loses to A:_ it collapses the persister's entire batching benefit on the hot path. Every
+ack (potentially every batch, at whatever cadence the pipeline processes batches) forces a
+synchronous durable write + fsync before the plugin can proceed, serializing plugin throughput
+behind storage latency instead of amortizing writes across a debounce window. `CLAUDE.md`'s
+performance discipline requires a benchi comparison before claiming any throughput number, and
+there is no need to run that comparison to know the qualitative direction: this converts a
+batched-write system into a per-ack-write system on exactly the path most sensitive to write
+latency. It also does not obviously help the _cross-connector blast radius_ problem (see Failure
+modes) — if anything it worsens it, since a slow store write now blocks the ack path directly
+instead of a background flush.
+
+**C — connector-protocol "position durable" signal.** Add a new message to
+`conduit-connector-protocol` that the engine sends only after a position is durably persisted;
+require connectors to gate their own upstream commit on receiving it, replacing the implicit
+"ack means durable" contract with an explicit one.
+
+_Why it loses to A:_ `conduit-connector-protocol` is explicitly breaking-change territory
+(`CLAUDE.md`: "Never change `conduit-connector-protocol` without an explicit versioning
+discussion"). This approach requires **every** connector — standalone, WASM, and the
+Kafka-Connect wrapper — to adopt the new signal and correctly gate its commit on it, or the bug
+persists unfixed for any connector that hasn't been updated. It spreads the crash-safety burden
+outward (every connector author must now get this right) instead of concentrating the fix once, in
+the one place (the engine) that can guarantee it for everyone. It is also strictly more invasive
+for equivalent safety: A achieves the same guarantee with zero protocol surface change.
+
+## Failure-mode analysis
+
+Walking `Source.Ack`'s sequence under Approach A (contrast with today's behavior in brackets):
+
+1. **Crash before the ack is enqueued** (record read, batch not yet acked). No change from today:
+   nothing happened anywhere; restart re-reads and reprocesses. Correct, benign duplicate.
+2. **Crash mid-`stream.Send` of a _different_, already-durable ack** (the deferred-ack callback is
+   mid-flight). The position is already on disk (that's why the callback fired); restart resumes
+   from it correctly. The plugin may or may not have received the ack message; if not, it
+   (re)commits on the next ack it does get. Benign duplicate — **[today: this exact window is where
+   the sev-0 gap lives, because the ack already went out before the persist happened]**.
+3. **Crash after the position is enqueued into the persister's batch, before that batch's flush
+   completes.** No ack has been sent to the plugin yet (ack is deferred to post-flush). Restart
+   resumes from the last durably-flushed position (behind the lost, unflushed one) and reprocesses
+   the gap — a duplicate from the plugin's perspective, because the plugin was never told to commit
+   past that point. **This is the exact scenario that produces a structural gap today; under A it
+   cannot, because the plugin never got ahead of durability in the first place.**
+4. **Crash during `flushNow`'s transaction commit** (torn-write risk, invariant 5). Unchanged from
+   today and already verified: `badger`'s commit is atomic at the KV layer: a `kill -9` here cannot
+   leave a half-written position, confirmed empirically by the chaos harness's restart path (any
+   `store.Get` error other than "key not found" is a hard-fail `CORRUPT_POSITION`, which never
+   fired across the DBZ-1 test's runs).
+5. **Crash after flush completes, before the deferred per-partition callback fires.** Same as case
+   2 — durable state is correct, plugin ack is merely delayed to the next opportunity, benign.
+
+**Per-partition ordering under the new scheme (invariant 4).** The deferred-ack callback must ack
+partition X's position N only once every position ≤ N on partition X has itself flushed — not
+merely "some flush completed." Two flush batches can complete out of order relative to when their
+constituent acks were originally issued (batch B might start after batch A but finish first, if A's
+transaction stalls). Approach A's per-partition high-water-mark tracking exists specifically to
+prevent acking N before N-1 on the same partition in that interleaving. This tracking is new;
+nothing today needs it because today's ack fires synchronously in position order at enqueue time,
+before any batching reordering could occur.
+
+**Graceful (SIGTERM) vs. `kill -9` shutdown.** Covered under Decision above:
+`lifecycle.Service.StopAndWait` must additionally wait for the final flush's deferred plugin-acks,
+not just the flush itself, or graceful shutdown reintroduces the same class of bug it was
+protecting against (dropping an ack the plugin was owed). This is a required code change alongside
+the `Source.Ack`/`Persister` reordering, not a follow-up.
+
+**Graceful shutdown racing a stuck/slow flush (new exposure this fix introduces, and explicitly
+bounds — added post-implementation, PR #2680).** Before this fix, `Teardown` never touched the
+persister at all, so waiting on the final flush's deferred ack during graceful shutdown is _new_
+exposure, not a pre-existing one: an unbounded wait here would trade the sev-0 ack-before-persist
+bug for a possible-hang-on-shutdown bug (a stalled disk or a `badger` compaction pause could hang
+graceful shutdown indefinitely). The shipped fix bounds this wait
+(`Persister.WaitPendingWritesContext`, `DefaultTeardownFlushTimeout` = 10s) — on timeout or ctx
+cancellation, `Teardown` logs a warning and proceeds with teardown anyway. That fallback is safe,
+not merely convenient: forcing teardown before the deferred ack is confirmed sent degrades to
+exactly the same, already-proven-safe outcome as crash case 3 above — at worst a benign duplicate
+on the next run (the position may not have reached disk yet, so a restart simply re-delivers it),
+**never a gap**. Regression-tested by `TestSource_Teardown_BoundedWaitOnStuckFlush` (a stuck
+flush: proves `Teardown` returns within the bounded timeout instead of hanging) and
+`TestSource_Teardown_FastFlushCompletesWithinBoundedTimeout` (the fast path: proves the same short
+timeout override does not truncate a normal flush, and the deferred ack still gets sent) — both in
+`pkg/connector/source_test.go`.
+
+**Process-wide blast radius (inherited, not introduced, by this fix — corrected here from
+"cross-connector" as originally scoped; see `persister.go`'s `WaitPendingWrites` doc comment,
+~lines 184-186).** `Persister.flushNow` (`persister.go:238-271`) flushes one shared `batch`
+covering _every_ connector currently pending a write in that debounce cycle, in one transaction —
+and, more than this doc originally stated, **`connector.Persister` is a single instance shared
+across every pipeline in the process**, not scoped per-pipeline. Under Approach A, a slow or stuck
+flush for one connector now delays not only that connector's own durable write (as today) but also
+every other connector's deferred plugin-ack in the same cycle — across every pipeline currently
+running in this process, not just other connectors within the same pipeline. This was already
+true of the _write_ under the current design; A extends the same shared-batch coupling to the
+_ack_, and widens the blast radius from "cross-connector" to **process-wide**. Worth naming
+explicitly because it means one badly-behaved connector's slow store I/O can now delay every other
+pipeline's upstream commits process-wide, not just its own local position durability. Not a
+blocker for A (the alternative, B, has the same coupling and makes it synchronous instead of
+async-deferred, which is worse), but a candidate follow-up if per-connector (or per-pipeline)
+flush isolation is ever wanted.
+
+**MySQL binlog / MongoDB change-stream connectors — must-verify, not yet classified.** DBZ-1's
+finding is specific to Postgres-replication-slot-like upstreams (prune-on-commit). Whether MySQL's
+binlog or MongoDB's change-stream/oplog connectors fall in the same structural-gap class depends
+entirely on their own retention behavior relative to what "ack" means to them:
+
+- MySQL binlog retention is typically time- or size-bounded (`expire_logs_days` /
+  `binlog_expire_logs_seconds`), not driven by an explicit "confirmed position" acknowledgment the
+  way a replication slot is — an unacked-but-committed offset does not, by itself, force binlog
+  file deletion the way an advanced `confirmed_flush_lsn` frees WAL. This suggests MySQL is likely
+  closer to the **retention-based / benign-duplicate** class, but this is an inference from how
+  binlog retention generally works, not a verified fact about this codebase's MySQL connector or
+  the wrapper's MySQL path (which DBZ-7 has not yet built — see the Debezium-compete roadmap,
+  `docs/design-documents/20260722-debezium-compete-roadmap.md`).
+- MongoDB's oplog/change-stream retention is a capped collection (oplog) with its own independent
+  time/size window, not gated by Conduit's ack either. Likely also retention-based, but equally
+  unverified here.
+
+Both are flagged **must-verify** for the follow-up fix PR: run the same DBZ-1-style chaos harness
+(`upstreamStore` with a `prune` toggle) against MySQL-binlog and MongoDB-change-stream semantics
+specifically, rather than assuming the Postgres finding or the "probably retention-based" reasoning
+above generalizes. Do not ship a "fixed for all CDC connectors" claim without that verification.
+
+## Backward-compatibility and versioning plan
+
+- **No position/state serialization format change.** The stored `SourceState{Position}` shape is
+  untouched; only the in-memory sequencing of ack vs. persist changes. No migration, no upgrade
+  test beyond the existing ones.
+- **No connector-protocol change.** `pconnector.SourceRunRequest{AckPositions: p}` keeps its
+  current shape; only when the engine calls `stream.Send` with it changes. Every existing
+  connector — built-in, standalone Go, WASM, or the Kafka-Connect wrapper — is fixed by this change
+  with no rebuild or protocol-version bump required.
+- **Config surface:** `DefaultPersisterDelayThreshold` / `DefaultPersisterBundleCountThreshold`
+  remain the only tunables; their semantics (batch window) are unchanged, only what happens at the
+  end of that window (ack now included) changes.
+- **Rollback:** the fix is a pure engine-code change with no format or protocol implications;
+  rolling back to the current build reverts to today's ack-before-persist ordering (the known bug,
+  not a new one) with no data-compat concerns in either direction.
+
+## Regression gate
+
+The DBZ-1 SIGKILL chaos test (PR #2677, `tests/chaos/`) already exercises exactly this window with
+a `prune` toggle and currently _demonstrates_ the gap by design (that PR explicitly does not change
+`Source.Ack`'s ordering). The follow-up fix PR must:
+
+- Land the fix with the `prune=true` (Postgres-slot-like) scenario asserting **no gap**, in
+  addition to the existing `prune=false` benign-duplicate assertion.
+- Until the fix lands, the `prune=true` gap assertion in DBZ-1 should be marked `t.Skip`
+  with a comment linking the tracking issue for this fix, so the chaos suite doesn't perpetually
+  red the build on a known, tracked, not-yet-approved-to-fix issue — and so the skip itself is a
+  visible, dated marker that this is not forgotten.
+- The fix PR must additionally add: a graceful-shutdown (SIGTERM) variant proving
+  `Teardown`/`StopAndWait` delivers the final deferred ack before returning (shipped as
+  `TestSource_Teardown_SendsPendingDeferredAckBeforeReturning`), a bounded-wait variant proving a
+  stuck/slow flush cannot hang graceful shutdown indefinitely (shipped as
+  `TestSource_Teardown_BoundedWaitOnStuckFlush` and
+  `TestSource_Teardown_FastFlushCompletesWithinBoundedTimeout`), and a test proving
+  out-of-order flush-completion still delivers acks in order (shipped as
+  `TestSource_OnPersistFlushed_OutOfOrderCompletionStillDeliversInOrder` — exercising the shipped
+  connector-level FIFO `seq`, not the per-partition HWM originally specified here; see the
+  Decision section's implementation note).
+
+## Observability
+
+Named in DBZ-1's failure-mode analysis and inherited here, not solved by this fix: there is
+currently **no metric or alert** for ack-vs-persist lag, replication-slot/WAL retention pressure, or
+"how far behind is the durable position from the last ack we sent" anywhere in Conduit. A
+production instance of today's bug is invisible until a downstream data-quality incident surfaces
+it. The fix in this doc removes the _correctness_ problem; it does not add visibility into how
+close to the debounce boundary the system is running. Recommend (as a follow-up, not blocking this
+fix): a gauge for time-since-last-flush per connector and a counter for deferred-acks-pending, so
+an operator (or the fix's own soak test) can see the mechanism working rather than only inferring
+correctness from the absence of gaps. Tracked for DBZ-3/DBZ-4 (Phase 2) per the Debezium-compete
+roadmap, consistent with the process-maturity table's current Phase 2 placement for
+chaos-suite-as-gate maturity.
+
+## Rollout
+
+- **Throughput:** the fix must ship with a benchi run on a reference pipeline (per `CLAUDE.md`,
+  no performance claim without a committed, reproducible benchi result) comparing record
+  throughput and p99 batch latency before/after, specifically because Alternative B was rejected on
+  a throughput argument that deserves empirical backing, and because Approach A's own claim ("hot
+  path unchanged, only ack timing moves") should be verified rather than assumed. A >10% regression
+  without justification fails the build per the existing benchmark-regression-gate discipline.
+- **No feature flag / staged rollout needed:** this is a correctness fix to existing behavior, not
+  a new capability; there is no meaningful "opt out of the fix" state to support, consistent with
+  not introducing a bespoke toggle for a data-integrity invariant.
+- **Sequencing:** this design doc → DeVaris Tier-1 sign-off on approach → fix PR (Tier 1: human
+  sign-off, chaos test updated per the Regression gate section, failure-mode analysis restated in
+  that PR) → un-skip the DBZ-1 `prune=true` assertion → benchi run attached to the fix PR.
+
+## Risk tier & tests
+
+**Tier 1** (data path: ack/position/checkpoint ordering, `pkg/connector/source.go`,
+`pkg/connector/persister.go`). This doc requires DeVaris's explicit sign-off on the **approach**
+(Approach A vs. the alternatives above) before the follow-up code PR is opened. Per the
+process-maturity table in `CLAUDE.md`, the chaos suite (`tests/chaos`) is not yet a nightly gate
+(Phase 2) — today it runs as a normal CI test, which is what the fix PR will rely on for its
+regression proof; the nightly-cadence gate is not claimed here.
+
+**Additionally pending re-affirmation:** PR #2680 shipped Approach A with a connector-level FIFO
+`seq` instead of the per-source-partition HWM tracking this doc originally specified (see the
+Decision section's implementation note) and added a bounded wait to `Teardown`'s flush-and-wait
+step that this doc did not originally call for. Both are argued above to be safe simplifications
+of what was approved, not departures from it, but neither has DeVaris's explicit sign-off as
+stated — flagged here for that sign-off at Tier-1 review rather than treated as automatically
+covered by the original approach approval.
+
+## Related
+
+- PR #2680 — `fix(engine): persist position before plugin ack — sev-0 Source.Ack ordering
+  (Approach A)` — the shipped fix this doc now describes. See the Decision section's
+  implementation note for where the shipped mechanism (connector-level FIFO `seq`, bounded
+  `Teardown` wait) diverges from what was originally specified here, pending DeVaris
+  re-affirmation at Tier-1 sign-off.
+- PR #2677 — `test(chaos): DBZ-1 SIGKILL crash-safety + engine FIFO-ack (first tests/chaos)` —
+  the chaos test that confirmed this bug and the source of the failure-mode analysis this doc
+  builds on.
+- `docs/design-documents/20260722-debezium-compete-roadmap.md` — DBZ-1/DBZ-2/DBZ-7 workstreams;
+  this doc's must-verify follow-ups (MySQL/Mongo) feed DBZ-2's CDC acceptance-suite scope.
+- `docs/design-documents/20260708-live-server-deploy-apply.md` — prior analysis of
+  `Persister`'s async-flush-vs-drain race (`WaitPendingWrites`, "blocker 1"), the closest existing
+  precedent for reasoning about this persister's durability-vs-timing behavior.
+- `docs/postmortems/20260723-source-ack-persist-ordering.md` — the companion postmortem for this
+  sev-0.

--- a/docs/postmortems/20260723-source-ack-persist-ordering.md
+++ b/docs/postmortems/20260723-source-ack-persist-ordering.md
@@ -1,0 +1,171 @@
+# Postmortem: Source.Ack acks upstream before the position is durably persisted
+
+This is a blameless postmortem. The goal is to record what happened, why the automated gates that
+exist today did not catch it sooner, and what changes as a result — not to assign fault. The bug
+predates this repo having any chaos-testing infrastructure at all; it was found by the first test
+ever written to look for it.
+
+## Summary
+
+`Source.Ack` (`pkg/connector/source.go:207-238`) sends the ack to the connector plugin
+(`stream.Send`, line 218) before the resulting position write reaches durable storage
+(`persister.Persist`, lines 223-235, which only enqueues into an in-memory batch flushed
+asynchronously on a ~1s debounce or 10k-item threshold — `pkg/connector/persister.go:28-29,
+137-170, 238-271`). For a plugin whose upstream **prunes** data once it is told to commit (Postgres
+logical replication slots: acking advances `confirmed_flush_lsn`, which frees WAL for recycling),
+a crash inside that window causes Conduit to resume, on restart, from a durably-persisted position
+that is now _behind_ data the upstream has already discarded — a structural, unrecoverable gap.
+This violates data-integrity invariants 1 (ack only after durable downstream handling), 2
+(crash-safe, gap-free position resume), and 3 (at-least-once floor).
+
+**Severity: sev-0** (confirmed data-loss class, per `CLAUDE.md`'s definition). **Status: latent,
+confirmed, not yet fixed.** No production data loss is known to have occurred from this — it was
+found by a chaos test in a PR that has not merged, before any release train shipped a
+Kafka-Connect-wrapper-backed Postgres CDC pipeline in anger. This postmortem is issued at
+discovery, per `CLAUDE.md`'s regression-response rule ("any regression that reaches a release
+triggers a blameless postmortem... and produces at least one new automated check") — treated here
+as if a release-blocking finding, because a sev-0 data-loss mechanism confirmed against real engine
+code deserves the same rigor whether or not it happened to reach a tagged release first.
+
+## Impact
+
+- **Confirmed structural gap:** any source connector backed by an upstream that prunes/discards
+  data once told it has been committed. The concrete case verified: Postgres logical replication
+  slots (`confirmed_flush_lsn` advancement frees WAL), as used by the
+  `conduit-kafka-connect-wrapper`'s Debezium-Postgres path (`DebeziumPgSourceIT`) — the one
+  wrapper-backed CDC path this repo currently has test coverage for (DBZ-1, per
+  `docs/design-documents/20260722-debezium-compete-roadmap.md`).
+- **Confirmed benign (no gap):** the identical code path and crash window against a
+  retention-based upstream (Kafka-like: replay from an older, still-valid offset simply
+  redelivers) produces only a duplicate — consistent with the at-least-once floor, not a violation.
+- **Not yet classified:** MySQL-binlog and MongoDB-change-stream/oplog-backed sources. Reasoning in
+  the companion design doc suggests both are more likely retention-based (and thus benign) than
+  prune-on-commit, but this is inference, not verification — flagged as a required follow-up, not
+  assumed safe.
+- **Blast radius within a single crash:** bounded to whatever positions were acked-but-unflushed at
+  the moment of the crash for the affected connector(s) — at most one debounce window (~1s) or
+  10k records, whichever triggers first. `Persister.flushNow` batches across **every** connector
+  sharing a debounce cycle in one transaction, so a slow write for one connector can extend the
+  window during which other connectors' acks are also unflushed, though this postmortem's finding
+  is about the ordering bug itself, not about that shared-batch coupling (named as inherited
+  context in the companion design doc).
+- **No customer/production impact is known.** This was caught by the repo's first chaos test,
+  running against a synthetic upstream, before any tagged release combined the wrapper's
+  Debezium-Postgres path with this exact crash-timing scenario in production use.
+
+## How it was detected
+
+`tests/chaos/` did not exist in this repo before PR #2677 (`test(chaos): DBZ-1 SIGKILL
+crash-safety + engine FIFO-ack`). DBZ-1 (Debezium-compete roadmap workstream 1: "validate the
+existing wrapper against Debezium-Postgres") called for a `kill -9` crash-safety test on the
+offset-to-position bridge specifically because the wrapper's ack queue assumes strict FIFO
+delivery and the offset↔position bridge is Tier-1 despite the wrapper already passing its
+functional acceptance suite (`DebeziumPgSourceIT`). Building that test required a real engine
+(`pkg/connector.Source`, `pkg/connector.Persister`, a real on-disk `badger` store — the same
+backend production uses) driven against a synthetic `upstreamStore` with an explicit `prune`
+toggle, because the one variable that decides gap-vs-duplicate is the upstream's own retention
+behavior, which no existing integration test parameterized.
+
+Two scenarios were run, both SIGKILL (not SIGTERM — per `CLAUDE.md`'s chaos-testing standard):
+
+- **mid-snapshot**: killed ~30ms into a fast burst, before any automatic flush — Conduit has
+  persisted nothing when the kill lands.
+- **mid-stream**: killed ~1.4s in, after one automatic flush already landed a valid-but-stale
+  checkpoint, with the kill inside the _next_ debounce window before its flush fires.
+
+Result, exactly as designed to isolate the variable:
+
+```text
+SEV-0 FINDING confirmed for mid-snapshot: OPEN_GAP_ERROR: could not open source
+connector plugin: GAP: chaos upstream already committed/pruned through position 30,
+but Conduit asked to resume from position 0 — the 30 position(s) in between are no
+longer available upstream
+
+SEV-0 FINDING confirmed for mid-stream: OPEN_GAP_ERROR: could not open source
+connector plugin: GAP: chaos upstream already committed/pruned through position 95,
+but Conduit asked to resume from position 64 — the 31 position(s) in between are no
+longer available upstream
+```
+
+`prune=false` (Kafka-like), same crash window, same engine code: restart resumes from the
+stale-but-valid checkpoint, redelivers a handful of already-committed positions as harmless
+duplicates, completes delivery. No gap, ever. `prune=true` (Postgres-slot-like): identical crash
+window, identical engine code, restart asks to resume from behind an already-pruned watermark —
+surfaced as a loud, structural `OPEN_GAP_ERROR` (modeling Postgres's real "requested WAL segment
+has already been removed" behavior), not a silent skip.
+
+## Timeline
+
+All dates 2026-07-23 unless noted.
+
+- **Unknown / pre-dates this analysis** — `Source.Ack`'s ack-before-persist ordering is introduced
+  as part of the connector/persister architecture; no test at the time exercises a
+  prune-on-commit upstream, so the ordering is never flagged.
+- **2026-07-22** — Debezium-compete CDC parity roadmap merged
+  (`docs/design-documents/20260722-debezium-compete-roadmap.md`), scoping DBZ-1: validate the
+  existing Kafka-Connect wrapper against Debezium-Postgres, including a `kill -9` crash-safety
+  test on the offset↔position bridge.
+- **2026-07-23** — PR #2677 lands the repo's first `tests/chaos` harness, implementing DBZ-1's
+  SIGKILL test. The `prune=true` scenario confirms a real, structural gap; the `prune=false`
+  scenario confirms the identical window is benign against a durable upstream. The PR explicitly
+  does not change `Source.Ack`'s ordering (out of scope, flagged as needing its own Tier-1 design
+  doc) and escalates the finding for a fix decision.
+- **2026-07-23** — This postmortem and the companion design doc
+  (`docs/design-documents/20260723-source-ack-persist-ordering-fix.md`) are written, proposing
+  Approach A (ack-follows-durable-flush) and requesting DeVaris's Tier-1 sign-off on the approach
+  before any code changes.
+
+## Root cause
+
+`Source.Ack` was designed with two separate concerns interleaved in one function: (1) tell the
+plugin its record(s) are safe to consider committed, and (2) durably remember the resulting
+position for crash recovery. These were implemented in the order "tell the plugin, then queue the
+remembering" rather than "remember durably, then tell the plugin" — the persister's async-batching
+was added for write-throughput without re-examining whether the _ack_ should be allowed to precede
+the _durability_ it implicitly promises. The two are only equivalent if the plugin's upstream
+commit is itself reversible or idempotent from Conduit's perspective; nothing in `Source.Ack` or
+`Persister` asserts or depends on that being true, and it is not true for replication-slot-based
+upstreams.
+
+## Remediation
+
+- **Immediate (this PR):** document the bug (this file) and the recommended fix approach
+  (companion design doc), and route both to DeVaris for Tier-1 sign-off on the _approach_ before
+  any code change, per the standing Tier-1 rule that no data-path change merges on automated
+  review alone.
+- **Follow-up (separate PR, blocked on sign-off):** implement Approach A — defer the plugin ack to
+  a post-flush callback, gated by per-source-partition high-water-mark tracking, with the
+  graceful-shutdown drain path (`lifecycle.Service.StopAndWait`) updated to wait for the final
+  deferred ack, not just the final flush. Un-skip the DBZ-1 `prune=true` gap assertion (marked
+  `t.Skip` with a link to this fix's tracking issue until then) so it asserts **no gap** instead
+  of demonstrating one.
+- **New automated gate, per `CLAUDE.md`'s regression-response rule** ("any regression... produces
+  at least one new automated check"): the DBZ-1 SIGKILL chaos test itself is that new check. It
+  already exists (PR #2677) and already runs in CI as a normal test; the fix PR converts its
+  `prune=true` scenario from a documented, skipped finding into an enforced regression gate. Note,
+  per the process-maturity table: this runs as ordinary CI today, not yet as a scheduled nightly
+  chaos job — that promotion is scoped for Phase 2, alongside the rest of the chaos-suite maturity
+  work, and is not claimed as live now.
+
+## Follow-ups
+
+- [ ] DeVaris Tier-1 sign-off on Approach A (or a decision to pursue an alternative), tracked in
+      the companion design doc.
+- [ ] Fix PR: engine-side reorder + per-partition HWM tracking + `StopAndWait` drain update +
+      un-skip the DBZ-1 gap assertion + benchi throughput comparison attached.
+- [ ] **Verify MySQL-binlog and MongoDB-change-stream/oplog connectors** against the same
+      DBZ-1-style `prune`-toggle chaos harness rather than relying on the design doc's inference
+      that they're likely retention-based. Do not extend a "fixed" claim to either without this
+      run.
+- [ ] Longer-term observability follow-up (not blocking the fix): no metric exists today for
+      ack-vs-persist lag or replication-slot retention pressure; a production instance of this bug
+      class would be invisible until a downstream data-quality incident surfaced it. Tracked
+      against DBZ-3/DBZ-4 (Phase 2), per the companion design doc's Observability section.
+
+## Related
+
+- PR #2677 — `test(chaos): DBZ-1 SIGKILL crash-safety + engine FIFO-ack (first tests/chaos)`.
+- `docs/design-documents/20260723-source-ack-persist-ordering-fix.md` — the fix design doc this
+  postmortem accompanies.
+- `docs/design-documents/20260722-debezium-compete-roadmap.md` — DBZ-1 workstream that produced
+  the test which found this.

--- a/pkg/connector/persister.go
+++ b/pkg/connector/persister.go
@@ -54,6 +54,16 @@ type Persister struct {
 	batch       map[string]persistData
 	flushTimer  stoppableTimer
 	flushWg     sync.WaitGroup
+
+	// callbackWg tracks every PersistCallback invocation flushNow has
+	// spawned but not yet returned from — distinct from flushWg, which only
+	// tracks flushNow's own function body (the store write). flushNow fires
+	// callbacks in their own goroutines without waiting for them, so a
+	// caller that needs to know a callback's side effects (not just the
+	// store write) have actually happened — e.g. connector.Source's
+	// deferred plugin-ack under Approach A, see source.go's Ack — must wait
+	// on this separately. See WaitPendingWrites.
+	callbackWg sync.WaitGroup
 }
 
 // clock abstracts the two time operations the persister needs in order to
@@ -169,16 +179,18 @@ func (p *Persister) Persist(ctx context.Context, conn *Instance, callback Persis
 	return nil
 }
 
-// Wait waits for all connectors to stop running and for the last flush to be executed.
+// Wait waits for all connectors to stop running and for the last flush
+// (including its callbacks — see WaitPendingWrites) to be executed.
 func (p *Persister) Wait() {
 	p.connWg.Wait()
-	p.flushWg.Wait()
+	p.WaitPendingWrites()
 }
 
 // WaitPendingWrites blocks until every flush already triggered (via Flush, the
 // bundle-count threshold, the delay timer, or ConnectorStopped) has finished
-// writing to the store — but, unlike Wait, it does NOT block on connWg (every
-// connector across the whole process reaching ConnectorStopped).
+// writing to the store AND every PersistCallback that flush invoked has
+// returned — but, unlike Wait, it does NOT block on connWg (every connector
+// across the whole process reaching ConnectorStopped).
 //
 // This distinction matters for a caller that only wants to know "has this
 // pipeline's already-triggered write actually landed durably", not "has every
@@ -186,14 +198,26 @@ func (p *Persister) Wait() {
 // shared across all pipelines, connWg only reaches zero once every connector
 // on every pipeline has stopped, so calling Wait from a single pipeline's
 // stop-and-drain path would deadlock for as long as any other pipeline stays
-// running. WaitPendingWrites has no such coupling — it only observes flushWg,
-// which a connector's own ConnectorStopped call already increments
-// synchronously (see triggerFlush) before that call returns. A caller that
-// calls WaitPendingWrites strictly after learning (e.g. via a WaitGroup/tomb
-// join) that ConnectorStopped has already been called for the connector it
-// cares about is guaranteed to observe that connector's flush complete: the
-// Add(1) happened-before the Wait() call by construction, and sync.WaitGroup
-// cannot miss a Done that was already pending when Wait was entered.
+// running. WaitPendingWrites has no such coupling — it only observes flushWg
+// and callbackWg, which a connector's own ConnectorStopped call already
+// increments synchronously (see triggerFlush and flushNow) before that call
+// returns. A caller that calls WaitPendingWrites strictly after learning (e.g.
+// via a WaitGroup/tomb join) that ConnectorStopped has already been called
+// for the connector it cares about is guaranteed to observe that connector's
+// flush AND callback complete: the Add(1) calls happened-before the Wait()
+// call by construction, and sync.WaitGroup cannot miss a Done that was
+// already pending when Wait was entered.
+//
+// The callbackWg half of this wait matters specifically for
+// connector.Source's Ack (Approach A, see source.go): the plugin-ack it sends
+// is deferred to run *inside* the PersistCallback, once the position is
+// durably flushed. Waiting only on flushWg (as this method did before that
+// fix) would let a caller proceed — and a graceful shutdown tear down the
+// plugin — after the store write landed but before the plugin was actually
+// told about it, reintroducing an invariant-1 gap on the graceful path even
+// though the crash path was fixed. See
+// docs/design-documents/20260723-source-ack-persist-ordering-fix.md,
+// "Graceful shutdown (invariant 7)".
 //
 // Used by lifecycle.Service.StopAndWait to await durability (invariant 1/3)
 // after a pipeline has fully drained, without deadlocking on unrelated running
@@ -201,6 +225,7 @@ func (p *Persister) Wait() {
 // "Review outcome & required rework", blocker 1.
 func (p *Persister) WaitPendingWrites() {
 	p.flushWg.Wait()
+	p.callbackWg.Wait()
 }
 
 // Flush will trigger a goroutine that persists any in-memory data to the store.
@@ -258,9 +283,19 @@ func (p *Persister) flushNow(ctx context.Context, batch map[string]persistData) 
 	if err == nil {
 		err = tx.Commit()
 	}
+	// Track every callback this flush is about to spawn so WaitPendingWrites
+	// can observe not just "the write landed" but "every side effect the
+	// write's callback performs has also finished" — see callbackWg's field
+	// doc and WaitPendingWrites. Add happens synchronously, before flushNow
+	// returns (and therefore before this flush's flushWg.Done() fires),
+	// which is what makes a subsequent WaitPendingWrites call race-free.
+	p.callbackWg.Add(len(batch))
 	for _, data := range batch {
 		// execute callbacks in go routines to make sure they can't block this function
-		go data.callback(err)
+		go func(cb PersistCallback) {
+			defer p.callbackWg.Done()
+			cb(err)
+		}(data.callback)
 	}
 
 	p.logger.Debug(ctx).

--- a/pkg/connector/persister.go
+++ b/pkg/connector/persister.go
@@ -228,6 +228,56 @@ func (p *Persister) WaitPendingWrites() {
 	p.callbackWg.Wait()
 }
 
+// WaitPendingWritesContext behaves like WaitPendingWrites, but returns early
+// — without waiting for the flush/callbacks to actually finish — if ctx is
+// canceled or timeout elapses, whichever comes first. It returns nil if the
+// wait completed normally, or the triggering error (ctx.Err() or
+// context.DeadlineExceeded) if it did not.
+//
+// This exists for a caller like Source.Teardown that must not hang
+// indefinitely on a stuck or slow flush (e.g. a disk stall or a badger
+// compaction pause) during graceful shutdown: before Approach A
+// (docs/design-documents/20260723-source-ack-persist-ordering-fix.md),
+// Teardown never waited on the persister at all, so this wait is new
+// exposure, not a pre-existing one — an unbounded wait here would trade the
+// sev-0 ack-before-persist bug for a possible-hang-on-graceful-shutdown bug,
+// which is not an improvement. A bounded, forced-teardown fallback is safe:
+// the SIGKILL chaos suite (tests/chaos) already proves the crash path never
+// produces a gap, so a caller proceeding with teardown without the deferred
+// ack having been confirmed sent is at worst a benign duplicate on the next
+// run (the position may not be durably flushed yet, so a restart simply
+// re-delivers it), never a gap — see Source.Teardown's doc comment for the
+// full failure-mode entry this covers.
+//
+// Note on the timeout/cancel path: the background goroutine wrapping
+// WaitPendingWrites is not itself abortable (sync.WaitGroup has no cancel),
+// so it keeps running until the underlying flush actually finishes, even
+// after this function has returned early. That goroutine is only leaked for
+// as long as the stuck flush is; if the flush eventually completes (the
+// common case — a slow disk, not a dead one), the goroutine exits normally.
+// A genuinely permanently-stuck flush would leak it permanently, but at that
+// point the process has a much bigger problem than one goroutine, and no
+// caller-side timeout can fix a store that will never respond.
+func (p *Persister) WaitPendingWritesContext(ctx context.Context, timeout time.Duration) error {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.WaitPendingWrites()
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return context.DeadlineExceeded
+	}
+}
+
 // Flush will trigger a goroutine that persists any in-memory data to the store.
 // To wait for the changes to be actually persisted you need to call Wait.
 func (p *Persister) Flush(ctx context.Context) {

--- a/pkg/connector/source.go
+++ b/pkg/connector/source.go
@@ -28,6 +28,18 @@ import (
 	connectorPlugin "github.com/conduitio/conduit/pkg/plugin/connector"
 )
 
+// DefaultTeardownFlushTimeout bounds how long Source.Teardown will wait
+// (Persister.WaitPendingWritesContext) for the final forced flush and its
+// deferred ack (Approach A, docs/design-documents/
+// 20260723-source-ack-persist-ordering-fix.md) before proceeding with
+// teardown regardless. Deliberately shorter than a typical Kubernetes
+// terminationGracePeriodSeconds (commonly 30s): if this wait itself took the
+// full grace period, a slow flush could cause the process to be SIGKILLed
+// before Teardown's own bounded-wait fallback ever got to run, which would
+// be strictly worse than proceeding early. See Teardown's doc comment for
+// the failure mode this bound exists for.
+const DefaultTeardownFlushTimeout = 10 * time.Second
+
 type Source struct {
 	Instance *Instance
 
@@ -76,6 +88,12 @@ type Source struct {
 	// ever advances (see onPersistFlushed) even if flush confirmations
 	// arrive out of order.
 	durableAckSeq uint64
+
+	// teardownFlushTimeout overrides DefaultTeardownFlushTimeout for
+	// Teardown's bounded flush wait. Zero (the production default — this
+	// field is only ever set by tests) means "use
+	// DefaultTeardownFlushTimeout"; see Teardown.
+	teardownFlushTimeout time.Duration
 }
 
 // pendingAck is one Source.Ack call's positions, queued until the resulting
@@ -211,6 +229,23 @@ func (s *Source) Stop(ctx context.Context) (opencdc.Position, error) {
 // unblocking (stopStream's other job, for a source blocked waiting for a
 // record that will never come) is deliberately delayed until after the
 // flush instead.
+//
+// Failure mode: graceful shutdown racing a stuck/slow flush. Before this
+// fix, Teardown never touched the persister at all, so a wait here is new
+// exposure: an unbounded wait would let a stalled disk or a badger
+// compaction pause hang graceful shutdown indefinitely, trading the sev-0
+// ack-before-persist bug for a possible-hang-on-shutdown bug. The wait below
+// is therefore bounded (Persister.WaitPendingWritesContext, honoring both
+// ctx and DefaultTeardownFlushTimeout) — on timeout or ctx cancellation,
+// Teardown logs a warning and proceeds with teardown anyway rather than
+// blocking forever. That fallback is safe, not merely convenient: the
+// SIGKILL chaos suite (tests/chaos, TestSIGKILL_PruningUpstream_NoGap /
+// TestSIGKILL_DurableUpstream_NoGap) already proves the crash path never
+// produces a gap, so a forced teardown here — before the deferred ack was
+// confirmed sent — degrades to exactly that same, already-proven-safe
+// outcome: at worst a benign duplicate on the next run (the position may
+// not have reached disk yet, so a restart simply re-delivers it), never a
+// gap.
 func (s *Source) Teardown(ctx context.Context) error {
 	s.Instance.Lock()
 	if s.plugin == nil {
@@ -227,8 +262,24 @@ func (s *Source) Teardown(ctx context.Context) error {
 	// the stop flag, see worker.go's Stop) already guarantees no new Ack
 	// call can start once a Teardown has begun, so this window introduces
 	// no new concurrent-Ack risk.
+	timeout := s.teardownFlushTimeout
+	if timeout <= 0 {
+		timeout = DefaultTeardownFlushTimeout
+	}
 	s.Instance.persister.Flush(ctx)
-	s.Instance.persister.WaitPendingWrites()
+	if err := s.Instance.persister.WaitPendingWritesContext(ctx, timeout); err != nil {
+		// Bounded-wait fallback (see doc comment above): proceed with
+		// teardown rather than hang. The deferred ack for whatever is still
+		// in flight may not have been sent, but the position is either
+		// already durable (benign duplicate) or not yet durable (the
+		// plugin was never told to commit past it either, so nothing is
+		// lost) — never a gap, by the same reasoning the SIGKILL chaos
+		// suite already establishes for a hard crash, which this bounded
+		// wait is strictly safer than.
+		s.Instance.logger.Warn(ctx).Err(err).
+			Dur("timeout", timeout).
+			Msg("timed out waiting for the final flush/deferred ack before tearing down source connector plugin; proceeding with teardown anyway (safe: at worst a benign duplicate on restart, never a gap — see Teardown's doc comment)")
+	}
 
 	s.Instance.Lock()
 	if s.plugin == nil {

--- a/pkg/connector/source.go
+++ b/pkg/connector/source.go
@@ -47,6 +47,43 @@ type Source struct {
 
 	// wg tracks the number of in flight calls to the connectorPlugin.
 	wg sync.WaitGroup
+
+	// ackMu guards pendingAcks, nextAckSeq and durableAckSeq below. It is
+	// deliberately separate from Instance's RWMutex: onPersistFlushed runs
+	// asynchronously (invoked from connector.Persister's flush callback,
+	// see persister.go's callbackWg) and must be able to send the deferred
+	// plugin-ack — which needs preparePluginCall's Instance.RLock — without
+	// itself holding a lock that could be held by a concurrent caller
+	// blocked waiting on this same flush (see Teardown, which forces and
+	// awaits a flush without holding Instance's lock for exactly this
+	// reason).
+	ackMu sync.Mutex
+	// pendingAcks is a FIFO queue, in the exact order Ack was called, of
+	// positions whose durable persistence has been requested but not yet
+	// confirmed. See Ack and onPersistFlushed.
+	pendingAcks []pendingAck
+	// nextAckSeq is a purely engine-internal, monotonically increasing
+	// counter assigned to each Ack call — NOT derived from the opaque
+	// connector Position bytes, which Source cannot generically parse or
+	// compare (a Position's structure, e.g. per-partition offsets, is
+	// entirely connector-defined). It is what lets onPersistFlushed
+	// determine, without understanding Position's contents, which queued
+	// acks a given durable flush covers, while still preserving invariant 4
+	// (per-partition — here, per-connector — ordering): acks are always
+	// delivered to the plugin in the exact order Ack assigned them a seq.
+	nextAckSeq uint64
+	// durableAckSeq is the highest seq confirmed durable so far. It only
+	// ever advances (see onPersistFlushed) even if flush confirmations
+	// arrive out of order.
+	durableAckSeq uint64
+}
+
+// pendingAck is one Source.Ack call's positions, queued until the resulting
+// state write is confirmed durably flushed by the persister. See the
+// Source.ackMu field doc.
+type pendingAck struct {
+	seq       uint64
+	positions []opencdc.Position
 }
 
 type SourceState struct {
@@ -147,22 +184,80 @@ func (s *Source) Stop(ctx context.Context) (opencdc.Position, error) {
 	return resp.LastPosition, nil
 }
 
+// Teardown closes the source's stream and plugin. Invariant 7 (graceful
+// shutdown must not drop the final ack): before actually tearing the plugin
+// down, this forces any position write still sitting in the persister's
+// debounce batch to flush now, and waits for that flush's deferred plugin-ack
+// (Ack/onPersistFlushed, Approach A) to actually be SENT — while the stream
+// is still fully open in both directions. Without this, a graceful shutdown
+// could tear down the plugin between "position flushed" and "plugin acked"
+// (lifecycle.Service.StopAndWait's own WaitPersisted call happens only after
+// the pipeline's nodes — including this Teardown — have already run),
+// silently dropping the final ack even though the crash-path ordering fix
+// prevents the equivalent data-loss bug on a kill -9. See
+// docs/design-documents/20260723-source-ack-persist-ordering-fix.md,
+// "Graceful shutdown (invariant 7)".
+//
+// Critically, this flush-and-wait must happen BEFORE stopStream, not after:
+// stopStream cancels the one context shared by both directions of the
+// plugin stream (see run's context.WithCancel and, for the in-memory
+// transport, pkg/plugin/connector/builtin/stream.go's inMemoryStream — a
+// real gRPC stream's client context works the same way). A deferred ack's
+// stream.Send racing an already-canceled context resolves to ctx.Err() far
+// more often than an actual send (a permanently-ready select case beats one
+// that depends on a concurrent receiver), so sending after stopStream would
+// silently and near-deterministically drop the final ack instead of
+// delivering it — the exact bug this reordering exists to avoid. Read
+// unblocking (stopStream's other job, for a source blocked waiting for a
+// record that will never come) is deliberately delayed until after the
+// flush instead.
 func (s *Source) Teardown(ctx context.Context) error {
-	// lock source as we are about to mutate the plugin field
+	s.Instance.Lock()
+	if s.plugin == nil {
+		s.Instance.Unlock()
+		return plugin.ErrPluginNotRunning
+	}
+	s.Instance.Unlock()
+
+	// Deliberately not holding s.Instance's lock across this wait:
+	// onPersistFlushed's deferred ack needs preparePluginCall's
+	// Instance.RLock to succeed while s.plugin is still considered running
+	// (checked again below), which would deadlock against an exclusive
+	// lock held here. funnel.Worker's own stop sequencing (processingLock +
+	// the stop flag, see worker.go's Stop) already guarantees no new Ack
+	// call can start once a Teardown has begun, so this window introduces
+	// no new concurrent-Ack risk.
+	s.Instance.persister.Flush(ctx)
+	s.Instance.persister.WaitPendingWrites()
+
+	s.Instance.Lock()
+	if s.plugin == nil {
+		// Another Teardown call already finished while this one was
+		// unlocked above. Should not happen given funnel.Worker's own
+		// teardownMu serialization, but Teardown is a public method on an
+		// exported type and must stay safe if ever called concurrently.
+		s.Instance.Unlock()
+		return plugin.ErrPluginNotRunning
+	}
+
+	s.Instance.logger.Debug(ctx).Msg("closing stream")
+	// close stream — only now that every deferred ack pending at the start
+	// of this call has already been sent (see doc comment above).
+	if s.stopStream != nil {
+		s.stopStream()
+	}
+	s.Instance.Unlock()
+
+	// wait for any calls to the plugin to stop running (e.g. Stop, or a Read
+	// that was blocked waiting for a record that will never come, now
+	// unblocked by the stopStream call above)
+	s.wg.Wait()
+
 	s.Instance.Lock()
 	defer s.Instance.Unlock()
 	if s.plugin == nil {
 		return plugin.ErrPluginNotRunning
 	}
-
-	s.Instance.logger.Debug(ctx).Msg("closing stream")
-	// close stream
-	if s.stopStream != nil {
-		s.stopStream()
-	}
-
-	// wait for any calls to the plugin to stop running first (e.g. Stop, Ack or Read)
-	s.wg.Wait()
 
 	s.Instance.logger.Debug(ctx).Msg("tearing down source connector plugin")
 	_, err := s.plugin.Teardown(ctx, pconnector.SourceTeardownRequest{})
@@ -204,6 +299,32 @@ func (s *Source) Read(ctx context.Context) ([]opencdc.Record, error) {
 	return resp.Records, nil
 }
 
+// Ack acknowledges that the records at the given positions were fully
+// processed downstream (or routed to the DLQ, from the caller's point of
+// view — see funnel.Worker.Ack/Nack). It does not send the ack to the plugin
+// synchronously.
+//
+// Invariant 1: ack only after the resulting position is durably persisted.
+// The plugin ack (stream.Send, driven from onPersistFlushed) is deferred
+// until the persister confirms this exact call's resulting state write has
+// been durably flushed. This is Approach A from
+// docs/design-documents/20260723-source-ack-persist-ordering-fix.md: a
+// plugin's own upstream commit — e.g. a Postgres replication slot's
+// confirmed_flush_lsn advance, which frees WAL for recycling — must never be
+// triggered before Conduit's own crash-recoverable record of that position
+// exists on disk, or a crash in between loses the position while the
+// upstream has already discarded the data (sev-0, see
+// docs/postmortems/20260723-source-ack-persist-ordering.md). Do not
+// reintroduce a synchronous stream.Send here without re-reading that design
+// doc.
+//
+// The persister's debounce/batching (persister.go's DefaultPersisterDelayThreshold
+// / DefaultPersisterBundleCountThreshold) is unchanged by this — durability
+// still lands on the same schedule it always did. What changes is that the
+// plugin only learns about it once it's true, which delays a pruning
+// upstream's WAL/log retention release by up to one debounce interval —
+// bounded, tunable, and the entire trade this fix makes (see the design
+// doc's Decision section).
 func (s *Source) Ack(ctx context.Context, p []opencdc.Position) error {
 	cleanup, err := s.preparePluginCall()
 	defer cleanup()
@@ -215,26 +336,119 @@ func (s *Source) Ack(ctx context.Context, p []opencdc.Position) error {
 		return cerrors.Errorf("source stream not open: %w", connectorPlugin.ErrStreamNotOpen)
 	}
 
-	err = s.stream.Send(pconnector.SourceRunRequest{AckPositions: p})
-	if err != nil {
-		return err
-	}
-
 	// lock as we are updating the state and leave it locked so the persister
 	// can safely prepare the connector before it stores it
 	s.Instance.Lock()
 	defer s.Instance.Unlock()
 	s.Instance.State = SourceState{Position: p[len(p)-1]}
+
+	// Invariant 4 (per-partition/per-connector ordering): queue this ack
+	// under the same lock used to update state and register the persist
+	// call, so pendingAcks is always populated in exactly the order Ack is
+	// called — see the seq field doc for why a purely-internal counter,
+	// not the opaque Position, is what onPersistFlushed uses to know what
+	// it may safely release to the plugin.
+	s.ackMu.Lock()
+	s.nextAckSeq++
+	seq := s.nextAckSeq
+	s.pendingAcks = append(s.pendingAcks, pendingAck{seq: seq, positions: p})
+	s.ackMu.Unlock()
+
 	err = s.Instance.persister.Persist(ctx, s.Instance, func(err error) {
-		if err != nil {
-			s.errs <- err
-		}
+		s.onPersistFlushed(seq, err)
 	})
 	if err != nil {
 		return cerrors.Errorf("failed to persist source connector: %w", err)
 	}
 
 	return nil
+}
+
+// onPersistFlushed is invoked by connector.Persister once the state write
+// registered by the Ack call that produced sequence number seq has either
+// been durably committed (err == nil) or failed (err != nil). It is called
+// from within a goroutine that persister.go's flushNow's callbackWg tracks,
+// so any deferred plugin-ack this method sends is awaited by
+// Persister.WaitPendingWrites — see that method's doc for why that matters
+// for graceful shutdown (invariant 7).
+//
+// seq need not be the exact Ack call whose PersistCallback the persister
+// happened to retain (Persister.Persist's batch map keeps only the LAST
+// callback registered for a connector before a flush runs, see persister.go)
+// — since Source.Ack always writes the connector's cumulative, monotonically
+// advancing SourceState.Position, whichever flush actually lands durably
+// necessarily covers every seq up to (and including) the one it was
+// registered for. Flush confirmations can also arrive out of order (case:
+// a later-registered flush's transaction happens to finish before an
+// earlier one still in flight); durableAckSeq only ever advances forward
+// and pendingAcks is drained from its head up to whatever the current
+// durableAckSeq permits, so out-of-order arrival can only make this method
+// a safe no-op for a seq already covered by a previous call — never a
+// double-send and never a gap.
+func (s *Source) onPersistFlushed(seq uint64, err error) {
+	if err != nil {
+		// Durability failed: propagate so the runtime can fail the
+		// connector/pipeline, exactly as before this fix. Invariant 1: never
+		// ack the plugin for a write that did not durably land — the queued
+		// positions stay queued; there is nothing safe to send, and this
+		// connector is on its way down regardless.
+		s.errs <- err
+		return
+	}
+
+	var toSend [][]opencdc.Position
+	s.ackMu.Lock()
+	if seq > s.durableAckSeq {
+		s.durableAckSeq = seq
+	}
+	i := 0
+	for ; i < len(s.pendingAcks) && s.pendingAcks[i].seq <= s.durableAckSeq; i++ {
+		toSend = append(toSend, s.pendingAcks[i].positions)
+	}
+	s.pendingAcks = s.pendingAcks[i:]
+	s.ackMu.Unlock()
+
+	for _, positions := range toSend {
+		s.sendDeferredAck(positions)
+	}
+}
+
+// sendDeferredAck sends one previously-queued Ack call's positions to the
+// plugin now that the resulting position is known durable. Unlike Ack's own
+// (pre-Approach-A) synchronous send, a failure here is never escalated via
+// errs, on purpose: the position this ack refers to is already durable
+// (that's precisely why onPersistFlushed called this), so failing to
+// deliver the message itself is always a benign, already-safe no-op, never a
+// data-integrity problem — the plugin will learn about it on the next ack it
+// does receive (see the design doc's failure-mode analysis, "crash between
+// flush-complete and plugin-ack"). This is not merely a style choice: Teardown
+// deliberately cancels the stream's context (stopStream) before forcing the
+// final flush that can trigger this exact call, specifically so any
+// still-batched position gets flushed and acked while the plugin is still
+// considered "running" for preparePluginCall's purposes — which means a
+// perfectly expected send here is one racing an already-canceled context,
+// returning context.Canceled (not io.EOF; see
+// pkg/plugin/connector/builtin/stream.go's inMemoryStreamClient.Send and
+// equivalents), not a real transport fault. Escalating that via the
+// unbuffered errs channel (as a genuine send failure was before this fix)
+// would risk this goroutine blocking forever the moment nothing is left
+// reading errs during teardown — a self-inflicted deadlock, not a
+// correctness improvement.
+func (s *Source) sendDeferredAck(positions []opencdc.Position) {
+	cleanup, err := s.preparePluginCall()
+	defer cleanup()
+	if err != nil {
+		// Plugin already torn down; benign, see doc comment above.
+		return
+	}
+	if s.stream == nil {
+		return
+	}
+
+	if sendErr := s.stream.Send(pconnector.SourceRunRequest{AckPositions: positions}); sendErr != nil {
+		s.Instance.logger.Debug(context.Background()).Err(sendErr).
+			Msg("failed to send deferred ack to source connector plugin; position is already durable, tolerating as benign (see sendDeferredAck's doc comment)")
+	}
 }
 
 func (s *Source) OnDelete(ctx context.Context) (err error) {

--- a/pkg/connector/source_bench_test.go
+++ b/pkg/connector/source_bench_test.go
@@ -1,0 +1,105 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connector
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/conduitio/conduit-commons/database/inmemory"
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit-connector-protocol/pconnector"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/matryer/is"
+	"go.uber.org/mock/gomock"
+)
+
+// BenchmarkSource_Ack measures the Source.Ack hot path in isolation: this is
+// the microbenchmark referenced by the sev-0 fix PR
+// (fix(engine): persist position before plugin ack - Approach A) as a
+// same-sandbox, immediately-reproducible A/B signal, alongside (not instead
+// of) the benchi end-to-end reference-pipeline run committed under
+// benchi/ack-hot-path/ (see that directory's README for why the full
+// benchi/Docker run itself could not be executed in this sandbox).
+//
+// It uses the real connector.Source / connector.Persister and a real
+// in-memory backing store (github.com/conduitio/conduit-commons/database/
+// inmemory), with the default production thresholds
+// (DefaultPersisterDelayThreshold / DefaultPersisterBundleCountThreshold), so
+// the batching/debounce behavior exercised here matches production. A
+// background goroutine continuously drains the plugin-side stream for the
+// entire benchmark (required in both the pre-fix and post-fix shape: the
+// pre-fix code also needs a reader or Source.Ack's synchronous stream.Send
+// blocks), so what's actually measured is Source.Ack's own per-call latency
+// and the persister's batching overhead - not plugin-stream throughput.
+//
+// To reproduce the "fails/regresses without the fix" comparison this
+// benchmark is used for: run it once on this branch, then run it again after
+// temporarily reverting Ack to send synchronously before persister.Persist
+// (see the fix PR description's "fails-without-fix" section for the exact,
+// reverted diff used), and compare ns/op and allocs/op. The PR description
+// reports both numbers.
+func BenchmarkSource_Ack(b *testing.B) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(b)
+	logger := log.Nop()
+	db := &inmemory.DB{}
+	persister := NewPersister(logger, db, DefaultPersisterDelayThreshold, DefaultPersisterBundleCountThreshold)
+
+	is := is.New(b)
+	src, sourceMock := newTestSourceWithPersister(ctx, b, ctrl, persister)
+	stream := expectSourceOpen(src, sourceMock)
+	sourceMock.EXPECT().LifecycleOnCreated(
+		gomock.Any(),
+		pconnector.SourceLifecycleOnCreatedRequest{Config: src.Instance.Config.Settings},
+	).Return(pconnector.SourceLifecycleOnCreatedResponse{}, nil)
+	sourceMock.EXPECT().Teardown(gomock.Any(), pconnector.SourceTeardownRequest{}).
+		Return(pconnector.SourceTeardownResponse{}, nil).AnyTimes()
+
+	is.NoErr(src.Open(ctx))
+
+	// Continuously drain the plugin-facing side of the stream for the whole
+	// benchmark, exactly as a real connector plugin's Recv loop would -
+	// otherwise Send (synchronous pre-fix, deferred post-fix) would block
+	// once the stream's unbuffered channel has no reader.
+	serverStream := stream.Server()
+	drainDone := make(chan struct{})
+	go func() {
+		defer close(drainDone)
+		for {
+			if _, err := serverStream.Recv(); err != nil {
+				return
+			}
+		}
+	}()
+
+	positions := make([]opencdc.Position, b.N)
+	for i := range positions {
+		positions[i] = opencdc.Position(strconv.Itoa(i))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := src.Ack(ctx, positions[i:i+1]); err != nil {
+			b.Fatalf("Ack: %v", err)
+		}
+	}
+	b.StopTimer()
+
+	is.NoErr(src.Teardown(ctx)) // forces the final flush/drain; closes the stream
+	<-drainDone
+}

--- a/pkg/connector/source_test.go
+++ b/pkg/connector/source_test.go
@@ -15,10 +15,13 @@
 package connector
 
 import (
+	"bytes"
 	"context"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/conduitio/conduit-commons/database"
 	"github.com/conduitio/conduit-commons/database/inmemory"
 	"github.com/conduitio/conduit-commons/opencdc"
 	"github.com/conduitio/conduit-connector-protocol/pconnector"
@@ -27,6 +30,7 @@ import (
 	"github.com/conduitio/conduit/pkg/plugin/connector/builtin"
 	"github.com/conduitio/conduit/pkg/plugin/connector/mock"
 	"github.com/matryer/is"
+	"github.com/rs/zerolog"
 	"go.uber.org/mock/gomock"
 )
 
@@ -428,6 +432,161 @@ func TestSource_Teardown_SendsPendingDeferredAckBeforeReturning(t *testing.T) {
 	default:
 		t.Fatal("Teardown returned without the pending deferred ack having been sent")
 	}
+}
+
+// blockingDB wraps a real database.DB and makes NewTransaction block until
+// unblock is closed (or ctx is done), whichever happens first. It exists to
+// deterministically simulate a stuck/slow persister flush (e.g. a stalled
+// disk or a badger compaction pause) for
+// TestSource_Teardown_BoundedWaitOnStuckFlush, without relying on a real
+// sleep racing against the assertion.
+type blockingDB struct {
+	database.DB
+	unblock chan struct{}
+}
+
+func (b *blockingDB) NewTransaction(ctx context.Context, update bool) (database.Transaction, context.Context, error) {
+	select {
+	case <-b.unblock:
+	case <-ctx.Done():
+		return nil, ctx, ctx.Err()
+	}
+	return b.DB.NewTransaction(ctx, update)
+}
+
+// TestSource_Teardown_BoundedWaitOnStuckFlush is the regression test for the
+// bounded-Teardown fix (source.go's Teardown, persister.go's
+// WaitPendingWritesContext): a stuck/slow persister flush must not hang
+// graceful shutdown. Before that fix, Teardown had no bound at all on this
+// wait, so a stalled disk (or a badger compaction pause) mid-flush would
+// have hung Teardown indefinitely - trading the sev-0 ack-before-persist bug
+// for a hang-on-shutdown bug. See Teardown's doc comment, "Failure mode:
+// graceful shutdown racing a stuck/slow flush", and
+// docs/design-documents/20260723-source-ack-persist-ordering-fix.md.
+//
+// blockingDB below never unblocks the in-flight flush until this test
+// itself is done asserting, which is what makes "Teardown returned quickly"
+// proof of the bounded-wait fallback firing rather than a coincidence: the
+// only other way Teardown could return here is the underlying flush
+// actually completing, and it structurally cannot until this test closes
+// the channel.
+func TestSource_Teardown_BoundedWaitOnStuckFlush(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	var logBuf bytes.Buffer
+	logger := log.New(zerolog.New(&logBuf))
+
+	unblock := make(chan struct{})
+	// Let the stuck flush actually finish once the test is done asserting,
+	// so its background goroutine (persister.go's flushNow) doesn't leak
+	// past this test.
+	defer close(unblock)
+
+	db := &blockingDB{DB: &inmemory.DB{}, unblock: unblock}
+	// A long delay threshold and high bundle-count threshold mean the ack
+	// below is never auto-flushed - the only flush is Teardown's own forced
+	// Flush call, which blockingDB then stalls forever (for the lifetime of
+	// this test), simulating a stuck store.
+	persister := NewPersister(logger, db, time.Hour, 100)
+
+	src, sourceMock := newTestSourceWithPersister(ctx, t, ctrl, persister)
+	// newTestSourceWithPersister wires up its own Nop logger on the
+	// Instance; replace it so this test can observe the bounded-wait
+	// warning Teardown logs on timeout.
+	src.Instance.logger = logger
+	// Short override so this test doesn't have to wait
+	// DefaultTeardownFlushTimeout (10s) for the bounded-wait fallback to
+	// kick in - see the teardownFlushTimeout field doc.
+	const shortTimeout = 30 * time.Millisecond
+	src.teardownFlushTimeout = shortTimeout
+
+	_ = expectSourceOpen(src, sourceMock)
+	sourceMock.EXPECT().LifecycleOnCreated(
+		gomock.Any(),
+		pconnector.SourceLifecycleOnCreatedRequest{Config: src.Instance.Config.Settings},
+	).Return(pconnector.SourceLifecycleOnCreatedResponse{}, nil)
+	sourceMock.EXPECT().Teardown(gomock.Any(), pconnector.SourceTeardownRequest{}).
+		Return(pconnector.SourceTeardownResponse{}, nil)
+
+	is.NoErr(src.Open(ctx))
+	is.NoErr(src.Ack(ctx, []opencdc.Position{opencdc.Position("stuck-pos")}))
+
+	start := time.Now()
+	err := src.Teardown(ctx)
+	elapsed := time.Since(start)
+
+	is.NoErr(err) // Teardown itself must not fail just because the flush wait timed out
+	// Comfortably below DefaultTeardownFlushTimeout (10s, let alone "forever"):
+	// proves Teardown returned via the bounded-wait fallback, not by
+	// coincidentally winning a race against the still-blocked flush.
+	is.True(elapsed < 2*time.Second)
+
+	is.True(strings.Contains(logBuf.String(), "timed out waiting for the final flush"))
+}
+
+// TestSource_Teardown_FastFlushCompletesWithinBoundedTimeout is the
+// fast-path complement to TestSource_Teardown_BoundedWaitOnStuckFlush: the
+// same short teardownFlushTimeout override must not truncate a normal,
+// quickly-completing flush. Teardown must wait for it and deliver the
+// deferred ack, and must NOT log the bounded-wait timeout warning - proving
+// the bound only ever fires on an actually-stuck flush, never as a false
+// positive against a healthy one.
+func TestSource_Teardown_FastFlushCompletesWithinBoundedTimeout(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	var logBuf bytes.Buffer
+	logger := log.New(zerolog.New(&logBuf))
+
+	db := &inmemory.DB{}
+	// Long delay/high bundle-count thresholds mean the ack below is only
+	// flushed by Teardown's own forced Flush call - but, unlike the
+	// stuck-flush test above, this store is not blocked, so that flush
+	// completes almost immediately.
+	persister := NewPersister(logger, db, time.Hour, 100)
+
+	src, sourceMock := newTestSourceWithPersister(ctx, t, ctrl, persister)
+	src.Instance.logger = logger
+	// Same short override as the stuck-flush test, to prove it's the
+	// stuck-ness (not the timeout value) that determines which path fires.
+	src.teardownFlushTimeout = 200 * time.Millisecond
+
+	stream := expectSourceOpen(src, sourceMock)
+	sourceMock.EXPECT().LifecycleOnCreated(
+		gomock.Any(),
+		pconnector.SourceLifecycleOnCreatedRequest{Config: src.Instance.Config.Settings},
+	).Return(pconnector.SourceLifecycleOnCreatedResponse{}, nil)
+	sourceMock.EXPECT().Teardown(gomock.Any(), pconnector.SourceTeardownRequest{}).
+		Return(pconnector.SourceTeardownResponse{}, nil)
+
+	is.NoErr(src.Open(ctx))
+	is.NoErr(src.Ack(ctx, []opencdc.Position{opencdc.Position("fast-pos")}))
+
+	serverStream := stream.Server()
+	recvDone := make(chan opencdc.Position, 1)
+	go func() {
+		resp, err := serverStream.Recv()
+		is.NoErr(err)
+		recvDone <- resp.AckPositions[0]
+	}()
+
+	is.NoErr(src.Teardown(ctx))
+
+	// Teardown already returned by this point - the ack must already have
+	// been delivered (same invariant-7 property as
+	// TestSource_Teardown_SendsPendingDeferredAckBeforeReturning), not
+	// merely "eventually" delivered on some later, unrelated event.
+	select {
+	case pos := <-recvDone:
+		is.Equal(pos, opencdc.Position("fast-pos"))
+	default:
+		t.Fatal("Teardown returned without the pending deferred ack having been sent")
+	}
+
+	is.True(!strings.Contains(logBuf.String(), "timed out waiting"))
 }
 
 func newTestSource(ctx context.Context, t testing.TB, ctrl *gomock.Controller) (*Source, *mock.SourcePlugin) {

--- a/pkg/connector/source_test.go
+++ b/pkg/connector/source_test.go
@@ -17,6 +17,7 @@ package connector
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/conduitio/conduit-commons/database/inmemory"
 	"github.com/conduitio/conduit-commons/opencdc"
@@ -254,11 +255,196 @@ func TestSource_Ack_Deadlock(t *testing.T) {
 	}
 }
 
-func newTestSource(ctx context.Context, t *testing.T, ctrl *gomock.Controller) (*Source, *mock.SourcePlugin) {
+// TestSource_Ack_DeferredUntilDurablyFlushed is the sev-0 fix's core unit-level
+// regression test (Approach A, docs/design-documents/
+// 20260723-source-ack-persist-ordering-fix.md): the plugin must NOT observe
+// an ack before the resulting position has been durably flushed by the
+// persister, and MUST observe it once the flush completes. This pins
+// invariant 1 at the pkg/connector level, independent of the chaos harness's
+// subprocess/SIGKILL mechanics (tests/chaos).
+func TestSource_Ack_DeferredUntilDurablyFlushed(t *testing.T) {
 	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
 	logger := log.Nop()
 	db := &inmemory.DB{}
+	// A high bundle-count threshold means the ack below stays batched (not
+	// auto-flushed) until the fake clock is advanced past the delay
+	// threshold - giving this test explicit, deterministic control over
+	// when the durable flush (and therefore the deferred ack) happens.
+	persister := NewPersister(logger, db, DefaultPersisterDelayThreshold, 100)
+	clk := newFakeClock()
+	persister.clock = clk
+
+	src, sourceMock := newTestSourceWithPersister(ctx, t, ctrl, persister)
+	stream := expectSourceOpen(src, sourceMock)
+	sourceMock.EXPECT().LifecycleOnCreated(
+		gomock.Any(),
+		pconnector.SourceLifecycleOnCreatedRequest{Config: src.Instance.Config.Settings},
+	).Return(pconnector.SourceLifecycleOnCreatedResponse{}, nil)
+
+	is.NoErr(src.Open(ctx))
+
+	is.NoErr(src.Ack(ctx, []opencdc.Position{opencdc.Position("test-pos")}))
+
+	serverStream := stream.Server()
+	recvDone := make(chan struct{})
+	var recvErr error
+	go func() {
+		defer close(recvDone)
+		_, recvErr = serverStream.Recv()
+	}()
+
+	select {
+	case <-recvDone:
+		t.Fatal("invariant 1 violated: plugin observed the ack before the position was durably flushed")
+	case <-time.After(50 * time.Millisecond):
+		// Expected: nothing delivered yet, the batch is still sitting in the
+		// persister waiting for the delay threshold (or a forced Flush).
+	}
+
+	// Advancing the fake clock past the delay threshold triggers the flush
+	// synchronously firing any due timers (see fakeClock.Advance's doc in
+	// persister_test.go) - the resulting durable write's callback
+	// (onPersistFlushed) is what sends the deferred ack.
+	clk.Advance(DefaultPersisterDelayThreshold + time.Millisecond)
+
+	select {
+	case <-recvDone:
+		is.NoErr(recvErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("plugin never observed the ack after the flush completed")
+	}
+}
+
+// TestSource_OnPersistFlushed_OutOfOrderCompletionStillDeliversInOrder pins
+// onPersistFlushed's core safety property directly (see its doc comment):
+// connector.Persister's flush callbacks can complete out of order relative to
+// the Ack calls that registered them (a later-registered flush's transaction
+// can finish before an earlier one still in flight). Regardless of which
+// order the callbacks fire in, the plugin must see every position exactly
+// once, strictly in the order Ack originally queued them (invariant 4) -
+// never a gap, never a double-send.
+func TestSource_OnPersistFlushed_OutOfOrderCompletionStillDeliversInOrder(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	src, sourceMock := newTestSource(ctx, t, ctrl)
+	stream := expectSourceOpen(src, sourceMock)
+	sourceMock.EXPECT().LifecycleOnCreated(
+		gomock.Any(),
+		pconnector.SourceLifecycleOnCreatedRequest{Config: src.Instance.Config.Settings},
+	).Return(pconnector.SourceLifecycleOnCreatedResponse{}, nil)
+	is.NoErr(src.Open(ctx))
+
+	// Seed three pending acks directly (bypassing Ack/Persist, which would
+	// race an automatic flush given newTestSource's bundleCountThreshold=1)
+	// to precisely control the seq each carries.
+	src.ackMu.Lock()
+	src.pendingAcks = []pendingAck{
+		{seq: 1, positions: []opencdc.Position{opencdc.Position("pos-1")}},
+		{seq: 2, positions: []opencdc.Position{opencdc.Position("pos-2")}},
+		{seq: 3, positions: []opencdc.Position{opencdc.Position("pos-3")}},
+	}
+	src.nextAckSeq = 3
+	src.ackMu.Unlock()
+
+	// Simulate the highest seq's flush completing FIRST (out of order): this
+	// must drain and send all three, in order. onPersistFlushed sends
+	// synchronously (that's what lets Persister.WaitPendingWrites prove the
+	// send happened, see its doc), so it must run concurrently with the
+	// Recv calls below rather than before them, or it would block forever
+	// waiting for a reader on the first send.
+	go src.onPersistFlushed(3, nil)
+
+	serverStream := stream.Server()
+	for _, want := range []opencdc.Position{opencdc.Position("pos-1"), opencdc.Position("pos-2"), opencdc.Position("pos-3")} {
+		resp, err := serverStream.Recv()
+		is.NoErr(err)
+		is.Equal(resp.AckPositions, []opencdc.Position{want})
+	}
+
+	// The earlier-registered flushes' callbacks arriving late must be safe
+	// no-ops: nothing left to send, no double-send.
+	src.onPersistFlushed(1, nil)
+	src.onPersistFlushed(2, nil)
+
+	src.ackMu.Lock()
+	remaining := len(src.pendingAcks)
+	durableSeq := src.durableAckSeq
+	src.ackMu.Unlock()
+	is.Equal(remaining, 0)
+	is.Equal(durableSeq, uint64(3))
+}
+
+// TestSource_Teardown_SendsPendingDeferredAckBeforeReturning pins invariant 7
+// (graceful shutdown must not drop the final ack) at the pkg/connector level:
+// Teardown must not return until any ack still pending at the time it was
+// called has actually been sent to the plugin. Without this, StopAndWait's
+// existing WaitPersisted call (which runs strictly after node/connector
+// teardown) would have nothing left to wait for - see Teardown's doc comment.
+func TestSource_Teardown_SendsPendingDeferredAckBeforeReturning(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	// A long delay threshold and high bundle-count threshold mean the ack
+	// below would NOT be auto-flushed for the lifetime of this test - the
+	// only thing that can flush it is Teardown's own forced Flush call.
+	logger := log.Nop()
+	db := &inmemory.DB{}
+	persister := NewPersister(logger, db, time.Hour, 100)
+
+	src, sourceMock := newTestSourceWithPersister(ctx, t, ctrl, persister)
+	stream := expectSourceOpen(src, sourceMock)
+	sourceMock.EXPECT().LifecycleOnCreated(
+		gomock.Any(),
+		pconnector.SourceLifecycleOnCreatedRequest{Config: src.Instance.Config.Settings},
+	).Return(pconnector.SourceLifecycleOnCreatedResponse{}, nil)
+	sourceMock.EXPECT().Teardown(gomock.Any(), pconnector.SourceTeardownRequest{}).
+		Return(pconnector.SourceTeardownResponse{}, nil)
+
+	is.NoErr(src.Open(ctx))
+	is.NoErr(src.Ack(ctx, []opencdc.Position{opencdc.Position("final-pos")}))
+
+	serverStream := stream.Server()
+	recvDone := make(chan opencdc.Position)
+	go func() {
+		resp, err := serverStream.Recv()
+		is.NoErr(err)
+		recvDone <- resp.AckPositions[0]
+	}()
+
+	is.NoErr(src.Teardown(ctx))
+
+	// Teardown already returned by this point - the ack must already have
+	// been delivered, not merely "eventually" delivered on some later,
+	// unrelated event.
+	select {
+	case pos := <-recvDone:
+		is.Equal(pos, opencdc.Position("final-pos"))
+	default:
+		t.Fatal("Teardown returned without the pending deferred ack having been sent")
+	}
+}
+
+func newTestSource(ctx context.Context, t testing.TB, ctrl *gomock.Controller) (*Source, *mock.SourcePlugin) {
+	logger := log.Nop()
+	db := &inmemory.DB{}
+	// bundleCountThreshold=1 means every Persist call hits the threshold and
+	// triggers an immediate (though still asynchronous) flush - tests using
+	// this helper don't exercise the debounce window itself. Tests that do
+	// (e.g. TestSource_Ack_DeferredUntilDurablyFlushed) build their own
+	// persister via newTestSourceWithPersister instead.
 	persister := NewPersister(logger, db, DefaultPersisterDelayThreshold, 1)
+	return newTestSourceWithPersister(ctx, t, ctrl, persister)
+}
+
+func newTestSourceWithPersister(ctx context.Context, t testing.TB, ctrl *gomock.Controller, persister *Persister) (*Source, *mock.SourcePlugin) {
+	is := is.New(t)
+	logger := log.Nop()
 
 	instance := &Instance{
 		ID:   "test-connector-id",

--- a/pkg/lifecycle-poc/funnel/worker_ack_order_test.go
+++ b/pkg/lifecycle-poc/funnel/worker_ack_order_test.go
@@ -1,0 +1,332 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funnel
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/database/inmemory"
+	"github.com/conduitio/conduit-commons/opencdc"
+	pconnectorv1client "github.com/conduitio/conduit-connector-protocol/pconnector/v1/client" //nolint:staticcheck // intentionally testing the v1 client: conduit-kafka-connect-wrapper (and other standalone connectors) still use it today
+	connectorv1 "github.com/conduitio/conduit-connector-protocol/proto/connector/v1"
+	"github.com/conduitio/conduit/pkg/connector"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/foundation/metrics/noop"
+	connectorPlugin "github.com/conduitio/conduit/pkg/plugin/connector"
+	"github.com/matryer/is"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// This file closes issue #2672: the engine sends multi-position Source.Ack
+// batches (funnel/worker.go:493 for a full-batch ack, funnel/worker.go:513 for
+// the partial-batch ack that follows a partial DLQ nack), and a v1-protocol
+// (out-of-process, standalone-connector-shaped) plugin — like
+// ConduitIO/conduit-kafka-connect-wrapper — depends on receiving those
+// positions as strictly ordered, individual messages, one per position. Before
+// this test, that ordering guarantee was upheld only by a comment in
+// conduit-connector-protocol's v1 client ("Batching is not supported in v1,
+// send each request individually", pconnector/v1/client/source.go:148) — a
+// third-party implementation detail, not anything asserted in this repo. If a
+// future change to that dependency (or to pkg/connector.Source.Ack itself)
+// ever reordered, batched, or dropped positions before delivery, nothing here
+// would catch it before every standalone connector's ack-ordering assumption
+// broke in production.
+//
+// To pin the contract at the boundary Conduit's own engine controls, these
+// tests exercise the REAL production code path end to end: funnel.Worker.Ack /
+// funnel.Worker.Nack -> pkg/connector.Source.Ack -> the real
+// conduit-connector-protocol v1 gRPC client (not a mock of it) -> a real gRPC
+// bidirectional stream (over an in-memory bufconn listener, so no network or
+// subprocess is needed) -> a fake v1 SourcePluginServer that records the
+// arrival order of ack positions. This is deliberately NOT a test of
+// pkg/connector.Source.Ack in isolation with a mocked stream (as
+// TestSource_Ack_Deadlock in pkg/connector/source_test.go already does for a
+// different property) — it is a test of what a v1-protocol plugin actually
+// observes on the wire, using the exact client library standalone connectors
+// use today.
+
+// fakeV1SourceServer is a minimal, real gRPC server implementing the v1
+// SourcePluginServer service. It only needs to support what Source.Open and
+// Source.Ack exercise: Configure, LifecycleOnCreated ("created" lifecycle
+// event, since this is the connector's first run), Start, and Run (the
+// bidirectional ack/record stream). Everything else embeds
+// UnimplementedSourcePluginServer and is never called by these tests.
+type fakeV1SourceServer struct {
+	connectorv1.UnimplementedSourcePluginServer
+
+	mu   sync.Mutex
+	acks []opencdc.Position
+}
+
+func (s *fakeV1SourceServer) Configure(context.Context, *connectorv1.Source_Configure_Request) (*connectorv1.Source_Configure_Response, error) {
+	return &connectorv1.Source_Configure_Response{}, nil
+}
+
+func (s *fakeV1SourceServer) LifecycleOnCreated(context.Context, *connectorv1.Source_Lifecycle_OnCreated_Request) (*connectorv1.Source_Lifecycle_OnCreated_Response, error) {
+	return &connectorv1.Source_Lifecycle_OnCreated_Response{}, nil
+}
+
+func (s *fakeV1SourceServer) Start(context.Context, *connectorv1.Source_Start_Request) (*connectorv1.Source_Start_Response, error) {
+	return &connectorv1.Source_Start_Response{}, nil
+}
+
+// Run mirrors what the wrapper's DefaultSourceStream.onNext does on receiving
+// an ack message: it observes exactly one AckPosition per message. It records
+// the arrival order and never batches multiple positions into one Recv.
+func (s *fakeV1SourceServer) Run(stream connectorv1.SourcePlugin_RunServer) error {
+	for {
+		req, err := stream.Recv()
+		if err != nil {
+			// Client closed the stream (io.EOF) or the context was canceled
+			// during test cleanup - nothing left to observe.
+			return nil //nolint:nilerr // stream teardown, not a test failure
+		}
+
+		s.mu.Lock()
+		// Clone the position: req is only valid until the next Recv call, and
+		// the underlying byte slice must not be aliased across appends.
+		s.acks = append(s.acks, append(opencdc.Position(nil), req.AckPosition...))
+		s.mu.Unlock()
+	}
+}
+
+func (s *fakeV1SourceServer) observedAcks() []opencdc.Position {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]opencdc.Position(nil), s.acks...)
+}
+
+// fakeSourceDispenser implements connectorPlugin.Dispenser and always
+// dispenses the same pre-built v1 client-backed SourcePlugin. Only
+// DispenseSource is exercised by these tests.
+type fakeSourceDispenser struct {
+	source connectorPlugin.SourcePlugin
+}
+
+func (d fakeSourceDispenser) DispenseSpecifier() (connectorPlugin.SpecifierPlugin, error) {
+	return nil, cerrors.New("fakeSourceDispenser: DispenseSpecifier not implemented")
+}
+
+func (d fakeSourceDispenser) DispenseSource() (connectorPlugin.SourcePlugin, error) {
+	return d.source, nil
+}
+
+func (d fakeSourceDispenser) DispenseDestination() (connectorPlugin.DestinationPlugin, error) {
+	return nil, cerrors.New("fakeSourceDispenser: DispenseDestination not implemented")
+}
+
+// fakePluginFetcher fulfills connector.PluginDispenserFetcher, mirroring the
+// identically named test helper in pkg/connector (unexported there, so it
+// can't be reused directly from this package).
+type fakePluginFetcher map[string]connectorPlugin.Dispenser
+
+func (f fakePluginFetcher) NewDispenser(_ log.CtxLogger, name string, _ string) (connectorPlugin.Dispenser, error) {
+	d, ok := f[name]
+	if !ok {
+		return nil, cerrors.Errorf("fakePluginFetcher: no dispenser registered for plugin %q", name)
+	}
+	return d, nil
+}
+
+// newV1FIFOTestSource builds a real *connector.Source backed by the real
+// conduit-connector-protocol v1 gRPC client, connected over an in-memory
+// bufconn listener to fakeV1SourceServer. The source is already Open when this
+// function returns (Configure, LifecycleOnCreated and Start have all gone over
+// the real gRPC stream), so a caller can immediately call src.Ack.
+func newV1FIFOTestSource(t *testing.T) (*connector.Source, *fakeV1SourceServer) {
+	t.Helper()
+	is := is.New(t)
+	ctx := context.Background()
+
+	lis := bufconn.Listen(1024 * 1024)
+	grpcServer := grpc.NewServer()
+	fakeServer := &fakeV1SourceServer{}
+	connectorv1.RegisterSourcePluginServer(grpcServer, fakeServer)
+
+	go func() { _ = grpcServer.Serve(lis) }()
+	t.Cleanup(grpcServer.Stop)
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	is.NoErr(err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	// This is the real, unmodified conduit-connector-protocol v1 client -
+	// the exact library standalone connectors (like the Debezium/Kafka
+	// Connect wrapper) use today. Its Send implementation is what fans a
+	// multi-position pconnector.SourceRunRequest out into individually
+	// ordered gRPC messages (pconnector/v1/client/source.go:145-156).
+	pluginClient := pconnectorv1client.NewSourcePluginClient(conn)
+
+	logger := log.Nop()
+	db := &inmemory.DB{}
+	persister := connector.NewPersister(logger, db, connector.DefaultPersisterDelayThreshold, connector.DefaultPersisterBundleCountThreshold)
+
+	instance := &connector.Instance{
+		ID:   "fifo-ack-test-source",
+		Type: connector.TypeSource,
+		Config: connector.Config{
+			Name:     "fifo-ack-test",
+			Settings: map[string]string{"foo": "bar"},
+		},
+		PipelineID:    "fifo-ack-test-pipeline",
+		Plugin:        "fifo-ack-test-plugin",
+		ProvisionedBy: connector.ProvisionTypeAPI,
+	}
+	instance.Init(logger, persister)
+
+	fetcher := fakePluginFetcher{instance.Plugin: fakeSourceDispenser{source: pluginClient}}
+	c, err := instance.Connector(ctx, fetcher)
+	is.NoErr(err)
+	src, ok := c.(*connector.Source)
+	is.True(ok)
+
+	is.NoErr(src.Open(ctx))
+	t.Cleanup(func() { _ = src.Teardown(ctx) })
+
+	return src, fakeServer
+}
+
+// waitForAcks polls until fakeServer has observed at least want ack messages,
+// or fails the test after a generous timeout. A gRPC Send call returning
+// successfully only guarantees the message was handed to the stream, not that
+// the server's Recv loop has already processed it - so a short poll (rather
+// than a fixed sleep or an immediate assertion) is what makes this
+// deterministic without being flaky.
+func waitForAcks(t *testing.T, fakeServer *fakeV1SourceServer, want int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(fakeServer.observedAcks()) >= want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d acks, got %d", want, len(fakeServer.observedAcks()))
+}
+
+func assertPositionsInOrder(is *is.I, got, want []opencdc.Position) {
+	is.Equal(len(got), len(want))
+	for i := range want {
+		is.Equal(got[i], want[i])
+	}
+}
+
+// newFIFOTestWorker builds a real *Worker (via NewWorker, so timer/logger
+// wiring matches production) around src, with a single no-op downstream mock
+// task to satisfy the pipeline-shape validation NewWorker performs. Worker.Ack
+// and Worker.Nack never invoke that downstream task's Do, so it only needs an
+// ID.
+func newFIFOTestWorker(t *testing.T, ctrl *gomock.Controller, logger log.CtxLogger, src *connector.Source, dlq *DLQ) *Worker {
+	t.Helper()
+	is := is.New(t)
+
+	sourceTask := NewSourceTask("fifo-ack-test-source-task", src, logger, NoOpConnectorMetrics{})
+	nextTask := NewMockTask(ctrl)
+	nextTask.EXPECT().ID().Return("fifo-ack-test-next-task").AnyTimes()
+
+	firstNode := &TaskNode{Task: sourceTask}
+	firstNode.Next = []*TaskNode{{Task: nextTask}}
+
+	worker, err := NewWorker(firstNode, dlq, logger, noop.Timer{})
+	is.NoErr(err)
+	return worker
+}
+
+// TestWorker_Ack_DeliversPositionsFIFOToV1Plugin covers the full-batch ack
+// path at funnel/worker.go:493 (w.Source.Ack(ctx, originalBatch.positions)).
+// It asserts a v1-protocol plugin observes every position in the batch as a
+// separate message, in the exact order they appear in the batch.
+func TestWorker_Ack_DeliversPositionsFIFOToV1Plugin(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	logger := log.Test(t)
+	ctrl := gomock.NewController(t)
+
+	src, fakeServer := newV1FIFOTestSource(t)
+	dlq, _ := NewMockDLQ(ctrl, logger)
+	worker := newFIFOTestWorker(t, ctrl, logger, src, dlq)
+
+	// Mirrors funnel/worker.go:493's real call shape: multiple positions
+	// acked together in one Worker.Ack call.
+	batch := randomBatch(5)
+
+	err := worker.Ack(ctx, batch)
+	is.NoErr(err)
+
+	waitForAcks(t, fakeServer, len(batch.positions))
+	assertPositionsInOrder(is, fakeServer.observedAcks(), batch.positions)
+}
+
+// TestWorker_Nack_DeliversPartialAckFIFOToV1Plugin covers the partial-batch
+// ack path at funnel/worker.go:513 (w.Source.Ack(ctx,
+// originalBatch.positions[:n])), which fires when a Nack's DLQ write only
+// partially succeeds: the successfully DLQ'd prefix must still be acked in
+// the source, in order, even though the overall Nack call returns an error.
+func TestWorker_Nack_DeliversPartialAckFIFOToV1Plugin(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	logger := log.Test(t)
+	ctrl := gomock.NewController(t)
+
+	src, fakeServer := newV1FIFOTestSource(t)
+	// windowSize=0 disables the DLQ nack-threshold window, so every nacked
+	// record in the batch is routed to the DLQ (see dlq.go's dlqWindow.store
+	// short-circuit for len(window)==0), matching the existing
+	// TestWorker_Nack pattern in worker_test.go.
+	dlq, dlqDestinationMock := NewMockDLQ(ctrl, logger)
+	worker := newFIFOTestWorker(t, ctrl, logger, src, dlq)
+
+	batch := randomBatch(5)
+	nackErr := cerrors.New("record error")
+	batch.Nack(0, nackErr, nackErr, nackErr, nackErr, nackErr) // nack all 5 records
+
+	// Simulate the DLQ destination accepting the write, but only acking
+	// records 0-2: this is what makes DLQ.Nack's returned prefix count n=3
+	// (out of 5), which drives the partial Source.Ack(positions[:3]) call at
+	// funnel/worker.go:513 - as opposed to the previous test's full-batch call.
+	dlqWriteErr := cerrors.New("dlq write failed")
+	dlqDestinationMock.EXPECT().Write(gomock.Any(), gomock.Any()).Return(nil)
+	dlqDestinationMock.EXPECT().Ack(gomock.Any()).Return(
+		toDestinationAcks(batch.records, []error{nil, nil, nil, dlqWriteErr, dlqWriteErr}),
+		nil,
+	)
+
+	err := worker.Nack(ctx, batch, "taskID")
+	is.True(err != nil) // the partial DLQ failure surfaces as a (fatal) error...
+
+	wantPositions := batch.positions[:3] // ...but the successfully-DLQ'd prefix must still be acked, in order
+	waitForAcks(t, fakeServer, len(wantPositions))
+	assertPositionsInOrder(is, fakeServer.observedAcks(), wantPositions)
+
+	// And, just as importantly: the two records that were never successfully
+	// DLQ'd must NOT have been acked in the source (that would be acking a
+	// record that was neither delivered downstream nor durably DLQ'd - a
+	// violation of invariant 1).
+	is.Equal(len(fakeServer.observedAcks()), 3)
+}

--- a/tests/chaos/child.go
+++ b/tests/chaos/child.go
@@ -1,0 +1,342 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chaos
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/conduitio/conduit-commons/database"
+	"github.com/conduitio/conduit-commons/database/badger"
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/connector"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	connectorPlugin "github.com/conduitio/conduit/pkg/plugin/connector"
+	"github.com/rs/zerolog"
+)
+
+// Environment variables the parent test process (harness.go) uses to
+// configure a child run. This is a test-only, out-of-band protocol between
+// this package's own test binary re-executing itself - it never touches
+// conduit run's actual config surface (see doc.go / the design doc's
+// observability section on this exact point).
+const (
+	envChild        = "CONDUIT_CHAOS_CHILD"
+	envDBDir        = "CONDUIT_CHAOS_DB_DIR"
+	envUpstreamDir  = "CONDUIT_CHAOS_UPSTREAM_DIR"
+	envPrune        = "CONDUIT_CHAOS_PRUNE"
+	envPaceMS       = "CONDUIT_CHAOS_PACE_MS"
+	envTotal        = "CONDUIT_CHAOS_TOTAL"
+	instanceID      = "chaos-source"
+	instancePlugin  = "chaos-plugin"
+	instancePipe    = "chaos-pipeline"
+	markerOpenGap   = "OPEN_GAP_ERROR"
+	markerDone      = "DONE"
+	markerFatal     = "FATAL"
+	markerCorruptPo = "CORRUPT_POSITION"
+)
+
+// exitCode values the parent harness distinguishes between. An OPEN_GAP_ERROR
+// (chaosPlugin.Open refusing a stale resume) exits with exitOK: it is a
+// clean, expected-shape outcome for the pruning-upstream scenario, and the
+// printed marker line - not the exit code - is what carries the verdict.
+const (
+	exitOK             = 0
+	exitOpenOtherError = 4
+	exitCorruptState   = 3
+	exitBadArgs        = 2
+)
+
+// isChildInvocation reports whether this process invocation should behave as
+// a chaos child runner instead of running the package's actual Go tests -
+// the standard "re-exec the test binary as a helper process" pattern (used
+// by, e.g., the Go standard library's own os/exec tests).
+func isChildInvocation() bool {
+	return os.Getenv(envChild) == "1"
+}
+
+// childEnv holds the parsed configuration a parent test process passes to a
+// chaos child via environment variables (see childConfig.env in harness.go).
+type childEnv struct {
+	dbDir       string
+	upstreamDir string
+	prune       bool
+	paceMS      int
+	total       uint64
+}
+
+// parseChildEnv reads and validates the child's environment. Any failure
+// here is a test-harness misconfiguration, not a scenario under test, so it
+// exits immediately with exitBadArgs.
+func parseChildEnv() childEnv {
+	var cfg childEnv
+	cfg.dbDir = os.Getenv(envDBDir)
+	cfg.upstreamDir = os.Getenv(envUpstreamDir)
+	cfg.prune = os.Getenv(envPrune) == "true"
+
+	paceMS, err := strconv.Atoi(os.Getenv(envPaceMS))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: invalid %s: %v\n", markerFatal, envPaceMS, err)
+		os.Exit(exitBadArgs)
+	}
+	cfg.paceMS = paceMS
+
+	total, err := strconv.ParseUint(os.Getenv(envTotal), 10, 64)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: invalid %s: %v\n", markerFatal, envTotal, err)
+		os.Exit(exitBadArgs)
+	}
+	cfg.total = total
+
+	if cfg.dbDir == "" || cfg.upstreamDir == "" {
+		fmt.Fprintf(os.Stderr, "%s: %s and %s are required\n", markerFatal, envDBDir, envUpstreamDir)
+		os.Exit(exitBadArgs)
+	}
+	return cfg
+}
+
+// loadOrCreateInstance loads the connector.Instance persisted by a previous
+// (possibly SIGKILL'd) run of this same chaos-source ID, or creates a fresh
+// one if none exists yet. It exits the process directly (exitCorruptState)
+// if the persisted state exists but fails to deserialize — per invariant 2,
+// that is itself a failing outcome for this test, never silently treated as
+// "fresh start".
+func loadOrCreateInstance(ctx context.Context, store *connector.Store) *connector.Instance {
+	instance, err := store.Get(ctx, instanceID)
+	switch {
+	case err == nil:
+		return instance // resumed from a previous (possibly killed) run's persisted state
+	case cerrors.Is(err, database.ErrKeyNotExist):
+		return &connector.Instance{
+			ID:            instanceID,
+			Type:          connector.TypeSource,
+			Config:        connector.Config{Name: instanceID, Settings: map[string]string{}},
+			PipelineID:    instancePipe,
+			Plugin:        instancePlugin,
+			ProvisionedBy: connector.ProvisionTypeAPI,
+		}
+	default:
+		fmt.Printf("%s: %v\n", markerCorruptPo, err)
+		os.Exit(exitCorruptState)
+		return nil // unreachable
+	}
+}
+
+// printResumePosition emits the diagnostic line the parent test relies on to
+// learn exactly where Conduit persisted state says this run is about to
+// resume from — printed unconditionally (fresh start included, where it's
+// the empty position) so the parent can compare it against the upstream's
+// independently-read committed watermark without opening the badger DB
+// itself.
+func printResumePosition(instance *connector.Instance) {
+	if src, ok := instance.State.(connector.SourceState); ok {
+		fmt.Printf("RESUME_POSITION %s\n", src.Position)
+		return
+	}
+	fmt.Printf("RESUME_POSITION %s\n", opencdc.Position(nil))
+}
+
+// runReadAckLoop reads and immediately acks records one batch at a time
+// until the last acked position reaches total (or forever, if total is 0).
+// It exits the process directly on any Read/Ack error.
+func runReadAckLoop(ctx context.Context, src *connector.Source, total uint64) {
+	for {
+		recs, err := src.Read(ctx)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: read failed: %v\n", markerFatal, err)
+			os.Exit(exitOpenOtherError)
+		}
+
+		positions := make([]opencdc.Position, len(recs))
+		for i, r := range recs {
+			positions[i] = r.Position
+		}
+		if err := src.Ack(ctx, positions); err != nil {
+			fmt.Fprintf(os.Stderr, "%s: ack failed: %v\n", markerFatal, err)
+			os.Exit(exitOpenOtherError)
+		}
+
+		if total > 0 {
+			last, _ := decodePosition(positions[len(positions)-1])
+			if last >= total {
+				return
+			}
+		}
+	}
+}
+
+// runChild is the entire child-process program: build a real
+// pkg/connector.Source, backed by a real on-disk badger DB (the same
+// production persister backend, via connector.NewPersister) and the
+// in-process chaosPlugin, then read+ack records sequentially until `total`
+// is reached. It never returns - it always calls os.Exit.
+//
+// This process is expected to be killed with SIGKILL by the parent test at
+// an arbitrary point; no cleanup on that path is possible or intended - that
+// is the entire point of the test (see doc.go).
+func runChild() {
+	ctx := context.Background()
+	cfg := parseChildEnv()
+
+	logger := log.New(zerolog.Nop()) // keep stdout clean; it is our progress-line channel
+
+	db, err := badger.New(zerolog.Nop(), cfg.dbDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: open badger db: %v\n", markerFatal, err)
+		os.Exit(exitBadArgs)
+	}
+
+	persister := connector.NewPersister(logger, db, connector.DefaultPersisterDelayThreshold, connector.DefaultPersisterBundleCountThreshold)
+	store := connector.NewStore(db, logger)
+
+	instance := loadOrCreateInstance(ctx, store)
+	instance.Init(logger, persister)
+	printResumePosition(instance)
+
+	upstream, err := openUpstreamStore(cfg.upstreamDir, cfg.prune)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %v\n", markerFatal, err)
+		os.Exit(exitBadArgs)
+	}
+	plugin := &chaosPlugin{store: upstream, total: cfg.total, paceMS: cfg.paceMS}
+
+	fetcher := staticFetcher{instance.Plugin: staticDispenser{source: plugin}}
+	c, err := instance.Connector(ctx, fetcher)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: build connector: %v\n", markerFatal, err)
+		os.Exit(exitBadArgs)
+	}
+	src, ok := c.(*connector.Source)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "%s: unexpected connector type %T\n", markerFatal, c)
+		os.Exit(exitBadArgs)
+	}
+
+	if err := src.Open(ctx); err != nil {
+		if containsGapMarker(err) {
+			// This IS the scenario this test exists to surface (see doc.go):
+			// on a pruning upstream, Conduit's persisted position lagged
+			// behind what was already durably committed at the moment of the
+			// kill, and the upstream can no longer supply the gap. Print the
+			// marker so the parent test can assert on it; this is an
+			// expected, clean exit for that scenario, not a
+			// test-infrastructure failure.
+			fmt.Printf("%s: %v\n", markerOpenGap, err)
+			os.Exit(exitOK)
+		}
+		fmt.Fprintf(os.Stderr, "%s: source open failed: %v\n", markerFatal, err)
+		os.Exit(exitOpenOtherError)
+	}
+
+	runReadAckLoop(ctx, src, cfg.total)
+
+	// src.Ack only guarantees the ack was HANDED OFF to the plugin
+	// (stream.Send rendezvous with the plugin's Recv) - it does not wait for
+	// chaosPlugin.ackLoop's subsequent, synchronous upstream.Commit call to
+	// finish. Without waiting here, this process could os.Exit before that
+	// last commit's fsync completes, truncating the run by one position and
+	// producing a false-positive gap that has nothing to do with the engine
+	// code under test. This wait is test-harness synchronization only - it
+	// has no analog in (and makes no claim about) production code.
+	waitForUpstreamCommitted(upstream, cfg.total)
+
+	// Graceful path: only reached when this run was allowed to finish
+	// (the parent didn't SIGKILL it). Tear down cleanly so the final
+	// persisted position is flushed and observable by the parent's
+	// post-run assertions.
+	if err := src.Teardown(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "%s: teardown failed: %v\n", markerFatal, err)
+		os.Exit(exitOpenOtherError)
+	}
+	persister.WaitPendingWrites()
+
+	fmt.Println(markerDone)
+	os.Exit(exitOK)
+}
+
+// waitForUpstreamCommitted blocks briefly until the upstream store reports
+// total positions committed, so this process doesn't exit while
+// chaosPlugin.ackLoop's goroutine still has an in-flight, not-yet-durable
+// commit for the very last ack this run just sent. See its call site for
+// why this is needed. A no-op when total is 0 (unbounded runs never reach
+// this graceful-exit path in the first place).
+func waitForUpstreamCommitted(upstream *upstreamStore, total uint64) {
+	if total == 0 {
+		return
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		committed, err := upstream.Committed()
+		if err == nil && committed >= total {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	// Falling through here would let the caller proceed to Teardown/DONE
+	// while the plugin's last commit is still in flight, silently
+	// undermining the very "committed == total" guarantee the parent test's
+	// duplicate-not-gap assertion depends on - so this must exit, not warn
+	// and continue.
+	fmt.Fprintf(os.Stderr, "%s: timed out waiting for upstream to reach position %d\n", markerFatal, total)
+	os.Exit(exitOpenOtherError)
+}
+
+// containsGapMarker reports whether err is (or wraps) the specific,
+// structural gap chaosPlugin.Open (upstream.go) returns when a pruning
+// upstream can no longer supply data behind its already-committed watermark.
+// pkg/connector.Source.open wraps that error ("could not open source
+// connector plugin: %w"), so a substring check - not a prefix check - is
+// needed. A substring check on a plain fmt.Errorf (rather than a typed
+// sentinel) is enough here: this is test-only harness code checking
+// test-only harness output, not a production error contract.
+func containsGapMarker(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "GAP:")
+}
+
+// staticDispenser and staticFetcher wire a single, already-constructed
+// chaosPlugin into pkg/connector's plugin-dispensing machinery
+// (connector.PluginDispenserFetcher -> connectorPlugin.Dispenser ->
+// connectorPlugin.SourcePlugin), mirroring the same pattern
+// pkg/connector's own tests use (fakePluginFetcher in instance_test.go).
+type staticDispenser struct {
+	source connectorPlugin.SourcePlugin
+}
+
+func (d staticDispenser) DispenseSpecifier() (connectorPlugin.SpecifierPlugin, error) {
+	return nil, cerrors.New("staticDispenser: DispenseSpecifier not implemented")
+}
+
+func (d staticDispenser) DispenseSource() (connectorPlugin.SourcePlugin, error) {
+	return d.source, nil
+}
+
+func (d staticDispenser) DispenseDestination() (connectorPlugin.DestinationPlugin, error) {
+	return nil, cerrors.New("staticDispenser: DispenseDestination not implemented")
+}
+
+type staticFetcher map[string]connectorPlugin.Dispenser
+
+func (f staticFetcher) NewDispenser(_ log.CtxLogger, name string, _ string) (connectorPlugin.Dispenser, error) {
+	d, ok := f[name]
+	if !ok {
+		return nil, cerrors.Errorf("staticFetcher: no dispenser registered for plugin %q", name)
+	}
+	return d, nil
+}

--- a/tests/chaos/doc.go
+++ b/tests/chaos/doc.go
@@ -1,0 +1,88 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package chaos is the repo's first chaos-testing harness (v0.19 Workstream 7,
+// DBZ-1). It is deliberately minimal — sized for one scenario family (a SIGKILL
+// crash-safety test on the source connector's offset↔position bridge), not a
+// generalized chaos framework. If a second scenario (DBZ-2) ever needs one,
+// it should generalize from this package rather than the reverse; see
+// docs/design-documents (dbz1-chaos.md, the design doc this package
+// implements) for why building the generalized skeleton now would be
+// speculative generality.
+//
+// # What this package tests, and why the real Debezium wrapper isn't here
+//
+// The workstream's motivating question is about
+// ConduitIO/conduit-kafka-connect-wrapper (a real Debezium Postgres connector
+// running inside Conduit): does its ack->commit ordering survive a `kill -9`
+// mid-snapshot or mid-stream without losing or duplicating records? That
+// wrapper is a separate JVM repo with a real Postgres dependency, and is not
+// checked out in this repository's module — it cannot be driven from a Go
+// test here.
+//
+// What CAN be tested here, with full fidelity, is the Go engine code the
+// wrapper (and every other v1-protocol, out-of-process connector) depends on:
+// pkg/connector.Source.Ack and pkg/connector.Persister. Reading
+// pkg/connector/source.go:207-238 shows the exact sequence a crash can land
+// in the middle of:
+//
+//  1. Source.Ack sends the ack to the plugin (source.go:218) — for the
+//     wrapper, this is what drives Debezium's task.commitRecord/task.commit,
+//     which durably (and, critically, IRREVERSIBLY from Conduit's point of
+//     view) advances Postgres's replication-slot confirmed LSN.
+//  2. ONLY AFTER that send succeeds does Source.Ack update its own state and
+//     call persister.Persist (source.go:223-235) — and Persister.Persist
+//     (persister.go:137-170) does NOT write through: it batches the change
+//     and flushes asynchronously after DefaultPersisterDelayThreshold (1s) or
+//     DefaultPersisterBundleCountThreshold (10k items), whichever comes
+//     first.
+//
+// So there is a real, ~1-second (or 10k-record) window after Conduit tells a
+// plugin "you may durably commit this" during which Conduit's OWN record of
+// "where we are" has not yet reached durable storage. A `kill -9` inside that
+// window is exactly what this package's tests target — with a plain
+// wall-clock delay, not a deterministic kill-hook, because the window is wide
+// enough (~1s) that timing it precisely isn't necessary.
+//
+// # Why "gap or duplicate" depends on the plugin, and this package tests both
+//
+// Whether that crash window is merely wasteful (Conduit re-delivers a few
+// already-committed records as harmless duplicates — fine, at-least-once) or
+// actually loses data (an unrecoverable GAP) depends entirely on whether the
+// plugin's backing system can still supply data from BEFORE its own most
+// recent commit. A Kafka-like log can. A Postgres replication slot, whose WAL
+// segments are eligible for recycling once the slot's confirmed_flush_lsn
+// advances past them, may not be able to — and real Postgres surfaces that
+// as a hard error ("requested WAL segment ... has already been removed"),
+// not a silent skip.
+//
+// Since the real wrapper+Postgres isn't available here, sigkill_test.go
+// drives BOTH assumptions against the identical engine code path, via a
+// synthetic upstreamStore (upstream.go) with a `prune` flag:
+//
+//   - prune=false (durable/Kafka-like upstream): the crash window must
+//     produce, at most, harmless duplicate re-delivery. No gap, ever.
+//   - prune=true (Postgres-replication-slot-like upstream): the SAME crash
+//     window, in the SAME engine code, is shown to make a GAP structurally
+//     reachable — Source.Open, on restart, is asked to resume from a
+//     position the upstream has already discarded.
+//
+// The verdict this package's tests establish is therefore conditional and
+// precise, not a blanket "crash-safe" or "not crash-safe" claim: Conduit's own
+// ack-before-persist ordering provides no protection on its own — safety
+// depends entirely on the connected plugin's ability to redeliver behind its
+// last commit, which for a real Debezium-Postgres connector is not
+// guaranteed. See the PR description's failure-mode analysis for the full
+// walk of the ack->commit->persist sequence and what each crash point does.
+package chaos

--- a/tests/chaos/harness.go
+++ b/tests/chaos/harness.go
@@ -62,7 +62,7 @@ type childProcess struct {
 
 	mu     sync.Mutex
 	lines  []string
-	stderr bytes.Buffer
+	stderr syncBuffer
 
 	readerDone chan struct{}
 
@@ -155,13 +155,21 @@ func (c *childProcess) linesSnapshot() []string {
 	return append([]string(nil), c.lines...)
 }
 
-// ackCount returns how many distinct "ACK <n>" progress lines have been
-// observed so far - i.e. how many positions the chaosPlugin has durably
-// committed upstream.
-func (c *childProcess) ackCount() int {
+// readCount returns how many distinct "READ <pos>" progress lines have been
+// observed so far - i.e. how many records chaosPlugin.produceLoop has sent
+// down the stream. Used for kill-timing (waitForReadCount): unlike ACK
+// progress, READ progress is paced directly by chaosPlugin.paceMS and is
+// unaffected by connector.Persister's debounce, so it remains a reliable
+// proxy for "at least N*paceMS of wall-clock time has elapsed" under
+// Approach A (see produceLoop's doc comment in upstream.go).
+func (c *childProcess) readCount() int {
+	return c.progressCount("READ ")
+}
+
+func (c *childProcess) progressCount(prefix string) int {
 	n := 0
 	for _, l := range c.linesSnapshot() {
-		if strings.HasPrefix(l, "ACK ") {
+		if strings.HasPrefix(l, prefix) {
 			n++
 		}
 	}
@@ -180,29 +188,60 @@ func (c *childProcess) line(prefix string) (string, bool) {
 }
 
 func (c *childProcess) diagnostics() string {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return fmt.Sprintf("stdout lines: %v\nstderr: %s", c.lines, c.stderr.String())
+	// stderr is its own syncBuffer (self-synchronizing, see its doc), not
+	// guarded by c.mu - c.mu only ever protected lines. Reading it while the
+	// child is still alive (e.g. from waitExit's timeout branch) races
+	// against os/exec's internal io.Copy goroutine, which keeps writing to
+	// it for as long as the child process keeps producing stderr output.
+	return fmt.Sprintf("stdout lines: %v\nstderr: %s", c.linesSnapshot(), c.stderr.String())
 }
 
-// waitForAckCount blocks (polling, not sleeping a fixed duration) until at
-// least n ACK lines have been observed, or fails the test after a generous
+// syncBuffer is a bytes.Buffer safe for concurrent Write (from os/exec's
+// internal stderr-copying goroutine, for as long as the child process is
+// alive) and String (from a test goroutine building a diagnostics message,
+// e.g. on a waitExit timeout while the child - and that copy goroutine - are
+// still running). A plain bytes.Buffer is not safe for this: os/exec.Cmd.Wait
+// only guarantees the copy goroutine has stopped once the process has
+// exited, which is exactly the case a timeout means never happened.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// waitForReadCount blocks (polling, not sleeping a fixed duration) until at
+// least n READ lines have been observed, or fails the test after a generous
 // timeout. Because the child's own pacing (chaosPlugin.paceMS) enforces a
-// MINIMUM real delay between acks via time.Sleep, waiting for n acks always
+// MINIMUM real delay between reads via time.Sleep, waiting for n reads always
 // means at least n*paceMS of wall-clock time has genuinely elapsed - slower
 // CI scheduling can only add delay, never let this return early. That is
-// what makes waitForAckCount a safe way to guarantee "at least this much
-// time has passed since the first ack" without a fragile fixed sleep.
-func (c *childProcess) waitForAckCount(t *testing.T, n int, timeout time.Duration) {
+// what makes this a safe way to guarantee "at least this much time has
+// passed since the first read" without a fragile fixed sleep. Unlike ack
+// progress, read progress stays reliable for this purpose even under
+// Approach A's deferred-ack timing (docs/design-documents/
+// 20260723-source-ack-persist-ordering-fix.md), which is why
+// sigkill_test.go's kill-timing uses this signal, not ack progress.
+func (c *childProcess) waitForReadCount(t *testing.T, n int, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		if c.ackCount() >= n {
+		if c.readCount() >= n {
 			return
 		}
 		time.Sleep(time.Millisecond)
 	}
-	t.Fatalf("timed out waiting for %d acks (saw %d)\n%s", n, c.ackCount(), c.diagnostics())
+	t.Fatalf("timed out waiting for %d reads (saw %d)\n%s", n, c.readCount(), c.diagnostics())
 }
 
 // sigkill sends SIGKILL (not SIGTERM, not context cancellation) and reaps

--- a/tests/chaos/harness.go
+++ b/tests/chaos/harness.go
@@ -1,0 +1,241 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chaos
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// childConfig configures one child-process run. dbDir and upstreamDir are
+// reused verbatim across a kill+restart pair - that persistence, on disk,
+// across two separate OS processes, is the entire point of this harness: it
+// is what makes "restart and check for a gap" mean something.
+type childConfig struct {
+	dbDir       string
+	upstreamDir string
+	prune       bool
+	paceMS      int
+	total       uint64
+}
+
+func (c childConfig) env() []string {
+	return []string{
+		envChild + "=1",
+		envDBDir + "=" + c.dbDir,
+		envUpstreamDir + "=" + c.upstreamDir,
+		envPrune + "=" + strconv.FormatBool(c.prune),
+		envPaceMS + "=" + strconv.Itoa(c.paceMS),
+		envTotal + "=" + strconv.FormatUint(c.total, 10),
+	}
+}
+
+// childProcess wraps a running (or exited) chaos child and its observed
+// stdout, so a test can wait for a specific number of ACK progress lines
+// before deciding when to SIGKILL - deterministic relative to the child's
+// own observed progress, not a blind wall-clock guess.
+type childProcess struct {
+	cmd *exec.Cmd
+
+	mu     sync.Mutex
+	lines  []string
+	stderr bytes.Buffer
+
+	readerDone chan struct{}
+
+	// reapOnce guards cmd.Wait(), which the os/exec docs require be called at
+	// most once. sigkill, waitExit and the spawnChild-registered t.Cleanup
+	// fallback can all end up trying to reap the same process (e.g. an
+	// assertion failing between spawnChild and the test's own sigkill/
+	// waitExit call would otherwise leak the process); routing all of them
+	// through reap() makes that safe regardless of which one gets there
+	// first.
+	reapOnce sync.Once
+	waitErr  error
+}
+
+// reap calls cmd.Wait() exactly once (idempotent - see reapOnce's doc
+// comment) and returns its result on every call.
+func (c *childProcess) reap() error {
+	c.reapOnce.Do(func() {
+		c.waitErr = c.cmd.Wait()
+	})
+	return c.waitErr
+}
+
+// spawnChild re-executes the current test binary (os.Args[0]) with
+// CONDUIT_CHAOS_CHILD=1, which - per TestMain in sigkill_test.go - makes it
+// behave as runChild (child.go) instead of running this package's actual Go
+// tests. This is the standard "re-exec the test binary as a helper process"
+// pattern.
+func spawnChild(t *testing.T, cfg childConfig) *childProcess {
+	t.Helper()
+
+	exe := os.Args[0]
+	if !filepath.IsAbs(exe) {
+		resolved, err := os.Executable()
+		if err != nil {
+			t.Fatalf("resolve test binary path: %v", err)
+		}
+		exe = resolved
+	}
+
+	// CommandContext with context.Background() (rather than exec.Command) is
+	// used only to satisfy the noctx linter - the child's lifecycle is
+	// controlled explicitly via sigkill/waitExit below, not via context
+	// cancellation.
+	//nolint:gosec // exe is this test binary's own path (os.Args[0]/os.Executable), not external input - the standard re-exec-self pattern
+	cmd := exec.CommandContext(context.Background(), exe)
+	cmd.Env = append(os.Environ(), cfg.env()...)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+
+	cp := &childProcess{cmd: cmd, readerDone: make(chan struct{})}
+	cmd.Stderr = &cp.stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+
+	// Fallback safety net: if the test function returns early (e.g. a failed
+	// assertion between spawnChild and the test's own sigkill/waitExit call)
+	// without explicitly reaping this child, don't leave a live or zombie
+	// process behind. Harmless (and a no-op beyond the Kill call) if the test
+	// already reaped it - see reap()'s doc comment.
+	t.Cleanup(func() {
+		if cp.cmd.Process != nil {
+			_ = cp.cmd.Process.Kill()
+		}
+		_ = cp.reap()
+	})
+
+	go func() {
+		defer close(cp.readerDone)
+		sc := bufio.NewScanner(stdout)
+		for sc.Scan() {
+			line := sc.Text()
+			cp.mu.Lock()
+			cp.lines = append(cp.lines, line)
+			cp.mu.Unlock()
+		}
+	}()
+
+	return cp
+}
+
+func (c *childProcess) linesSnapshot() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.lines...)
+}
+
+// ackCount returns how many distinct "ACK <n>" progress lines have been
+// observed so far - i.e. how many positions the chaosPlugin has durably
+// committed upstream.
+func (c *childProcess) ackCount() int {
+	n := 0
+	for _, l := range c.linesSnapshot() {
+		if strings.HasPrefix(l, "ACK ") {
+			n++
+		}
+	}
+	return n
+}
+
+// line returns the first observed line with the given prefix, and whether
+// one was found.
+func (c *childProcess) line(prefix string) (string, bool) {
+	for _, l := range c.linesSnapshot() {
+		if strings.HasPrefix(l, prefix) {
+			return l, true
+		}
+	}
+	return "", false
+}
+
+func (c *childProcess) diagnostics() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return fmt.Sprintf("stdout lines: %v\nstderr: %s", c.lines, c.stderr.String())
+}
+
+// waitForAckCount blocks (polling, not sleeping a fixed duration) until at
+// least n ACK lines have been observed, or fails the test after a generous
+// timeout. Because the child's own pacing (chaosPlugin.paceMS) enforces a
+// MINIMUM real delay between acks via time.Sleep, waiting for n acks always
+// means at least n*paceMS of wall-clock time has genuinely elapsed - slower
+// CI scheduling can only add delay, never let this return early. That is
+// what makes waitForAckCount a safe way to guarantee "at least this much
+// time has passed since the first ack" without a fragile fixed sleep.
+func (c *childProcess) waitForAckCount(t *testing.T, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if c.ackCount() >= n {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d acks (saw %d)\n%s", n, c.ackCount(), c.diagnostics())
+}
+
+// sigkill sends SIGKILL (not SIGTERM, not context cancellation) and reaps
+// the process. This is the actual chaos: no cleanup, no graceful shutdown,
+// no final flush - exactly what CLAUDE.md's chaos-testing standard requires
+// ("SIGKILL (not SIGTERM)").
+func (c *childProcess) sigkill(t *testing.T) {
+	t.Helper()
+	if err := c.cmd.Process.Signal(syscall.SIGKILL); err != nil {
+		t.Fatalf("SIGKILL child (pid %d): %v", c.cmd.Process.Pid, err)
+	}
+	_ = c.reap() // a "signal: killed" wait error is expected here, not a failure
+	<-c.readerDone
+}
+
+// waitExit blocks until the child exits on its own (the "let it run to
+// completion" restart run), failing the test if it doesn't within timeout or
+// exits with an unexpected non-zero code.
+func (c *childProcess) waitExit(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		_ = c.reap()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		<-c.readerDone
+		if c.waitErr != nil {
+			t.Fatalf("child exited unexpectedly: %v\n%s", c.waitErr, c.diagnostics())
+		}
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for child to exit\n%s", c.diagnostics())
+	}
+}

--- a/tests/chaos/sigkill_test.go
+++ b/tests/chaos/sigkill_test.go
@@ -1,0 +1,228 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chaos
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/matryer/is"
+)
+
+// TestMain intercepts the "am I a chaos child?" case before any actual Go
+// test runs. See child.go/isChildInvocation and harness.go/spawnChild for the
+// re-exec protocol.
+func TestMain(m *testing.M) {
+	if isChildInvocation() {
+		runChild() // never returns; always os.Exit's
+	}
+	os.Exit(m.Run())
+}
+
+// sigkillCase drives a single SIGKILL scenario. paceMS and killAfterAcks
+// together determine where in the ack->commit->persist crash window
+// (source.go:207-238, see doc.go) the kill lands: with the persister's real
+// DefaultPersisterDelayThreshold (1s), waiting for killAfterAcks acks at
+// paceMS each guarantees at least killAfterAcks*paceMS of genuine elapsed
+// time (childProcess.waitForAckCount's guarantee - see its doc comment), so
+// the numbers below are chosen to land reliably inside or across that 1s
+// boundary without needing a deterministic kill-hook, matching the finding
+// this workstream was built around.
+type sigkillCase struct {
+	name          string
+	paceMS        int
+	killAfterAcks int
+	total         uint64
+}
+
+var sigkillCases = []sigkillCase{
+	{
+		// Mid-snapshot: an initial, fast burst (minimal pacing, mirroring
+		// Debezium's initial full-table snapshot dumping many rows quickly).
+		// killAfterAcks=30 at 1ms/ack is ~30ms in - well before the FIRST
+		// automatic flush (which fires at ~1000ms), so Conduit has not
+		// persisted ANY position yet when the kill lands. This is the
+		// highest-stakes edge case named in the design doc: a crash before
+		// the snapshot watermark is durably recorded at all.
+		name:          "mid-snapshot",
+		paceMS:        1,
+		killAfterAcks: 30,
+		total:         500,
+	},
+	{
+		// Mid-stream: steady-state pacing slow enough that, by the time we
+		// reach killAfterAcks=95 acks (~1.4s in), one automatic flush has
+		// already happened (~1s, around ack ~66) AND a second debounce
+		// window has already started (on the next ack after that flush) but
+		// not yet fired (its own 1s timer would land around ack ~133). So
+		// Conduit's persisted position is a valid but STALE checkpoint
+		// (unlike the mid-snapshot case's "nothing at all"), which is the
+		// other edge case named in the design doc.
+		name:          "mid-stream",
+		paceMS:        15,
+		killAfterAcks: 95,
+		total:         400,
+	},
+}
+
+// TestSIGKILL_PruningUpstream_ProducesGap is DBZ-1's central result: killing
+// the engine inside the ack-sent/not-yet-persisted window (source.go:207-238)
+// against an upstream that cannot redeliver behind its own last commit
+// (modeling a Postgres replication slot - see doc.go) makes a genuine,
+// structural GAP reachable - not a hypothetical one. Restarting resumes from
+// Conduit's stale persisted position, which the upstream has already
+// discarded, and chaosPlugin.Open (upstream.go) surfaces that as a loud,
+// unambiguous error rather than a silent skip.
+//
+// What this catches: a violation of invariant 3 (a record that was
+// legitimately available before the kill becomes permanently unreachable
+// after it) - this is the sev-0 class of bug CLAUDE.md's data-integrity
+// invariants exist to prevent. Per this workstream's explicit instruction,
+// finding this is the deliverable: pkg/connector/source.go's ack-before-
+// persist ordering is NOT fixed in this PR (that would touch Source.Ack for
+// every connector and needs its own Tier-1 design doc); this test is the
+// demonstration + escalation.
+func TestSIGKILL_PruningUpstream_ProducesGap(t *testing.T) {
+	for _, tc := range sigkillCases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			dir := t.TempDir()
+			cfg := childConfig{
+				dbDir:       dir + "/db",
+				upstreamDir: dir + "/upstream",
+				prune:       true,
+				paceMS:      tc.paceMS,
+				total:       tc.total,
+			}
+
+			first := spawnChild(t, cfg)
+			first.waitForAckCount(t, tc.killAfterAcks, 30*time.Second)
+			first.sigkill(t)
+
+			committedAtKill, err := openUpstreamStore(cfg.upstreamDir, cfg.prune)
+			is.NoErr(err)
+			committedWatermark, err := committedAtKill.Committed()
+			is.NoErr(err)
+			// Sanity check on the harness itself: the plugin must have
+			// actually committed at least killAfterAcks positions before
+			// the kill landed, or this test isn't exercising the window it
+			// claims to.
+			is.True(committedWatermark >= uint64(tc.killAfterAcks))
+
+			second := spawnChild(t, cfg)
+			second.waitExit(t, 30*time.Second)
+
+			resumeLine, ok := second.line("RESUME_POSITION")
+			is.True(ok)
+			resumePos := parseResumePosition(t, resumeLine)
+
+			// The core verdict: with a pruning upstream, the stale resume
+			// position must be behind the committed watermark (proving this
+			// really is the ack-before-persist crash window), AND the
+			// restart must surface that as a loud, structural GAP - never a
+			// silent skip, never a false "all good".
+			is.True(resumePos < committedWatermark)
+
+			gapLine, foundGap := second.line(markerOpenGap)
+			if !foundGap {
+				t.Fatalf(
+					"SEV-0 ESCALATION MISSED OR CHANGED BEHAVIOR: expected chaosPlugin.Open to refuse a "+
+						"stale resume (position %d) behind the committed watermark (%d) with an %s marker, "+
+						"but the restart did not report one - re-verify pkg/connector/source.go's ack-before-persist "+
+						"ordering before assuming this is safe.\n%s",
+					resumePos, committedWatermark, markerOpenGap, second.diagnostics(),
+				)
+			}
+			t.Logf("SEV-0 FINDING confirmed for %s: %s", tc.name, gapLine)
+
+			_, corrupt := second.line(markerCorruptPo)
+			is.True(!corrupt) // this is a resume-refusal, not a torn/corrupted position (invariant 2 still holds)
+		})
+	}
+}
+
+// TestSIGKILL_DurableUpstream_ProducesDuplicateNotGap is the counterfactual
+// control for TestSIGKILL_PruningUpstream_ProducesGap: the IDENTICAL crash
+// window, against the IDENTICAL engine code (pkg/connector.Source.Ack /
+// Persister), but against an upstream that CAN redeliver behind its last
+// commit (modeling a durable, replayable log such as Kafka). Here the same
+// stale resume must be harmless: Conduit re-reads and re-acks a few already-
+// committed positions as duplicates (consistent with the at-least-once
+// floor, invariant 3) and then continues on to complete delivery of every
+// position through total.
+//
+// Running both variants side by side is what lets this workstream state
+// precisely (per CLAUDE.md's "determine, don't assume" standard) that the
+// gap in the other test is conditional on the connected plugin's own
+// redelivery guarantees, not an unconditional property of Conduit's engine.
+func TestSIGKILL_DurableUpstream_ProducesDuplicateNotGap(t *testing.T) {
+	for _, tc := range sigkillCases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			dir := t.TempDir()
+			cfg := childConfig{
+				dbDir:       dir + "/db",
+				upstreamDir: dir + "/upstream",
+				prune:       false,
+				paceMS:      tc.paceMS,
+				total:       tc.total,
+			}
+
+			first := spawnChild(t, cfg)
+			first.waitForAckCount(t, tc.killAfterAcks, 30*time.Second)
+			first.sigkill(t)
+
+			second := spawnChild(t, cfg)
+			second.waitExit(t, 30*time.Second)
+
+			_, gap := second.line(markerOpenGap)
+			is.True(!gap) // no gap: a non-pruning upstream must never refuse a stale resume
+
+			_, corrupt := second.line(markerCorruptPo)
+			is.True(!corrupt) // invariant 2: no torn/corrupted position on restart
+
+			_, done := second.line(markerDone)
+			is.True(done) // invariant 3: at-least-once delivery completed through `total` despite the kill
+
+			finalWatermark, err := openUpstreamStore(cfg.upstreamDir, cfg.prune)
+			is.NoErr(err)
+			committed, err := finalWatermark.Committed()
+			is.NoErr(err)
+			is.Equal(committed, tc.total) // every position 1..total was durably committed exactly once by the end
+		})
+	}
+}
+
+// parseResumePosition extracts the integer position from a "RESUME_POSITION
+// <pos>" line (or 0 for "RESUME_POSITION" with an empty position, i.e. a
+// genuinely fresh start with no persisted state at all).
+func parseResumePosition(t *testing.T, line string) uint64 {
+	t.Helper()
+	fields := strings.Fields(line)
+	// opencdc.Position.String() prints the literal "<nil>" for a nil
+	// position (see conduit-commons/opencdc/position.go) - i.e. a genuinely
+	// fresh start with nothing persisted yet.
+	if len(fields) < 2 || fields[1] == "<nil>" {
+		return 0
+	}
+	n, err := strconv.ParseUint(fields[1], 10, 64)
+	if err != nil {
+		t.Fatalf("unparseable RESUME_POSITION line %q: %v", line, err)
+	}
+	return n
+}

--- a/tests/chaos/sigkill_test.go
+++ b/tests/chaos/sigkill_test.go
@@ -34,178 +34,176 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-// sigkillCase drives a single SIGKILL scenario. paceMS and killAfterAcks
+// sigkillCase drives a single SIGKILL scenario. paceMS and killAfterReads
 // together determine where in the ack->commit->persist crash window
-// (source.go:207-238, see doc.go) the kill lands: with the persister's real
-// DefaultPersisterDelayThreshold (1s), waiting for killAfterAcks acks at
-// paceMS each guarantees at least killAfterAcks*paceMS of genuine elapsed
-// time (childProcess.waitForAckCount's guarantee - see its doc comment), so
-// the numbers below are chosen to land reliably inside or across that 1s
-// boundary without needing a deterministic kill-hook, matching the finding
-// this workstream was built around.
+// (source.go's Ack, see doc.go) the kill lands: with the persister's real
+// DefaultPersisterDelayThreshold (1s), waiting for killAfterReads records to
+// be read off the stream at paceMS each guarantees at least
+// killAfterReads*paceMS of genuine elapsed time (childProcess.
+// waitForReadCount's guarantee - see its doc comment), so the numbers below
+// are chosen to land reliably inside or across that 1s boundary without
+// needing a deterministic kill-hook, matching the finding this workstream was
+// built around.
+//
+// This keys off READ progress, not ACK progress (see waitForReadCount's doc
+// for why): under the sev-0 fix (Approach A, docs/design-documents/
+// 20260723-source-ack-persist-ordering-fix.md), the plugin's ack visibility
+// is deliberately deferred behind connector.Persister's debounce, so "N acks
+// observed" no longer tracks wall-clock-since-start at fine grain for a fast
+// burst - a stale, ack-keyed version of this table drove the mid-snapshot
+// case's entire read+ack loop to completion before the debounce's first
+// flush ever fired, which starved chaosPlugin.produceLoop (nothing left to
+// read after a full resume) and hung the second child indefinitely.
 type sigkillCase struct {
-	name          string
-	paceMS        int
-	killAfterAcks int
-	total         uint64
+	name           string
+	paceMS         int
+	killAfterReads int
+	total          uint64
 }
 
 var sigkillCases = []sigkillCase{
 	{
 		// Mid-snapshot: an initial, fast burst (minimal pacing, mirroring
 		// Debezium's initial full-table snapshot dumping many rows quickly).
-		// killAfterAcks=30 at 1ms/ack is ~30ms in - well before the FIRST
+		// killAfterReads=30 at 1ms/read is ~30ms in - well before the FIRST
 		// automatic flush (which fires at ~1000ms), so Conduit has not
 		// persisted ANY position yet when the kill lands. This is the
 		// highest-stakes edge case named in the design doc: a crash before
 		// the snapshot watermark is durably recorded at all.
-		name:          "mid-snapshot",
-		paceMS:        1,
-		killAfterAcks: 30,
-		total:         500,
+		name:           "mid-snapshot",
+		paceMS:         1,
+		killAfterReads: 30,
+		total:          500,
 	},
 	{
 		// Mid-stream: steady-state pacing slow enough that, by the time we
-		// reach killAfterAcks=95 acks (~1.4s in), one automatic flush has
-		// already happened (~1s, around ack ~66) AND a second debounce
+		// reach killAfterReads=95 reads (~1.4s in), one automatic flush has
+		// already happened (~1s, around read ~66) AND a second debounce
 		// window has already started (on the next ack after that flush) but
-		// not yet fired (its own 1s timer would land around ack ~133). So
+		// not yet fired (its own 1s timer would land around read ~133). So
 		// Conduit's persisted position is a valid but STALE checkpoint
 		// (unlike the mid-snapshot case's "nothing at all"), which is the
 		// other edge case named in the design doc.
-		name:          "mid-stream",
-		paceMS:        15,
-		killAfterAcks: 95,
-		total:         400,
+		name:           "mid-stream",
+		paceMS:         15,
+		killAfterReads: 95,
+		total:          400,
 	},
 }
 
-// TestSIGKILL_PruningUpstream_ProducesGap is DBZ-1's central result: killing
-// the engine inside the ack-sent/not-yet-persisted window (source.go:207-238)
-// against an upstream that cannot redeliver behind its own last commit
-// (modeling a Postgres replication slot - see doc.go) makes a genuine,
-// structural GAP reachable - not a hypothetical one. Restarting resumes from
-// Conduit's stale persisted position, which the upstream has already
-// discarded, and chaosPlugin.Open (upstream.go) surfaces that as a loud,
-// unambiguous error rather than a silent skip.
+// TestSIGKILL_PruningUpstream_NoGap is the sev-0 fix's central regression
+// gate. It supersedes PR #2677's TestSIGKILL_PruningUpstream_ProducesGap,
+// which demonstrated (and was designed to demonstrate) a genuine, structural
+// gap in this exact crash window against a pruning upstream - see
+// docs/postmortems/20260723-source-ack-persist-ordering.md for that finding.
+// With the fix (docs/design-documents/20260723-source-ack-persist-ordering-fix.md,
+// Approach A: the plugin ack is deferred until the resulting position is
+// durably flushed, per-connector FIFO order preserved via source.go's
+// pendingAcks/onPersistFlushed), the identical crash window - identical
+// engine code, identical kill timing, identical pruning upstream that cannot
+// redeliver behind its own last commit - must no longer be able to produce
+// that gap: restarting must always resume from a position at or ahead of
+// whatever the upstream has committed, never behind it.
 //
-// What this catches: a violation of invariant 3 (a record that was
-// legitimately available before the kill becomes permanently unreachable
-// after it) - this is the sev-0 class of bug CLAUDE.md's data-integrity
-// invariants exist to prevent. Per this workstream's explicit instruction,
-// finding this is the deliverable: pkg/connector/source.go's ack-before-
-// persist ordering is NOT fixed in this PR (that would touch Source.Ack for
-// every connector and needs its own Tier-1 design doc); this test is the
-// demonstration + escalation.
-func TestSIGKILL_PruningUpstream_ProducesGap(t *testing.T) {
+// This test is verified to FAIL without the fix: temporarily reverting
+// Source.Ack's ordering (moving the plugin ack back before persister.Persist)
+// reproduces the exact OPEN_GAP_ERROR this test now asserts never happens -
+// see the fix PR's description for that run's output.
+func TestSIGKILL_PruningUpstream_NoGap(t *testing.T) {
 	for _, tc := range sigkillCases {
 		t.Run(tc.name, func(t *testing.T) {
-			is := is.New(t)
-			dir := t.TempDir()
-			cfg := childConfig{
-				dbDir:       dir + "/db",
-				upstreamDir: dir + "/upstream",
-				prune:       true,
-				paceMS:      tc.paceMS,
-				total:       tc.total,
-			}
-
-			first := spawnChild(t, cfg)
-			first.waitForAckCount(t, tc.killAfterAcks, 30*time.Second)
-			first.sigkill(t)
-
-			committedAtKill, err := openUpstreamStore(cfg.upstreamDir, cfg.prune)
-			is.NoErr(err)
-			committedWatermark, err := committedAtKill.Committed()
-			is.NoErr(err)
-			// Sanity check on the harness itself: the plugin must have
-			// actually committed at least killAfterAcks positions before
-			// the kill landed, or this test isn't exercising the window it
-			// claims to.
-			is.True(committedWatermark >= uint64(tc.killAfterAcks))
-
-			second := spawnChild(t, cfg)
-			second.waitExit(t, 30*time.Second)
-
-			resumeLine, ok := second.line("RESUME_POSITION")
-			is.True(ok)
-			resumePos := parseResumePosition(t, resumeLine)
-
-			// The core verdict: with a pruning upstream, the stale resume
-			// position must be behind the committed watermark (proving this
-			// really is the ack-before-persist crash window), AND the
-			// restart must surface that as a loud, structural GAP - never a
-			// silent skip, never a false "all good".
-			is.True(resumePos < committedWatermark)
-
-			gapLine, foundGap := second.line(markerOpenGap)
-			if !foundGap {
-				t.Fatalf(
-					"SEV-0 ESCALATION MISSED OR CHANGED BEHAVIOR: expected chaosPlugin.Open to refuse a "+
-						"stale resume (position %d) behind the committed watermark (%d) with an %s marker, "+
-						"but the restart did not report one - re-verify pkg/connector/source.go's ack-before-persist "+
-						"ordering before assuming this is safe.\n%s",
-					resumePos, committedWatermark, markerOpenGap, second.diagnostics(),
-				)
-			}
-			t.Logf("SEV-0 FINDING confirmed for %s: %s", tc.name, gapLine)
-
-			_, corrupt := second.line(markerCorruptPo)
-			is.True(!corrupt) // this is a resume-refusal, not a torn/corrupted position (invariant 2 still holds)
+			assertSigkillIsGapFree(t, tc, true)
 		})
 	}
 }
 
-// TestSIGKILL_DurableUpstream_ProducesDuplicateNotGap is the counterfactual
-// control for TestSIGKILL_PruningUpstream_ProducesGap: the IDENTICAL crash
-// window, against the IDENTICAL engine code (pkg/connector.Source.Ack /
-// Persister), but against an upstream that CAN redeliver behind its last
-// commit (modeling a durable, replayable log such as Kafka). Here the same
-// stale resume must be harmless: Conduit re-reads and re-acks a few already-
-// committed positions as duplicates (consistent with the at-least-once
-// floor, invariant 3) and then continues on to complete delivery of every
-// position through total.
-//
-// Running both variants side by side is what lets this workstream state
-// precisely (per CLAUDE.md's "determine, don't assume" standard) that the
-// gap in the other test is conditional on the connected plugin's own
-// redelivery guarantees, not an unconditional property of Conduit's engine.
-func TestSIGKILL_DurableUpstream_ProducesDuplicateNotGap(t *testing.T) {
+// TestSIGKILL_DurableUpstream_NoGap is the counterfactual control for
+// TestSIGKILL_PruningUpstream_NoGap: the IDENTICAL crash window, against the
+// IDENTICAL engine code (pkg/connector.Source.Ack / Persister), but against
+// an upstream that CAN redeliver behind its last commit (modeling a durable,
+// replayable log such as Kafka). This upstream class was never able to
+// produce a structural gap even before the fix (see the superseded PR
+// #2677's TestSIGKILL_DurableUpstream_ProducesDuplicateNotGap) - keeping it
+// here, with the fix applied, proves the fix didn't regress the
+// already-safe case while closing the pruning-upstream one: both classes are
+// now gap-free by the identical assertion, not by a different one per class.
+func TestSIGKILL_DurableUpstream_NoGap(t *testing.T) {
 	for _, tc := range sigkillCases {
 		t.Run(tc.name, func(t *testing.T) {
-			is := is.New(t)
-			dir := t.TempDir()
-			cfg := childConfig{
-				dbDir:       dir + "/db",
-				upstreamDir: dir + "/upstream",
-				prune:       false,
-				paceMS:      tc.paceMS,
-				total:       tc.total,
-			}
-
-			first := spawnChild(t, cfg)
-			first.waitForAckCount(t, tc.killAfterAcks, 30*time.Second)
-			first.sigkill(t)
-
-			second := spawnChild(t, cfg)
-			second.waitExit(t, 30*time.Second)
-
-			_, gap := second.line(markerOpenGap)
-			is.True(!gap) // no gap: a non-pruning upstream must never refuse a stale resume
-
-			_, corrupt := second.line(markerCorruptPo)
-			is.True(!corrupt) // invariant 2: no torn/corrupted position on restart
-
-			_, done := second.line(markerDone)
-			is.True(done) // invariant 3: at-least-once delivery completed through `total` despite the kill
-
-			finalWatermark, err := openUpstreamStore(cfg.upstreamDir, cfg.prune)
-			is.NoErr(err)
-			committed, err := finalWatermark.Committed()
-			is.NoErr(err)
-			is.Equal(committed, tc.total) // every position 1..total was durably committed exactly once by the end
+			assertSigkillIsGapFree(t, tc, false)
 		})
 	}
+}
+
+// assertSigkillIsGapFree drives one SIGKILL scenario against an upstream of
+// the given prune class and asserts the sev-0 invariants (1, 2, 3) all hold:
+// no gap ever gets reported on resume (invariant 1: the plugin was never
+// told to commit ahead of what's durable), no torn/corrupted position is
+// ever read back (invariant 2), and the run still completes end-to-end
+// despite the kill, committing every position exactly through total
+// (invariant 3, at-least-once - duplicates are fine, gaps are not).
+func assertSigkillIsGapFree(t *testing.T, tc sigkillCase, prune bool) {
+	t.Helper()
+	is := is.New(t)
+	dir := t.TempDir()
+	cfg := childConfig{
+		dbDir:       dir + "/db",
+		upstreamDir: dir + "/upstream",
+		prune:       prune,
+		paceMS:      tc.paceMS,
+		total:       tc.total,
+	}
+
+	first := spawnChild(t, cfg)
+	first.waitForReadCount(t, tc.killAfterReads, 30*time.Second)
+	first.sigkill(t)
+
+	committedAtKill, err := openUpstreamStore(cfg.upstreamDir, cfg.prune)
+	is.NoErr(err)
+	watermarkAtKill, err := committedAtKill.Committed()
+	is.NoErr(err)
+
+	second := spawnChild(t, cfg)
+	second.waitExit(t, 30*time.Second)
+
+	resumeLine, ok := second.line("RESUME_POSITION")
+	is.True(ok)
+	resumePos := parseResumePosition(t, resumeLine)
+
+	// The core verdict, and this workstream's whole point: Conduit's own
+	// durably-persisted resume position must never be behind what it already
+	// told the plugin (and, for a pruning upstream, therefore the plugin's
+	// own irreversible commit) it could consider committed. Before the fix,
+	// this could go either way depending on the upstream's prune behavior;
+	// after it, it must hold unconditionally - see assertSigkillIsGapFree's
+	// doc and the two callers for why the same assertion now covers both
+	// upstream classes.
+	is.True(resumePos >= watermarkAtKill)
+
+	_, foundGap := second.line(markerOpenGap)
+	if foundGap {
+		gapLine, _ := second.line(markerOpenGap)
+		t.Fatalf(
+			"SEV-0 REGRESSION: chaosPlugin.Open reported a gap (resume position %d, "+
+				"upstream committed watermark at kill time %d, prune=%v) - the "+
+				"ack-follows-durable-flush ordering in pkg/connector/source.go (Approach A) "+
+				"should make this structurally unreachable; re-verify Source.Ack/onPersistFlushed "+
+				"before assuming this is safe.\n%s\n%s",
+			resumePos, watermarkAtKill, prune, gapLine, second.diagnostics(),
+		)
+	}
+
+	_, corrupt := second.line(markerCorruptPo)
+	is.True(!corrupt) // invariant 2: no torn/corrupted position on restart
+
+	_, done := second.line(markerDone)
+	is.True(done) // invariant 3: at-least-once delivery completed through `total` despite the kill
+
+	finalWatermark, err := openUpstreamStore(cfg.upstreamDir, cfg.prune)
+	is.NoErr(err)
+	committed, err := finalWatermark.Committed()
+	is.NoErr(err)
+	is.Equal(committed, tc.total) // every position 1..total was durably committed exactly once by the end
 }
 
 // parseResumePosition extracts the integer position from a "RESUME_POSITION

--- a/tests/chaos/upstream.go
+++ b/tests/chaos/upstream.go
@@ -202,6 +202,16 @@ func (p *chaosPlugin) Run(ctx context.Context, stream pconnector.SourceRunStream
 // producing is independent of committing, exactly like a real source
 // connector's read loop runs concurrently with (and ahead of) acks arriving
 // for records it already sent.
+//
+// It prints a "READ <pos>" progress line right after each successful send —
+// deliberately NOT gated on any ack/commit/flush behavior, unlike "ACK" lines
+// (see ackLoop). Approach A (docs/design-documents/
+// 20260723-source-ack-persist-ordering-fix.md) defers the plugin's ack
+// visibility behind connector.Persister's debounce, so "ACK" progress no
+// longer tracks wall-clock-since-start at a fine grain for a fast burst — it
+// can arrive in one lump once a flush fires. "READ" progress does not have
+// that problem: production is paced by paceMS exactly as before this fix, so
+// harness.go's kill-timing waits on READ lines, not ACK lines.
 func (p *chaosPlugin) produceLoop(server pconnector.SourceRunStreamServer, start uint64) {
 	pos := start
 	for {
@@ -214,6 +224,7 @@ func (p *chaosPlugin) produceLoop(server pconnector.SourceRunStreamServer, start
 		if err := server.Send(pconnector.SourceRunResponse{Records: []opencdc.Record{rec}}); err != nil {
 			return // stream closed (process exiting, or Teardown ran)
 		}
+		printProgress("READ", pos)
 
 		if p.paceMS > 0 {
 			time.Sleep(time.Duration(p.paceMS) * time.Millisecond)

--- a/tests/chaos/upstream.go
+++ b/tests/chaos/upstream.go
@@ -1,0 +1,310 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chaos
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit-connector-protocol/pconnector"
+	"github.com/conduitio/conduit/pkg/plugin/connector/builtin"
+)
+
+// upstreamStore models the durable external system a source connector reads
+// from and commits records to — e.g. Debezium reading Postgres's replication
+// slot. Its "committed" watermark is written to disk and fsynced
+// SYNCHRONOUSLY on every commit, deliberately unlike Conduit's own
+// Persister (persister.go), which debounces. That asymmetry is the point:
+// this store models a plugin/upstream whose own commit is immediate and
+// irreversible from Conduit's perspective, exactly as pkg/connector/source.go
+// assumes when it sends the ack to the plugin before persisting its own
+// state.
+//
+// If prune is true, the store also models a replication slot whose WAL
+// segments are recycled once confirmed: Committed() reports the highest
+// position ever committed across ALL runs (including ones a SIGKILL cut
+// short), and the chaosPlugin's Open refuses to resume from anywhere behind
+// it. If prune is false, the store never restricts where a resume can start
+// from — the modeled upstream is a durable, replayable log (e.g. Kafka) that
+// can redeliver from an arbitrarily old offset.
+type upstreamStore struct {
+	path  string
+	prune bool
+
+	mu sync.Mutex
+}
+
+func openUpstreamStore(dir string, prune bool) (*upstreamStore, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("upstreamStore: mkdir %s: %w", dir, err)
+	}
+	return &upstreamStore{path: filepath.Join(dir, "committed"), prune: prune}, nil
+}
+
+// Committed returns the highest position ever durably committed, read fresh
+// from disk every call — so a freshly restarted process picks up whatever a
+// previous, killed process last committed. Returns 0 if nothing was ever
+// committed.
+func (u *upstreamStore) Committed() (uint64, error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.readLocked()
+}
+
+func (u *upstreamStore) readLocked() (uint64, error) {
+	raw, err := os.ReadFile(u.path)
+	if os.IsNotExist(err) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("upstreamStore: read %s: %w", u.path, err)
+	}
+	n, err := strconv.ParseUint(string(raw), 10, 64)
+	if err != nil {
+		// A torn/corrupted read of the upstream's OWN commit marker is not
+		// what this workstream's invariant-2 assertion is about (that's
+		// Conduit's persisted position, checked independently in
+		// child.go) — but it should never happen given the synchronous
+		// write+fsync below, so surface it loudly rather than silently
+		// treating it as "nothing committed".
+		return 0, fmt.Errorf("upstreamStore: corrupt commit marker %q in %s: %w", raw, u.path, err)
+	}
+	return n, nil
+}
+
+// Commit durably records that pos has been committed upstream (Debezium's
+// task.commitRecord+task.commit, in the real wrapper). It is synchronous and
+// fsynced before returning — modeling an upstream commit that is immediate
+// and durable, unlike Conduit's own debounced Persister.
+func (u *upstreamStore) Commit(pos uint64) error {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	cur, err := u.readLocked()
+	if err != nil {
+		return err
+	}
+	if pos <= cur {
+		return nil // already committed at least this far; idempotent
+	}
+
+	tmp := u.path + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("upstreamStore: open %s: %w", tmp, err)
+	}
+	if _, err := fmt.Fprintf(f, "%d", pos); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("upstreamStore: write %s: %w", tmp, err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("upstreamStore: fsync %s: %w", tmp, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("upstreamStore: close %s: %w", tmp, err)
+	}
+	// Atomic rename: the marker file is never observed half-written.
+	if err := os.Rename(tmp, u.path); err != nil {
+		return fmt.Errorf("upstreamStore: rename %s -> %s: %w", tmp, u.path, err)
+	}
+	return nil
+}
+
+// chaosPlugin is a minimal, in-process pconnector.SourcePlugin standing in
+// for the wrapper's DefaultSourceStream. It produces a deterministic stream
+// of records (position N's payload is always "record-N", so "was record N
+// ever delivered" needs no separate ledger — it's a pure function of
+// position) and, on ack, durably commits to upstream via upstreamStore.
+type chaosPlugin struct {
+	store  *upstreamStore
+	total  uint64 // 0 means unbounded
+	paceMS int    // delay between produced records; 0 = as-fast-as-possible burst
+
+	mu         sync.Mutex
+	nextToRead uint64 // set by Open, read by the producer goroutine
+}
+
+var _ pconnector.SourcePlugin = (*chaosPlugin)(nil)
+
+func (p *chaosPlugin) Configure(context.Context, pconnector.SourceConfigureRequest) (pconnector.SourceConfigureResponse, error) {
+	return pconnector.SourceConfigureResponse{}, nil
+}
+
+// Open is where the crash window's consequence becomes observable: if the
+// upstream prunes (Postgres-slot-like) and Conduit asks to resume from
+// behind the already-committed watermark, this returns a hard, loud error —
+// modeling Postgres's real "requested WAL segment has already been removed"
+// behavior, not a silent skip. See doc.go for why gap-vs-duplicate depends on
+// this flag.
+func (p *chaosPlugin) Open(_ context.Context, req pconnector.SourceOpenRequest) (pconnector.SourceOpenResponse, error) {
+	resume, err := decodePosition(req.Position)
+	if err != nil {
+		return pconnector.SourceOpenResponse{}, fmt.Errorf("chaos plugin: invalid resume position %q: %w", req.Position, err)
+	}
+
+	committed, err := p.store.Committed()
+	if err != nil {
+		return pconnector.SourceOpenResponse{}, err
+	}
+
+	if p.store.prune && resume < committed {
+		return pconnector.SourceOpenResponse{}, fmt.Errorf(
+			"GAP: chaos upstream already committed/pruned through position %d, but Conduit asked to "+
+				"resume from position %d — the %d position(s) in between are no longer available upstream "+
+				"(modeling a Postgres replication slot whose WAL for already-confirmed positions was recycled)",
+			committed, resume, committed-resume)
+	}
+
+	p.mu.Lock()
+	p.nextToRead = resume
+	p.mu.Unlock()
+	return pconnector.SourceOpenResponse{}, nil
+}
+
+func (p *chaosPlugin) Run(ctx context.Context, stream pconnector.SourceRunStream) error {
+	inmemStream, ok := stream.(*builtin.InMemorySourceRunStream)
+	if !ok {
+		return fmt.Errorf("chaos plugin: unexpected stream type %T", stream)
+	}
+	inmemStream.Init(ctx)
+	server := inmemStream.Server()
+
+	p.mu.Lock()
+	start := p.nextToRead
+	p.mu.Unlock()
+
+	go p.produceLoop(server, start)
+	go p.ackLoop(server)
+	return nil
+}
+
+// produceLoop delivers records start+1, start+2, ... up to p.total
+// (inclusive), pacing each send by p.paceMS. It never re-checks Committed —
+// producing is independent of committing, exactly like a real source
+// connector's read loop runs concurrently with (and ahead of) acks arriving
+// for records it already sent.
+func (p *chaosPlugin) produceLoop(server pconnector.SourceRunStreamServer, start uint64) {
+	pos := start
+	for {
+		if p.total > 0 && pos >= p.total {
+			return
+		}
+		pos++
+
+		rec := makeRecord(pos)
+		if err := server.Send(pconnector.SourceRunResponse{Records: []opencdc.Record{rec}}); err != nil {
+			return // stream closed (process exiting, or Teardown ran)
+		}
+
+		if p.paceMS > 0 {
+			time.Sleep(time.Duration(p.paceMS) * time.Millisecond)
+		}
+	}
+}
+
+// ackLoop drains ack messages and durably commits each one. It also emits a
+// progress line to stdout right after the durable commit completes, so the
+// parent test process can wait for a specific number of DURABLE commits
+// (rather than guessing with a fixed sleep) before deciding when to SIGKILL —
+// per the design doc's flakiness-mitigation guidance to prefer a record-count/
+// log-line trigger over a wall-clock sleep guess where it's this cheap to do.
+func (p *chaosPlugin) ackLoop(server pconnector.SourceRunStreamServer) {
+	for {
+		req, err := server.Recv()
+		if err != nil {
+			return // stream closed
+		}
+		for _, pos := range req.AckPositions {
+			n, err := decodePosition(pos)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "chaos plugin: invalid ack position %q: %v\n", pos, err)
+				continue
+			}
+			if err := p.store.Commit(n); err != nil {
+				fmt.Fprintf(os.Stderr, "chaos plugin: commit %d failed: %v\n", n, err)
+				continue
+			}
+			printProgress("ACK", n)
+		}
+	}
+}
+
+func (p *chaosPlugin) Stop(context.Context, pconnector.SourceStopRequest) (pconnector.SourceStopResponse, error) {
+	return pconnector.SourceStopResponse{}, nil
+}
+
+func (p *chaosPlugin) Teardown(context.Context, pconnector.SourceTeardownRequest) (pconnector.SourceTeardownResponse, error) {
+	return pconnector.SourceTeardownResponse{}, nil
+}
+
+func (p *chaosPlugin) LifecycleOnCreated(context.Context, pconnector.SourceLifecycleOnCreatedRequest) (pconnector.SourceLifecycleOnCreatedResponse, error) {
+	return pconnector.SourceLifecycleOnCreatedResponse{}, nil
+}
+
+func (p *chaosPlugin) LifecycleOnUpdated(context.Context, pconnector.SourceLifecycleOnUpdatedRequest) (pconnector.SourceLifecycleOnUpdatedResponse, error) {
+	return pconnector.SourceLifecycleOnUpdatedResponse{}, nil
+}
+
+func (p *chaosPlugin) LifecycleOnDeleted(context.Context, pconnector.SourceLifecycleOnDeletedRequest) (pconnector.SourceLifecycleOnDeletedResponse, error) {
+	return pconnector.SourceLifecycleOnDeletedResponse{}, nil
+}
+
+func (p *chaosPlugin) NewStream() pconnector.SourceRunStream {
+	return &builtin.InMemorySourceRunStream{}
+}
+
+// makeRecord deterministically builds the record for position pos: "was
+// record N ever delivered end-to-end" therefore needs no separate ledger —
+// it's answerable purely from the position, both here and in the parent
+// test's final verification.
+func makeRecord(pos uint64) opencdc.Record {
+	return opencdc.Record{
+		Position:  encodePosition(pos),
+		Operation: opencdc.OperationCreate,
+		Metadata:  opencdc.Metadata{},
+		Key:       opencdc.RawData(fmt.Sprintf("key-%d", pos)),
+		Payload:   opencdc.Change{After: opencdc.RawData(fmt.Sprintf("record-%d", pos))},
+	}
+}
+
+func encodePosition(pos uint64) opencdc.Position {
+	return opencdc.Position(strconv.FormatUint(pos, 10))
+}
+
+// decodePosition returns 0 for a nil/empty position (Conduit's Source.Open
+// with no persisted state, i.e. a genuinely fresh start).
+func decodePosition(p opencdc.Position) (uint64, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return strconv.ParseUint(string(p), 10, 64)
+}
+
+// printProgress emits a machine-parseable progress line to stdout. os.Stdout
+// writes go straight to the underlying file descriptor (fmt does no
+// buffering of its own), so this reaches the parent process's pipe
+// immediately - the parent reads these to know precisely how many positions
+// have been durably committed upstream, instead of guessing with a fixed
+// sleep. See the design doc's flakiness-mitigation guidance.
+func printProgress(tag string, pos uint64) {
+	fmt.Printf("%s %d\n", tag, pos)
+}


### PR DESCRIPTION
## Summary

Implements **Approach A** (ack-follows-durable-flush) for the sev-0 `Source.Ack` persist-ordering
bug, per DeVaris's sign-off on the approach in #2679's design doc
(`docs/design-documents/20260723-source-ack-persist-ordering-fix.md`) and postmortem
(`docs/postmortems/20260723-source-ack-persist-ordering.md`).

`Source.Ack` (`pkg/connector/source.go`) sent the ack to the plugin (`stream.Send`) **before** the
resulting position reached durable storage (`persister.Persist` only enqueues into an in-memory
batch, flushed asynchronously on a ~1s debounce). For a source backed by a pruning upstream (e.g. a
Postgres replication slot, whose ack advances `confirmed_flush_lsn` and frees WAL for recycling), a
crash in that window loses the durable position after the plugin was already told to commit — a
structural, unrecoverable gap. This was confirmed, not hypothetical: DBZ-1's chaos test (#2677)
drove this exact window and reproduced the gap on demand.

**Supersedes #2677**, folding in its chaos harness and flipping its central assertion from
"demonstrates the gap" to "asserts no gap."

## The per-connector FIFO high-water-mark mechanism

`Source.Ack` no longer sends the plugin ack inline. It:

1. Updates `Instance.State` and appends `(seq, positions)` to a new `pendingAcks` FIFO queue
   (`seq` is a purely engine-internal, monotonically increasing counter — **not** derived from the
   opaque `opencdc.Position` bytes, which the engine cannot generically parse or compare; a
   Position's structure, e.g. per-partition offsets, is entirely connector-defined).
2. Registers `persister.Persist(..., func(err) { s.onPersistFlushed(seq, err) })`.

`onPersistFlushed` only sends the plugin ack once the persister confirms durability:

- On success, it advances `durableAckSeq` to `max(durableAckSeq, seq)` and drains `pendingAcks`
  from the front for every entry whose `seq <= durableAckSeq`, sending each in the exact order
  `Ack` originally queued them (invariant 4), then removes them from the queue.
- This is safe even when flush confirmations arrive **out of order** (a later-registered flush's
  transaction can finish before an earlier one still in flight, since `Persister.flushNow`'s
  callback goroutines aren't ordered relative to each other): `durableAckSeq` only ever advances,
  and draining is idempotent — a stale, late callback finds nothing left to send.
- On failure, nothing is sent (invariant 1) and the error propagates via `s.errs`, same as before.

**Graceful shutdown (invariant 7):** `Source.Teardown` now forces a final `persister.Flush` and
waits for it (`Persister.WaitPendingWrites`, extended with a new `callbackWg` so it waits for the
callback — and therefore the deferred send — not just the store write) **before** canceling the
stream (`stopStream`). This ordering is load-bearing, not incidental: the in-memory stream (and a
real gRPC stream) shares one context between both directions, so canceling it first would make the
deferred ack's `stream.Send` race an already-closed `ctx.Done()` and very likely lose the message
instead of delivering it — I hit this as a real bug during implementation (see Adversarial
self-review below) before reordering fixed it.

## Fails-without-fix verification

Per `CLAUDE.md`'s "every bug fix ships with the test that would have caught it," I temporarily
reverted just the ordering change (reintroducing a synchronous `stream.Send` before
`persister.Persist` in `Source.Ack`, then restored it) and reran the new chaos assertion:

```text
$ go test -race -v -run TestSIGKILL_PruningUpstream_NoGap -count=1 ./tests/chaos/...
=== RUN   TestSIGKILL_PruningUpstream_NoGap/mid-snapshot
    sigkill_test.go:181: not true: resumePos >= watermarkAtKill
=== RUN   TestSIGKILL_PruningUpstream_NoGap/mid-stream
    sigkill_test.go:181: not true: resumePos >= watermarkAtKill
--- FAIL: TestSIGKILL_PruningUpstream_NoGap (4.04s)
```

Red on both scenarios with the bug reintroduced; restored the fix and confirmed green
(`diff` against the pre-revert file showed byte-identical restoration).

## Failure-mode analysis

Walking `Source.Ack`'s sequence under Approach A (today's behavior in brackets):

1. **Crash before the ack is enqueued.** No change: nothing happened; restart re-reads/re-acks.
2. **Crash mid-send of an already-durable deferred ack.** Position is already on disk; restart
   resumes correctly. Plugin may or may not have received that specific message — benign duplicate
   if not. **[today: this exact window is the sev-0, since the ack already went out before
   persistence.]**
3. **Crash after enqueue, before that batch's flush completes.** No ack has been sent (deferred);
   restart resumes from the last durably-flushed position and reprocesses the gap as a duplicate,
   not a data-loss gap. **[today: this is the exact scenario that produces the structural gap.]**
4. **Crash during `flushNow`'s transaction commit.** Unchanged, already verified atomic (`badger`'s
   commit; chaos harness never observed `CORRUPT_POSITION`).
5. **Crash after flush completes, before the deferred callback fires.** Same as case 2: durable
   state is correct, ack is merely delayed to the next opportunity.
6. **Per-partition/per-connector ordering (invariant 4) under interleaved out-of-order flush
   completion.** Covered by the new unit test
   `TestSource_OnPersistFlushed_OutOfOrderCompletionStillDeliversInOrder` — simulates the
   highest-seq flush completing first and asserts all three positions are still delivered in
   order, with the two late/lower-seq callbacks arriving as safe no-ops.
7. **Graceful (SIGTERM-style) vs. `kill -9` shutdown.** Covered by
   `TestSource_Teardown_SendsPendingDeferredAckBeforeReturning`: `Teardown` must not return until a
   pending ack has actually been sent. This is where I found and fixed the stream-context-ordering
   bug described above — without the fix, this specific test hung indefinitely (a real deadlock,
   not a flaky timing issue), because the deferred send raced an already-canceled stream context.
8. **Cross-connector blast radius (inherited, not introduced).** `Persister.flushNow` still flushes
   one shared batch across every connector pending in a debounce cycle; under this fix, a slow
   flush for one connector now also delays other connectors' deferred acks in the same cycle, not
   just their own write. Named in the design doc as inherited context, not a blocker.
9. **MySQL/Mongo — not extended beyond what's proven here.** See below.

**What could this break / how would we know / rollback:** the risk surface is entirely within
`pkg/connector/{source,persister}.go`; a regression would show up as either (a) the chaos suite
regressing to gap-producing (caught by `TestSIGKILL_PruningUpstream_NoGap`), (b) acks silently
never arriving at the plugin (caught by the FIFO-ack tests and would manifest as stalled upstream
commits / growing WAL in a real Postgres-slot deployment — no metric exists for this yet, tracked
as a follow-up per the design doc's Observability section), or (c) a deadlock on shutdown (caught
by `TestSource_Teardown_SendsPendingDeferredAckBeforeReturning`, which is exactly how I found the
stream-ordering bug in my own first draft). Rollback is a plain revert: no format/protocol change,
no migration.

## MySQL/Mongo harness result

Per the design doc's explicit scope: this PR proves the fix gap-free against **both** a prune-class
synthetic upstream (`TestSIGKILL_PruningUpstream_NoGap`, modeling a Postgres replication slot) and a
retention-class synthetic upstream (`TestSIGKILL_DurableUpstream_NoGap`, modeling a durable,
replayable log such as Kafka) — both now pass with the identical assertion, proving the fix removes
the upstream-class-dependence entirely at the engine level. **This does not verify the real MySQL
binlog or MongoDB oplog connectors** (those don't exist yet per the Debezium-compete roadmap, DBZ-7)
— tracked as a required follow-up before claiming "fixed for all CDC," exactly as the design doc and
postmortem flag it. Not claiming more than this proves.

## benchi / performance

- **Committed, not run**: `benchi/ack-hot-path/` (config, pipeline, two tool variants for
  `origin/main` vs this branch, README). The sandbox this was authored in has `benchi` installable
  but no reachable Docker daemon, so the actual orchestrated run could not be executed — stated
  plainly, not glossed over.
- **What I did run**: `pkg/connector/source_bench_test.go`'s `BenchmarkSource_Ack`, a same-sandbox
  Go microbenchmark of `Source.Ack` in isolation, at `-benchtime=20000x -count=3`, both on this
  branch and on the same temporary pre-fix revert used for the fails-without-fix check:

  ```text
  # this branch (fix):      ~640-740 ns/op, 707 B/op, 6 allocs/op
  # reverted (pre-fix):     ~1180-1500 ns/op, 742-743 B/op, 8 allocs/op
  ```

  The fix is faster per call in this microbenchmark, not slower — pre-fix pays a synchronous
  stream `Send` (channel rendezvous with the plugin reader) on every call; the fix only enqueues
  and reuses the already-existing debounced persister. This is a single-function microbenchmark on
  one machine, not an end-to-end throughput/latency number — the benchi run above is what would
  actually gate a >10% regression claim per `CLAUDE.md`, and it has not been run. See
  `benchi/ack-hot-path/README.md` for full numbers and exact reproduction steps.

## Adversarial self-review

- Re-read the diff hunting specifically for the class of bug this PR is about (ordering/timing
  around ack-vs-durability) and found a real one during implementation, not after: my first
  `Teardown` draft canceled the stream (`stopStream`) *before* forcing the final flush, which
  deadlocked (or, worse, silently dropped the ack) because the deferred send's `stream.Send` raced
  an already-canceled context. Caught by `TestSource_Teardown_SendsPendingDeferredAckBeforeReturning`
  hanging, not by inspection — fixed by reordering flush-then-cancel, documented at length in
  `Teardown`'s doc comment so it isn't re-broken.
  Also required a Persister change (`WaitPendingWrites`), and I re-checked that this new
  `callbackWg` doesn't affect `Destination`'s unrelated use of the same `Persister.Persist` — its
  callback is a trivial error-forward, so the extra wait is harmless there.
- Checked concurrency/lock ordering explicitly: `onPersistFlushed` runs from a goroutine spawned by
  `Persister.flushNow` and needs `preparePluginCall`'s `Instance.RLock` — `Teardown` never holds
  `Instance`'s exclusive lock across the flush-and-wait for exactly this reason (documented inline).
  `pendingAcks`/`nextAckSeq`/`durableAckSeq` are guarded by a dedicated `ackMu`, deliberately
  separate from `Instance`'s lock, to avoid exactly this class of deadlock.
- Checked error paths: a flush failure leaves `pendingAcks` un-drained (nothing acked, matching
  invariant 1) and propagates via `s.errs`, unchanged from before this fix. A deferred send failure
  (e.g. a genuinely closed stream, not just a canceled context) is intentionally **not** escalated
  via `s.errs` — logged instead — because escalating it risks blocking that goroutine forever on an
  unbuffered channel nobody is guaranteed to still be draining mid-teardown; I hit exactly this as a
  second real deadlock while developing the chaos test (the chaos harness's `runChild` doesn't
  drain `errs`), fixed the same way.
  reader has finished draining before that.
- Checked resource cleanup: `Source.Teardown`'s double-teardown defense (re-checking
  `s.plugin == nil` after each lock re-acquisition) is new relative to before, added because the
  reordering now releases `Instance`'s lock mid-function; `funnel.Worker`'s own `teardownMu` already
  serializes this in practice, but `Teardown` is a public method and shouldn't rely on that alone.
- Uncertainty I'm not resolving myself, surfaced for DeVaris: the cross-connector shared-batch
  blast radius (failure mode 8 above) now extends from "delays other connectors' writes" to "delays
  other connectors' acks too" — inherited from the existing `Persister` design, not introduced here,
  and already named in the design doc, but worth an explicit go/no-go rather than assuming it's
  fine by inheritance alone.

## Gates

- `make generate && git diff --exit-code`: clean (no diff beyond this PR's own changes).
- `golangci-lint run ./pkg/connector/... ./tests/chaos/...`: 0 issues. (Repo-wide
  `golangci-lint run ./...` surfaces 36 pre-existing issues, all in
  `pkg/plugin/processor/builtin/internal/diff/` — a vendored Go-stdlib diff package — and
  `pkg/foundation/cerrors/conduiterr` — none in files this PR touches.)
- `go build ./...`: clean.
- `go test -race -count=1 ./...` (whole repo): all packages green.
- `go test -race -run TestSIGKILL -count=3 ./tests/chaos/...`: green, 3x for flake-safety
  (~88s/run).
- New unit tests, all green under `-race`: `TestSource_Ack_DeferredUntilDurablyFlushed`,
  `TestSource_OnPersistFlushed_OutOfOrderCompletionStillDeliversInOrder`,
  `TestSource_Teardown_SendsPendingDeferredAckBeforeReturning`.
- Existing FIFO-ack tests still pass unchanged (`TestWorker_Ack_DeliversPositionsFIFOToV1Plugin`,
  `TestWorker_Nack_DeliversPartialAckFIFOToV1Plugin`) — now take ~1s each (waiting on the real
  debounce) instead of near-instant, since acks are genuinely deferred now.
- `TestSource_Ack_Deadlock` (pre-existing, concurrent-Ack stress test) still passes under `-race`.
- No new error codes added; `TestAllCodesComplete` unaffected (ran green as part of the full suite).

## Risk tier

**Tier 1** (data path: `pkg/connector/source.go`, `pkg/connector/persister.go`, plus the chaos
regression suite). **Requires DeVaris Tier-1 sign-off** before merge — per the standing rule, no
data-path change merges on automated review alone, and this session does not review or merge its
own PR.

## Related

- Supersedes #2677 (`test(chaos): DBZ-1 SIGKILL crash-safety + engine FIFO-ack`) — folds in its
  chaos harness and FIFO-ack test; this PR's `TestSIGKILL_PruningUpstream_NoGap` /
  `TestSIGKILL_DurableUpstream_NoGap` replace its `..._ProducesGap` /
  `..._ProducesDuplicateNotGap` tests.
- #2679 — `docs(design): Source.Ack persist-ordering fix + sev-0 postmortem` (design doc + blameless
  postmortem this PR implements; approach sign-off required there first).
- Closes the DBZ-1 loop from the Debezium-compete roadmap
  (`docs/design-documents/20260722-debezium-compete-roadmap.md`) and closes #2672: the chaos suite
  now proves the sev-0 fixed (for the two upstream classes the harness models) rather than merely
  documenting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD
