### PR TITLE
docs: surface Go embed + registry install in README; fix stale libconduit roadmap line

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Conduit was created and open-sourced by [Meroxa](https://meroxa.io).
 - [Connectors](#connectors)
 - [Processors](#processors)
 - [API](#api)
+- [Embed Conduit in your Go app](#embed-conduit-in-your-go-app)
 - [Documentation](#documentation)
 - [Contributing](#contributing)
 
@@ -230,6 +231,10 @@ there's a connector that you're looking for that isn't available in Conduit,
 please file an [issue](https://github.com/ConduitIO/conduit/issues/new?assignees=&labels=triage&template=3-connector-request.yml&title=Connector%3A+%3Cresource%3E+%5BSource%2FDestination%5D)
 .
 
+The quickest way to add a connector is the signed connector registry:
+`conduit connectors install <name>` — see the
+[registry install guide](https://conduitdata.io/docs/using/connectors/installing).
+
 Conduit loads standalone connectors at startup. The connector binaries need to
 be placed in the `connectors` directory relative to the Conduit binary so
 Conduit can find them. Alternatively, the path to the standalone connectors can
@@ -299,6 +304,34 @@ API please have a look at the [API documentation](https://www.conduit.io/api),
 or run Conduit and navigate to `http://localhost:8080/openapi` to open
 a [Swagger UI](https://github.com/swagger-api/swagger-ui) which makes it easy to
 try it out.
+
+## Embed Conduit in your Go app
+
+You can run a full Conduit engine in-process, inside your own Go application, and
+drive its lifecycle with ordinary function calls — no subprocess, no socket. The
+engine that powers the CLI is the one you embed.
+
+```sh
+go get github.com/conduitio/conduit
+```
+
+```go
+e, _ := conduit.New(ctx, conduit.Options{DB: conduit.DBOptions{Type: "badger"}})
+h, _ := e.Run(ctx)
+defer h.Stop(ctx)
+
+_ = e.ImportPipeline(ctx, conduit.NewPipeline("hello").
+    WithConnector(conduit.NewSourceConnector("src", "builtin:generator")).
+    WithConnector(conduit.NewDestinationConnector("dst", "builtin:log")))
+_ = e.StartPipeline(ctx, "hello")
+```
+
+The exported API (`Options`, `Engine`, `Handle`, `New`, and the pipelines-in-code
+builder) is a semver-committed, frozen import path. See the
+[Embedding Conduit (Go) guide](https://conduitdata.io/docs/developing/embedding-go)
+for the full lifecycle, options (logger/metrics injection, storage), deployment and
+state considerations, and known limitations. Non-Go bindings (Python, Node) are
+planned as gRPC client libraries — see the [roadmap](ROADMAP.md).
 
 ## Exit codes
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -163,10 +163,16 @@ and for their agents._
 
 ### Embedded v1
 
-- [ ] Stable, documented Go library API for embedding Conduit in applications — _partial:
-      embedding surface exists; stability/docs guarantee TBD_
-- [ ] C ABI shared library (`libconduit`) as the base for cross-language bindings
-- [ ] Python and Node.js bindings (Java/Ruby to follow on demand)
+- [x] Stable, documented Go library API for embedding Conduit in applications — shipped: the root
+      `github.com/conduitio/conduit` package (`New`/`Run`/`Stop`/`Close`/`Import` plus a
+      pipelines-in-code builder) on a semver-committed, frozen import path, with an
+      [embedding guide](https://conduitdata.io/docs/developing/embedding-go)
+- [ ] Non-Go embed bindings as **gRPC client libraries** over the control-plane API, Python first then
+      Node — the same client code targets a local subprocess or a remote, already-deployed engine. The
+      data path never crosses the host boundary, so a C-ABI `libconduit` is a demand-gated escape hatch
+      only, not the base for bindings — see
+      [ADR 20260724](docs/architecture-decision-records/20260724-embed-bindings-via-grpc.md)
+- [ ] Python client library (v0.20 anchor); Node.js to follow (Java/Ruby on demand)
 
 ## Phase 2 — Kafka Connect Migration, Connector Coverage & AI Pipelines (Months 3–8)
 


### PR DESCRIPTION
**Risk tier:** Tier 3 (docs only — no code, no data path).

Roadmap item: **Phase 1 → Embedded v1** (documenting the shipped Go embed surface) and roadmap correction.

## What
- **README:** new "Embed Conduit in your Go app" section — `go get`, a short `New`/`Run`/`ImportPipeline`/`Stop` quickstart, and a link to the new [Embedding Conduit (Go) guide](https://conduitdata.io/docs/developing/embedding-go). Added to the table of contents.
- **README:** one-line link to the connector-registry install docs (`conduit connectors install`) in the Connectors section — the README previously did not surface the signed registry install path.
- **ROADMAP:** the "Embedded v1" block was stale. It marked the Go library API "partial" and framed a C-ABI `libconduit` as *the base for cross-language bindings*. That contradicts ADR [`20260724-embed-bindings-via-grpc.md`](docs/architecture-decision-records/20260724-embed-bindings-via-grpc.md) and the SDK-rollout section. Reworded to: **Go embed shipped**; non-Go bindings are **gRPC client libraries** over the control-plane API (Python v0.20 anchor, Node next); a C-ABI is a **demand-gated escape hatch only**.

## Verification
- API surface verified against `conduit.go`, `builder.go`, `doc.go`, `example_test.go` on current `main` (not a stale checkout).
- `markdownlint-cli2 README.md ROADMAP.md`: my edits introduce **zero** new errors. The 5 pre-existing MD060 warnings are in the unrelated Exit-codes table and are present on `main` unchanged.

Paired website PR adds the full guide this README/ROADMAP links to. **Do not merge** pending review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD