### PR TITLE
test(chaos): DBZ-2 Phase 1b — invariant-6 transport half + SIGTERM/invariant-7

### DIFF
--- a/tests/chaos/child.go
+++ b/tests/chaos/child.go
@@ -18,8 +18,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/conduitio/conduit-commons/database"
@@ -47,6 +51,8 @@ const (
 	envSnapshotK      = "CONDUIT_CHAOS_SNAPSHOT_K"
 	envSnapshotPaceMS = "CONDUIT_CHAOS_SNAPSHOT_PACE_MS"
 	envNumKeys        = "CONDUIT_CHAOS_NUM_KEYS"
+	envDriftAt        = "CONDUIT_CHAOS_DRIFT_AT"
+	envSigtermMode    = "CONDUIT_CHAOS_SIGTERM_MODE"
 	instanceID        = "chaos-source"
 	instancePlugin    = "chaos-plugin"
 	instancePipe      = "chaos-pipeline"
@@ -56,6 +62,19 @@ const (
 	markerCorruptPo   = "CORRUPT_POSITION"
 	markerHandoff     = "HANDOFF"   // Property 1/2: producer crossed the snapshot->stream boundary, see upstream.go/produceLoop
 	markerAckOrder    = "ACK_ORDER" // Property 3: per-key ack delivery ledger, see upstream.go/ackLoop
+	// markerSigtermDone is the SIGTERM/invariant-7 case's completion marker
+	// (sigterm_test.go, runChildSigterm) - deliberately distinct from
+	// markerDone, which means "ran to cfg.total and tore down at the natural
+	// end of the run". This marker means "a SIGTERM arrived mid-run and
+	// Source.Teardown's flush-and-wait-then-stopStream ordering
+	// (source.go:249-326) completed" - a graceful stop, not a completed run.
+	markerSigtermDone = "SIGTERM_TEARDOWN_OK"
+
+	// envValueTrue is the string childConfig.env() writes (via
+	// strconv.FormatBool) for boolean env flags (envPrune, envSigtermMode) -
+	// named so the comparisons in parseChildEnv/TestMain share one constant
+	// instead of repeating the literal (goconst).
+	envValueTrue = "true"
 )
 
 // exitCode values the parent harness distinguishes between. An OPEN_GAP_ERROR
@@ -96,6 +115,18 @@ type childEnv struct {
 	// unkeyed position space" (DBZ-1's original behavior) - see
 	// chaosPlugin's type doc (upstream.go).
 	numKeys int
+
+	// driftAt: Property 4's synthetic drift/poison-marker knob. 0 (the
+	// default) means no record in this run carries the marker - see
+	// chaosPlugin.driftAt's field doc (upstream.go).
+	driftAt uint64
+
+	// sigtermMode: if true, runChildSigterm runs instead of runChild - an
+	// unbounded read/ack loop that waits for SIGTERM and drives
+	// Source.Teardown's flush-and-wait-then-stopStream ordering
+	// (source.go:249-326) explicitly, rather than tearing down at the
+	// natural end of a total-bounded run. See sigterm_test.go.
+	sigtermMode bool
 }
 
 // parseChildEnv reads and validates the child's environment. Any failure
@@ -105,7 +136,7 @@ func parseChildEnv() childEnv {
 	var cfg childEnv
 	cfg.dbDir = os.Getenv(envDBDir)
 	cfg.upstreamDir = os.Getenv(envUpstreamDir)
-	cfg.prune = os.Getenv(envPrune) == "true"
+	cfg.prune = os.Getenv(envPrune) == envValueTrue
 
 	paceMS, err := strconv.Atoi(os.Getenv(envPaceMS))
 	if err != nil {
@@ -146,6 +177,15 @@ func parseChildEnv() childEnv {
 		os.Exit(exitBadArgs)
 	}
 	cfg.numKeys = numKeys
+
+	driftAt, err := strconv.ParseUint(os.Getenv(envDriftAt), 10, 64)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: invalid %s: %v\n", markerFatal, envDriftAt, err)
+		os.Exit(exitBadArgs)
+	}
+	cfg.driftAt = driftAt
+
+	cfg.sigtermMode = os.Getenv(envSigtermMode) == envValueTrue
 
 	if cfg.dbDir == "" || cfg.upstreamDir == "" {
 		fmt.Fprintf(os.Stderr, "%s: %s and %s are required\n", markerFatal, envDBDir, envUpstreamDir)
@@ -246,6 +286,81 @@ func runReadAckLoop(ctx context.Context, src *connector.Source, total uint64, ke
 	}
 }
 
+// childBuilt bundles the real engine pieces buildChild wires together for a
+// single child run: a real *connector.Source, backed by a real on-disk
+// badger DB and connector.Persister, driven by an in-process chaosPlugin.
+// Factored out of runChild so Property 4's in-process funnel integration
+// (property4_test.go) can build and drive the IDENTICAL construction through
+// a real funnel.Worker instead of runReadAckLoop's direct src.Read/src.Ack
+// calls - see doc.go's note on why the direct loop bypasses the
+// funnel/DLQ/destination entirely, which is exactly the gap Property 4
+// closes.
+type childBuilt struct {
+	logger    log.CtxLogger
+	persister *connector.Persister
+	store     *connector.Store
+	instance  *connector.Instance
+	upstream  *upstreamStore
+	plugin    *chaosPlugin
+	src       *connector.Source
+}
+
+// buildChild opens (or creates) the badger DB at cfg.dbDir and the
+// upstreamStore at cfg.upstreamDir, then constructs a real *connector.Source
+// around an in-process chaosPlugin configured per cfg - the exact
+// construction runChild used inline before this refactor. Every error here is
+// a test-harness misconfiguration (bad dirs, unexpected connector type), not
+// a scenario under test, mirroring the exitBadArgs treatment the inline code
+// gave each of these failures.
+func buildChild(ctx context.Context, cfg childEnv) (*childBuilt, error) {
+	logger := log.New(zerolog.Nop()) // keep stdout clean; it is our progress-line channel
+
+	db, err := badger.New(zerolog.Nop(), cfg.dbDir)
+	if err != nil {
+		return nil, fmt.Errorf("open badger db: %w", err)
+	}
+
+	persister := connector.NewPersister(logger, db, connector.DefaultPersisterDelayThreshold, connector.DefaultPersisterBundleCountThreshold)
+	store := connector.NewStore(db, logger)
+
+	instance := loadOrCreateInstance(ctx, store)
+	instance.Init(logger, persister)
+
+	upstream, err := openUpstreamStore(cfg.upstreamDir, cfg.prune)
+	if err != nil {
+		return nil, err
+	}
+	plugin := &chaosPlugin{
+		store:          upstream,
+		total:          cfg.total,
+		paceMS:         cfg.paceMS,
+		snapshotK:      cfg.snapshotK,
+		snapshotPaceMS: cfg.snapshotPaceMS,
+		numKeys:        cfg.numKeys,
+		driftAt:        cfg.driftAt,
+	}
+
+	fetcher := staticFetcher{instance.Plugin: staticDispenser{source: plugin}}
+	c, err := instance.Connector(ctx, fetcher)
+	if err != nil {
+		return nil, fmt.Errorf("build connector: %w", err)
+	}
+	src, ok := c.(*connector.Source)
+	if !ok {
+		return nil, fmt.Errorf("unexpected connector type %T", c)
+	}
+
+	return &childBuilt{
+		logger:    logger,
+		persister: persister,
+		store:     store,
+		instance:  instance,
+		upstream:  upstream,
+		plugin:    plugin,
+		src:       src,
+	}, nil
+}
+
 // runChild is the entire child-process program: build a real
 // pkg/connector.Source, backed by a real on-disk badger DB (the same
 // production persister backend, via connector.NewPersister) and the
@@ -259,46 +374,17 @@ func runChild() {
 	ctx := context.Background()
 	cfg := parseChildEnv()
 
-	logger := log.New(zerolog.Nop()) // keep stdout clean; it is our progress-line channel
-
-	db, err := badger.New(zerolog.Nop(), cfg.dbDir)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s: open badger db: %v\n", markerFatal, err)
-		os.Exit(exitBadArgs)
-	}
-
-	persister := connector.NewPersister(logger, db, connector.DefaultPersisterDelayThreshold, connector.DefaultPersisterBundleCountThreshold)
-	store := connector.NewStore(db, logger)
-
-	instance := loadOrCreateInstance(ctx, store)
-	instance.Init(logger, persister)
-	printResumePosition(instance)
-
-	upstream, err := openUpstreamStore(cfg.upstreamDir, cfg.prune)
+	built, err := buildChild(ctx, cfg)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s: %v\n", markerFatal, err)
 		os.Exit(exitBadArgs)
 	}
-	plugin := &chaosPlugin{
-		store:          upstream,
-		total:          cfg.total,
-		paceMS:         cfg.paceMS,
-		snapshotK:      cfg.snapshotK,
-		snapshotPaceMS: cfg.snapshotPaceMS,
-		numKeys:        cfg.numKeys,
-	}
+	printResumePosition(built.instance)
 
-	fetcher := staticFetcher{instance.Plugin: staticDispenser{source: plugin}}
-	c, err := instance.Connector(ctx, fetcher)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s: build connector: %v\n", markerFatal, err)
-		os.Exit(exitBadArgs)
-	}
-	src, ok := c.(*connector.Source)
-	if !ok {
-		fmt.Fprintf(os.Stderr, "%s: unexpected connector type %T\n", markerFatal, c)
-		os.Exit(exitBadArgs)
-	}
+	src := built.src
+	persister := built.persister
+	upstream := built.upstream
+	plugin := built.plugin
 
 	if err := src.Open(ctx); err != nil {
 		if containsGapMarker(err) {
@@ -353,6 +439,180 @@ func runChild() {
 
 	fmt.Println(markerDone)
 	os.Exit(exitOK)
+}
+
+// runChildSigterm is runChild's counterpart for the SIGTERM/invariant-7 case
+// (sigterm_test.go). Unlike runChild, it does not run to cfg.total and tear
+// down at the natural end of the run - it runs the read/ack loop
+// indefinitely in the background and waits for a SIGTERM, then drives
+// Source.Teardown's flush-and-wait-then-stopStream ordering
+// (source.go:249-326) explicitly: invariant 7 requires that the ack deferred
+// at the moment the signal lands is actually SENT to the plugin (and, per
+// Ack's own invariant 1, only sent once the resulting position is durably
+// flushed) before the stream is torn down - the graceful-path complement to
+// sigkill_test.go's/property2_test.go's SIGKILL cases, which instead prove
+// "eventually safe after a restart".
+//
+// Prints markerSigtermDone (never markerDone, which means "reached cfg.total
+// and tore down normally") once Teardown has confirmed the deferred ack was
+// drained, so the parent test can tell this exit apart from both a normal
+// completed run and a crash.
+func runChildSigterm() {
+	ctx := context.Background()
+	cfg := parseChildEnv()
+
+	built, err := buildChild(ctx, cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %v\n", markerFatal, err)
+		os.Exit(exitBadArgs)
+	}
+	printResumePosition(built.instance)
+
+	src := built.src
+	if err := src.Open(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "%s: source open failed: %v\n", markerFatal, err)
+		os.Exit(exitOpenOtherError)
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM)
+
+	// stopping + processingMu mirror funnel.Worker.Stop's own
+	// stop-flag-plus-processingLock discipline (worker.go's Stop and doTask):
+	// Source.Teardown's own doc comment explicitly relies on "no new Ack call
+	// can start once a Teardown has begun" being guaranteed by the CALLER,
+	// not by Teardown itself. In production that guarantee comes from
+	// funnel.Worker's processingLock; this child has no funnel.Worker (see
+	// property4_test.go's package doc for why Property 4 is the one that
+	// needs a real Worker - this SIGTERM case does not), so it must
+	// reconstruct the same discipline directly: processingMu is held for
+	// exactly one Read+Ack cycle at a time, and the signal handler
+	// synchronizes on it before calling Teardown, guaranteeing no cycle is
+	// in flight (and none will start) once Teardown begins. Without this,
+	// a late Ack racing Teardown's own forced flush could register a
+	// position that never gets flushed before the process exits - not a
+	// bug in Source.Teardown, but exactly the caller-side race its doc
+	// comment warns about.
+	var stopping atomic.Bool
+	var processingMu sync.Mutex
+	readLoopDone := make(chan struct{})
+	go func() {
+		defer close(readLoopDone)
+		for {
+			processingMu.Lock()
+			if stopping.Load() {
+				processingMu.Unlock()
+				return
+			}
+
+			recs, err := src.Read(ctx)
+			if err != nil {
+				processingMu.Unlock()
+				if stopping.Load() {
+					return // expected: Teardown's stopStream unblocked this Read
+				}
+				fmt.Fprintf(os.Stderr, "%s: read failed: %v\n", markerFatal, err)
+				os.Exit(exitOpenOtherError)
+			}
+
+			positions := make([]opencdc.Position, len(recs))
+			for i, r := range recs {
+				positions[i] = r.Position
+			}
+			ackErr := src.Ack(ctx, positions)
+			processingMu.Unlock()
+			if ackErr != nil {
+				if stopping.Load() {
+					return // expected: the stream closed while Teardown was tearing it down
+				}
+				fmt.Fprintf(os.Stderr, "%s: ack failed: %v\n", markerFatal, ackErr)
+				os.Exit(exitOpenOtherError)
+			}
+		}
+	}()
+
+	<-sigCh
+	stopping.Store(true)
+	// Block until no Read+Ack cycle is in flight (see the goroutine's own
+	// comment above) - after this returns, the reader goroutine is
+	// guaranteed to observe stopping==true and exit without starting
+	// another cycle, so no Ack can race what follows.
+	processingMu.Lock()
+	processingMu.Unlock() //nolint:staticcheck // deliberate lock/unlock handshake, not a no-op - see comment above
+
+	// Invariant 7, the property this entire case exists to pin: Teardown
+	// forces the pending flush and waits (bounded) for its resulting
+	// deferred ack to actually be SENT to the plugin - which, per Ack's own
+	// invariant-1 ordering, only happens once that flush's write is durably
+	// confirmed - BEFORE stopping the stream (source.go:249-326). Only once
+	// this returns is it safe to treat whatever was in flight at signal-time
+	// as drained, not dropped.
+	if err := src.Teardown(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "%s: teardown failed: %v\n", markerFatal, err)
+		os.Exit(exitOpenOtherError)
+	}
+	<-readLoopDone
+
+	built.persister.WaitPendingWrites() // belt-and-suspenders; Teardown's own wait already covers this (see its doc comment)
+
+	// Teardown's (and WaitPendingWrites') guarantee only reaches as far as
+	// "the deferred ack was HANDED OFF to the plugin" (stream.Send
+	// rendezvous with chaosPlugin.ackLoop's Recv) - exactly like
+	// runReadAckLoop's own tail comment explains, it does not wait for
+	// ackLoop's subsequent side effect (upstreamStore.Commit) to finish.
+	// Without this wait, this process could exit while that commit is still
+	// in flight, making the parent test observe a stale upstream watermark
+	// that has nothing to do with whether Teardown actually drained the
+	// deferred ack - see waitForUpstreamAtLeast.
+	finalPos := readPersistedPosition(ctx, built.store)
+	if !waitForUpstreamAtLeast(built.upstream, finalPos, 5*time.Second) {
+		fmt.Fprintf(os.Stderr, "%s: timed out waiting for upstream to catch up to persisted position %d\n", markerFatal, finalPos)
+		os.Exit(exitOpenOtherError)
+	}
+
+	fmt.Println(markerSigtermDone)
+	os.Exit(exitOK)
+}
+
+// readPersistedPosition reads Conduit's own durably-persisted resume
+// position directly from the store (a fresh round-trip through
+// connector.Store.Get/decode, not the in-memory Instance this process
+// already holds), mirroring printResumePosition's own durability check.
+// Returns 0 if nothing has been acked/persisted yet.
+func readPersistedPosition(ctx context.Context, store *connector.Store) uint64 {
+	instance, err := store.Get(ctx, instanceID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: read persisted position: %v\n", markerFatal, err)
+		os.Exit(exitOpenOtherError)
+	}
+	state, ok := instance.State.(connector.SourceState)
+	if !ok {
+		return 0
+	}
+	pos, err := decodePosition(state.Position)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: decode persisted position: %v\n", markerFatal, err)
+		os.Exit(exitOpenOtherError)
+	}
+	return pos
+}
+
+// waitForUpstreamAtLeast blocks (polling) until the upstream store reports at
+// least target positions committed, or returns false once timeout has
+// elapsed. See runChildSigterm's call site for why this - not just
+// Persister.WaitPendingWrites - is needed to bridge the "handed off to the
+// plugin" vs. "the plugin's side effect actually landed" gap.
+func waitForUpstreamAtLeast(upstream *upstreamStore, target uint64, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		committed, err := upstream.Committed()
+		if err == nil && committed >= target {
+			return true
+		}
+		time.Sleep(time.Millisecond)
+	}
+	committed, err := upstream.Committed()
+	return err == nil && committed >= target
 }
 
 // waitForUpstreamCommitted blocks briefly until the upstream store reports

--- a/tests/chaos/doc.go
+++ b/tests/chaos/doc.go
@@ -45,10 +45,41 @@
 //     plugin in strict Source.Ack call order, one Ack-call at a time, via a
 //     real per-key delivery ledger (not just a max-position counter).
 //
-// Property 4 (schema-drift transport half, requiring a real funnel.Worker +
-// DLQ + destination the harness doesn't yet have) and the SIGTERM/Teardown
-// graceful-shutdown case are out of scope for Phase 1a — see the design
-// doc's Rollout section for their own phase.
+// DBZ-2 Phase 1b (per DeVaris's sign-off, 2026-07-26, PR #2692) adds the two
+// cases Phase 1a deferred — both pulled forward because the AI-pipeline
+// record-path work depends on the engine-side no-silent-drop gate:
+//
+//   - Property 4 transport half (property4_test.go, invariant 6): the one
+//     property in this package that is not near-verbatim harness reuse. The
+//     direct child.go read/ack loop (runReadAckLoop) deliberately bypasses
+//     the funnel, DLQ, and any destination by calling src.Read/src.Ack
+//     directly — so there was previously no routing path in this package to
+//     assert invariant 6 against. property4_test.go stands up a real
+//     pkg/lifecycle-poc/funnel.Worker (SourceTask wrapping the same real
+//     *connector.Source Properties 1-3 use, via buildChild) with a small
+//     transport-level drift-detection Task and a synthetic destination
+//     behind a real funnel.DLQ, and drives a record carrying chaosPlugin's
+//     synthetic drift/poison marker (metadataDriftKey, upstream.go) through
+//     it under two funnel.DLQ configurations: always-route (the "DLQ"
+//     policy) and never-route (the "halt" policy, DLQ effectively disabled —
+//     see newFunnelHarness's doc for the exact dlqWindow semantics that
+//     produce each). It is deliberately NOT a crash-safety scenario (no
+//     SIGKILL, no cross-process re-exec) — it is a routing/ack/position
+//     correctness property. Per the design doc's Q1 boundary, this is a
+//     transport-level marker check, never a real schema/DDL engine; real
+//     drift-policy application against a real database is DBZ-3's job.
+//   - SIGTERM/invariant-7 (sigterm_test.go): the graceful-path complement to
+//     Property 2's SIGKILL cases. It mirrors the cross-process child pattern
+//     (runChildSigterm, child.go) but sends SIGTERM instead of SIGKILL,
+//     asserting Source.Teardown's flush-and-wait-then-stopStream ordering
+//     (source.go:249-326) actually drains the ack that was still deferred at
+//     the moment the signal landed — no restart required, unlike the SIGKILL
+//     cases' "eventually safe after a restart" guarantee. Because
+//     runChildSigterm has no funnel.Worker serializing its read/ack loop
+//     against Teardown, it reconstructs that same discipline directly
+//     (processingMu, mirroring worker.go's processingLock) — see its doc
+//     comment for why Source.Teardown's own doc explicitly delegates that
+//     guarantee to the caller.
 //
 // # What this package tests, and why the real Debezium wrapper isn't here
 //

--- a/tests/chaos/harness.go
+++ b/tests/chaos/harness.go
@@ -51,6 +51,22 @@ type childConfig struct {
 	// doc, upstream.go). Zero/one preserves DBZ-1's original,
 	// single-position-space behavior.
 	numKeys int
+
+	// driftAt: Property 4's synthetic drift/poison-marker knob (see
+	// chaosPlugin.driftAt's field doc, upstream.go). Zero preserves every
+	// existing scenario's behavior unchanged - no record in the run carries
+	// the marker. Property 4 itself (property4_test.go) drives this
+	// in-process via buildChild directly, not through this cross-process
+	// config; this field exists so the knob is available end-to-end for
+	// symmetry/parity with the rest of childConfig, and so a future
+	// cross-process drift scenario doesn't need new plumbing.
+	driftAt uint64
+
+	// sigtermMode: DBZ-2's SIGTERM/invariant-7 knob (see runChildSigterm,
+	// child.go, and sigterm_test.go). false preserves every existing
+	// scenario's behavior unchanged - the child runs runChild, not
+	// runChildSigterm.
+	sigtermMode bool
 }
 
 func (c childConfig) env() []string {
@@ -64,6 +80,8 @@ func (c childConfig) env() []string {
 		envSnapshotK + "=" + strconv.FormatUint(c.snapshotK, 10),
 		envSnapshotPaceMS + "=" + strconv.Itoa(c.snapshotPaceMS),
 		envNumKeys + "=" + strconv.Itoa(c.numKeys),
+		envDriftAt + "=" + strconv.FormatUint(c.driftAt, 10),
+		envSigtermMode + "=" + strconv.FormatBool(c.sigtermMode),
 	}
 }
 
@@ -303,6 +321,23 @@ func (c *childProcess) sigkill(t *testing.T) {
 	}
 	_ = c.reap() // a "signal: killed" wait error is expected here, not a failure
 	<-c.readerDone
+}
+
+// sigterm sends SIGTERM (not SIGKILL) and waits (via waitExit) for the child
+// to exit gracefully on its own within timeout. Used by the SIGTERM/
+// invariant-7 case (sigterm_test.go): unlike sigkill (which expects and
+// tolerates a "signal: killed" wait error - see its doc comment), this
+// expects the child to catch SIGTERM, run Source.Teardown's
+// flush-and-wait-then-stopStream ordering (source.go:249-326, runChildSigterm
+// in child.go), and exit cleanly with code 0 - a graceful shutdown, not a
+// crash. waitExit already fails the test on a nonzero exit code or a timeout,
+// so a child that doesn't handle SIGTERM cleanly fails loudly here.
+func (c *childProcess) sigterm(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	if err := c.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("SIGTERM child (pid %d): %v", c.cmd.Process.Pid, err)
+	}
+	c.waitExit(t, timeout)
 }
 
 // waitExit blocks until the child exits on its own (the "let it run to

--- a/tests/chaos/property4_test.go
+++ b/tests/chaos/property4_test.go
@@ -1,0 +1,438 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chaos
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/connector"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/foundation/metrics/noop"
+	"github.com/conduitio/conduit/pkg/lifecycle-poc/funnel"
+	"github.com/matryer/is"
+)
+
+// Property 4 (docs/design-documents/20260726-dbz2-cdc-correctness-suite.md,
+// Property 4 section) is DBZ-2's transport-half no-silent-drop gate
+// (invariant 6). Unlike Properties 1-3, it is NOT a crash-safety scenario -
+// it is a routing/ack/position correctness property, so it needs no
+// SIGKILL and no cross-process re-exec. What it DOES need, and what the
+// existing harness has never had, is a real funnel.Worker (pkg/lifecycle-poc/
+// funnel) plus a synthetic destination and a real funnel.DLQ - the direct
+// child.go read/ack loop (runReadAckLoop) deliberately bypasses all three
+// (see doc.go), so there was previously no routing path to assert invariant
+// 6 against at all.
+//
+// This file builds that path in-process: a REAL *connector.Source (via
+// buildChild - byte-for-byte the same construction runChild uses for
+// Properties 1-3) is wrapped in a REAL funnel.Worker, with a small
+// transport-level drift-detection Task (driftDetectTask) between the source
+// and a synthetic main destination, and its own synthetic destination behind
+// a REAL funnel.DLQ. Per the design doc's Q1 boundary, driftDetectTask is
+// NOT a schema engine: it only inspects chaosPlugin's synthetic
+// metadataDriftKey marker (upstream.go) and flags the record as nacked -
+// the actual disposition (routed to DLQ vs. propagated/halted) is decided
+// entirely by funnel.DLQ's real windowNackThreshold semantics, exactly as
+// production DLQ policy would.
+
+// driftDetectTask is Property 4's transport-level policy-ENFORCEMENT POINT -
+// deliberately NOT a schema engine (see this file's package doc and the
+// design doc's explicit Q1 boundary). It inspects each record for
+// chaosPlugin's synthetic drift marker (metadataDriftKey, upstream.go) and
+// marks matching records Nack'd; funnel.Worker's real Nack path
+// (worker.go:507, which calls w.DLQ.Nack then Source.Ack for the
+// successfully-DLQ'd prefix) makes the actual deliver/DLQ/halt decision,
+// driven by how the test configures the DLQ's windowNackThreshold - see
+// newFunnelHarness's doc comment for the two configurations this test uses.
+type driftDetectTask struct {
+	id string
+}
+
+func (t *driftDetectTask) ID() string                  { return t.id }
+func (t *driftDetectTask) Open(context.Context) error  { return nil }
+func (t *driftDetectTask) Close(context.Context) error { return nil }
+
+func (t *driftDetectTask) Do(_ context.Context, b *funnel.Batch) error {
+	for i, r := range b.ActiveRecords() {
+		if _, ok := r.Metadata[metadataDriftKey]; ok {
+			b.Nack(i, fmt.Errorf("chaos: record at position %s carries a synthetic drift/poison marker", r.Position))
+		}
+	}
+	return nil
+}
+
+// synthDestination is Property 4's synthetic in-memory funnel.Destination -
+// standing in for a real sink exactly as chaosPlugin (upstream.go) stands in
+// for a real source plugin. Write appends every written record's position
+// (in order); Ack immediately acks everything written so far, matching
+// DestinationTask.Do's polling contract (destination.go): one Write followed
+// by repeated Ack calls until every position has been acknowledged.
+type synthDestination struct {
+	id string
+
+	mu        sync.Mutex
+	delivered []opencdc.Position
+	pending   []connector.DestinationAck
+}
+
+func (d *synthDestination) ID() string                     { return d.id }
+func (d *synthDestination) Open(context.Context) error     { return nil }
+func (d *synthDestination) Teardown(context.Context) error { return nil }
+func (d *synthDestination) Errors() <-chan error           { return make(chan error) }
+
+func (d *synthDestination) Write(_ context.Context, recs []opencdc.Record) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, r := range recs {
+		d.delivered = append(d.delivered, r.Position)
+		d.pending = append(d.pending, connector.DestinationAck{Position: r.Position})
+	}
+	return nil
+}
+
+func (d *synthDestination) Ack(context.Context) ([]connector.DestinationAck, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	acks := d.pending
+	d.pending = nil
+	return acks, nil
+}
+
+func (d *synthDestination) deliveredCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.delivered)
+}
+
+func (d *synthDestination) hasPosition(pos opencdc.Position) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, p := range d.delivered {
+		if string(p) == string(pos) {
+			return true
+		}
+	}
+	return false
+}
+
+// funnelHarness stands up Property 4's transport-half integration: SourceTask
+// (wrapping a real *connector.Source) -> driftDetectTask -> DestinationTask
+// (mainDest), with a real funnel.DLQ (its own synthDestination, dlqDest)
+// wired into the Worker. See newFunnelHarness for the two DLQ configurations
+// this file uses to select between the DLQ-routing and halt policies.
+type funnelHarness struct {
+	t   *testing.T
+	cfg childEnv
+
+	built    *childBuilt
+	mainDest *synthDestination
+	dlqDest  *synthDestination
+	worker   *funnel.Worker
+
+	doErr chan error
+}
+
+// newFunnelHarness builds the pipeline described above around a real
+// *connector.Source (buildChild - identical construction to runChild's).
+//
+// dlqWindowSize/dlqWindowThreshold select Property 4's two policies, via
+// funnel.DLQ's real dlqWindow semantics (pkg/lifecycle-poc/funnel/dlq.go) -
+// confirmed against that package's own worker_ack_order_test.go comment
+// ("windowSize=0 disables the DLQ nack-threshold window, so every nacked
+// record ... is routed to the DLQ"):
+//
+//   - (0, 0): the window is disabled outright (len(window)==0 short-circuits
+//     dlqWindow.store to unconditionally accept), so the drift record is
+//     ALWAYS routed to the DLQ - Property 4's "DLQ-routing" policy case.
+//   - (1, 0): windowNackThreshold=0 forces the window to size 1 (dlqWindow's
+//     own documented optimization) and the very first nack immediately
+//     exceeds a zero threshold, so dlqWindow.store returns 0 accepted -
+//     nothing is EVER written to the DLQ destination, and the nack's error
+//     propagates immediately as a fatal error. This is Property 4's "halt"
+//     policy case: the DLQ is, in effect, disabled.
+func newFunnelHarness(t *testing.T, driftAt, total uint64, dlqWindowSize, dlqWindowThreshold int) *funnelHarness {
+	t.Helper()
+	is := is.New(t)
+	dir := t.TempDir()
+
+	cfg := childEnv{
+		dbDir:       dir + "/db",
+		upstreamDir: dir + "/upstream",
+		prune:       false, // Property 4 has no crash/resume path of its own - prune-vs-durable is Property 1/2's axis
+		paceMS:      0,     // as fast as possible - this is a routing/ack correctness property, not a timing one
+		total:       total,
+		driftAt:     driftAt,
+	}
+
+	built, err := buildChild(context.Background(), cfg)
+	is.NoErr(err)
+
+	logger := log.Test(t)
+
+	mainDest := &synthDestination{id: "chaos-main-dest"}
+	dlqDest := &synthDestination{id: "chaos-dlq-dest"}
+
+	srcTask := funnel.NewSourceTask("chaos-source-task", built.src, logger, funnel.NoOpConnectorMetrics{})
+	driftTask := &driftDetectTask{id: "chaos-drift-detect"}
+	destTask := funnel.NewDestinationTask("chaos-main-dest-task", mainDest, logger, funnel.NoOpConnectorMetrics{})
+
+	destNode := &funnel.TaskNode{Task: destTask}
+	driftNode := &funnel.TaskNode{Task: driftTask, Next: []*funnel.TaskNode{destNode}}
+	srcNode := &funnel.TaskNode{Task: srcTask, Next: []*funnel.TaskNode{driftNode}}
+
+	dlq := funnel.NewDLQ("chaos-dlq", dlqDest, logger, funnel.NoOpConnectorMetrics{}, dlqWindowSize, dlqWindowThreshold)
+
+	worker, err := funnel.NewWorker(srcNode, dlq, logger, noop.Timer{})
+	is.NoErr(err)
+
+	// worker.Open opens every task in the pipeline, including SourceTask,
+	// which calls built.src.Open internally (funnel/source.go's
+	// SourceTask.Open) - calling src.Open again here directly would hit
+	// Source.Open's own "another instance of the connector is already
+	// running" guard, so this is the only Open call the source gets.
+	is.NoErr(worker.Open(context.Background()))
+
+	h := &funnelHarness{
+		t:        t,
+		cfg:      cfg,
+		built:    built,
+		mainDest: mainDest,
+		dlqDest:  dlqDest,
+		worker:   worker,
+		doErr:    make(chan error, 1),
+	}
+
+	go func() { h.doErr <- worker.Do(context.Background()) }()
+
+	return h
+}
+
+// waitDelivered polls until mainDest+dlqDest have together delivered at
+// least n records, or fails the test after timeout.
+func (h *funnelHarness) waitDelivered(t *testing.T, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if h.mainDest.deliveredCount()+h.dlqDest.deliveredCount() >= n {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf(
+		"timed out waiting for %d records delivered (main=%d, dlq=%d)",
+		n, h.mainDest.deliveredCount(), h.dlqDest.deliveredCount(),
+	)
+}
+
+// stopGracefully stops the worker (draining any in-flight batch, tearing
+// down the source) and waits for the Do goroutine to return, asserting it
+// returned cleanly (no error) - used by the DLQ-routing case, which is
+// expected to complete every record without ever halting.
+func (h *funnelHarness) stopGracefully(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	is := is.New(t)
+	is.NoErr(h.worker.Stop(context.Background()))
+	select {
+	case err := <-h.doErr:
+		is.NoErr(err)
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for worker.Do to return after Stop")
+	}
+	is.NoErr(h.worker.Close(context.Background()))
+}
+
+// waitHalted waits for the Do goroutine to return an error (the halt case:
+// doTask propagates the DLQ-disabled Nack's fatal error up through Do without
+// ever calling Stop), then closes the worker so the source is torn down (see
+// worker.go's Close doc: "on a fatal-error path Stop is never called, so this
+// is where the source's resources are released").
+func (h *funnelHarness) waitHalted(t *testing.T, timeout time.Duration) error {
+	t.Helper()
+	is := is.New(t)
+	select {
+	case err := <-h.doErr:
+		is.NoErr(h.worker.Close(context.Background()))
+		return err
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for worker.Do to halt")
+		return nil // unreachable
+	}
+}
+
+// persistedPosition reads Conduit's own durably-persisted resume position
+// directly from the store (not the in-memory Instance the harness already
+// holds), the same round-trip through connector.Store.Get/decode every other
+// scenario in this suite uses to confirm durability, not just in-memory
+// state.
+func (h *funnelHarness) persistedPosition(t *testing.T) uint64 {
+	t.Helper()
+	is := is.New(t)
+	instance, err := h.built.store.Get(context.Background(), instanceID)
+	is.NoErr(err)
+	state, ok := instance.State.(connector.SourceState)
+	if !ok {
+		return 0 // never acked anything yet
+	}
+	pos, err := decodePosition(state.Position)
+	is.NoErr(err)
+	return pos
+}
+
+// redeliverAfterRestart models a genuine process restart in-process: it
+// reloads the connector.Instance FRESH from the same on-disk store (the same
+// durability round-trip a brand-new process's loadOrCreateInstance would
+// make - see child.go) and builds a brand-new *connector.Source around a
+// brand-new chaosPlugin (standing in for the reconnected upstream, exactly
+// as chaosPlugin already stands in for a real source plugin elsewhere in
+// this suite), reusing the same badger DB/persister/upstreamStore (a single
+// OS process never needs to reacquire the badger directory lock, unlike the
+// cross-process SIGKILL cases). It returns the very first record the
+// restarted source reads - proving at-least-once redelivery of whatever
+// Conduit's persisted position says comes next, without needing a real
+// SIGKILL/re-exec cycle (Property 4 is a routing/ack property, not a
+// crash-safety one - see this file's package doc).
+func (h *funnelHarness) redeliverAfterRestart(t *testing.T) opencdc.Record {
+	t.Helper()
+	is := is.New(t)
+	ctx := context.Background()
+
+	instance2 := loadOrCreateInstance(ctx, h.built.store)
+	instance2.Init(h.built.logger, h.built.persister)
+
+	plugin2 := &chaosPlugin{
+		store:   h.built.upstream,
+		total:   h.cfg.total,
+		paceMS:  0,
+		driftAt: h.cfg.driftAt,
+	}
+	fetcher2 := staticFetcher{instance2.Plugin: staticDispenser{source: plugin2}}
+	c2, err := instance2.Connector(ctx, fetcher2)
+	is.NoErr(err)
+	src2, ok := c2.(*connector.Source)
+	is.True(ok)
+
+	is.NoErr(src2.Open(ctx))
+	t.Cleanup(func() { _ = src2.Teardown(ctx) })
+
+	recs, err := src2.Read(ctx)
+	is.NoErr(err)
+	is.True(len(recs) > 0)
+	return recs[0]
+}
+
+// TestSchemaDrift_TransportHalf_DLQRouting is Property 4's DLQ-routing case
+// (docs/design-documents/20260726-dbz2-cdc-correctness-suite.md, Property 4
+// section). It drives 5 records through the funnel, one of them (position 3)
+// carrying the synthetic drift marker, under a DLQ config that always
+// accepts (see newFunnelHarness's doc). Assertion: the drift record lands in
+// the DLQ's own synthetic destination (never the main one), and Source.Ack
+// IS called for it (it was handled, not silently dropped) - so the final
+// persisted/upstream position reaches every position through total, not just
+// the non-drift ones.
+func TestSchemaDrift_TransportHalf_DLQRouting(t *testing.T) {
+	is := is.New(t)
+
+	const (
+		total   = 5
+		driftAt = 3
+	)
+
+	h := newFunnelHarness(t, driftAt, total, 0, 0) // windowSize=0: DLQ always accepts, see doc
+	h.waitDelivered(t, total, 10*time.Second)
+	h.stopGracefully(t, 10*time.Second)
+
+	// The drift record landed in the DLQ's synthetic destination, never the
+	// main one - routed per policy, never silently coerced through.
+	is.True(h.dlqDest.hasPosition(encodePosition(driftAt)))
+	is.True(!h.mainDest.hasPosition(encodePosition(driftAt)))
+
+	// Every other position went through the main destination undisturbed.
+	for _, pos := range []uint64{1, 2, 4, 5} {
+		if !h.mainDest.hasPosition(encodePosition(pos)) {
+			t.Fatalf("position %d (non-drift) was never delivered to the main destination", pos)
+		}
+	}
+	is.Equal(h.dlqDest.deliveredCount(), 1) // exactly the one drift record, nothing else
+
+	// The core non-silent-drop assertion: the drift record WAS handled (DLQ
+	// routing counts as handled, per the design doc), so it was acked
+	// upstream like everything else - the persisted/upstream position
+	// reaches every position through total, not stopping short at the
+	// drift record.
+	committed, err := h.built.upstream.Committed()
+	is.NoErr(err)
+	is.Equal(committed, uint64(total))
+	is.Equal(h.persistedPosition(t), uint64(total))
+}
+
+// TestSchemaDrift_TransportHalf_Halt_PositionNeverAdvances is Property 4's
+// halt case. The drift record (position 3 of 5) hits a DLQ config that never
+// accepts (windowNackThreshold=0, see newFunnelHarness's doc), so
+// funnel.Worker.Nack propagates a fatal error without ever calling
+// Source.Ack for it - the pipeline halts. Assertion: positions 1-2 (before
+// the drift record) were delivered and acked normally; the drift record and
+// everything after it (3, 4, 5) were NEVER delivered anywhere (not the main
+// destination, not the DLQ); the persisted/upstream position never advances
+// past 2; and a modeled restart (redeliverAfterRestart) redelivers exactly
+// the drift record, never skipping it - at-least-once preserved.
+func TestSchemaDrift_TransportHalf_Halt_PositionNeverAdvances(t *testing.T) {
+	is := is.New(t)
+
+	const (
+		total   = 5
+		driftAt = 3
+	)
+
+	h := newFunnelHarness(t, driftAt, total, 1, 0) // windowSize=1, threshold=0: DLQ disabled, see doc
+	err := h.waitHalted(t, 10*time.Second)
+	is.True(err != nil) // the pipeline halted - Do did not complete all 5 records
+
+	for _, pos := range []uint64{1, 2} {
+		if !h.mainDest.hasPosition(encodePosition(pos)) {
+			t.Fatalf("position %d (before the drift record) should have been delivered normally before the halt", pos)
+		}
+	}
+	for _, pos := range []uint64{driftAt, 4, 5} {
+		if h.mainDest.hasPosition(encodePosition(pos)) || h.dlqDest.hasPosition(encodePosition(pos)) {
+			t.Fatalf(
+				"position %d (the drift record or anything after it) was delivered SOMEWHERE despite the "+
+					"halt - invariant 6 requires it never be silently coerced/delivered once the pipeline "+
+					"has halted on it",
+				pos,
+			)
+		}
+	}
+
+	// The core invariant-6 transport assertion: the persisted/upstream
+	// position must NEVER advance past the last successfully handled record
+	// (2) - the drift record must never be acked upstream "for free" just
+	// because the pipeline gave up on it.
+	committed, err := h.built.upstream.Committed()
+	is.NoErr(err)
+	is.Equal(committed, uint64(2))
+	is.Equal(h.persistedPosition(t), uint64(2)) // Conduit's own persisted resume position agrees
+
+	// At-least-once: a restart must redeliver the unhandled record, not skip
+	// it.
+	redelivered := h.redeliverAfterRestart(t)
+	is.Equal(redelivered.Position, encodePosition(driftAt))
+	_, hasMarker := redelivered.Metadata[metadataDriftKey]
+	is.True(hasMarker) // it's genuinely the SAME poison record, not a coincidentally-numbered one
+}

--- a/tests/chaos/sigkill_test.go
+++ b/tests/chaos/sigkill_test.go
@@ -29,6 +29,9 @@ import (
 // re-exec protocol.
 func TestMain(m *testing.M) {
 	if isChildInvocation() {
+		if os.Getenv(envSigtermMode) == envValueTrue {
+			runChildSigterm() // never returns; always os.Exit's - see sigterm_test.go
+		}
 		runChild() // never returns; always os.Exit's
 	}
 	os.Exit(m.Run())

--- a/tests/chaos/sigterm_test.go
+++ b/tests/chaos/sigterm_test.go
@@ -1,0 +1,167 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chaos
+
+import (
+	"testing"
+	"time"
+
+	"github.com/matryer/is"
+)
+
+// TestSIGTERM_GracefulTeardown_DrainsDeferredAck is DBZ-2's SIGTERM/
+// invariant-7 case (docs/design-documents/20260726-dbz2-cdc-correctness-suite.md,
+// Rollout section and Resolved decision 4). It is the graceful-path
+// complement to Property 2's SIGKILL cases (property2_test.go): instead of
+// asking "did a crash lose the record" (answer: no, but only after a
+// restart, and duplicates are fine), it asks the strictly stronger question
+// a graceful stop must answer: did Source.Teardown's flush-and-wait-then-
+// stopStream ordering (source.go:249-326) actually SEND the ack that was
+// still deferred at the moment the signal landed, before the process ever
+// exited - no restart required at all.
+//
+// Timing mirrors property2_test.go's mid-position-write case exactly
+// (paceMS=15, killAfterReads=95): by read #95 (~1.4s in) one automatic
+// debounce flush has already happened (~1s, around read ~66) and a second
+// debounce window has already started (on the next ack after that flush) but
+// not yet fired - so there is a genuine deferred ack in flight when SIGTERM
+// lands, which is exactly the window invariant 7 protects.
+func TestSIGTERM_GracefulTeardown_DrainsDeferredAck(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+
+	const (
+		paceMS         = 15
+		killAfterReads = 95
+		// total is deliberately unbounded (0): this run terminates via
+		// SIGTERM, never by reaching a target count - see runChildSigterm.
+		total = 0
+	)
+
+	cfg := childConfig{
+		dbDir:       dir + "/db",
+		upstreamDir: dir + "/upstream",
+		prune:       false, // graceful path; prune-vs-durable is irrelevant here (Property 2 already covers that axis)
+		paceMS:      paceMS,
+		total:       total,
+		sigtermMode: true,
+	}
+
+	cp := spawnChild(t, cfg)
+	cp.waitForReadCount(t, killAfterReads, 30*time.Second)
+
+	// Read the upstream's committed watermark BEFORE sending SIGTERM, so we
+	// know exactly how much was durable before the graceful stop forced the
+	// still-pending flush.
+	upstreamBefore, err := openUpstreamStore(cfg.upstreamDir, cfg.prune)
+	is.NoErr(err)
+	committedBefore, err := upstreamBefore.Committed()
+	is.NoErr(err)
+	// The timing (see doc comment) is chosen so a flush has already
+	// happened, but nowhere near killAfterReads worth of positions -
+	// confirming there's genuinely a "deferred and not yet visible upstream"
+	// gap for Teardown to close, not something that had already caught up
+	// on its own.
+	if committedBefore == 0 || committedBefore >= uint64(killAfterReads) {
+		t.Fatalf(
+			"test setup assumption violated: expected 0 < committedBefore(%d) < killAfterReads(%d) - "+
+				"either the persister debounce timing changed, or this case's pacing no longer lands "+
+				"in the intended mid-position-write window\n%s",
+			committedBefore, killAfterReads, cp.diagnostics(),
+		)
+	}
+
+	cp.sigterm(t, 30*time.Second) // graceful: child catches SIGTERM, Teardown drains the deferred ack, exits 0 (waitExit asserts this)
+
+	_, ok := cp.line(markerSigtermDone)
+	if !ok {
+		t.Fatalf("child did not reach its own graceful-shutdown marker (%s) - see diagnostics\n%s", markerSigtermDone, cp.diagnostics())
+	}
+
+	// The core invariant-7 assertion: the ack that was DEFERRED (queued via
+	// Source.Ack, registered with the persister, but not yet confirmed
+	// durable) at the moment SIGTERM landed must have been flushed - not
+	// dropped - by the time the process exited. This is a SPECIFIC,
+	// non-tautological claim: it is not "no error happened", it is "the
+	// upstream watermark advanced past what was already durable before the
+	// signal, all the way to (approximately) the read point" - i.e. nothing
+	// was left "deferred and lost".
+	upstreamAfter, err := openUpstreamStore(cfg.upstreamDir, cfg.prune)
+	is.NoErr(err)
+	committedAfter, err := upstreamAfter.Committed()
+	is.NoErr(err)
+
+	if committedAfter <= committedBefore {
+		t.Fatalf(
+			"SEV-0-CLASS REGRESSION: graceful SIGTERM teardown did not drain the deferred ack - "+
+				"upstream watermark before signal was %d, after graceful teardown still %d "+
+				"(expected it to advance past killAfterReads-ish, %d) - Source.Teardown's "+
+				"flush-and-wait-then-stopStream ordering (source.go:249-326) should make this "+
+				"structurally unreachable; re-verify Teardown before assuming this is safe.\n%s",
+			committedBefore, committedAfter, killAfterReads, cp.diagnostics(),
+		)
+	}
+	// Allow a small margin below killAfterReads: the producer's own pacing
+	// means the very last read(s) before the signal may not have been acked
+	// yet (an Ack call happens strictly after its Read), so the drained
+	// position can be a few short of killAfterReads without indicating any
+	// drop - what matters is that it advanced well past committedBefore,
+	// not that it hit the read count exactly.
+	const slack = 5
+	if committedAfter+slack < uint64(killAfterReads) {
+		t.Fatalf(
+			"graceful SIGTERM teardown drained fewer acks than expected - committed only reached %d, "+
+				"expected within %d of killAfterReads (%d) - the deferred ack pending at signal-time "+
+				"looks like it was NOT fully flushed before the process exited\n%s",
+			committedAfter, slack, killAfterReads, cp.diagnostics(),
+		)
+	}
+
+	// Cross-check against Conduit's own persisted position too (not just the
+	// plugin-side upstream commit): a fresh child pointed at the same
+	// on-disk state must report RESUME_POSITION consistent with what the
+	// upstream says was committed - nothing left un-persisted that the
+	// plugin was already told (upstream) to consider durable. Give it a
+	// small, fast-paced total just past the current watermark so it
+	// completes quickly.
+	third := spawnChild(t, childConfig{
+		dbDir:       cfg.dbDir,
+		upstreamDir: cfg.upstreamDir,
+		prune:       cfg.prune,
+		paceMS:      1,
+		total:       committedAfter + 10,
+	})
+	third.waitExit(t, 30*time.Second)
+
+	resumeLine, ok := third.line("RESUME_POSITION")
+	is.True(ok)
+	resumePos := parseResumePosition(t, resumeLine)
+	is.True(resumePos >= committedBefore) // no gap either way
+	if resumePos < committedAfter-slack {
+		t.Fatalf(
+			"Conduit's own persisted resume position (%d) is suspiciously behind the upstream's "+
+				"committed watermark after the graceful stop (%d) - the deferred ack may have reached "+
+				"the plugin without Conduit's own state write actually landing durably first, which "+
+				"would itself be an invariant-1 violation\n%s",
+			resumePos, committedAfter, third.diagnostics(),
+		)
+	}
+
+	_, corrupt := third.line(markerCorruptPo)
+	is.True(!corrupt) // invariant 2: no torn/corrupted position
+
+	_, done := third.line(markerDone)
+	is.True(done)
+}

--- a/tests/chaos/upstream.go
+++ b/tests/chaos/upstream.go
@@ -178,6 +178,19 @@ type chaosPlugin struct {
 	// tracked by a single watermark).
 	numKeys int
 
+	// driftAt is Property 4's synthetic drift/poison-marker knob (see
+	// docs/design-documents/20260726-dbz2-cdc-correctness-suite.md, Property
+	// 4 section, and property4_test.go). If nonzero, the single-key producer
+	// (produceLoop; Property 4 never uses numKeys>1) marks the record at
+	// exactly this position with metadataDriftKey instead of producing it
+	// normally - a transport-level "explicit schema-change/error flag on a
+	// chaosPlugin record", never a real schema/DDL engine (see the design
+	// doc's Q1 boundary: DBZ-2 core owns only the routing/ack/position
+	// transport guarantee, not real drift detection). driftAt == 0 (the
+	// default) means no record in this run carries the marker - identical to
+	// every existing scenario.
+	driftAt uint64
+
 	mu         sync.Mutex
 	nextToRead uint64 // set by Open, read by the producer goroutine (single-key mode only, see Open)
 
@@ -297,6 +310,14 @@ func (p *chaosPlugin) produceLoop(server pconnector.SourceRunStreamServer, start
 		pos++
 
 		rec := makeRecord(pos)
+		if p.driftAt > 0 && pos == p.driftAt {
+			// Property 4 (docs/design-documents/20260726-dbz2-cdc-correctness-suite.md):
+			// this is the one record in the run carrying the synthetic
+			// drift/poison marker - see the field doc above and
+			// property4_test.go's driftDetectTask, which is the only code
+			// that ever inspects metadataDriftKey.
+			rec = makeDriftRecord(pos)
+		}
 		if err := server.Send(pconnector.SourceRunResponse{Records: []opencdc.Record{rec}}); err != nil {
 			return // stream closed (process exiting, or Teardown ran)
 		}
@@ -446,6 +467,33 @@ func makeRecord(pos uint64) opencdc.Record {
 
 func encodePosition(pos uint64) opencdc.Position {
 	return opencdc.Position(strconv.FormatUint(pos, 10))
+}
+
+// metadataDriftKey is Property 4's synthetic transport-level drift/poison
+// marker (see chaosPlugin.driftAt's field doc and property4_test.go's
+// driftDetectTask, the only reader of this key). It is deliberately just a
+// metadata flag - never a real schema encoding - per the design doc's Q1
+// boundary: DBZ-2 core never fakes a schema engine, it only routes on an
+// explicit marker.
+const metadataDriftKey = "chaos.drift"
+
+// metadataDriftValue is the value stored under metadataDriftKey - its
+// content is never inspected, only its presence (see driftDetectTask), so
+// any non-empty string would do; named as its own constant (rather than an
+// inline literal) purely to keep goconst happy alongside envValueTrue's
+// unrelated "true" (child.go).
+const metadataDriftValue = "true"
+
+// makeDriftRecord is makeRecord plus Property 4's synthetic drift/poison
+// marker. Everything else about the record (position, key, payload) is
+// unchanged, so the same deterministic-payload trick (makeRecord's doc)
+// still applies - only the disposition differs, decided entirely by
+// property4_test.go's driftDetectTask + funnel.DLQ policy, never by this
+// plugin.
+func makeDriftRecord(pos uint64) opencdc.Record {
+	rec := makeRecord(pos)
+	rec.Metadata[metadataDriftKey] = metadataDriftValue
+	return rec
 }
 
 // decodePosition returns 0 for a nil/empty position (Conduit's Source.Open


### PR DESCRIPTION
## What

DBZ-2 **Phase 1b** — completes the DBZ-2 engine-side core: **Property 4 (invariant-6 transport half)** and the **SIGTERM/invariant-7** case (design doc `docs/design-documents/20260726-dbz2-cdc-correctness-suite.md`, merged #2692; builds on Phase 1a #2693). v0.20 WS6.

## Property 4 — invariant-6 transport half (never silently mangled)

The chaos harness previously acked directly, bypassing all routing. This stands up a **real** funnel pipeline in-process: `SourceTask` (wrapping a real `*connector.Source`, identical construction to Phase-1a) → `driftDetectTask` → `DestinationTask` (synthetic destination), with a **real `funnel.DLQ`**. Per the design's Q1 boundary, `driftDetectTask` is **not a schema engine** — it only marks `chaosPlugin`'s synthetic drift marker `Nack`'d; the real DLQ `windowNackThreshold` makes the deliver/DLQ/halt decision, exactly as production policy would.

- **DLQ-routing** (window disabled): the drift record lands in the DLQ destination (never the main), is acked upstream (handled, not dropped); `committed` reaches `total`.
- **Halt** (DLQ disabled): the pipeline halts on the drift record; positions before it are delivered/acked; the drift record and everything after are delivered **nowhere**; the upstream **and** Conduit's own persisted position **never advance past the last handled record**; a modeled restart **redelivers exactly the drift record** (at-least-once preserved).

## SIGTERM / invariant-7

Graceful `Teardown` must drain the deferred ack before `stopStream` (`source.go:249-326`). Lands in the mid-position-write window (a real deferred ack in flight when the signal arrives), asserts the upstream watermark advances past what was durable before the signal (deferred ack **flushed, not dropped**), and cross-checks Conduit's own persisted position against the upstream watermark (catching an invariant-1 violation).

## Verified non-tautological (perturbation proof)

Breaking drift-detection (making it never fire → drift record silently passes through) makes **both P4 tests fail** — the halt test times out waiting for a halt that no longer happens. Reverted (zero net diff) → green. The SIGTERM assertion (`committedAfter > committedBefore`, an explicit SEV-0-class failure otherwise) was verified by review. The P4 halt assertion (`committed==2`-not-`total`, position never advances, exact drift record redelivered) is manifestly specific.

## Verification (in-process — real funnel + DLQ + synthetic destination, no docker)

`go test -race -count=3 -shuffle=on ./tests/chaos/...` → **57 passed** (48 from Phase 1a + 9 new subtests), zero races, single uncontended run. `go build`/`go vet` clean; repo-pinned `golangci-lint` → 0 issues. DBZ-1's `sigkill_test.go` + Phase-1a tests unaffected (new capabilities opt-in via zero-valued fields; the SIGTERM child dispatches only via an env flag).

## Scope / status

This completes **DBZ-2 Phase 1** (Properties 1–4 + SIGTERM). The definition-of-done that unblocks DBZ-3 (Properties 1+2+3) was already met by #2693; this adds the invariant-6 transport gate the AI-pipeline record work depends on. Real DDL reconstruction/policy remains deferred to DBZ-3 against a real DB, per the design boundary.

## Risk tier

Tier-1-adjacent test infrastructure (tests engine behavior, doesn't change it). Gated by the required `tests/chaos (race, x3)` check. Adversarial self-review: real funnel/DLQ (not fakes), honest Q1 boundary (drift-detect is not a schema engine), assertions specific + perturbation-proven.

Design: #2692 · Phase 1a: #2693

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD