### PR TITLE
test(connector): de-flake the Teardown deferred-ack regression tests

### DIFF
--- a/pkg/connector/source_test.go
+++ b/pkg/connector/source_test.go
@@ -394,14 +394,30 @@ func TestSource_Teardown_SendsPendingDeferredAckBeforeReturning(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 
-	// A long delay threshold and high bundle-count threshold mean the ack
-	// below would NOT be auto-flushed for the lifetime of this test - the
-	// only thing that can flush it is Teardown's own forced Flush call.
+	// This test proves invariant 7 (Teardown drains the deferred ack before
+	// returning) DETERMINISTICALLY, without racing a receiver goroutine's
+	// scheduling against a non-blocking check. It does so by gating the flush -
+	// the only thing that sends the deferred ack - on a blockingDB the test
+	// controls: while the flush is blocked, Teardown must NOT return and the ack
+	// must NOT be sent; only once the flush is unblocked does the ack go out and
+	// Teardown return. A regression that let Teardown return WITHOUT waiting for
+	// the flush would return (or let the async flush send the ack) while the
+	// flush is still blocked here, tripping one of the "still blocked" asserts -
+	// which a naive bounded-wait-after-Teardown check would instead silently
+	// mask, since the async flush would deliver the ack a few microseconds late.
 	logger := log.Nop()
-	db := &inmemory.DB{}
+	unblock := make(chan struct{})
+	db := &blockingDB{DB: &inmemory.DB{}, unblock: unblock}
+	// A long delay threshold and high bundle-count threshold mean the ack below
+	// is never auto-flushed - the only flush is Teardown's own forced Flush
+	// call, which blockingDB gates on `unblock`.
 	persister := NewPersister(logger, db, time.Hour, 100)
 
 	src, sourceMock := newTestSourceWithPersister(ctx, t, ctrl, persister)
+	// Generous flush timeout so the bounded-wait fallback (the stuck-flush path,
+	// covered by TestSource_Teardown_BoundedWaitOnStuckFlush) never fires here -
+	// we unblock the flush well within it, exercising the wait-then-succeed path.
+	src.teardownFlushTimeout = 10 * time.Second
 	stream := expectSourceOpen(src, sourceMock)
 	sourceMock.EXPECT().LifecycleOnCreated(
 		gomock.Any(),
@@ -414,23 +430,43 @@ func TestSource_Teardown_SendsPendingDeferredAckBeforeReturning(t *testing.T) {
 	is.NoErr(src.Ack(ctx, []opencdc.Position{opencdc.Position("final-pos")}))
 
 	serverStream := stream.Server()
-	recvDone := make(chan opencdc.Position)
+	recvDone := make(chan opencdc.Position, 1)
 	go func() {
 		resp, err := serverStream.Recv()
 		is.NoErr(err)
 		recvDone <- resp.AckPositions[0]
 	}()
 
-	is.NoErr(src.Teardown(ctx))
+	teardownErr := make(chan error, 1)
+	go func() { teardownErr <- src.Teardown(ctx) }()
 
-	// Teardown already returned by this point - the ack must already have
-	// been delivered, not merely "eventually" delivered on some later,
-	// unrelated event.
+	// While the flush is stuck, Teardown must be blocked waiting for it, and the
+	// ack must not have been sent. This is the deterministic anti-regression
+	// assertion: Teardown genuinely WAITS for the drain.
+	select {
+	case err := <-teardownErr:
+		t.Fatalf("Teardown returned before the deferred-ack flush completed (err=%v) - it did not wait to drain the ack", err)
+	case pos := <-recvDone:
+		t.Fatalf("deferred ack (%s) was sent before the flush was even allowed to complete - it bypassed the persister", pos)
+	case <-time.After(200 * time.Millisecond):
+		// Correct: Teardown is blocked waiting for the (still-stuck) flush.
+	}
+
+	// Let the flush complete: onPersistFlushed drains the pending ack and sends
+	// it, WaitPendingWritesContext returns, Teardown returns.
+	close(unblock)
+
 	select {
 	case pos := <-recvDone:
-		is.Equal(pos, opencdc.Position("final-pos"))
-	default:
-		t.Fatal("Teardown returned without the pending deferred ack having been sent")
+		is.Equal(pos, opencdc.Position("final-pos")) // the deferred ack was delivered by the flush Teardown waited for
+	case <-time.After(5 * time.Second):
+		t.Fatal("deferred ack was never delivered after the flush completed")
+	}
+	select {
+	case err := <-teardownErr:
+		is.NoErr(err) // Teardown returned cleanly, after the ack went out
+	case <-time.After(5 * time.Second):
+		t.Fatal("Teardown did not return after the flush completed")
 	}
 }
 
@@ -575,15 +611,20 @@ func TestSource_Teardown_FastFlushCompletesWithinBoundedTimeout(t *testing.T) {
 
 	is.NoErr(src.Teardown(ctx))
 
-	// Teardown already returned by this point - the ack must already have
-	// been delivered (same invariant-7 property as
-	// TestSource_Teardown_SendsPendingDeferredAckBeforeReturning), not
-	// merely "eventually" delivered on some later, unrelated event.
+	// The deferred ack must be delivered. A bounded wait (not a non-blocking
+	// check) accommodates the receiver goroutine's scheduling without flaking;
+	// nothing else in this test sends this ack (delayThreshold=time.Hour,
+	// bundleCountThreshold=100, so no auto-flush), so its arrival proves
+	// Teardown's forced flush delivered it. The strictly-before-return
+	// invariant-7 guarantee is proven deterministically by
+	// TestSource_Teardown_SendsPendingDeferredAckBeforeReturning; this case's
+	// distinct job is that the SHORT teardownFlushTimeout did not falsely
+	// truncate a healthy fast flush (asserted by the no-timeout-log check below).
 	select {
 	case pos := <-recvDone:
 		is.Equal(pos, opencdc.Position("fast-pos"))
-	default:
-		t.Fatal("Teardown returned without the pending deferred ack having been sent")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Teardown returned without the pending deferred ack ever being sent")
 	}
 
 	is.True(!strings.Contains(logBuf.String(), "timed out waiting"))
@@ -634,7 +675,8 @@ func newTestSourceWithPersister(ctx context.Context, t testing.TB, ctrl *gomock.
 func expectSourceOpen(src *Source, sourceMock *mock.SourcePlugin) *builtin.InMemorySourceRunStream {
 	stream := &builtin.InMemorySourceRunStream{}
 
-	sourceMock.EXPECT().Configure(gomock.Any(),
+	sourceMock.EXPECT().Configure(
+		gomock.Any(),
 		pconnector.SourceConfigureRequest{
 			Config: src.Instance.Config.Settings,
 		},


### PR DESCRIPTION
## What

De-flakes the two #2680 sev-0 regression tests in `pkg/connector` — `TestSource_Teardown_SendsPendingDeferredAckBeforeReturning` and `TestSource_Teardown_FastFlushCompletesWithinBoundedTimeout`. They flake in CI (pass locally), intermittently reddening the `test` job on unrelated PRs (surfaced on #2694).

## Root cause — a test-side goroutine race, not an engine bug

Each test spawns a receiver goroutine (`stream.Recv()` → chan) and then checks the chan with a **non-blocking `select`/`default`** immediately after `Teardown` returns. Even when `Teardown` correctly sent the deferred ack before returning, the receiver goroutine may not have been scheduled yet when the `default` branch fires → false failure. CI's slower, contended scheduling loses that race; local runs win it.

## Fix — without masking the regression these guard

A naive bounded wait would **mask** the exact regression these tests exist to catch: with `delayThreshold=time.Hour`, a regression where `Teardown` returns *without* waiting for the flush would let the async flush deliver the ack a few microseconds late — a bounded wait would still receive it and pass.

So `SendsPendingDeferredAckBeforeReturning` is made **deterministic** via the existing `blockingDB`: while the flush (the only thing that sends the ack) is blocked, assert `Teardown` has **not** returned and the ack has **not** been sent; unblock, then assert both complete. `FastFlush` keeps its fast-path/no-false-timeout job with a bounded wait for the receiver goroutine — the strict before-return guarantee is now owned deterministically by the test above.

## Verified

- **Perturbation proof:** removing `Teardown`'s `WaitPendingWritesContext` (the flush-wait) makes the deterministic test **fail** ("did not wait to drain the ack") — proving it catches the regression a bounded wait would mask. Reverted, green.
- **Stress:** `go test -race -count=100` on all three Teardown tests → **300 passed**.
- Test-only; no engine change. `blockingDB` (already in the file) reused.

## Risk tier

Tier 3 (test-only), but hardens a sev-0 (#2680) regression gate's reliability. No `pkg/connector` production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD