### PR TITLE
feat(plugin): embed Slice-2 slice 1 — external-connector dispenser

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -614,7 +614,7 @@ Author: Meroxa, Inc.
 | `sdk.schema.extract.key.enabled` | bool | true | no | Whether to extract and decode the record key with a schema. |  |
 | `sdk.schema.extract.payload.enabled` | bool | true | no | Whether to extract and decode the record payload with a schema. |  |
 
-## 3. Error codes (81)
+## 3. Error codes (83)
 
 | Reason | gRPC status | Description |
 | --- | --- | --- |
@@ -627,6 +627,8 @@ Author: Meroxa, Inc.
 | `config.field_too_long` | InvalidArgument | config: field too long |
 | `config.id_duplicate` | InvalidArgument | config: id duplicate |
 | `config.parse_error` | InvalidArgument | CodeParseError is raised when a pipeline config document can't be parsed at all (invalid YAML, unrecognized version). It exists for offline consumers (cmd/conduit/internal/validate) that need a stable code for parser failures, which the parser itself returns as plain errors since it has no per-field configPath to attach at that stage. |
+| `connector.external_unreachable` | Unavailable | CodeExternalConnectorUnreachable is raised when an external connector's dialed address (pkg/plugin/connector/external, embed Slice 2) cannot be reached - at registration time (fail fast, never discovered on the first pipeline record) or when the connection is lost. |
+| `connector.external_version_mismatch` | FailedPrecondition | CodeExternalConnectorVersionMismatch is raised when an external connector's dialed address does not implement the pconnector protocol version pkg/plugin/connector/external's Dispenser hard-coded (go-plugin performs no version negotiation on the Reattach path, so this package must verify it explicitly via a Specify round trip). |
 | `connector.instance_not_found` | NotFound | CodeConnectorNotFound is raised when a referenced connector instance cannot be located. |
 | `connector.invalid_type` | InvalidArgument | CodeConnectorInvalidType is raised when a connector type is neither "source" nor "destination". |
 | `connector.plugin_not_found` | NotFound | CodeConnectorPluginNotFound is raised when a referenced connector plugin cannot be located. |

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@
 (6 built-in connectors; full parameters in llms-full.txt)
 
 ## Error codes
-- 81 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
+- 83 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
 
 ## MCP tools
 - Read: deploy, doctor, dry_run, inspect, lint, repair, validate

--- a/pkg/foundation/cerrors/conduiterr/conduiterr.go
+++ b/pkg/foundation/cerrors/conduiterr/conduiterr.go
@@ -109,6 +109,17 @@ var (
 	// CodeProcessorPluginNotFound is raised when a referenced processor plugin
 	// cannot be located.
 	CodeProcessorPluginNotFound = Register("processor.plugin_not_found", codes.NotFound)
+	// CodeExternalConnectorUnreachable is raised when an external connector's
+	// dialed address (pkg/plugin/connector/external, embed Slice 2) cannot be
+	// reached - at registration time (fail fast, never discovered on the
+	// first pipeline record) or when the connection is lost.
+	CodeExternalConnectorUnreachable = Register("connector.external_unreachable", codes.Unavailable)
+	// CodeExternalConnectorVersionMismatch is raised when an external
+	// connector's dialed address does not implement the pconnector protocol
+	// version pkg/plugin/connector/external's Dispenser hard-coded (go-plugin
+	// performs no version negotiation on the Reattach path, so this package
+	// must verify it explicitly via a Specify round trip).
+	CodeExternalConnectorVersionMismatch = Register("connector.external_version_mismatch", codes.FailedPrecondition)
 )
 
 // Fix is a structured, machine-appliable change that resolves an error. The same

--- a/pkg/plugin/connector/external/dispenser.go
+++ b/pkg/plugin/connector/external/dispenser.go
@@ -169,12 +169,21 @@ func (d *Dispenser) teardown() {
 	}
 
 	d.logger.Debug().Msg("tearing down external connector client")
-	// Unblock the runner's Wait before Kill(), so plugin.Client.Kill() does
-	// not block for its full 2s graceful-exit timeout on every teardown (see
-	// attachedRunner.markDone's doc). This is purely a latency optimization:
-	// Kill() is safe (a no-op against the external process) with or without
-	// this call.
-	d.runner.markDone()
+	// Deliberately NOT calling d.runner.markDone() here first: that would
+	// race plugin.Client.Kill()'s own graceful Controller.Shutdown RPC
+	// against the doneCtx cancellation that follows immediately from Wait
+	// returning, aborting the graceful shutdown message roughly half the
+	// time (see attachedRunner.markDone's doc). Kill() runs go-plugin's
+	// normal path uncontended: it issues the graceful Controller.Shutdown
+	// RPC via client.Close(), then selects on doneCtx (canceled once Wait
+	// returns) racing a 2s timer before falling back to calling this
+	// runner's Kill (the only thing that ever calls markDone). Since
+	// nothing else ever unblocks Wait, that select's doneCtx branch can
+	// never win - teardown of an external connector deterministically takes
+	// go-plugin's full ~2s graceful window every time, not merely "up to"
+	// it. That is the cost of giving the peer a clean shutdown signal
+	// instead of an abrupt disconnect, and this package is not yet wired
+	// into any hot path where that latency matters.
 	d.client.Kill()
 	d.client = nil
 	d.dispensed = false

--- a/pkg/plugin/connector/external/dispenser.go
+++ b/pkg/plugin/connector/external/dispenser.go
@@ -1,0 +1,282 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package external
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"sync"
+
+	"github.com/conduitio/conduit-connector-protocol/pconnector"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/plugin/connector"
+	goplugin "github.com/hashicorp/go-plugin"
+	"github.com/rs/zerolog"
+)
+
+// Dispenser dispenses a connector plugin already running at addr, by
+// reattaching to it (plugin.ClientConfig.Reattach) instead of spawning a
+// subprocess. See the package doc for the mechanism and the go-plugin
+// behaviors this type exists to close the gap on.
+//
+// A Dispenser is single-use, matching standalone.Dispenser's contract: once
+// its underlying plugin.Client is torn down (after the terminal
+// Specify/Teardown call - see the *Signaller wrappers below), it cannot be
+// reused. Callers that need to both validate and then actually use a
+// connection (e.g. registration-time Validate followed by dispensing a
+// running source/destination) construct two Dispensers against the same
+// addr, the same way standalone.Registry.loadSpecifications constructs a
+// throwaway Dispenser distinct from the one that is actually wired into a
+// pipeline.
+type Dispenser struct {
+	logger zerolog.Logger
+	addr   net.Addr
+	proto  ProtocolVersion
+	tls    *tls.Config
+
+	dispensed bool
+	client    *goplugin.Client
+	runner    *attachedRunner
+	m         sync.Mutex
+}
+
+// Option configures a Dispenser.
+type Option func(*Dispenser)
+
+// WithProtocolVersion hard-codes which pconnector wire-protocol version the
+// Dispenser expects the dialed server to speak. Defaults to
+// ProtocolVersionV2 (latest). go-plugin's Reattach path performs no version
+// negotiation (see ProtocolVersion's doc), so this choice is final for a
+// given Dispenser; Validate confirms it against the live server via a
+// Specify round trip rather than trusting it silently.
+func WithProtocolVersion(v ProtocolVersion) Option {
+	return func(d *Dispenser) { d.proto = v }
+}
+
+// WithTLSConfig enables TLS on the connection to the external connector.
+// go-plugin's SecureConfig (its checksum-based binary-integrity check, the
+// spawn path's baseline defense against a swapped plugin binary) is
+// structurally unavailable here: plugin.Client.Start hard-fails if both
+// SecureConfig and Reattach are set (ErrSecureConfigAndReattach) - there is
+// no binary to checksum, since nothing is executed. Authenticating and
+// encrypting the channel must therefore be an on-the-wire property from the
+// start. TLSConfig already applies transparently to Reattach connections
+// (go-plugin's newGRPCClient/dialGRPCConn is the single dial call site
+// shared by the Cmd and Reattach paths); this option is how a caller
+// supplies it. Certificate provisioning/rotation is out of scope for this
+// package - an open question the Slice 2 addendum defers to that slice's own
+// design pass.
+func WithTLSConfig(cfg *tls.Config) Option {
+	return func(d *Dispenser) { d.tls = cfg }
+}
+
+// NewDispenser creates a Dispenser that reattaches to a connector plugin's
+// gRPC server already listening at addr, instead of spawning one. Only a
+// loopback, same-machine addr is supported (Mode 1, per the Slice 2
+// addendum's hard gate against Mode 2) - NewDispenser does not enforce this
+// itself (that belongs to the config/registration layer that will wrap this
+// package), it only documents the constraint this package was designed and
+// verified against.
+func NewDispenser(logger zerolog.Logger, addr net.Addr, opts ...Option) (*Dispenser, error) {
+	d := &Dispenser{
+		logger: logger,
+		addr:   addr,
+		proto:  ProtocolVersionV2,
+	}
+	for _, opt := range opts {
+		opt(d)
+	}
+
+	if err := d.initClient(); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+func (d *Dispenser) initClient() error {
+	plugins, err := pluginSet(d.proto)
+	if err != nil {
+		return cerrors.Errorf("could not build plugin set: %w", err)
+	}
+
+	d.runner = newAttachedRunner(d.addr)
+
+	clientConfig := &goplugin.ClientConfig{
+		HandshakeConfig: pconnector.HandshakeConfig,
+		// Plugins (singular), not VersionedPlugins: go-plugin's Reattach path
+		// never calls checkProtoVersion and never derives Plugins from
+		// VersionedPlugins (see ProtocolVersion's doc) - the hard-coded set
+		// is used unconditionally, unchecked by go-plugin itself. Validate
+		// closes that gap with a live Specify round trip.
+		Plugins: plugins,
+		Reattach: &goplugin.ReattachConfig{
+			Protocol: goplugin.ProtocolGRPC,
+			Addr:     d.addr,
+			// ReattachFunc: our own, not go-plugin's default
+			// cmdrunner.ReattachFunc (PID-based, local-machine-only, and
+			// whose Kill sends an OS-level kill signal - unsafe for a peer
+			// this engine did not spawn). See reattach.go.
+			ReattachFunc: d.runner.reattachFunc(),
+			// Test is deliberately left false (its zero value): it is a
+			// go-plugin test-harness-only flag (see reattach() in
+			// client.go) - setting it in production code would silently
+			// skip the runner assignment Kill's no-op-safety depends on.
+		},
+		AllowedProtocols: []goplugin.Protocol{goplugin.ProtocolGRPC},
+		TLSConfig:        d.tls,
+		Logger:           &hcLogger{logger: d.logger},
+	}
+
+	d.client = goplugin.NewClient(clientConfig)
+	return nil
+}
+
+func (d *Dispenser) dispense() error {
+	d.m.Lock()
+	defer d.m.Unlock()
+
+	if d.dispensed {
+		return cerrors.New("plugin already dispensed, can't dispense twice")
+	}
+
+	d.dispensed = true
+	return nil
+}
+
+// teardown closes this Dispenser's gRPC client connection. It never signals
+// the external connector process itself - see the package invariant and
+// attachedRunner's doc.
+func (d *Dispenser) teardown() {
+	d.m.Lock()
+	defer d.m.Unlock()
+
+	if !d.dispensed {
+		// nothing to do here
+		return
+	}
+
+	d.logger.Debug().Msg("tearing down external connector client")
+	// Unblock the runner's Wait before Kill(), so plugin.Client.Kill() does
+	// not block for its full 2s graceful-exit timeout on every teardown (see
+	// attachedRunner.markDone's doc). This is purely a latency optimization:
+	// Kill() is safe (a no-op against the external process) with or without
+	// this call.
+	d.runner.markDone()
+	d.client.Kill()
+	d.client = nil
+	d.dispensed = false
+}
+
+func (d *Dispenser) DispenseSpecifier() (connector.SpecifierPlugin, error) {
+	err := d.dispense()
+	if err != nil {
+		return nil, err
+	}
+
+	rpcClient, err := d.client.Client()
+	if err != nil {
+		return nil, err
+	}
+	raw, err := rpcClient.Dispense("specifier")
+	if err != nil {
+		return nil, err
+	}
+
+	specifier, ok := raw.(connector.SpecifierPlugin)
+	if !ok {
+		return nil, cerrors.Errorf("plugin did not dispense specifier, got type: %T", raw)
+	}
+
+	return specifierPluginDispenserSignaller{specifier, d}, nil
+}
+
+func (d *Dispenser) DispenseSource() (connector.SourcePlugin, error) {
+	err := d.dispense()
+	if err != nil {
+		return nil, err
+	}
+
+	rpcClient, err := d.client.Client()
+	if err != nil {
+		return nil, err
+	}
+	raw, err := rpcClient.Dispense("source")
+	if err != nil {
+		return nil, err
+	}
+
+	source, ok := raw.(connector.SourcePlugin)
+	if !ok {
+		return nil, cerrors.Errorf("plugin did not dispense source, got type: %T", raw)
+	}
+
+	return sourcePluginDispenserSignaller{source, d}, nil
+}
+
+func (d *Dispenser) DispenseDestination() (connector.DestinationPlugin, error) {
+	err := d.dispense()
+	if err != nil {
+		return nil, err
+	}
+
+	rpcClient, err := d.client.Client()
+	if err != nil {
+		return nil, err
+	}
+	raw, err := rpcClient.Dispense("destination")
+	if err != nil {
+		return nil, err
+	}
+
+	destination, ok := raw.(connector.DestinationPlugin)
+	if !ok {
+		return nil, cerrors.Errorf("plugin did not dispense destination, got type: %T", raw)
+	}
+
+	return destinationPluginDispenserSignaller{destination, d}, nil
+}
+
+var _ connector.Dispenser = (*Dispenser)(nil)
+
+type specifierPluginDispenserSignaller struct {
+	connector.SpecifierPlugin
+	d *Dispenser
+}
+
+func (s specifierPluginDispenserSignaller) Specify(ctx context.Context, req pconnector.SpecifierSpecifyRequest) (pconnector.SpecifierSpecifyResponse, error) {
+	defer s.d.teardown()
+	return s.SpecifierPlugin.Specify(ctx, req)
+}
+
+type sourcePluginDispenserSignaller struct {
+	connector.SourcePlugin
+	d *Dispenser
+}
+
+func (s sourcePluginDispenserSignaller) Teardown(ctx context.Context, req pconnector.SourceTeardownRequest) (pconnector.SourceTeardownResponse, error) {
+	defer s.d.teardown()
+	return s.SourcePlugin.Teardown(ctx, req)
+}
+
+type destinationPluginDispenserSignaller struct {
+	connector.DestinationPlugin
+	d *Dispenser
+}
+
+func (s destinationPluginDispenserSignaller) Teardown(ctx context.Context, req pconnector.DestinationTeardownRequest) (pconnector.DestinationTeardownResponse, error) {
+	defer s.d.teardown()
+	return s.DestinationPlugin.Teardown(ctx, req)
+}

--- a/pkg/plugin/connector/external/dispenser_test.go
+++ b/pkg/plugin/connector/external/dispenser_test.go
@@ -1,0 +1,208 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package external_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/config"
+	"github.com/conduitio/conduit-connector-protocol/pconnector"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/plugin/connector/external"
+	"github.com/matryer/is"
+	"github.com/rs/zerolog"
+)
+
+// TestDispenser_Specify_RoundTrip proves the core mechanism this slice adds:
+// Dispenser reaches a real gRPC server by reattaching to a pre-known address
+// (goplugin.ReattachConfig) instead of spawning a subprocess, using the
+// hard-coded pconnector v2 stub set, and gets back a real Specify response -
+// with zero conduit-connector-protocol wire changes.
+func TestDispenser_Specify_RoundTrip(t *testing.T) {
+	is := is.New(t)
+
+	wantSpec := pconnector.Specification{Name: "fake-connector", Version: "v1.2.3"}
+	srv := startFakeServer(t, &fakeSpecifier{spec: wantSpec}, &fakeSource{}, &fakeDestination{})
+
+	d, err := external.NewDispenser(zerolog.Nop(), srv.addr)
+	is.NoErr(err)
+
+	specifier, err := d.DispenseSpecifier()
+	is.NoErr(err)
+
+	resp, err := specifier.Specify(context.Background(), pconnector.SpecifierSpecifyRequest{})
+	is.NoErr(err)
+	is.Equal(resp.Specification.Name, wantSpec.Name)
+	is.Equal(resp.Specification.Version, wantSpec.Version)
+}
+
+// TestDispenser_DispenseSource_ConfigureRoundTrip proves DispenseSource
+// produces a working connector.SourcePlugin over the reattached connection,
+// not just the specifier path.
+func TestDispenser_DispenseSource_ConfigureRoundTrip(t *testing.T) {
+	is := is.New(t)
+
+	configured := make(chan pconnector.SourceConfigureRequest, 1)
+	srv := startFakeServer(t, &fakeSpecifier{}, &fakeSource{configured: configured}, &fakeDestination{})
+
+	d, err := external.NewDispenser(zerolog.Nop(), srv.addr)
+	is.NoErr(err)
+
+	source, err := d.DispenseSource()
+	is.NoErr(err)
+
+	wantCfg := config.Config{"foo": "bar"}
+	_, err = source.Configure(context.Background(), pconnector.SourceConfigureRequest{Config: wantCfg})
+	is.NoErr(err)
+
+	select {
+	case got := <-configured:
+		is.Equal(got.Config["foo"], "bar")
+	case <-time.After(2 * time.Second):
+		t.Fatal("fake source never received Configure")
+	}
+
+	_, err = source.Teardown(context.Background(), pconnector.SourceTeardownRequest{})
+	is.NoErr(err)
+}
+
+// TestDispenser_DispenseDestination_ConfigureRoundTrip mirrors the source
+// test for DispenseDestination.
+func TestDispenser_DispenseDestination_ConfigureRoundTrip(t *testing.T) {
+	is := is.New(t)
+
+	configured := make(chan pconnector.DestinationConfigureRequest, 1)
+	srv := startFakeServer(t, &fakeSpecifier{}, &fakeSource{}, &fakeDestination{configured: configured})
+
+	d, err := external.NewDispenser(zerolog.Nop(), srv.addr)
+	is.NoErr(err)
+
+	destination, err := d.DispenseDestination()
+	is.NoErr(err)
+
+	wantCfg := config.Config{"foo": "bar"}
+	_, err = destination.Configure(context.Background(), pconnector.DestinationConfigureRequest{Config: wantCfg})
+	is.NoErr(err)
+
+	select {
+	case got := <-configured:
+		is.Equal(got.Config["foo"], "bar")
+	case <-time.After(2 * time.Second):
+		t.Fatal("fake destination never received Configure")
+	}
+
+	_, err = destination.Teardown(context.Background(), pconnector.DestinationTeardownRequest{})
+	is.NoErr(err)
+}
+
+// TestDispenser_Validate_Success proves the registration-time reachability +
+// version check (Failure modes 1 and 4 of the Slice 2 addendum) passes
+// cleanly against a server that is both reachable and speaks the hard-coded
+// protocol version.
+func TestDispenser_Validate_Success(t *testing.T) {
+	is := is.New(t)
+
+	srv := startFakeServer(t, &fakeSpecifier{}, &fakeSource{}, &fakeDestination{})
+
+	d, err := external.NewDispenser(zerolog.Nop(), srv.addr, external.WithProtocolVersion(external.ProtocolVersionV2))
+	is.NoErr(err)
+
+	err = d.Validate(context.Background())
+	is.NoErr(err)
+}
+
+// TestDispenser_Validate_Unreachable proves Failure mode 1: a dead address
+// fails fast, at registration time, with a stable, actionable error code -
+// never silently accepted and discovered on the first pipeline record.
+func TestDispenser_Validate_Unreachable(t *testing.T) {
+	is := is.New(t)
+
+	// Bind a listener to get a genuinely free, syntactically valid loopback
+	// address, then close it immediately: nothing is listening there for the
+	// Dispenser to reach.
+	var lc net.ListenConfig
+	l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	is.NoErr(err)
+	addr := l.Addr()
+	is.NoErr(l.Close())
+
+	d, err := external.NewDispenser(zerolog.Nop(), addr)
+	is.NoErr(err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err = d.Validate(ctx)
+	is.True(err != nil)
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code, conduiterr.CodeExternalConnectorUnreachable)
+}
+
+// TestDispenser_Validate_VersionMismatch proves Failure mode 4: go-plugin's
+// Reattach path performs no version negotiation of its own (verified against
+// go-plugin@v1.8.0 for the Slice 2 addendum), so a Dispenser hard-coded to a
+// protocol version the dialed server does not implement must be caught here,
+// not surfaced as a raw gRPC decode error on the first real record.
+func TestDispenser_Validate_VersionMismatch(t *testing.T) {
+	is := is.New(t)
+
+	// A server that only implements the v2 specifier service.
+	srv := startFakeV2OnlyServer(t, &fakeSpecifier{})
+
+	// A Dispenser hard-coded to v1 dialing a v2-only server.
+	d, err := external.NewDispenser(zerolog.Nop(), srv.addr, external.WithProtocolVersion(external.ProtocolVersionV1))
+	is.NoErr(err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err = d.Validate(ctx)
+	is.True(err != nil)
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code, conduiterr.CodeExternalConnectorVersionMismatch)
+}
+
+// TestDispenser_Teardown_DoesNotBlockOnGracefulTimeout proves
+// attachedRunner.markDone's latency optimization: tearing down a Dispenser
+// must not incur go-plugin's full 2-second graceful-exit wait on every
+// teardown (see reattach.go's markDone doc) - it should return quickly.
+func TestDispenser_Teardown_DoesNotBlockOnGracefulTimeout(t *testing.T) {
+	is := is.New(t)
+
+	srv := startFakeServer(t, &fakeSpecifier{}, &fakeSource{}, &fakeDestination{})
+
+	d, err := external.NewDispenser(zerolog.Nop(), srv.addr)
+	is.NoErr(err)
+
+	specifier, err := d.DispenseSpecifier()
+	is.NoErr(err)
+
+	start := time.Now()
+	_, err = specifier.Specify(context.Background(), pconnector.SpecifierSpecifyRequest{})
+	is.NoErr(err)
+	elapsed := time.Since(start)
+
+	// go-plugin's Client.Kill() would otherwise block for up to 2s waiting
+	// to observe the runner's death before falling back to Runner.Kill();
+	// markDone should make this resolve immediately instead.
+	is.True(elapsed < 1*time.Second)
+}

--- a/pkg/plugin/connector/external/dispenser_test.go
+++ b/pkg/plugin/connector/external/dispenser_test.go
@@ -181,11 +181,20 @@ func TestDispenser_Validate_VersionMismatch(t *testing.T) {
 	is.Equal(ce.Code, conduiterr.CodeExternalConnectorVersionMismatch)
 }
 
-// TestDispenser_Teardown_DoesNotBlockOnGracefulTimeout proves
-// attachedRunner.markDone's latency optimization: tearing down a Dispenser
-// must not incur go-plugin's full 2-second graceful-exit wait on every
-// teardown (see reattach.go's markDone doc) - it should return quickly.
-func TestDispenser_Teardown_DoesNotBlockOnGracefulTimeout(t *testing.T) {
+// TestDispenser_Teardown_CompletesGracefully proves teardown actually
+// completes (doesn't hang) and, deliberately, exercises go-plugin's full
+// graceful-shutdown window rather than short-circuiting it: Dispenser.
+// teardown does NOT call attachedRunner.markDone proactively (an earlier
+// version of this package did, and that raced plugin.Client.Kill()'s own
+// graceful Controller.Shutdown RPC against the doneCtx cancellation that
+// follows immediately from Wait returning, aborting the graceful shutdown
+// message roughly half the time - see markDone's doc). Since nothing else
+// ever unblocks this runner's Wait, Kill()'s internal select always takes
+// its 2s-timeout branch before falling back to Runner.Kill() (which is what
+// finally calls markDone) - so teardown here reliably takes on the order of
+// go-plugin's ~2s graceful window, not less. This test asserts it still
+// completes well within that plus a comfortable margin, not that it's fast.
+func TestDispenser_Teardown_CompletesGracefully(t *testing.T) {
 	is := is.New(t)
 
 	srv := startFakeServer(t, &fakeSpecifier{}, &fakeSource{}, &fakeDestination{})
@@ -201,8 +210,8 @@ func TestDispenser_Teardown_DoesNotBlockOnGracefulTimeout(t *testing.T) {
 	is.NoErr(err)
 	elapsed := time.Since(start)
 
-	// go-plugin's Client.Kill() would otherwise block for up to 2s waiting
-	// to observe the runner's death before falling back to Runner.Kill();
-	// markDone should make this resolve immediately instead.
-	is.True(elapsed < 1*time.Second)
+	// Comfortably above go-plugin's ~2s graceful window - this bounds
+	// "teardown eventually completes" (catches a real hang), it does not
+	// assert low latency.
+	is.True(elapsed < 5*time.Second)
 }

--- a/pkg/plugin/connector/external/doc.go
+++ b/pkg/plugin/connector/external/doc.go
@@ -1,0 +1,91 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package external dispenses a connector plugin that is already running at a
+// known address, instead of spawning a subprocess
+// (pkg/plugin/connector/standalone's model). It is the foundational piece of
+// embed Slice 2 (docs/design-documents/20260724-embed-slice2-external-connector.md,
+// the gating addendum to
+// docs/design-documents/20260724-embed-grpc-client-libraries.md and
+// docs/architecture-decision-records/20260724-embed-bindings-via-grpc.md):
+// the mechanism inline_source/inline_destination (a host-language connector
+// server running in-process inside an embedding application) is built on.
+//
+// # Mechanism
+//
+// go-plugin (github.com/hashicorp/go-plugin) supports acquiring a
+// plugin.Client two ways: spawning a subprocess (plugin.ClientConfig.Cmd,
+// what standalone.Dispenser uses via conduit-connector-protocol's
+// pconnector/client.New) or reattaching to a process already running at a
+// known address (plugin.ClientConfig.Reattach). Both converge on the exact
+// same code path once a plugin.Client has an address: gRPC dial, then
+// dispensing the pconnector v1/v2 gRPC client stubs. No conduit-connector-
+// protocol wire message or .proto file changes between the two - Reattach
+// only changes how the client finds the server, never what it says to it
+// once connected. Dispenser implements the same connector.Dispenser
+// interface (DispenseSpecifier/Source/Destination) as standalone.Dispenser,
+// so pkg/connector's Source/Destination call sites are unaware of which one
+// produced their stream.
+//
+// # What go-plugin does NOT do on the Reattach path (and this package must)
+//
+// Two behaviors verified directly against github.com/hashicorp/go-plugin
+// v1.8.0 for the Slice 2 addendum change what this package builds, not just
+// documents:
+//
+//  1. Production Reattach performs zero version-based plugin-set selection.
+//     checkProtoVersion (the spawn path's handshake-line parser) never runs;
+//     plugin.ClientConfig.Plugins is never derived from VersionedPlugins.
+//     Dispenser therefore hard-codes a single ProtocolVersion's gRPC stub
+//     set into ClientConfig.Plugins (pluginset.go) and closes the resulting
+//     gap itself: Validate (validate.go) performs a live Specify round trip
+//     immediately after dial and classifies failure as unreachable
+//     (connector.external_unreachable) or version-incompatible
+//     (connector.external_version_mismatch) before a caller wires the
+//     connector into a running pipeline.
+//  2. go-plugin's default Reattach death-detection (cmdrunner.ReattachFunc)
+//     is local-OS-PID-based and, load-bearing for safety: its Kill()
+//     ultimately calls os.Process.Kill() on that PID. That default is wrong
+//     for an external connector on two counts - the PID is not guaranteed to
+//     identify Conduit's peer at all, and Conduit did not spawn this
+//     process and must never send it a termination signal (a coincidentally
+//     reused local PID would otherwise be killed instead). reattach.go
+//     supplies a custom ReattachFunc/AttachedRunner whose Kill is a
+//     deliberate no-op; a dead peer is discovered the same way a crashed
+//     spawned plugin already is today - the next failed Send/Recv on the
+//     gRPC stream (pkg/connector/source.go, destination.go) - not via
+//     proactive health-checking. This is a deliberate no-speculative-
+//     generality choice, not an oversight; see reattach.go's doc comment for
+//     the trade-off.
+//
+// # Scope of this slice
+//
+// This package is the dispenser only: Reattach-based client construction,
+// the hard-coded plugin set, the safe custom ReattachFunc, and the
+// reachability/version-check Validate step. It does not (yet) wire an
+// "address:" connector into config.Connector, the connector registry, or
+// CreatePipeline - that is a separate, later reviewable slice building on
+// this one (see the Slice 2 addendum's own gate list and this repo's
+// tracking issue for the remaining slices). Mode 2 (dialing a genuinely
+// remote, non-loopback host process) is explicitly out of scope everywhere
+// in this package, per the addendum's hard gate; only Mode 1
+// (conduit.local(), loopback, same machine) is supported.
+//
+// # Invariant
+//
+// Dispenser and its ReattachFunc never send a termination signal to the
+// process listening at the dispensed address. Conduit did not spawn it and
+// cannot safely assume a local OS PID identifies it. Teardown only closes
+// this package's own gRPC client connection.
+package external

--- a/pkg/plugin/connector/external/fakeplugin_test.go
+++ b/pkg/plugin/connector/external/fakeplugin_test.go
@@ -1,0 +1,277 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package external_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-connector-protocol/pconnector"
+	pconnserver "github.com/conduitio/conduit-connector-protocol/pconnector/server"
+	v2 "github.com/conduitio/conduit-connector-protocol/pconnector/v2"
+	serverv2 "github.com/conduitio/conduit-connector-protocol/pconnector/v2/server"
+	connectorv2 "github.com/conduitio/conduit-connector-protocol/proto/connector/v2"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	goplugin "github.com/hashicorp/go-plugin"
+	"github.com/matryer/is"
+	"google.golang.org/grpc"
+)
+
+// fakeSpecifier is a minimal pconnector.SpecifierPlugin used to drive a real
+// gRPC server for the tests in this package - it exists to prove the
+// Reattach + hard-coded-PluginSet wiring actually carries a real RPC round
+// trip, not to test conduit-connector-protocol itself.
+type fakeSpecifier struct {
+	spec pconnector.Specification
+}
+
+func (f *fakeSpecifier) Specify(context.Context, pconnector.SpecifierSpecifyRequest) (pconnector.SpecifierSpecifyResponse, error) {
+	return pconnector.SpecifierSpecifyResponse{Specification: f.spec}, nil
+}
+
+// fakeSource is a minimal pconnector.SourcePlugin - every method is a no-op
+// stub except Configure, which is what the tests in this package exercise.
+type fakeSource struct {
+	configured chan pconnector.SourceConfigureRequest
+}
+
+func (f *fakeSource) Configure(_ context.Context, req pconnector.SourceConfigureRequest) (pconnector.SourceConfigureResponse, error) {
+	if f.configured != nil {
+		f.configured <- req
+	}
+	return pconnector.SourceConfigureResponse{}, nil
+}
+
+func (f *fakeSource) Open(context.Context, pconnector.SourceOpenRequest) (pconnector.SourceOpenResponse, error) {
+	return pconnector.SourceOpenResponse{}, nil
+}
+
+func (f *fakeSource) Run(context.Context, pconnector.SourceRunStream) error { return nil }
+
+func (f *fakeSource) Stop(context.Context, pconnector.SourceStopRequest) (pconnector.SourceStopResponse, error) {
+	return pconnector.SourceStopResponse{}, nil
+}
+
+func (f *fakeSource) Teardown(context.Context, pconnector.SourceTeardownRequest) (pconnector.SourceTeardownResponse, error) {
+	return pconnector.SourceTeardownResponse{}, nil
+}
+
+func (f *fakeSource) LifecycleOnCreated(context.Context, pconnector.SourceLifecycleOnCreatedRequest) (pconnector.SourceLifecycleOnCreatedResponse, error) {
+	return pconnector.SourceLifecycleOnCreatedResponse{}, nil
+}
+
+func (f *fakeSource) LifecycleOnUpdated(context.Context, pconnector.SourceLifecycleOnUpdatedRequest) (pconnector.SourceLifecycleOnUpdatedResponse, error) {
+	return pconnector.SourceLifecycleOnUpdatedResponse{}, nil
+}
+
+func (f *fakeSource) LifecycleOnDeleted(context.Context, pconnector.SourceLifecycleOnDeletedRequest) (pconnector.SourceLifecycleOnDeletedResponse, error) {
+	return pconnector.SourceLifecycleOnDeletedResponse{}, nil
+}
+
+// fakeDestination is a minimal pconnector.DestinationPlugin - every method is
+// a no-op stub except Configure.
+type fakeDestination struct {
+	configured chan pconnector.DestinationConfigureRequest
+}
+
+func (f *fakeDestination) Configure(_ context.Context, req pconnector.DestinationConfigureRequest) (pconnector.DestinationConfigureResponse, error) {
+	if f.configured != nil {
+		f.configured <- req
+	}
+	return pconnector.DestinationConfigureResponse{}, nil
+}
+
+func (f *fakeDestination) Open(context.Context, pconnector.DestinationOpenRequest) (pconnector.DestinationOpenResponse, error) {
+	return pconnector.DestinationOpenResponse{}, nil
+}
+
+func (f *fakeDestination) Run(context.Context, pconnector.DestinationRunStream) error { return nil }
+
+func (f *fakeDestination) Stop(context.Context, pconnector.DestinationStopRequest) (pconnector.DestinationStopResponse, error) {
+	return pconnector.DestinationStopResponse{}, nil
+}
+
+func (f *fakeDestination) Teardown(context.Context, pconnector.DestinationTeardownRequest) (pconnector.DestinationTeardownResponse, error) {
+	return pconnector.DestinationTeardownResponse{}, nil
+}
+
+func (f *fakeDestination) LifecycleOnCreated(context.Context, pconnector.DestinationLifecycleOnCreatedRequest) (pconnector.DestinationLifecycleOnCreatedResponse, error) {
+	return pconnector.DestinationLifecycleOnCreatedResponse{}, nil
+}
+
+func (f *fakeDestination) LifecycleOnUpdated(context.Context, pconnector.DestinationLifecycleOnUpdatedRequest) (pconnector.DestinationLifecycleOnUpdatedResponse, error) {
+	return pconnector.DestinationLifecycleOnUpdatedResponse{}, nil
+}
+
+func (f *fakeDestination) LifecycleOnDeleted(context.Context, pconnector.DestinationLifecycleOnDeletedRequest) (pconnector.DestinationLifecycleOnDeletedResponse, error) {
+	return pconnector.DestinationLifecycleOnDeletedResponse{}, nil
+}
+
+// fakeServer is a real, listening go-plugin gRPC server standing in for an
+// inline_source/inline_destination host process - the same shape
+// docs/design-documents/20260707-python-connector-sdk.md's server is, minus
+// the handshake-line-on-stdout write a spawned plugin does (this package
+// never spawns anything, so nothing reads that line). Built with
+// go-plugin's own test-mode Serve (plugin.ServeConfig.Test), the same
+// mechanism go-plugin's own test suite (server_test.go) uses to test
+// Reattach without an actual subprocess.
+type fakeServer struct {
+	addr    net.Addr
+	closeCh chan struct{}
+	cancel  context.CancelFunc
+}
+
+// stop shuts the fake server down, tolerating that it may already be
+// stopped: every test in this package that completes a terminal Specify/
+// Teardown call already causes Dispenser.teardown to Kill its plugin.Client,
+// which gracefully closes the gRPC connection - go-plugin's Controller
+// service Shutdown RPC - causing this server to call GRPCServer.Stop() on
+// itself well before this cleanup ever runs. go-plugin's own server-side
+// shutdown-on-context-cancellation path calls the same Stop() again
+// independently, and go-plugin's GRPCServer.Stop() is not safe to call
+// concurrently with itself (a data race in go-plugin@v1.8.0 itself, not in
+// this package). Waiting for closeCh first, and only falling back to
+// cancel() if the server has not already exited on its own, avoids
+// exercising that race in the (typical, in this package) case where the
+// Dispenser already shut it down.
+func (s *fakeServer) stop() {
+	select {
+	case <-s.closeCh:
+		return
+	case <-time.After(2 * time.Second):
+	}
+	s.cancel()
+	<-s.closeCh
+}
+
+// startFakeServer starts a full v1+v2 conduit-connector-protocol server
+// (via pconnector/server.Serve, the same entry point a real connector
+// plugin - standalone or external - uses) and returns its listening
+// address.
+func startFakeServer(t *testing.T, specifier pconnector.SpecifierPlugin, source pconnector.SourcePlugin, destination pconnector.DestinationPlugin) *fakeServer {
+	t.Helper()
+	is := is.New(t)
+
+	// go-plugin's VersionedPlugins mechanism picks which version's PluginSet
+	// a *spawned* server actually registers on its grpc.Server by reading
+	// PLUGIN_PROTOCOL_VERSIONS from its own environment (server.go's
+	// protocolVersion, matched against client.go:642, which sets it on
+	// cmd.Env before spawning) - that negotiation is carried entirely by the
+	// spawn path's environment, not by anything Reattach participates in.
+	// An external connector process is never spawned by Conduit, so nothing
+	// sets this for it automatically; a real external-connector host process
+	// serving multiple versions needs to set it out-of-band (or simply only
+	// ever serve one version). This test pins it explicitly to reproduce
+	// that same deterministic selection, rather than falling through to
+	// go-plugin's documented fallback ("return the lowest version") and
+	// silently exercising v1 instead of the v2 this package defaults to.
+	t.Setenv("PLUGIN_PROTOCOL_VERSIONS", "2")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	reattachCh := make(chan *goplugin.ReattachConfig, 1)
+	closeCh := make(chan struct{})
+
+	go func() {
+		_ = pconnserver.Serve(
+			func() pconnector.SpecifierPlugin { return specifier },
+			func() pconnector.SourcePlugin { return source },
+			func() pconnector.DestinationPlugin { return destination },
+			pconnserver.WithDebug(ctx, reattachCh, closeCh),
+		)
+	}()
+
+	var cfg *goplugin.ReattachConfig
+	select {
+	case cfg = <-reattachCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for fake server to start")
+	}
+	is.True(cfg != nil)
+
+	srv := &fakeServer{addr: cfg.Addr, closeCh: closeCh, cancel: cancel}
+	t.Cleanup(srv.stop)
+	return srv
+}
+
+// startFakeV2OnlyServer starts a go-plugin server that ONLY implements the
+// pconnector v2 gRPC services (no v1) - used to prove Dispenser.Validate's
+// version-mismatch classification against a server that genuinely doesn't
+// speak the version a Dispenser hard-coded, as opposed to one that is merely
+// unreachable. pconnector/server.Serve always registers both v1 and v2
+// (matching a real connector plugin, which supports both), so a v1-only or
+// v2-only server has to be built directly against go-plugin.
+func startFakeV2OnlyServer(t *testing.T, specifier pconnector.SpecifierPlugin) *fakeServer {
+	t.Helper()
+	is := is.New(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	reattachCh := make(chan *goplugin.ReattachConfig, 1)
+	closeCh := make(chan struct{})
+
+	plugins := goplugin.PluginSet{
+		"specifier": &v2OnlySpecifierPlugin{impl: specifier},
+	}
+
+	go goplugin.Serve(&goplugin.ServeConfig{
+		HandshakeConfig: pconnector.HandshakeConfig,
+		VersionedPlugins: map[int]goplugin.PluginSet{
+			v2.Version: plugins,
+		},
+		GRPCServer: goplugin.DefaultGRPCServer,
+		Test: &goplugin.ServeTestConfig{
+			Context:          ctx,
+			ReattachConfigCh: reattachCh,
+			CloseCh:          closeCh,
+		},
+	})
+
+	var cfg *goplugin.ReattachConfig
+	select {
+	case cfg = <-reattachCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for fake v2-only server to start")
+	}
+	is.True(cfg != nil)
+
+	srv := &fakeServer{addr: cfg.Addr, closeCh: closeCh, cancel: cancel}
+	t.Cleanup(srv.stop)
+	return srv
+}
+
+// v2OnlySpecifierPlugin registers only the v2 specifier gRPC service - it
+// deliberately does not implement source/destination or v1, so a Dispenser
+// hard-coded to a different ProtocolVersion dialing it gets a real
+// "service/method unknown" gRPC error, not a hand-rolled stand-in for one.
+type v2OnlySpecifierPlugin struct {
+	goplugin.NetRPCUnsupportedPlugin
+	impl pconnector.SpecifierPlugin
+}
+
+var (
+	_ goplugin.Plugin     = (*v2OnlySpecifierPlugin)(nil)
+	_ goplugin.GRPCPlugin = (*v2OnlySpecifierPlugin)(nil)
+)
+
+// GRPCClient always errors; this fake only implements the server half.
+func (p *v2OnlySpecifierPlugin) GRPCClient(context.Context, *goplugin.GRPCBroker, *grpc.ClientConn) (any, error) {
+	return nil, cerrors.New("v2OnlySpecifierPlugin only implements a gRPC server")
+}
+
+func (p *v2OnlySpecifierPlugin) GRPCServer(_ *goplugin.GRPCBroker, s *grpc.Server) error {
+	connectorv2.RegisterSpecifierPluginServer(s, serverv2.NewSpecifierPluginServer(p.impl))
+	return nil
+}

--- a/pkg/plugin/connector/external/logger.go
+++ b/pkg/plugin/connector/external/logger.go
@@ -1,0 +1,204 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package external
+
+import (
+	"fmt"
+	"io"
+	stdlog "log"
+	"strings"
+
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/hashicorp/go-hclog"
+	"github.com/rs/zerolog"
+)
+
+// hcLogger adapts a zerolog.Logger to go-plugin's hclog.Logger interface, so
+// plugin.ClientConfig.Logger emits through Conduit's own structured logger
+// instead of hclog's default writer.
+//
+// This is a deliberate, known duplicate of
+// pkg/plugin/connector/standalone's hcLogger (same adapter, same behavior):
+// that type is unexported in its package, so it cannot be imported here.
+// Extracting a shared pkg/plugin/connector/internal/hclogadapter package
+// (or similar) is a reasonable Tier-3 chore follow-up once a second
+// dispenser variant makes the duplication concrete rather than
+// speculative - deliberately not bundled into this slice, to keep this PR's
+// diff limited to new files with zero changes to the existing, working
+// standalone package.
+type hcLogger struct {
+	name   string
+	logger zerolog.Logger
+}
+
+var _ hclog.Logger = (*hcLogger)(nil)
+
+func (h *hcLogger) Log(level hclog.Level, msg string, args ...interface{}) {
+	zlevel := hclogZerologLevelMapping[level]
+	h.applyArgs(h.logger.WithLevel(zlevel), args).Msg(msg)
+}
+
+func (h *hcLogger) Trace(msg string, args ...interface{}) {
+	h.applyArgs(h.logger.Trace(), args).Msg(msg)
+}
+
+func (h *hcLogger) Debug(msg string, args ...interface{}) {
+	h.applyArgs(h.logger.Debug(), args).Msg(msg)
+}
+
+func (h *hcLogger) Info(msg string, args ...interface{}) {
+	h.applyArgs(h.logger.Info(), args).Msg(msg)
+}
+
+func (h *hcLogger) Warn(msg string, args ...interface{}) {
+	h.applyArgs(h.logger.Warn(), args).Msg(msg)
+}
+
+func (h *hcLogger) Error(msg string, args ...interface{}) {
+	h.applyArgs(h.logger.Error(), args).Msg(msg)
+}
+
+func (h *hcLogger) IsTrace() bool {
+	return h.isLevel(zerolog.TraceLevel)
+}
+
+func (h *hcLogger) IsDebug() bool {
+	return h.isLevel(zerolog.DebugLevel)
+}
+
+func (h *hcLogger) IsInfo() bool {
+	return h.isLevel(zerolog.InfoLevel)
+}
+
+func (h *hcLogger) IsWarn() bool {
+	return h.isLevel(zerolog.WarnLevel)
+}
+
+func (h *hcLogger) IsError() bool {
+	return h.isLevel(zerolog.ErrorLevel)
+}
+
+func (h *hcLogger) ImpliedArgs() []interface{} {
+	panic("implement me") // TODO
+}
+
+func (h *hcLogger) With(args ...interface{}) hclog.Logger {
+	c := h.logger.With()
+	for i := 0; i < len(args)-1; i += 2 {
+		key := args[i].(string) // keys must be strings
+		val := args[i+1]
+		c.Interface(key, val)
+	}
+	h.logger = c.Logger()
+	return h
+}
+
+func (h *hcLogger) Name() string {
+	return h.name
+}
+
+func (h *hcLogger) Named(name string) hclog.Logger {
+	hCopy := *h
+	hCopy.name = strings.TrimLeft(h.name+" "+name, " ")
+	return &hCopy
+}
+
+func (h *hcLogger) ResetNamed(name string) hclog.Logger {
+	hCopy := *h
+	hCopy.name = name
+	return &hCopy
+}
+
+func (h *hcLogger) SetLevel(level hclog.Level) {
+	zlevel := hclogZerologLevelMapping[level]
+	h.logger = h.logger.Level(zlevel)
+}
+
+func (h *hcLogger) GetLevel() hclog.Level {
+	level := h.logger.GetLevel()
+	return zerologHclogLevelMapping[level]
+}
+
+func (h *hcLogger) StandardLogger(opts *hclog.StandardLoggerOptions) *stdlog.Logger {
+	var prefix string
+	if h.name != "" {
+		prefix = fmt.Sprintf("%s: ", h.name)
+	}
+
+	return stdlog.New(h.StandardWriter(opts), prefix, 0)
+}
+
+func (h *hcLogger) StandardWriter(*hclog.StandardLoggerOptions) io.Writer {
+	return h.logger
+}
+
+func (h *hcLogger) applyArgs(e *zerolog.Event, args []interface{}) *zerolog.Event {
+	if h.name != "" {
+		// add plugin path name
+		e.Str(log.PluginNameField, h.name)
+	}
+	for i := 0; i < len(args)-1; i += 2 {
+		key, ok := args[i].(string) // keys should be strings
+		if !ok {
+			// do our best to format the key as a string
+			key = fmt.Sprintf("%v", args[i])
+		}
+		switch key {
+		case "timestamp":
+			// skip timestamps, they are added by our internal logger
+			continue
+		case "@module":
+			key = log.ComponentField
+		}
+
+		val := args[i+1]
+		switch v := val.(type) {
+		case error:
+			e.AnErr(key, v)
+		default:
+			e.Interface(key, val)
+		}
+	}
+
+	if len(args)%2 == 1 {
+		// odd number of params means they are not pairs
+		// add last param with empty key, so it's not lost
+		e.Interface("", args[len(args)-1])
+	}
+
+	return e
+}
+
+func (h *hcLogger) isLevel(lvl zerolog.Level) bool {
+	return lvl >= h.logger.GetLevel() && lvl >= zerolog.GlobalLevel()
+}
+
+var hclogZerologLevelMapping = map[hclog.Level]zerolog.Level{
+	hclog.NoLevel: zerolog.NoLevel,
+	hclog.Trace:   zerolog.TraceLevel,
+	hclog.Debug:   zerolog.DebugLevel,
+	hclog.Info:    zerolog.InfoLevel,
+	hclog.Warn:    zerolog.WarnLevel,
+	hclog.Error:   zerolog.ErrorLevel,
+}
+
+var zerologHclogLevelMapping = func() map[zerolog.Level]hclog.Level {
+	// reverse hclog->zerolog level mapping
+	m := make(map[zerolog.Level]hclog.Level, len(hclogZerologLevelMapping))
+	for k, v := range hclogZerologLevelMapping {
+		m[v] = k
+	}
+	return m
+}()

--- a/pkg/plugin/connector/external/pluginset.go
+++ b/pkg/plugin/connector/external/pluginset.go
@@ -1,0 +1,110 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package external
+
+import (
+	"context"
+
+	v1 "github.com/conduitio/conduit-connector-protocol/pconnector/v1"              //nolint:staticcheck // v1 is used for backwards compatibility
+	clientv1 "github.com/conduitio/conduit-connector-protocol/pconnector/v1/client" //nolint:staticcheck // v1 is used for backwards compatibility
+	v2 "github.com/conduitio/conduit-connector-protocol/pconnector/v2"
+	clientv2 "github.com/conduitio/conduit-connector-protocol/pconnector/v2/client"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	goplugin "github.com/hashicorp/go-plugin"
+	"google.golang.org/grpc"
+)
+
+// ProtocolVersion identifies which conduit-connector-protocol (pconnector)
+// wire-protocol version a Dispenser speaks.
+//
+// Unlike standalone.Dispenser (which builds its plugin.Client via
+// conduit-connector-protocol's pconnector/client.New and hands go-plugin a
+// VersionedPlugins map keyed by every supported version, letting the
+// spawn-path handshake negotiate which one is actually used),
+// plugin.ClientConfig.Reattach carries no such negotiation: go-plugin's
+// reattach() (client.go:972-1026 in github.com/hashicorp/go-plugin@v1.8.0)
+// never calls checkProtoVersion and never touches VersionedPlugins at all.
+// A Dispenser must therefore pick one ProtocolVersion up front and hard-code
+// its gRPC stub set into plugin.ClientConfig.Plugins (singular, not
+// VersionedPlugins) - see initClient in dispenser.go. Validate then confirms,
+// via a live Specify round trip, that the dialed server actually implements
+// the version this Dispenser hard-coded; go-plugin itself performs no such
+// check on this path.
+type ProtocolVersion int
+
+const (
+	// ProtocolVersionV1 hard-codes the pconnector v1 gRPC stub set.
+	ProtocolVersionV1 ProtocolVersion = ProtocolVersion(v1.Version)
+	// ProtocolVersionV2 hard-codes the pconnector v2 gRPC stub set. This is
+	// the default a Dispenser uses unless overridden with WithProtocolVersion.
+	ProtocolVersionV2 ProtocolVersion = ProtocolVersion(v2.Version)
+)
+
+// pluginSet returns the goplugin.PluginSet for the given hard-coded protocol
+// version, built from conduit-connector-protocol's exported v1/v2 client
+// constructors (clientv1.NewSpecifierPluginClient and friends) - the same
+// constructors pconnector/client.New uses for the spawn path. The
+// plugin.Plugin/plugin.GRPCPlugin wiring below (grpcPlugin) is duplicated
+// from that package's own (unexported) newPluginSet/grpcPlugin: it is only
+// reachable there through client.New's Cmd/spawn construction, and this
+// package needs to set plugin.ClientConfig.Plugins directly instead. See
+// pconnector/client/client.go in conduit-connector-protocol for the original.
+func pluginSet(v ProtocolVersion) (goplugin.PluginSet, error) {
+	switch v {
+	case ProtocolVersionV1:
+		return goplugin.PluginSet{
+			"specifier":   newGRPCPlugin(clientv1.NewSpecifierPluginClient),
+			"source":      newGRPCPlugin(clientv1.NewSourcePluginClient),
+			"destination": newGRPCPlugin(clientv1.NewDestinationPluginClient),
+		}, nil
+	case ProtocolVersionV2:
+		return goplugin.PluginSet{
+			"specifier":   newGRPCPlugin(clientv2.NewSpecifierPluginClient),
+			"source":      newGRPCPlugin(clientv2.NewSourcePluginClient),
+			"destination": newGRPCPlugin(clientv2.NewDestinationPluginClient),
+		}, nil
+	default:
+		return nil, cerrors.Errorf("unsupported pconnector protocol version %d", v)
+	}
+}
+
+// grpcPlugin adapts one of conduit-connector-protocol's NewXPluginClient
+// constructors into a goplugin.Plugin/goplugin.GRPCPlugin, so it can be
+// placed directly into a plugin.ClientConfig.Plugins set. It only implements
+// the client half (GRPCServer always errors) - this package dials existing
+// servers, it never serves.
+type grpcPlugin[T any] struct {
+	goplugin.NetRPCUnsupportedPlugin
+	newPluginClient func(cc *grpc.ClientConn) T
+}
+
+func newGRPCPlugin[T any](newPluginClient func(cc *grpc.ClientConn) T) *grpcPlugin[T] {
+	return &grpcPlugin[T]{newPluginClient: newPluginClient}
+}
+
+var (
+	_ goplugin.Plugin     = (*grpcPlugin[any])(nil)
+	_ goplugin.GRPCPlugin = (*grpcPlugin[any])(nil)
+)
+
+func (p *grpcPlugin[T]) GRPCClient(_ context.Context, _ *goplugin.GRPCBroker, cc *grpc.ClientConn) (any, error) {
+	return p.newPluginClient(cc), nil
+}
+
+// GRPCServer always returns an error; this package only implements gRPC
+// clients (it dials a server, it never stands one up).
+func (p *grpcPlugin[T]) GRPCServer(*goplugin.GRPCBroker, *grpc.Server) error {
+	return cerrors.New("pkg/plugin/connector/external only implements gRPC clients")
+}

--- a/pkg/plugin/connector/external/reattach.go
+++ b/pkg/plugin/connector/external/reattach.go
@@ -96,14 +96,17 @@ func (r *attachedRunner) Kill(context.Context) error {
 	return nil
 }
 
-// markDone unblocks Wait. Dispenser.teardown calls it proactively, before
-// invoking the underlying plugin.Client's Kill(), to avoid that call
-// blocking for its full 2-second graceful-exit timeout on every teardown:
-// plugin.Client.Kill() closes its own gRPC connection first, then selects on
-// this runner's death being observed (via Wait returning) racing a 2s timer,
-// before falling back to calling Kill on the runner. Closing done early
-// means that race is already resolved by the time Client.Kill() reaches it.
-// Safe to call more than once.
+// markDone unblocks Wait. It is only ever called from Kill (never
+// proactively by Dispenser.teardown - see the doc there for why): closing
+// done any earlier races the graceful Controller.Shutdown RPC that
+// plugin.Client.Kill()'s own client.Close() call issues on c.doneCtx against
+// that same doneCtx being canceled the moment Wait returns
+// (client.go:989-1004's reattach bookkeeping goroutine cancels doneCtx as
+// its very next step after Wait returns) - aborting the graceful shutdown
+// message roughly half the time in practice, and leaving the peer with an
+// abrupt disconnect instead of the clean Controller.Shutdown signal it may
+// use as its flush-and-exit cue. Safe to call more than once (idempotent via
+// closeOnce).
 func (r *attachedRunner) markDone() {
 	r.closeOnce.Do(func() { close(r.done) })
 }

--- a/pkg/plugin/connector/external/reattach.go
+++ b/pkg/plugin/connector/external/reattach.go
@@ -1,0 +1,131 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package external
+
+import (
+	"context"
+	"net"
+	"sync"
+
+	"github.com/hashicorp/go-plugin/runner"
+)
+
+// attachedRunner is Dispenser's runner.AttachedRunner for a dialed external
+// connector. go-plugin defaults to cmdrunner.ReattachFunc
+// (internal/cmdrunner/cmd_reattach.go in github.com/hashicorp/go-plugin) when
+// ReattachConfig.ReattachFunc is nil: it looks up ReattachConfig.Pid via
+// os.FindProcess on the machine running the Conduit engine, and its Kill
+// calls os.Process.Kill() on whatever it found. That default is unsafe here
+// for two reasons, not one: the PID is not guaranteed to identify Conduit's
+// peer in the first place (nothing established the PID belongs to the
+// dialed server, and it is meaningless for a non-co-located host process),
+// and even when it happens to be co-located, Conduit did not spawn that
+// process and must never send it a termination signal - a coincidentally
+// reused local PID would otherwise be killed instead of the intended
+// process. attachedRunner replaces both the liveness check and the kill
+// behavior; see Kill's doc for the invariant this enforces.
+type attachedRunner struct {
+	addr net.Addr
+
+	closeOnce sync.Once
+	done      chan struct{}
+}
+
+func newAttachedRunner(addr net.Addr) *attachedRunner {
+	return &attachedRunner{addr: addr, done: make(chan struct{})}
+}
+
+// reattachFunc adapts this attachedRunner into a runner.ReattachFunc for
+// plugin.ReattachConfig.ReattachFunc. go-plugin's Client.reattach calls it
+// exactly once per Dispenser and always succeeds - there is no local process
+// to probe, so there is nothing to fail here. Confirming the dialed address
+// is actually live is Validate's job (validate.go), via a real RPC; a
+// ReattachFunc has no protocol-level way to do that (it never dials
+// anything, it only supplies go-plugin's runner.AttachedRunner).
+func (r *attachedRunner) reattachFunc() runner.ReattachFunc {
+	return func() (runner.AttachedRunner, error) {
+		return r, nil
+	}
+}
+
+// Wait blocks until markDone is called or ctx is canceled. It intentionally
+// does not detect the external process's death by itself: go-plugin has no
+// cross-machine-safe way to do that on the Reattach path (Failure mode 3 of
+// docs/design-documents/20260724-embed-slice2-external-connector.md), and
+// this package deliberately does not add new machinery for it
+// (no-speculative-generality: Conduit's crash detection for a spawned plugin
+// is already "the next RPC call fails," not proactive health-checking -
+// external connectors inherit that same posture for free). A dead peer is
+// discovered when a subsequent Send/Recv on the gRPC stream fails
+// (pkg/connector/source.go, destination.go's existing, already
+// invariant-tested path) - not here.
+func (r *attachedRunner) Wait(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-r.done:
+		return nil
+	}
+}
+
+// Kill deliberately does not kill anything.
+//
+// Invariant: this package never sends a termination signal to a process it
+// did not spawn. go-plugin's default CmdAttachedRunner.Kill calls
+// os.Process.Kill() on whatever local PID happens to match
+// ReattachConfig.Pid - for a genuinely external connector that is not a
+// weaker check, it is a different and dangerous operation (see the type
+// doc). Kill only unblocks Wait, so go-plugin's own bookkeeping goroutine in
+// Client.reattach can finish; go-plugin's Client.Kill() blocks on that
+// goroutine before it returns. Safe to call more than once (idempotent via
+// closeOnce), and safe to call even if markDone already ran.
+func (r *attachedRunner) Kill(context.Context) error {
+	r.markDone()
+	return nil
+}
+
+// markDone unblocks Wait. Dispenser.teardown calls it proactively, before
+// invoking the underlying plugin.Client's Kill(), to avoid that call
+// blocking for its full 2-second graceful-exit timeout on every teardown:
+// plugin.Client.Kill() closes its own gRPC connection first, then selects on
+// this runner's death being observed (via Wait returning) racing a 2s timer,
+// before falling back to calling Kill on the runner. Closing done early
+// means that race is already resolved by the time Client.Kill() reaches it.
+// Safe to call more than once.
+func (r *attachedRunner) markDone() {
+	r.closeOnce.Do(func() { close(r.done) })
+}
+
+// ID reports the dialed address as this runner's identity. There is no OS
+// process to key off of; the address is the only identifier go-plugin's
+// Client.Kill() needs (it only uses ID() to short-circuit when there is
+// "nothing to kill" - see runner == nil || runner.ID() == "" in client.go).
+func (r *attachedRunner) ID() string { return r.addr.String() }
+
+// PluginToHost and HostToPlugin implement runner.AddrTranslator as identity
+// functions. AddrTranslator exists so a containerized plugin's file-path
+// addresses (e.g. a Unix socket) can differ between the plugin's and host's
+// mount namespaces; this package's only supported deployment (Mode 1 -
+// conduit.local(), a loopback TCP peer on the same machine, per the Slice 2
+// addendum's hard gate against Mode 2) never needs translation.
+func (r *attachedRunner) PluginToHost(pluginNet, pluginAddr string) (string, string, error) {
+	return pluginNet, pluginAddr, nil
+}
+
+func (r *attachedRunner) HostToPlugin(hostNet, hostAddr string) (string, string, error) {
+	return hostNet, hostAddr, nil
+}
+
+var _ runner.AttachedRunner = (*attachedRunner)(nil)

--- a/pkg/plugin/connector/external/reattach_test.go
+++ b/pkg/plugin/connector/external/reattach_test.go
@@ -41,8 +41,9 @@ func testAddr(t *testing.T) net.Addr {
 // (which returns once the OS-level process actually exits), this runner has
 // no independent way to observe the external connector's death (see the
 // type's doc: that gap is deliberate, not a bug). It only unblocks via
-// markDone (called from Kill, or proactively from Dispenser.teardown) or
-// context cancellation.
+// markDone (called from Kill only - see markDone's doc for why Dispenser.
+// teardown deliberately does not call it proactively) or context
+// cancellation.
 func TestAttachedRunner_Wait_BlocksUntilMarkDone(t *testing.T) {
 	is := is.New(t)
 	r := newAttachedRunner(testAddr(t))

--- a/pkg/plugin/connector/external/reattach_test.go
+++ b/pkg/plugin/connector/external/reattach_test.go
@@ -1,0 +1,145 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package external
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/matryer/is"
+)
+
+func testAddr(t *testing.T) net.Addr {
+	t.Helper()
+	var lc net.ListenConfig
+	l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := l.Addr()
+	_ = l.Close()
+	return addr
+}
+
+// TestAttachedRunner_Wait_BlocksUntilMarkDone proves Wait does not return on
+// its own - unlike go-plugin's default, PID-based CmdAttachedRunner.Wait
+// (which returns once the OS-level process actually exits), this runner has
+// no independent way to observe the external connector's death (see the
+// type's doc: that gap is deliberate, not a bug). It only unblocks via
+// markDone (called from Kill, or proactively from Dispenser.teardown) or
+// context cancellation.
+func TestAttachedRunner_Wait_BlocksUntilMarkDone(t *testing.T) {
+	is := is.New(t)
+	r := newAttachedRunner(testAddr(t))
+
+	waitReturned := make(chan error, 1)
+	go func() { waitReturned <- r.Wait(context.Background()) }()
+
+	select {
+	case <-waitReturned:
+		t.Fatal("Wait returned before markDone was called")
+	case <-time.After(100 * time.Millisecond):
+		// expected: still blocked
+	}
+
+	r.markDone()
+
+	select {
+	case err := <-waitReturned:
+		is.NoErr(err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Wait did not return after markDone")
+	}
+}
+
+// TestAttachedRunner_Wait_RespectsContext proves Wait also unblocks on
+// context cancellation (go-plugin's own reattach() bookkeeping goroutine
+// calls Wait with context.Background(), but this behavior matters for the
+// contract callers of Wait can rely on independent of go-plugin's own usage).
+func TestAttachedRunner_Wait_RespectsContext(t *testing.T) {
+	is := is.New(t)
+	r := newAttachedRunner(testAddr(t))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	waitReturned := make(chan error, 1)
+	go func() { waitReturned <- r.Wait(ctx) }()
+
+	cancel()
+
+	select {
+	case err := <-waitReturned:
+		is.True(err != nil) // ctx.Err()
+	case <-time.After(2 * time.Second):
+		t.Fatal("Wait did not return after context cancellation")
+	}
+}
+
+// TestAttachedRunner_Kill_NeverSignalsAProcess is the safety-critical
+// invariant this type exists to enforce: Kill must be a pure no-op against
+// the outside world. There is no OS process handle anywhere in this type to
+// signal - this test documents and pins that structural guarantee (there is
+// no os.Process field to accidentally wire up in a future change) alongside
+// asserting Kill's only observable effect: unblocking Wait.
+func TestAttachedRunner_Kill_NeverSignalsAProcess(t *testing.T) {
+	is := is.New(t)
+	r := newAttachedRunner(testAddr(t))
+
+	err := r.Kill(context.Background())
+	is.NoErr(err)
+
+	// Kill's only observable side effect is unblocking Wait.
+	select {
+	case err := <-waitCh(r):
+		is.NoErr(err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Kill did not unblock Wait")
+	}
+}
+
+// TestAttachedRunner_Kill_Idempotent proves calling Kill (or markDone)
+// multiple times, including concurrently, never panics (closing an
+// already-closed channel would) - go-plugin's Client.Kill() plus a
+// proactive Dispenser.teardown call both reach this path, and must both be
+// safe to do so.
+func TestAttachedRunner_Kill_Idempotent(t *testing.T) {
+	is := is.New(t)
+	r := newAttachedRunner(testAddr(t))
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			is.NoErr(r.Kill(context.Background()))
+		}()
+	}
+	wg.Wait()
+}
+
+func TestAttachedRunner_ID_IsAddr(t *testing.T) {
+	is := is.New(t)
+	addr := testAddr(t)
+	r := newAttachedRunner(addr)
+	is.Equal(r.ID(), addr.String())
+}
+
+func waitCh(r *attachedRunner) <-chan error {
+	ch := make(chan error, 1)
+	go func() { ch <- r.Wait(context.Background()) }()
+	return ch
+}

--- a/pkg/plugin/connector/external/validate.go
+++ b/pkg/plugin/connector/external/validate.go
@@ -1,0 +1,121 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package external
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/conduitio/conduit-connector-protocol/pconnector"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Validate dials d's address (if not already connected) and performs a
+// Specify round trip. This is what closes two gaps go-plugin's Reattach path
+// leaves open, per Failure modes 1 and 4 of
+// docs/design-documents/20260724-embed-slice2-external-connector.md:
+//
+//   - Reachability. go-plugin's Reattach never itself confirms the address
+//     is live: grpc.Dial (called from go-plugin's dialGRPCConn) is
+//     non-blocking by default, and plugin.Client.Start's Reattach branch
+//     just records the address without dialing anything. The first real RPC
+//     is what actually opens the TCP connection. Validate forces that to
+//     happen at registration time, with an actionable error, instead of on
+//     the first pipeline record.
+//   - Version compatibility. go-plugin's Reattach never runs
+//     checkProtoVersion, so nothing confirms the hard-coded
+//     plugin.ClientConfig.Plugins stub set (see ProtocolVersion) matches
+//     what the dialed server actually implements. If it doesn't, the dialed
+//     server's gRPC layer rejects the hard-coded stub's service/method as
+//     unknown (codes.Unimplemented) or the connection resolves to nothing
+//     implementing it (codes.NotFound) - Validate classifies either as
+//     CodeExternalConnectorVersionMismatch rather than letting it surface as
+//     a raw gRPC error on the first real record.
+//
+// Validate consumes the Dispenser: like standalone.Registry.loadSpecifications,
+// it dispenses the specifier plugin and lets the terminal Specify call tear
+// the connection down (specifierPluginDispenserSignaller in dispenser.go).
+// A caller that needs the connection afterward (to actually dispense a
+// source or destination) constructs a second, fresh Dispenser against the
+// same address - see Dispenser's doc for why that mirrors the existing
+// standalone contract rather than introducing a new one.
+func (d *Dispenser) Validate(ctx context.Context) error {
+	specifier, err := d.DispenseSpecifier()
+	if err != nil {
+		return conduiterr.Wrap(
+			conduiterr.CodeExternalConnectorUnreachable,
+			fmt.Sprintf("could not dispense specifier for external connector at %s", d.addr),
+			err,
+		)
+	}
+
+	_, err = specifier.Specify(ctx, pconnector.SpecifierSpecifyRequest{})
+	if err != nil {
+		return classifySpecifyError(d.addr.String(), d.proto, err)
+	}
+
+	return nil
+}
+
+// classifySpecifyError maps a failed Specify round trip to a stable,
+// actionable ConduitError.
+//
+// This cannot simply switch on the raw gRPC status code: conduit-connector-
+// protocol's client stubs (pconnector/internal.UnwrapGRPCError, called from
+// e.g. clientv1.SpecifierPluginClient.Specify) already strip the gRPC status
+// out of the error before it ever reaches this package - verified directly
+// against conduit-connector-protocol@v0.9.5's source, not assumed. A
+// codes.Unimplemented status (exactly what a version mismatch produces:
+// the hard-coded stub dialed a service the peer never registered)
+// specifically becomes a plain error wrapping the sentinel
+// pconnector.ErrUnimplemented ("%s: %w", st.Message(), ErrUnimplemented);
+// every other status becomes a bare errors.New(st.Message()) with no status
+// left to recover at all; and a failure with no status in the first place
+// (a transport-level error - connection refused, DNS failure - before any
+// status could be established) passes through UnwrapGRPCError completely
+// unchanged. So: check the sentinel first (the one case conduit-connector-
+// protocol preserves deliberately), and treat everything else - including
+// any status that did survive, for robustness against a future protocol
+// version that stops unwrapping - as unreachable, which is what it means in
+// every case this package can actually observe today.
+func classifySpecifyError(addr string, proto ProtocolVersion, err error) error {
+	if cerrors.Is(err, pconnector.ErrUnimplemented) {
+		return conduiterr.Wrap(
+			conduiterr.CodeExternalConnectorVersionMismatch,
+			fmt.Sprintf("external connector at %s does not implement pconnector protocol version %d", addr, proto),
+			err,
+		)
+	}
+
+	if st, ok := status.FromError(err); ok {
+		switch st.Code() { //nolint:exhaustive // only classifying the codes this path can actually observe; everything else falls through to the default "unreachable" wrap below.
+		case codes.Unimplemented, codes.NotFound:
+			return conduiterr.Wrap(
+				conduiterr.CodeExternalConnectorVersionMismatch,
+				fmt.Sprintf("external connector at %s does not implement pconnector protocol version %d", addr, proto),
+				err,
+			)
+		}
+	}
+
+	return conduiterr.Wrap(
+		conduiterr.CodeExternalConnectorUnreachable,
+		fmt.Sprintf("external connector at %s is unreachable", addr),
+		err,
+	)
+}

--- a/pkg/plugin/connector/external/validate.go
+++ b/pkg/plugin/connector/external/validate.go
@@ -21,8 +21,6 @@ import (
 	"github.com/conduitio/conduit-connector-protocol/pconnector"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // Validate dials d's address (if not already connected) and performs a
@@ -40,10 +38,11 @@ import (
 //   - Version compatibility. go-plugin's Reattach never runs
 //     checkProtoVersion, so nothing confirms the hard-coded
 //     plugin.ClientConfig.Plugins stub set (see ProtocolVersion) matches
-//     what the dialed server actually implements. If it doesn't, the dialed
-//     server's gRPC layer rejects the hard-coded stub's service/method as
-//     unknown (codes.Unimplemented) or the connection resolves to nothing
-//     implementing it (codes.NotFound) - Validate classifies either as
+//     what the dialed server actually implements. If it doesn't, grpc-go
+//     rejects the hard-coded stub's unknown service/method with
+//     codes.Unimplemented - the only status an unknown gRPC service or
+//     method actually produces (verified against grpc-go's source, not
+//     assumed) - and Validate classifies that as
 //     CodeExternalConnectorVersionMismatch rather than letting it surface as
 //     a raw gRPC error on the first real record.
 //
@@ -75,24 +74,27 @@ func (d *Dispenser) Validate(ctx context.Context) error {
 // classifySpecifyError maps a failed Specify round trip to a stable,
 // actionable ConduitError.
 //
-// This cannot simply switch on the raw gRPC status code: conduit-connector-
+// This cannot switch on the raw gRPC status code at all: conduit-connector-
 // protocol's client stubs (pconnector/internal.UnwrapGRPCError, called from
 // e.g. clientv1.SpecifierPluginClient.Specify) already strip the gRPC status
 // out of the error before it ever reaches this package - verified directly
-// against conduit-connector-protocol@v0.9.5's source, not assumed. A
-// codes.Unimplemented status (exactly what a version mismatch produces:
-// the hard-coded stub dialed a service the peer never registered)
-// specifically becomes a plain error wrapping the sentinel
-// pconnector.ErrUnimplemented ("%s: %w", st.Message(), ErrUnimplemented);
-// every other status becomes a bare errors.New(st.Message()) with no status
-// left to recover at all; and a failure with no status in the first place
-// (a transport-level error - connection refused, DNS failure - before any
-// status could be established) passes through UnwrapGRPCError completely
-// unchanged. So: check the sentinel first (the one case conduit-connector-
-// protocol preserves deliberately), and treat everything else - including
-// any status that did survive, for robustness against a future protocol
-// version that stops unwrapping - as unreachable, which is what it means in
-// every case this package can actually observe today.
+// against conduit-connector-protocol@v0.9.5's source, not assumed. Exactly
+// one status is special-cased there: codes.Unimplemented - the only status
+// grpc-go actually returns for an unknown service or method (also verified
+// against source, not assumed; there is no codes.NotFound case to worry
+// about, unknown-service and unknown-method both come back as
+// Unimplemented) - which is what dialing a hard-coded stub the peer never
+// registered produces. UnwrapGRPCError turns that specific status into a
+// plain error wrapping the sentinel pconnector.ErrUnimplemented ("%s: %w",
+// st.Message(), ErrUnimplemented); every other status becomes a bare
+// errors.New(st.Message()) with no status left to recover at all; and a
+// failure with no status in the first place (a transport-level error -
+// connection refused, DNS failure - before any status could be established)
+// passes through UnwrapGRPCError completely unchanged. So the sentinel is
+// not just the most convenient signal, it is the only one conduit-connector-
+// protocol preserves - everything else this package can observe is
+// classified as unreachable, which is what it means in every case that
+// reaches here today.
 func classifySpecifyError(addr string, proto ProtocolVersion, err error) error {
 	if cerrors.Is(err, pconnector.ErrUnimplemented) {
 		return conduiterr.Wrap(
@@ -100,17 +102,6 @@ func classifySpecifyError(addr string, proto ProtocolVersion, err error) error {
 			fmt.Sprintf("external connector at %s does not implement pconnector protocol version %d", addr, proto),
 			err,
 		)
-	}
-
-	if st, ok := status.FromError(err); ok {
-		switch st.Code() { //nolint:exhaustive // only classifying the codes this path can actually observe; everything else falls through to the default "unreachable" wrap below.
-		case codes.Unimplemented, codes.NotFound:
-			return conduiterr.Wrap(
-				conduiterr.CodeExternalConnectorVersionMismatch,
-				fmt.Sprintf("external connector at %s does not implement pconnector protocol version %d", addr, proto),
-				err,
-			)
-		}
 	}
 
 	return conduiterr.Wrap(


### PR DESCRIPTION
## What

Embed Slice-2, **slice 1 of 5** — the external-connector `Dispenser`: a go-plugin client built with `ClientConfig.Reattach` to dial a **pre-known address** instead of spawning a subprocess. New isolated package `pkg/plugin/connector/external/`. Design: `docs/design-documents/20260724-embed-slice2-external-connector.md` (signed off). No `conduit-connector-protocol` wire change. v0.20 WS3.

## Slice 1 scope

The dispenser in isolation — testable end-to-end, **zero wiring into the live pipeline** (no CreatePipeline/registry/config change; that's slice 2). Every later slice depends on it.

- **`ReattachConfig`-based client** with a hard-coded `ClientConfig.Plugins` set per protocol version (production `Reattach` does zero version-based plugin selection, so the dispenser must supply the stubs itself — verified against go-plugin source).
- **Custom `attachedRunner`** replacing go-plugin's default PID-based `ReattachFunc`: its `Kill` is a deliberate no-op. go-plugin's default reattach `Kill` calls `os.Process.Kill()` on the reattach PID (verified in `cmdrunner/cmd_reattach.go`) — for a process we didn't spawn that could kill an unrelated/reused PID. Death detection is pure RPC-failure, matching the spawned-plugin posture.
- **`Validate`** does a live `Specify` round-trip (go-plugin `Reattach` never dials — `grpc.Dial` is lazy), catching both unreachable-address and protocol-version-mismatch with stable error codes (`connector.external_unreachable`, `connector.external_version_mismatch`). Version classification rests on the `pconnector.ErrUnimplemented` sentinel (the protocol client strips the raw gRPC status).
- `SecureConfig`/`Reattach` mutual exclusivity and TLS-via-shared-`dialGRPCConn` documented.

## Adversarial review — SOUND-WITH-CHANGES, both fixes folded

Independent review (grounded in go-plugin@v1.8.0 + conduit-connector-protocol@v0.9.5 source, not the PR's self-report) confirmed the Kill-safety invariant (never signals an external process — traced every `Kill` call site), the byte-for-byte-equivalent plugin set, and zero data-path wiring. It **empirically reproduced** one real teardown race and flagged a doc overclaim; both fixed:

1. **Teardown shutdown-RPC race (eliminated):** calling `markDone()` before `client.Kill()` raced the graceful `Controller.Shutdown` RPC against its own shared context-cancel (~50% of the time the peer got an abrupt disconnect instead of a clean shutdown). Removed the proactive `markDone` — `Kill()` now runs go-plugin's normal path and the graceful RPC fires uncontended every time (teardown is a deterministic ~2s; the earlier "purely a latency optimization, safe" comment is corrected). Inert today (nothing wired in) but this removes a regression Slice 3 would otherwise inherit.
2. **`codes.NotFound` dead branch removed** — grpc-go only ever returns `Unimplemented` for an unknown service, and the protocol client strips the status anyway; classification now rests solely on the sentinel.

## Verification

`go build`/`go vet` clean (one pre-existing unrelated funnel finding); `go test -race ./pkg/plugin/connector/external/...` → **12/12 pass, race-clean across 3 runs**. Tests use a real in-process go-plugin gRPC server (not mocks) for the reattach, unreachable, and version-mismatch cases. `llms.txt`/`llms-full.txt` regenerated for the new error codes.

## Risk tier

Tier-1-adjacent (plugin runtime), but this slice wires nothing into the data path — **zero data-path risk**, confirmed by the review. That changes at slice 2 (registry/config wiring), which is where the chaos test (Gate 1) and the failure-mode addendum's semantics land.

## Slicing plan

Slice 2: config `Address` field + registry wiring + registration-time `Validate` in CreatePipeline · Slice 3: SIGKILL-the-external-host chaos test (Gate 1) · Slice 4: security posture (mTLS/token provisioning) · Slice 5: `inline_source`/`inline_destination` client-library integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD