### PR TITLE
test: de-flake Property-4 halt watermark + lifecycle FailureEvent under CI load

### DIFF
--- a/pkg/lifecycle/service_test.go
+++ b/pkg/lifecycle/service_test.go
@@ -343,7 +343,13 @@ func TestServiceLifecycle_PipelineError(t *testing.T) {
 	// pipeline errors contain only string messages, so we can only compare the errors by the messages
 	t.Log(pl.Error)
 
-	event, eventReceived, err := cchan.Chan[FailureEvent](events).RecvTimeout(ctx, 200*time.Millisecond)
+	// The OnFailure event is emitted as part of the degradation that WaitPipeline
+	// above already observed, so it arrives ~immediately - but it's delivered on a
+	// separate goroutine, so a too-tight timeout flakes under CI load (the full
+	// -race suite saturating CPUs can delay the send past a sub-second window).
+	// A generous bound removes the flake without weakening the assertion: the
+	// event still MUST arrive.
+	event, eventReceived, err := cchan.Chan[FailureEvent](events).RecvTimeout(ctx, 10*time.Second)
 	is.NoErr(err)
 	is.True(eventReceived)
 	is.Equal(pl.ID, event.ID)

--- a/tests/chaos/property4_test.go
+++ b/tests/chaos/property4_test.go
@@ -241,6 +241,58 @@ func (h *funnelHarness) waitDelivered(t *testing.T, n int, timeout time.Duration
 	)
 }
 
+// waitUpstreamCommitted polls until the synthetic upstream's committed watermark
+// equals want, or fails after timeout. On the halt path, waitHalted returns as
+// soon as Do propagates the fatal error, but the funnel's acks for records
+// handled BEFORE the halt (and thus the upstream commits they drive) land
+// ASYNCHRONOUSLY relative to that — so reading the watermark the instant
+// waitHalted returns races that pipeline. Under CI load (the full -race suite
+// contending) the last handled position's commit can lag the read, and a commit
+// still in flight when the test returns can even race t.TempDir cleanup (a
+// "rename ... no such file" on the store's atomic commit). Polling to the exact
+// expected value removes both races: it waits for precisely the commits that
+// must happen and guarantees they have landed before the test proceeds. It
+// fails loudly if the watermark advances PAST want — that would be the real
+// invariant-6 violation (a halted/DLQ'd record acked upstream "for free").
+func (h *funnelHarness) waitUpstreamCommitted(t *testing.T, want uint64, timeout time.Duration) {
+	t.Helper()
+	is := is.New(t)
+	deadline := time.Now().Add(timeout)
+	var last uint64
+	for time.Now().Before(deadline) {
+		committed, err := h.built.upstream.Committed()
+		is.NoErr(err)
+		last = committed
+		if committed == want {
+			return
+		}
+		if committed > want {
+			t.Fatalf("upstream committed watermark advanced to %d, past the expected %d - a handled-record was acked upstream that should not have been (invariant 6)", committed, want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for upstream committed watermark to reach %d (last observed %d)", want, last)
+}
+
+// waitPersistedPosition polls Conduit's own durably-persisted resume position
+// until it equals want, for the same async-ack reason as waitUpstreamCommitted.
+func (h *funnelHarness) waitPersistedPosition(t *testing.T, want uint64, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last uint64
+	for time.Now().Before(deadline) {
+		last = h.persistedPosition(t)
+		if last == want {
+			return
+		}
+		if last > want {
+			t.Fatalf("persisted resume position advanced to %d, past the expected %d (invariant 6)", last, want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for persisted resume position to reach %d (last observed %d)", want, last)
+}
+
 // stopGracefully stops the worker (draining any in-flight batch, tearing
 // down the source) and waits for the Do goroutine to return, asserting it
 // returned cleanly (no error) - used by the DLQ-routing case, which is
@@ -423,11 +475,13 @@ func TestSchemaDrift_TransportHalf_Halt_PositionNeverAdvances(t *testing.T) {
 	// The core invariant-6 transport assertion: the persisted/upstream
 	// position must NEVER advance past the last successfully handled record
 	// (2) - the drift record must never be acked upstream "for free" just
-	// because the pipeline gave up on it.
-	committed, err := h.built.upstream.Committed()
-	is.NoErr(err)
-	is.Equal(committed, uint64(2))
-	is.Equal(h.persistedPosition(t), uint64(2)) // Conduit's own persisted resume position agrees
+	// because the pipeline gave up on it. Poll (don't read instantly): the
+	// halt path's acks for positions 1-2 land asynchronously relative to
+	// waitHalted returning - see waitUpstreamCommitted. Both helpers fail loudly
+	// if the watermark ever creeps PAST 2, which is the actual invariant-6
+	// violation this test exists to catch.
+	h.waitUpstreamCommitted(t, 2, 10*time.Second)
+	h.waitPersistedPosition(t, 2, 10*time.Second) // Conduit's own persisted resume position agrees
 
 	// At-least-once: a restart must redeliver the unhandled record, not skip
 	// it.


### PR DESCRIPTION
## What

De-flakes two timing-sensitive tests that pass reliably locally (20–30× under `-race`) but flake **only** under the full `-race` test suite's CPU contention in CI — intermittently reddening the `test` job on unrelated PRs (surfaced on #2697).

## The flakes

**1. `tests/chaos` Property-4 halt (`TestSchemaDrift_TransportHalf_Halt_PositionNeverAdvances`) — I introduced this flake in #2694; owning + fixing it.** The fatal-error halt path (`waitHalted`) returns as soon as `Do` propagates the error, but the funnel's acks for records handled *before* the halt — and the upstream commits they drive — land **asynchronously**. Reading the watermark the instant `waitHalted` returned raced that pipeline (`committed==1` vs expected `2`), and a commit still in flight when the test returned could even race `t.TempDir` cleanup (`rename ... no such file`). The DLQ-routing sibling doesn't flake because `stopGracefully` drains first.
Fix: replace the instant reads with `waitUpstreamCommitted`/`waitPersistedPosition` polls (mirroring the existing `waitDelivered`). They fail loudly if the watermark ever creeps **past** the expected value — the actual invariant-6 violation this test guards, so the assertion is *strengthened*, not weakened.

**2. `pkg/lifecycle` `TestServiceLifecycle_PipelineError` (pre-existing).** The `OnFailure` event — emitted as part of the degradation `WaitPipeline` already observed, but delivered on a separate goroutine — was awaited with a **200ms** timeout, too tight under CI load. Bumped to 10s; the event still must arrive, so the assertion is unchanged.

## Why this matters

The Property-4 flake is in the **DBZ-2 suite that's supposed to be a *reliable* gate** — a flaky test there undermines the whole point. This is the third flaky-test incident this session (the `pkg/connector` teardown tests were fixed in #2695); the pattern is timing-sensitive assertions that only break under CI contention.

## Verification

`go build`/`go vet` clean; Property-4 tests **20 passed** under `-race -count=10`, lifecycle **10 passed** under `-race -count=10`; `golangci-lint --new-from-rev=origin/main` → 0 issues. Test-only; no production code.

## Risk tier

Tier 3 (test-only), but hardens the DBZ-2 correctness gate's reliability. Unblocks #2697 (whose `test` job these were flaking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD