### PR TITLE
feat(standalone): WASM host-egress capability (http_request) + SSRF gate + config + bundle e2e

### DIFF
--- a/.github/workflows/bundle-e2e.yml
+++ b/.github/workflows/bundle-e2e.yml
@@ -1,0 +1,61 @@
+name: bundle-e2e
+
+# Cross-repo end-to-end test for the WASM host-egress bundle: builds the REAL
+# embedding.wasm from conduitio/conduit-processor-ai and drives it through this
+# repo's standalone host module + SSRF egress gate. This is the acceptance bar
+# for the host-egress capability (design docs/design-documents/20260726-wasm-host-egress-capability.md).
+#
+# It is intentionally scoped to the paths that make up the bundle, so it runs on
+# changes to the egress gate, the standalone host module, the processor service,
+# or engine config — the surfaces the e2e actually exercises.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    paths:
+      - 'pkg/plugin/processor/egress/**'
+      - 'pkg/plugin/processor/standalone/**'
+      - 'pkg/processor/**'
+      - 'pkg/conduit/**'
+      - '.github/workflows/bundle-e2e.yml'
+      - 'go.mod'
+      - 'go.sum'
+  workflow_dispatch:
+    inputs:
+      processor_ai_ref:
+        description: 'conduit-processor-ai ref to test against'
+        required: false
+        default: 'main'
+
+env:
+  # The conduit-processor-ai ref whose embedding processor is built into WASM
+  # and exercised. Defaults to main; overridable via workflow_dispatch.
+  PROCESSOR_AI_REF: ${{ github.event.inputs.processor_ai_ref || 'main' }}
+
+jobs:
+  bundle-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out conduit
+        uses: actions/checkout@v4
+
+      - name: Check out conduit-processor-ai
+        uses: actions/checkout@v4
+        with:
+          repository: ConduitIO/conduit-processor-ai
+          ref: ${{ env.PROCESSOR_AI_REF }}
+          path: _bundle/conduit-processor-ai
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run host-egress bundle e2e (real guest through host gate)
+        env:
+          CONDUIT_PROCESSOR_AI_DIR: ${{ github.workspace }}/_bundle/conduit-processor-ai
+        run: |
+          go test -race -count=1 -v \
+            -run 'TestEmbeddingWASM_HostEgressBundle_EndToEnd' \
+            ./pkg/plugin/processor/standalone/...

--- a/README.md
+++ b/README.md
@@ -286,6 +286,59 @@ to write custom processors in JavaScript.
 More detailed information as well as examples can be found in
 the [Processors documentation](https://conduitdata.io/docs/using/processors/getting-started).
 
+### Processor host egress
+
+Standalone (WASM) processors can reach the network — for example to call an
+embedding provider — through a host-provided HTTP capability. This is a
+security boundary, so it is **closed by default** and opens in two independent
+tiers (a processor gets egress only where both agree):
+
+1. **Per-processor opt-in (pipeline config).** The pipeline author enables
+   egress for a specific processor with a `sdk.egress.allow` allowlist in that
+   processor's config.
+2. **Engine-level ceiling (instance config, `processors.egress.*`).** The
+   operator running the instance sets an outer bound no pipeline can exceed. The
+   effective allowlist is the **intersection** of the two; entries a pipeline
+   requests that the ceiling does not permit are dropped with a startup warning,
+   never silently honored.
+
+The engine ceiling defaults to **deny-all** — on a stock instance a processor
+requesting egress gets nothing until an operator affirmatively sets
+`processors.egress.enabled: true`. The allowlist is the opt-in; the real SSRF
+guarantee is the dial-time resolved-IP gate (a matched hostname that resolves to
+a private/link-local/hostile address is still refused at connect time), not this
+coarse host pre-filter.
+
+Engine-level configuration options (CLI flag / env var / `conduit.yaml`):
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `processors.egress.enabled` | `false` | Open the ceiling. `false` = deny-all; no pipeline opt-in can override it. |
+| `processors.egress.allow` | _(empty)_ | Allowlist of `host[:port]` / `scheme://host[:port]` entries (repeatable). Empty **with `enabled: true`** means unrestricted (single-tenant convenience). |
+| `processors.egress.secret-refs` | _(empty)_ | Secret names a pipeline may reference for host-injected `Authorization` (repeatable). |
+| `processors.egress.timeout` | `0` (no cap) | Upper bound on the per-call egress timeout; a larger per-processor value is clamped down. |
+| `processors.egress.max-response-bytes` | `0` (no cap) | Upper bound on the buffered response body in bytes; a larger per-processor value is clamped down. |
+
+A malformed engine egress config (for example a wildcard or otherwise invalid
+allowlist entry) fails startup with an actionable error — egress is never
+silently disabled. Example scoping an instance to two embedding providers:
+
+```yaml
+processors:
+  egress:
+    enabled: true
+    allow:
+      - api.openai.com
+      - https://api.voyageai.com:443
+    secret-refs:
+      - openai_api_key
+    max-response-bytes: 4194304 # 4 MiB
+```
+
+See the
+[host-egress design document](docs/design-documents/20260726-wasm-host-egress-capability.md)
+for the full threat model and the two-tier resolution semantics.
+
 ## API
 
 Conduit exposes a gRPC API and an HTTP API.

--- a/cmd/conduit/root/config/config_test.go
+++ b/cmd/conduit/root/config/config_test.go
@@ -133,6 +133,27 @@ func TestConfigWithFlags(t *testing.T) {
 				"pipelines.error-recovery.max-retries-window: 5m0s",
 				"schema-registry.type: builtin",
 				"preview.pipeline-arch-v2: false",
+				// Host-egress ceiling is deny-all by default (the flag is
+				// registered and reads false unless an operator opts in).
+				"processors.egress.enabled: false",
+			},
+		},
+		{
+			name: "egress ceiling flags",
+			args: []string{
+				"--processors.egress.enabled=true",
+				"--processors.egress.allow", "api.openai.com",
+				"--processors.egress.allow", "https://api.voyageai.com:443",
+				"--processors.egress.secret-refs", "openai_api_key",
+				"--processors.egress.timeout", "5s",
+				"--processors.egress.max-response-bytes", "1048576",
+			},
+			wantLines: []string{
+				"processors.egress.enabled: true",
+				"processors.egress.allow: [api.openai.com https://api.voyageai.com:443]",
+				"processors.egress.secret-refs: [openai_api_key]",
+				"processors.egress.timeout: 5s",
+				"processors.egress.max-response-bytes: 1048576",
 			},
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -374,3 +374,5 @@ require (
 	mvdan.cc/gofumpt v0.8.0 // indirect
 	mvdan.cc/unparam v0.0.0-20240528143540-8a5130ca722f // indirect
 )
+
+replace github.com/conduitio/conduit-processor-sdk => /private/tmp/claude-501/-Users-devarisbrown-Code-projects-conduit/ca8b4be3-81fb-4e36-9ea0-6d0dd3d91d7a/scratchpad/sdk

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/conduitio/conduit-connector-protocol v0.9.5
 	github.com/conduitio/conduit-connector-s3 v0.9.3
 	github.com/conduitio/conduit-connector-sdk v0.14.2
-	github.com/conduitio/conduit-processor-sdk v0.5.1
+	github.com/conduitio/conduit-processor-sdk v0.5.2-0.20260727035706-8376e49ad512
 	github.com/conduitio/conduit-schema-registry v0.2.6
 	github.com/conduitio/ecdysis v0.6.0
 	github.com/conduitio/yaml/v3 v3.3.0
@@ -374,5 +374,3 @@ require (
 	mvdan.cc/gofumpt v0.8.0 // indirect
 	mvdan.cc/unparam v0.0.0-20240528143540-8a5130ca722f // indirect
 )
-
-replace github.com/conduitio/conduit-processor-sdk => /private/tmp/claude-501/-Users-devarisbrown-Code-projects-conduit/ca8b4be3-81fb-4e36-9ea0-6d0dd3d91d7a/scratchpad/sdk

--- a/go.sum
+++ b/go.sum
@@ -242,6 +242,8 @@ github.com/conduitio/conduit-connector-s3 v0.9.3 h1:mBLW9WAFzNr0uFTF3PGeMEP6oacY
 github.com/conduitio/conduit-connector-s3 v0.9.3/go.mod h1:rTiVYyOxGEXyYOdsLUyY3nNRAf867entlDYx1I/wl2g=
 github.com/conduitio/conduit-connector-sdk v0.14.2 h1:rRoKXkrLohwj7VV5OFKCI8+Hp7gGi0eyPO5M+QrRoiY=
 github.com/conduitio/conduit-connector-sdk v0.14.2/go.mod h1:U5yE16Y6qT15ZZA7IqXHrR3nI9YRapBeFH/FX1v2q24=
+github.com/conduitio/conduit-processor-sdk v0.5.2-0.20260727035706-8376e49ad512 h1:Em8SA08YQli9fCLNWpCqYeB6iUcgZ259m9Fb8abTNHE=
+github.com/conduitio/conduit-processor-sdk v0.5.2-0.20260727035706-8376e49ad512/go.mod h1:GCbaiprjw+8Q3hDodZx47oXjcENRcLQyKcQLLVyGeQg=
 github.com/conduitio/conduit-schema-registry v0.2.6 h1:39a7AUp3ZM6Hq1vKKpVTmwSTvKbwKC2kxsnkP6H9qrQ=
 github.com/conduitio/conduit-schema-registry v0.2.6/go.mod h1:1A1FUC3SZeU8tBEtSY35Xzfrw7k3Z6FHA0XWyROkbyE=
 github.com/conduitio/ecdysis v0.6.0 h1:sSvB6wMXoBOya96dpAEJxOV7VvvVFEokQavKsG61tcM=

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,6 @@ github.com/conduitio/conduit-connector-s3 v0.9.3 h1:mBLW9WAFzNr0uFTF3PGeMEP6oacY
 github.com/conduitio/conduit-connector-s3 v0.9.3/go.mod h1:rTiVYyOxGEXyYOdsLUyY3nNRAf867entlDYx1I/wl2g=
 github.com/conduitio/conduit-connector-sdk v0.14.2 h1:rRoKXkrLohwj7VV5OFKCI8+Hp7gGi0eyPO5M+QrRoiY=
 github.com/conduitio/conduit-connector-sdk v0.14.2/go.mod h1:U5yE16Y6qT15ZZA7IqXHrR3nI9YRapBeFH/FX1v2q24=
-github.com/conduitio/conduit-processor-sdk v0.5.1 h1:MeZw0smfE5MONQJD+SolMczcTEASagrT8rNBd5vXuyA=
-github.com/conduitio/conduit-processor-sdk v0.5.1/go.mod h1:GCbaiprjw+8Q3hDodZx47oXjcENRcLQyKcQLLVyGeQg=
 github.com/conduitio/conduit-schema-registry v0.2.6 h1:39a7AUp3ZM6Hq1vKKpVTmwSTvKbwKC2kxsnkP6H9qrQ=
 github.com/conduitio/conduit-schema-registry v0.2.6/go.mod h1:1A1FUC3SZeU8tBEtSY35Xzfrw7k3Z6FHA0XWyROkbyE=
 github.com/conduitio/ecdysis v0.6.0 h1:sSvB6wMXoBOya96dpAEJxOV7VvvVFEokQavKsG61tcM=

--- a/pkg/conduit/config.go
+++ b/pkg/conduit/config.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/conduitio/conduit-commons/database"
@@ -29,6 +30,7 @@ import (
 	"github.com/conduitio/conduit/pkg/lifecycle"
 	"github.com/conduitio/conduit/pkg/plugin/connector/builtin"
 	proc_builtin "github.com/conduitio/conduit/pkg/plugin/processor/builtin"
+	"github.com/conduitio/conduit/pkg/plugin/processor/egress"
 	"github.com/conduitio/conduit/pkg/registry/index"
 	"github.com/rs/zerolog"
 	"golang.org/x/exp/constraints"
@@ -167,6 +169,46 @@ type Config struct {
 
 	Processors struct {
 		Path string `long:"processors.path" usage:"path to standalone processors' directory"`
+
+		// Egress is the engine-level host-egress ceiling for standalone (WASM)
+		// processors — the operator's outer bound on the network hosts a
+		// processor may reach via the host `http_request` capability. It clamps
+		// every pipeline's per-processor `sdk.egress.*` opt-in by intersection
+		// (see pkg/plugin/processor/egress.ResolvePolicy).
+		//
+		// SECURITY POSTURE: the default is DENY-ALL. Egress stays fully closed
+		// until an operator affirmatively sets processors.egress.enabled=true
+		// (defense in depth for shared/multi-tenant instances) — a processor
+		// requesting egress on a stock instance gets DenyAll. The allowlist is
+		// the opt-in; the dial-time resolved-IP gate (egress.Refuse) is the real
+		// SSRF guarantee, not this coarse host pre-filter. See
+		// docs/design-documents/20260726-wasm-host-egress-capability.md and the
+		// README "Processor host egress" section.
+		Egress struct {
+			// Enabled opens the engine-level egress ceiling. When false (the
+			// default) the ceiling is deny-all and no pipeline opt-in can
+			// override it, regardless of the fields below.
+			Enabled bool `long:"processors.egress.enabled" mapstructure:"enabled" usage:"open the engine-level host-egress ceiling for standalone processors (default false = deny-all; no pipeline can exceed this ceiling)"`
+			// Allow is the ceiling allowlist of host[:port] / scheme://host[:port]
+			// entries (repeatable, or comma/space-separated). Empty + enabled =>
+			// unrestricted single-tenant mode (honor whatever pipelines request).
+			// Each entry is parsed by egress.ParseAllowlist; a malformed entry
+			// fails startup.
+			Allow []string `long:"processors.egress.allow" mapstructure:"allow" usage:"engine-level egress allowlist: host[:port] or scheme://host[:port] entries (repeatable); empty with enabled=true means unrestricted (single-tenant)"`
+			// SecretRefs is the set of secret names the ceiling grants; a
+			// pipeline may reference (via sdk.egress.secretRefs) only secrets in
+			// this set on a restricted (non-empty Allow) ceiling.
+			SecretRefs []string `long:"processors.egress.secret-refs" mapstructure:"secret-refs" usage:"engine-level egress secret grants: secret names a pipeline may reference for host-injected Authorization (repeatable)"`
+			// Timeout, when > 0, is an upper bound on the per-call egress timeout
+			// no pipeline can exceed (tightening only). 0 means no ceiling cap
+			// (the per-processor value / egress.DefaultTimeout applies).
+			Timeout time.Duration `long:"processors.egress.timeout" mapstructure:"timeout" usage:"engine-level upper bound on the per-call egress timeout (0 = no ceiling cap)"`
+			// MaxResponseBytes, when > 0, is an upper bound on the buffered
+			// response body no pipeline can exceed (tightening only). 0 means no
+			// ceiling cap (the per-processor value / egress.DefaultMaxResponseBytes
+			// applies).
+			MaxResponseBytes int64 `long:"processors.egress.max-response-bytes" mapstructure:"max-response-bytes" usage:"engine-level upper bound on the buffered egress response body in bytes (0 = no ceiling cap)"`
+		} `mapstructure:"egress"`
 	}
 
 	Pipelines struct {
@@ -283,6 +325,10 @@ func DefaultConfigWithBasePath(basePath string) Config {
 	cfg.Install.AllowStaleBundle = false
 
 	cfg.Processors.Path = filepath.Join(basePath, "processors")
+	// Deny-all by default: the host-egress ceiling is closed until an operator
+	// affirmatively opens it (processors.egress.enabled=true). Set explicitly so
+	// the security default is legible here and anchored by a test.
+	cfg.Processors.Egress.Enabled = false
 
 	cfg.Pipelines.Path = filepath.Join(basePath, "pipelines")
 	cfg.Pipelines.ErrorRecovery.MinDelay = time.Second
@@ -397,6 +443,73 @@ func (c Config) validateSchemaRegistryConfig() error {
 	return nil
 }
 
+// egressCeiling translates the operator's engine-level egress config
+// (processors.egress.*) into the egress.Policy ceiling handed to the processor
+// service via processor.WithEgressCeiling. It is the single source of truth for
+// that translation: Config.Validate calls it to surface a malformed config as a
+// startup error, and createServices calls it to build the ceiling actually
+// passed to the engine.
+//
+// SECURITY: a zero/disabled config yields egress.DenyAll() (Enabled=false) — the
+// deny-all default that keeps the host-egress boundary closed until an operator
+// sets processors.egress.enabled=true. A malformed allowlist or negative bound
+// is a startup error, NEVER a silent disable (a silent disable would be a
+// confusing security surprise: the operator thinks egress is scoped when it is
+// actually off, or vice-versa).
+func (c Config) egressCeiling() (egress.Policy, error) {
+	e := c.Processors.Egress
+
+	// Parse/validate the allowlist regardless of Enabled so a typo fails startup
+	// rather than silently doing nothing. ParseAllowlist accepts the repeatable
+	// []string joined with commas (it also splits on commas/whitespace itself),
+	// so both `--processors.egress.allow a --processors.egress.allow b` and a
+	// single "a,b" env/yaml value parse identically.
+	allow, err := egress.ParseAllowlist(strings.Join(e.Allow, ","))
+	if err != nil {
+		return egress.DenyAll(), cerrors.Errorf("%q config value is invalid: %w", "processors.egress.allow", err)
+	}
+	if e.Timeout < 0 {
+		return egress.DenyAll(), invalidConfigFieldErr("processors.egress.timeout")
+	}
+	if e.MaxResponseBytes < 0 {
+		return egress.DenyAll(), invalidConfigFieldErr("processors.egress.max-response-bytes")
+	}
+
+	if !e.Enabled {
+		// Deny-all default (defense in depth): the ceiling stays closed no matter
+		// what else is configured. Returning the zero-value Policy makes
+		// ResolvePolicy return DenyAll for every processor.
+		return egress.DenyAll(), nil
+	}
+
+	var secretRefs map[string]struct{}
+	if len(e.SecretRefs) > 0 {
+		secretRefs = make(map[string]struct{})
+		for _, raw := range e.SecretRefs {
+			for _, name := range strings.FieldsFunc(raw, func(r rune) bool {
+				return r == ',' || r == ' ' || r == '\t' || r == '\n'
+			}) {
+				secretRefs[name] = struct{}{}
+			}
+		}
+	}
+
+	return egress.Policy{
+		Enabled:          true,
+		Allowlist:        allow,
+		SecretRefs:       secretRefs,
+		Timeout:          e.Timeout,          // 0 => ResolvePolicy applies no ceiling cap
+		MaxResponseBytes: e.MaxResponseBytes, // 0 => ResolvePolicy applies no ceiling cap
+	}, nil
+}
+
+// validateEgressConfig fails startup on a malformed engine-level egress config
+// (bad allowlist entry, negative bound). It never silently disables egress.
+func (c Config) validateEgressConfig() error {
+	_, err := c.egressCeiling()
+	return err
+}
+
 func (c Config) validateErrorRecovery() error {
 	errRecoveryCfg := c.Pipelines.ErrorRecovery
 	var errs []error
@@ -465,6 +578,10 @@ func (c Config) Validate() error {
 
 	if err := c.validateErrorRecovery(); err != nil {
 		return cerrors.Errorf("invalid error recovery config: %w", err)
+	}
+
+	if err := c.validateEgressConfig(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/conduit/config_test.go
+++ b/pkg/conduit/config_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/conduitio/conduit-commons/database/inmemory"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/lifecycle"
+	"github.com/conduitio/conduit/pkg/plugin/processor/egress"
 	"github.com/matryer/is"
 )
 
@@ -44,6 +45,70 @@ func TestDefaultConfig_AllowUnsignedDisabledByDefault(t *testing.T) {
 	is := is.New(t)
 	cfg := DefaultConfigWithBasePath(t.TempDir())
 	is.True(!cfg.Install.AllowUnsigned)
+}
+
+// TestDefaultConfig_EgressCeilingDenyAllByDefault locks in the host-egress
+// security default (docs/design-documents/20260726-wasm-host-egress-capability.md
+// §"Default deny-all"): a fresh config produces a deny-all engine egress ceiling
+// (Enabled=false). Egress must stay fully closed until an operator affirmatively
+// sets processors.egress.enabled=true — so a processor requesting egress on a
+// stock instance resolves to DenyAll.
+func TestDefaultConfig_EgressCeilingDenyAllByDefault(t *testing.T) {
+	is := is.New(t)
+	cfg := DefaultConfigWithBasePath(t.TempDir())
+	is.True(!cfg.Processors.Egress.Enabled) // the operator has not opted in
+
+	ceiling, err := cfg.egressCeiling()
+	is.NoErr(err)
+	is.True(!ceiling.Enabled) // the ceiling handed to the engine is deny-all
+
+	// End-to-end: a processor that requests egress against this default ceiling
+	// resolves to DenyAll — the closed default is the effective policy, not just
+	// the config value.
+	requested := egress.Policy{
+		Enabled:   true,
+		Allowlist: []egress.AllowEntry{{Scheme: "https", Host: "api.openai.com", Port: "443"}},
+	}
+	effective, dropped := egress.ResolvePolicy(requested, ceiling)
+	is.True(!effective.Enabled) // deny-all: the pipeline opt-in cannot open a closed ceiling
+	is.Equal(len(dropped), 1)   // the requested entry is reported as dropped, never honored
+}
+
+// TestConfig_EgressCeiling_EnabledIntersection verifies that an operator-enabled
+// ceiling with an allowlist produces the expected intersection through the same
+// egress.ResolvePolicy the engine uses, and that the ceiling's timeout/size caps
+// clamp a wider per-processor request (tightening-only).
+func TestConfig_EgressCeiling_EnabledIntersection(t *testing.T) {
+	is := is.New(t)
+	cfg := DefaultConfigWithBasePath(t.TempDir())
+	cfg.Processors.Egress.Enabled = true
+	cfg.Processors.Egress.Allow = []string{"api.openai.com", "api.voyageai.com"}
+	cfg.Processors.Egress.Timeout = 5 * time.Second
+	cfg.Processors.Egress.MaxResponseBytes = 1 << 20 // 1 MiB
+
+	ceiling, err := cfg.egressCeiling()
+	is.NoErr(err)
+	is.True(ceiling.Enabled)
+	is.Equal(len(ceiling.Allowlist), 2)
+
+	// Pipeline requests one in-ceiling host + one outside it, with a wider timeout.
+	requested := egress.Policy{
+		Enabled: true,
+		Allowlist: []egress.AllowEntry{
+			{Scheme: "https", Host: "api.openai.com", Port: "443"},
+			{Scheme: "https", Host: "evil.example.com", Port: "443"},
+		},
+		Timeout:          60 * time.Second,
+		MaxResponseBytes: 8 << 20,
+	}
+	effective, dropped := egress.ResolvePolicy(requested, ceiling)
+	is.True(effective.Enabled)
+	is.Equal(len(effective.Allowlist), 1) // intersection: only the in-ceiling host survives
+	is.Equal(effective.Allowlist[0].Host, "api.openai.com")
+	is.Equal(len(dropped), 1) // the out-of-ceiling host is dropped, never honored
+	is.Equal(dropped[0].Host, "evil.example.com")
+	is.Equal(effective.Timeout, 5*time.Second)         // clamped down to the ceiling
+	is.Equal(effective.MaxResponseBytes, int64(1<<20)) // clamped down to the ceiling
 }
 
 func TestConfig_Validate(t *testing.T) {
@@ -308,6 +373,60 @@ func TestConfig_Validate(t *testing.T) {
 				return c
 			},
 			want: cerrors.New(`invalid error recovery config: "max-retries-window" config value must be positive (got: -1s)`),
+		},
+		{
+			name: "egress: disabled with entries is valid (deny-all, entries still validated)",
+			setupConfig: func(c Config) Config {
+				c.Processors.Egress.Enabled = false
+				c.Processors.Egress.Allow = []string{"api.openai.com"}
+				return c
+			},
+			want: nil,
+		},
+		{
+			name: "egress: enabled with valid allowlist",
+			setupConfig: func(c Config) Config {
+				c.Processors.Egress.Enabled = true
+				c.Processors.Egress.Allow = []string{"api.openai.com", "https://api.voyageai.com:443"}
+				return c
+			},
+			want: nil,
+		},
+		{
+			name: "egress: malformed allowlist entry fails startup (never silently disables)",
+			setupConfig: func(c Config) Config {
+				c.Processors.Egress.Enabled = true
+				c.Processors.Egress.Allow = []string{"*.evil.com"}
+				return c
+			},
+			want: cerrors.New(`"processors.egress.allow" config value is invalid: wildcard allowlist entries are not permitted: "*.evil.com"`),
+		},
+		{
+			name: "egress: malformed allowlist entry fails even when disabled",
+			setupConfig: func(c Config) Config {
+				c.Processors.Egress.Enabled = false
+				c.Processors.Egress.Allow = []string{"*.evil.com"}
+				return c
+			},
+			want: cerrors.New(`"processors.egress.allow" config value is invalid: wildcard allowlist entries are not permitted: "*.evil.com"`),
+		},
+		{
+			name: "egress: negative timeout fails startup",
+			setupConfig: func(c Config) Config {
+				c.Processors.Egress.Enabled = true
+				c.Processors.Egress.Timeout = -time.Second
+				return c
+			},
+			want: invalidConfigFieldErr("processors.egress.timeout"),
+		},
+		{
+			name: "egress: negative max-response-bytes fails startup",
+			setupConfig: func(c Config) Config {
+				c.Processors.Egress.Enabled = true
+				c.Processors.Egress.MaxResponseBytes = -1
+				return c
+			},
+			want: invalidConfigFieldErr("processors.egress.max-response-bytes"),
 		},
 	}
 

--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -293,7 +293,8 @@ func NewRuntime(cfg Config, opts ...RuntimeOption) (*Runtime, error) {
 	measure.ConduitInfo.WithValues(Version(true)).Inc()
 
 	// Start the connector persister
-	connectorPersister := connector.NewPersister(logger, db,
+	connectorPersister := connector.NewPersister(
+		logger, db,
 		connector.DefaultPersisterDelayThreshold,
 		connector.DefaultPersisterBundleCountThreshold,
 	)
@@ -413,7 +414,18 @@ func createServices(r *Runtime) error {
 
 	plService := pipeline.NewService(r.logger, r.DB)
 	connService := connector.NewService(r.logger, r.DB, r.connectorPersister)
-	procService := processor.NewService(r.logger, r.DB, procPluginService)
+
+	// Engine-level host-egress ceiling (processors.egress.*). Its default is
+	// deny-all, so on a stock instance this passes a closed ceiling and every
+	// processor resolves to DenyAll. Already validated in Config.Validate (called
+	// in NewRuntime before createServices); rebuilt here as the single source of
+	// truth. Re-checked defensively so a future caller that skips Validate still
+	// fails closed rather than silently running with no ceiling.
+	egressCeiling, err := r.Config.egressCeiling()
+	if err != nil {
+		return cerrors.Errorf("invalid processor egress config: %w", err)
+	}
+	procService := processor.NewService(r.logger, r.DB, procPluginService, processor.WithEgressCeiling(egressCeiling))
 
 	var lifecycleService lifecycleService
 	if r.Config.Preview.PipelineArchV2 {

--- a/pkg/orchestrator/mock/orchestrator.go
+++ b/pkg/orchestrator/mock/orchestrator.go
@@ -1227,45 +1227,6 @@ func (c *ProcessorPluginServiceListCall) DoAndReturn(f func(context.Context) (ma
 	return c
 }
 
-// NewProcessor mocks base method.
-func (m *ProcessorPluginService) NewProcessor(ctx context.Context, pluginName, id string) (sdk.Processor, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewProcessor", ctx, pluginName, id)
-	ret0, _ := ret[0].(sdk.Processor)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// NewProcessor indicates an expected call of NewProcessor.
-func (mr *ProcessorPluginServiceMockRecorder) NewProcessor(ctx, pluginName, id any) *ProcessorPluginServiceNewProcessorCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewProcessor", reflect.TypeOf((*ProcessorPluginService)(nil).NewProcessor), ctx, pluginName, id)
-	return &ProcessorPluginServiceNewProcessorCall{Call: call}
-}
-
-// ProcessorPluginServiceNewProcessorCall wrap *gomock.Call
-type ProcessorPluginServiceNewProcessorCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *ProcessorPluginServiceNewProcessorCall) Return(arg0 sdk.Processor, arg1 error) *ProcessorPluginServiceNewProcessorCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *ProcessorPluginServiceNewProcessorCall) Do(f func(context.Context, string, string) (sdk.Processor, error)) *ProcessorPluginServiceNewProcessorCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ProcessorPluginServiceNewProcessorCall) DoAndReturn(f func(context.Context, string, string) (sdk.Processor, error)) *ProcessorPluginServiceNewProcessorCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // RegisterStandalonePlugin mocks base method.
 func (m *ProcessorPluginService) RegisterStandalonePlugin(ctx context.Context, path string) (string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -121,7 +121,6 @@ type ConnectorPluginService interface {
 
 type ProcessorPluginService interface {
 	List(ctx context.Context) (map[string]processorSdk.Specification, error)
-	NewProcessor(ctx context.Context, pluginName string, id string) (processorSdk.Processor, error)
 	RegisterStandalonePlugin(ctx context.Context, path string) (string, error)
 }
 

--- a/pkg/plugin/processor/builtin/registry.go
+++ b/pkg/plugin/processor/builtin/registry.go
@@ -38,6 +38,7 @@ import (
 	"github.com/conduitio/conduit/pkg/plugin/processor/builtin/impl/openai"
 	"github.com/conduitio/conduit/pkg/plugin/processor/builtin/impl/unwrap"
 	"github.com/conduitio/conduit/pkg/plugin/processor/builtin/impl/webhook"
+	"github.com/conduitio/conduit/pkg/plugin/processor/egress"
 	"github.com/conduitio/conduit/pkg/plugin/processor/procutils"
 	"github.com/conduitio/conduit/pkg/schemaregistry"
 )
@@ -189,7 +190,11 @@ func newFullName(pluginName, pluginVersion string) plugin.FullName {
 	return plugin.NewFullName(plugin.PluginTypeBuiltin, pluginName, pluginVersion)
 }
 
-func (r *Registry) NewProcessor(_ context.Context, fullName plugin.FullName, id string) (sdk.Processor, error) {
+// NewProcessor builds a built-in processor. The egressPolicy argument exists to
+// satisfy the shared registry interface; built-in processors are compiled into
+// the core binary with full net/http and are NOT sandboxed, so the WASM
+// host-egress gate does not apply to them and the policy is ignored here.
+func (r *Registry) NewProcessor(_ context.Context, fullName plugin.FullName, id string, _ egress.Policy) (sdk.Processor, error) {
 	versionMap, ok := r.plugins[fullName.PluginName()]
 	if !ok {
 		// Invariant: errors.Is(err, plugin.ErrPluginNotFound) still holds — the

--- a/pkg/plugin/processor/egress/config.go
+++ b/pkg/plugin/processor/egress/config.go
@@ -1,0 +1,96 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package egress
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+)
+
+// Host-reserved processor config keys that opt a standalone processor into
+// egress. They are operator-authored (the pipeline YAML author is the operator),
+// read HOST-SIDE at processor-open time, and never trusted from guest runtime
+// input — a guest cannot widen its own policy by echoing these back.
+const (
+	// ConfigKeyAllow is a comma/space-separated allowlist of host[:port] or
+	// scheme://host[:port] entries. Presence opts the processor into egress.
+	ConfigKeyAllow = "sdk.egress.allow"
+	// ConfigKeyTimeout is a Go duration (e.g. "30s") for the per-call timeout.
+	ConfigKeyTimeout = "sdk.egress.timeout"
+	// ConfigKeyMaxResponseBytes caps the buffered (decompressed) response body.
+	ConfigKeyMaxResponseBytes = "sdk.egress.maxResponseBytes"
+	// ConfigKeySecretRefs is a comma/space-separated list of secret names this
+	// processor may reference via HTTPRequest.AuthSecretRef.
+	ConfigKeySecretRefs = "sdk.egress.secretRefs" //nolint:gosec // config key name, not a credential value
+)
+
+// splitList splits a comma/whitespace-separated config value into trimmed,
+// non-empty tokens.
+func splitList(raw string) []string {
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n'
+	})
+	return fields
+}
+
+// PolicyFromSettings builds an unresolved per-processor Policy from a processor's
+// config Settings. It does NOT apply the engine ceiling — call ResolvePolicy with
+// the returned policy and the ceiling to get the effective, clamped policy. A
+// Settings map with no ConfigKeyAllow yields a deny-all policy (egress off).
+func PolicyFromSettings(settings map[string]string) (Policy, error) {
+	allowRaw, ok := settings[ConfigKeyAllow]
+	if !ok || strings.TrimSpace(allowRaw) == "" {
+		return DenyAll(), nil
+	}
+
+	allow, err := ParseAllowlist(allowRaw)
+	if err != nil {
+		return Policy{}, cerrors.Errorf("invalid %s: %w", ConfigKeyAllow, err)
+	}
+
+	p := Policy{
+		Enabled:          true,
+		Allowlist:        allow,
+		Timeout:          DefaultTimeout,
+		MaxResponseBytes: DefaultMaxResponseBytes,
+	}
+
+	if v := strings.TrimSpace(settings[ConfigKeyTimeout]); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil || d <= 0 {
+			return Policy{}, cerrors.Errorf("invalid %s: %q", ConfigKeyTimeout, v)
+		}
+		p.Timeout = d
+	}
+	if v := strings.TrimSpace(settings[ConfigKeyMaxResponseBytes]); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil || n <= 0 {
+			return Policy{}, cerrors.Errorf("invalid %s: %q", ConfigKeyMaxResponseBytes, v)
+		}
+		p.MaxResponseBytes = n
+	}
+	if v := strings.TrimSpace(settings[ConfigKeySecretRefs]); v != "" {
+		refs := splitList(v)
+		p.SecretRefs = make(map[string]struct{}, len(refs))
+		for _, r := range refs {
+			p.SecretRefs[r] = struct{}{}
+		}
+	}
+
+	return p, nil
+}

--- a/pkg/plugin/processor/egress/doc.go
+++ b/pkg/plugin/processor/egress/doc.go
@@ -1,0 +1,53 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package egress implements the host side of the WASM host-mediated
+// network-egress capability for standalone (WASM) processors, per
+// docs/design-documents/20260726-wasm-host-egress-capability.md.
+//
+// This package IS the security boundary. Standalone processors are untrusted,
+// possibly-third-party guest code with no socket API; egress means the host
+// (which can reach cloud metadata, loopback, and the private VPC) makes an
+// outbound request whose destination is influenced by that guest. That is the
+// textbook Server-Side Request Forgery (SSRF) setup, so every request is
+// enforced against a per-processor policy in two independent stages:
+//
+//   - Stage 1 (coarse, [Policy.MatchHostPort]): the request URL's scheme and
+//     host:port must match an entry in the processor's resolved allowlist. This
+//     is a fast reject and a usability aid — it is NOT the guarantee, because a
+//     matched hostname can still resolve to a hostile address.
+//
+//   - Stage 2 (load-bearing, [Service.dialControl] via [Guard.Refuse]): a
+//     net.Dialer.Control hook fires immediately before every connect(2), for
+//     every candidate address the resolver returns, for http AND TLS dials
+//     alike. It refuses the connection if the resolved IP is in a private,
+//     loopback, link-local, reserved, or embedded-v4 (v4-mapped / NAT64 /
+//     6to4 / Teredo) range, UNLESS the exact (IP, port) pair is an explicit
+//     allowlist entry (the local-Ollama carve-out). Running per resolved IP at
+//     dial time closes the DNS-rebinding / TOCTOU window a string allowlist
+//     leaves open.
+//
+// Additional hardening the [Service] applies: the transport uses NO proxy
+// (Transport.Proxy is pinned nil so HTTP(S)_PROXY / ALL_PROXY cannot bypass the
+// dialer), redirects are not followed, Host / Authorization / Accept-Encoding
+// are host-reserved (guest overrides rejected), the per-call timeout and the
+// response-size cap (io.LimitReader on the decompressed stream) are
+// host-enforced, and credentials are host-injected from a secret reference the
+// guest names — the key never enters guest memory.
+//
+// Policy is bound per-processor: each processor instance gets its own Service
+// with its own Policy captured in the dialer's Control closure. No egress
+// policy is ever held on a shared registry field, so one pipeline's allowlist
+// cannot leak to another (a tested isolation invariant).
+package egress

--- a/pkg/plugin/processor/egress/ipguard.go
+++ b/pkg/plugin/processor/egress/ipguard.go
@@ -29,9 +29,11 @@ const (
 	reasonV4CGNAT      refusedReason = "v4_cgnat"
 	reasonV6Loopback   refusedReason = "v6_loopback_or_unspecified"
 	reasonV6LinkLocal  refusedReason = "v6_link_local"
+	reasonV6SiteLocal  refusedReason = "v6_site_local"
 	reasonV6ULA        refusedReason = "v6_ula"
 	reasonV4Mapped     refusedReason = "v4_mapped_embedded"
 	reasonV4Compatible refusedReason = "v4_compatible_embedded"
+	reasonV4Translated refusedReason = "v4_translated_embedded"
 	reasonNAT64        refusedReason = "nat64_embedded_v4"
 	reasonSixToFour    refusedReason = "6to4_embedded_v4"
 	reasonTeredo       refusedReason = "teredo_embedded_v4"
@@ -74,10 +76,21 @@ var refusedV6 = []struct {
 	{mustCIDR("::1/128"), reasonV6Loopback},
 	{mustCIDR("::/128"), reasonV6Loopback},
 	{mustCIDR("fe80::/10"), reasonV6LinkLocal},
+	{mustCIDR("fec0::/10"), reasonV6SiteLocal}, // RFC 3879 deprecated site-local, still parseable/private
 	{mustCIDR("fc00::/7"), reasonV6ULA},
 }
 
-var nat64Net = mustCIDR("64:ff9b::/96") // RFC 6052 well-known NAT64 prefix
+var (
+	nat64Net = mustCIDR("64:ff9b::/96") // RFC 6052 well-known NAT64 prefix
+	// v4TranslatedNet is the RFC 6052 IPv4-Translated special-purpose prefix. It
+	// is DISTINCT from the v4-mapped ::ffff:0:0/96 that ip.To4() unwraps: the
+	// embedded v4 sits one 16-bit group further right (bytes [12:16] with ffff at
+	// bytes [8:9]), so To4() returns nil for it and classifyV4 never sees it. A
+	// DNS64/SIIT translator can synthesize ::ffff:0:<metadata-v4> to smuggle a
+	// private/metadata dial past a gate that only unwraps v4-mapped — refuse the
+	// whole block wholesale, in the same threat class as NAT64/6to4/Teredo.
+	v4TranslatedNet = mustCIDR("::ffff:0:0:0/96")
+)
 
 // classifyV4 runs the IPv4 refused-range floor on a 4-byte (or v4-mapped) IP.
 func classifyV4(ip net.IP) refusedReason {
@@ -144,6 +157,12 @@ func Refuse(ip net.IP) (bool, refusedReason) {
 	if nat64Net.Contains(ip16) {
 		return true, reasonNAT64
 	}
+	// IPv4-Translated ::ffff:0:0:0/96 (RFC 6052) — embeds a v4 in bytes [12:16]
+	// that To4() does NOT unwrap (ffff sits at [8:9], not [10:11]); refuse
+	// wholesale so a synthesized ::ffff:0:<private-v4> cannot slip the gate.
+	if v4TranslatedNet.Contains(ip16) {
+		return true, reasonV4Translated
+	}
 	// 6to4 2002::/16 embeds the v4 in bytes [2:6]; refuse wholesale.
 	if ip16[0] == 0x20 && ip16[1] == 0x02 {
 		return true, reasonSixToFour
@@ -199,6 +218,8 @@ func embeddedV4(ip net.IP) net.IP {
 	}
 	switch {
 	case nat64Net.Contains(ip16):
+		return net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15])
+	case v4TranslatedNet.Contains(ip16): // RFC 6052 IPv4-translated: embedded v4 in [12:16]
 		return net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15])
 	case ip16[0] == 0x20 && ip16[1] == 0x02: // 6to4
 		return net.IPv4(ip16[2], ip16[3], ip16[4], ip16[5])

--- a/pkg/plugin/processor/egress/ipguard.go
+++ b/pkg/plugin/processor/egress/ipguard.go
@@ -1,0 +1,210 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package egress
+
+import "net"
+
+// refusedReason is a stable, log-safe label for why a resolved IP was refused.
+// It is emitted in the audit log (never the request/response body).
+type refusedReason string
+
+const (
+	reasonNotRefused   refusedReason = ""
+	reasonUnparseable  refusedReason = "unparseable_ip"
+	reasonV4Loopback   refusedReason = "v4_loopback_or_any"
+	reasonV4Private    refusedReason = "v4_private"
+	reasonV4LinkLocal  refusedReason = "v4_link_local_or_metadata"
+	reasonV4CGNAT      refusedReason = "v4_cgnat"
+	reasonV6Loopback   refusedReason = "v6_loopback_or_unspecified"
+	reasonV6LinkLocal  refusedReason = "v6_link_local"
+	reasonV6ULA        refusedReason = "v6_ula"
+	reasonV4Mapped     refusedReason = "v4_mapped_embedded"
+	reasonV4Compatible refusedReason = "v4_compatible_embedded"
+	reasonNAT64        refusedReason = "nat64_embedded_v4"
+	reasonSixToFour    refusedReason = "6to4_embedded_v4"
+	reasonTeredo       refusedReason = "teredo_embedded_v4"
+	reasonMulticastEtc refusedReason = "reserved_or_multicast"
+)
+
+// mustCIDR parses a CIDR at init and panics on error; the inputs are compile-time
+// constants, so a parse failure is a programming error, not a runtime condition.
+func mustCIDR(s string) *net.IPNet {
+	_, n, err := net.ParseCIDR(s)
+	if err != nil {
+		panic("egress: invalid built-in CIDR " + s + ": " + err.Error())
+	}
+	return n
+}
+
+// refusedV4 is the fixed IPv4 floor: loopback/any, RFC 1918 private, link-local
+// (incl. the 169.254.169.254 metadata endpoint), and CGNAT. This floor is
+// non-negotiable per the design; the classifier may only ever get stricter.
+var refusedV4 = []struct {
+	net    *net.IPNet
+	reason refusedReason
+}{
+	{mustCIDR("127.0.0.0/8"), reasonV4Loopback},
+	{mustCIDR("0.0.0.0/8"), reasonV4Loopback},
+	{mustCIDR("10.0.0.0/8"), reasonV4Private},
+	{mustCIDR("172.16.0.0/12"), reasonV4Private},
+	{mustCIDR("192.168.0.0/16"), reasonV4Private},
+	{mustCIDR("169.254.0.0/16"), reasonV4LinkLocal}, // includes 169.254.169.254 (metadata)
+	{mustCIDR("100.64.0.0/10"), reasonV4CGNAT},
+}
+
+// refusedV6 is the fixed IPv6 floor for genuinely-v6 addresses (loopback,
+// unspecified, link-local, ULA). Embedded-v4 forms are handled separately in
+// Refuse by unwrapping to their v4 representation and re-running the v4 floor.
+var refusedV6 = []struct {
+	net    *net.IPNet
+	reason refusedReason
+}{
+	{mustCIDR("::1/128"), reasonV6Loopback},
+	{mustCIDR("::/128"), reasonV6Loopback},
+	{mustCIDR("fe80::/10"), reasonV6LinkLocal},
+	{mustCIDR("fc00::/7"), reasonV6ULA},
+}
+
+var nat64Net = mustCIDR("64:ff9b::/96") // RFC 6052 well-known NAT64 prefix
+
+// classifyV4 runs the IPv4 refused-range floor on a 4-byte (or v4-mapped) IP.
+func classifyV4(ip net.IP) refusedReason {
+	v4 := ip.To4()
+	if v4 == nil {
+		return reasonUnparseable
+	}
+	for _, r := range refusedV4 {
+		if r.net.Contains(v4) {
+			return r.reason
+		}
+	}
+	// Also refuse anything not a global unicast address that slipped through
+	// (multicast 224.0.0.0/4, broadcast 255.255.255.255).
+	if v4[0] >= 224 {
+		return reasonMulticastEtc
+	}
+	return reasonNotRefused
+}
+
+// Refuse reports whether an IP about to be dialed must be refused, and why.
+//
+// It is the single classifier used by the dial-time Control hook. It runs on
+// the parsed net.IP (not the textual form), so decimal/octal/hex encodings are
+// irrelevant — they all parse to the same address bytes. Embedded-v4 IPv6 forms
+// (v4-mapped ::ffff:, v4-compatible ::/96, NAT64 64:ff9b::/96, 6to4 2002::/16,
+// Teredo 2001::/32) are unwrapped to their v4 form and re-checked against the v4
+// floor, and the synthesized-prefix blocks (NAT64/6to4/Teredo/v4-compatible) are
+// refused wholesale as a belt-and-braces default — no legitimate egress target
+// is reached only via a synthesized address. reasonNotRefused ("") means allowed
+// by range (the caller still applies the explicit-(IP,port) carve-out).
+//
+// Invariant (design § Security boundary, Stage 2): every candidate resolved IP
+// is classified here at dial time; the metadata endpoint (169.254.169.254) and
+// all private/loopback ranges are refused unless an explicit (IP, port)
+// carve-out admits the exact pair.
+func Refuse(ip net.IP) (bool, refusedReason) {
+	if ip == nil {
+		return true, reasonUnparseable
+	}
+	ip16 := ip.To16()
+	if ip16 == nil {
+		return true, reasonUnparseable
+	}
+
+	// IPv4 or IPv4-mapped IPv6 (::ffff:a.b.c.d): To4 returns the 4-byte form for
+	// both, so this branch covers the v4-mapped unwrap for free.
+	if v4 := ip.To4(); v4 != nil {
+		if r := classifyV4(v4); r != reasonNotRefused {
+			// Distinguish a mapped form for the audit log.
+			if len(ip) == net.IPv6len && !isRawV4(ip) {
+				return true, reasonV4Mapped
+			}
+			return true, r
+		}
+		return false, reasonNotRefused
+	}
+
+	// From here the address is genuinely IPv6.
+
+	// NAT64 64:ff9b::/96 — a DNS64 resolver (or a hostile authoritative server)
+	// can legitimately synthesize 64:ff9b::a9fe:a9fe which EMBEDS 169.254.169.254.
+	// Unwrap the embedded v4 and re-check, and refuse the whole block outright.
+	if nat64Net.Contains(ip16) {
+		return true, reasonNAT64
+	}
+	// 6to4 2002::/16 embeds the v4 in bytes [2:6]; refuse wholesale.
+	if ip16[0] == 0x20 && ip16[1] == 0x02 {
+		return true, reasonSixToFour
+	}
+	// Teredo 2001:0000::/32 embeds a v4 (obfuscated) client/server address; refuse wholesale.
+	if ip16[0] == 0x20 && ip16[1] == 0x01 && ip16[2] == 0x00 && ip16[3] == 0x00 {
+		return true, reasonTeredo
+	}
+	// IPv4-compatible ::/96 (first 12 bytes zero, not :: or ::1): deprecated,
+	// unwrap the embedded v4 and refuse wholesale.
+	if isV4Compatible(ip16) {
+		return true, reasonV4Compatible
+	}
+
+	for _, r := range refusedV6 {
+		if r.net.Contains(ip16) {
+			return true, r.reason
+		}
+	}
+	// Refuse multicast (ff00::/8) and other non-global scopes defensively.
+	if ip16[0] == 0xff {
+		return true, reasonMulticastEtc
+	}
+	return false, reasonNotRefused
+}
+
+// isRawV4 reports whether ip is stored as a native 4-byte IPv4 (vs a 16-byte
+// v4-mapped form), used only to label the audit reason.
+func isRawV4(ip net.IP) bool { return len(ip) == net.IPv4len }
+
+// isV4Compatible reports whether ip16 is an IPv4-compatible IPv6 address
+// (::a.b.c.d, first 12 bytes zero) other than :: and ::1.
+func isV4Compatible(ip16 net.IP) bool {
+	for i := 0; i < 12; i++ {
+		if ip16[i] != 0 {
+			return false
+		}
+	}
+	// exclude :: (all zero) and ::1 — those are caught by the v6 loopback floor,
+	// but if this runs first, still unwrap: last 4 bytes 0.0.0.0 / 0.0.0.1 are in
+	// 0.0.0.0/8 so they'd be refused anyway. Treat anything with a non-trivial
+	// embedded v4 as v4-compatible.
+	last4 := ip16[12:16]
+	return last4[0] != 0 || last4[1] != 0 || last4[2] != 0 || (last4[3] != 0 && last4[3] != 1)
+}
+
+// embeddedV4 extracts the IPv4 address embedded in a synthesized IPv6 form, for
+// audit logging. Returns nil if none is embedded.
+func embeddedV4(ip net.IP) net.IP {
+	ip16 := ip.To16()
+	if ip16 == nil {
+		return nil
+	}
+	switch {
+	case nat64Net.Contains(ip16):
+		return net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15])
+	case ip16[0] == 0x20 && ip16[1] == 0x02: // 6to4
+		return net.IPv4(ip16[2], ip16[3], ip16[4], ip16[5])
+	case isV4Compatible(ip16):
+		return net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15])
+	default:
+		return nil
+	}
+}

--- a/pkg/plugin/processor/egress/ipguard_test.go
+++ b/pkg/plugin/processor/egress/ipguard_test.go
@@ -1,0 +1,168 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package egress
+
+import (
+	"net"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+// TestRefuse_RefusedRanges is the parameterized refused-range table (design
+// § Testing). It proves the Stage-2 classifier refuses every private, loopback,
+// link-local, reserved, and embedded-v4 range — including the metadata endpoint,
+// the v4-mapped form, and the NAT64/6to4/Teredo/v4-compatible embedded forms.
+func TestRefuse_RefusedRanges(t *testing.T) {
+	cases := []struct {
+		name string
+		ip   string
+	}{
+		// IPv4 floor
+		{"v4 loopback", "127.0.0.1"},
+		{"v4 loopback high", "127.255.255.254"},
+		{"v4 any", "0.0.0.0"},
+		{"v4 private 10", "10.1.2.3"},
+		{"v4 private 172.16", "172.16.5.5"},
+		{"v4 private 172.31", "172.31.255.255"},
+		{"v4 private 192.168", "192.168.1.1"},
+		{"v4 link-local", "169.254.1.1"},
+		{"v4 METADATA 169.254.169.254", "169.254.169.254"},
+		{"v4 cgnat", "100.64.0.1"},
+		{"v4 multicast", "224.0.0.1"},
+		{"v4 broadcast", "255.255.255.255"},
+		// IPv6 floor
+		{"v6 loopback", "::1"},
+		{"v6 unspecified", "::"},
+		{"v6 link-local", "fe80::1"},
+		{"v6 ULA", "fc00::1"},
+		{"v6 ULA fd", "fd12:3456::1"},
+		{"v6 multicast", "ff02::1"},
+		// embedded-v4 forms — the encoding-trick / DNS64 defenses
+		{"v4-mapped metadata", "::ffff:169.254.169.254"},
+		{"v4-mapped private", "::ffff:10.0.0.1"},
+		{"v4-mapped loopback", "::ffff:127.0.0.1"},
+		{"NAT64 metadata (64:ff9b::a9fe:a9fe)", "64:ff9b::a9fe:a9fe"},
+		{"NAT64 private", "64:ff9b::0a00:0001"},
+		{"NAT64 public-embedded still refused wholesale", "64:ff9b::5db8:d822"},
+		{"6to4 embedding metadata", "2002:a9fe:a9fe::1"},
+		{"6to4 embedding public still refused wholesale", "2002:5db8:d822::1"},
+		{"Teredo", "2001::1"},
+		{"Teredo full", "2001:0:4136:e378:8000:63bf:3fff:fdd2"},
+		{"v4-compatible metadata", "::169.254.169.254"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			ip := net.ParseIP(tc.ip)
+			is.True(ip != nil) // test IP must parse
+			refused, reason := Refuse(ip)
+			is.True(refused)                    // must be refused
+			is.True(reason != reasonNotRefused) // must carry a reason
+		})
+	}
+}
+
+// TestRefuse_AllowedRanges proves the classifier does NOT over-block ordinary
+// public unicast addresses (both families), so egress to real providers works.
+func TestRefuse_AllowedRanges(t *testing.T) {
+	cases := []struct {
+		name string
+		ip   string
+	}{
+		{"public v4 (OpenAI-ish)", "104.18.0.1"},
+		{"public v4 TEST-NET-3 (non-refused)", "203.0.113.10"},
+		{"public v4 8.8.8.8", "8.8.8.8"},
+		{"public v6", "2606:4700::1"},
+		{"v4-mapped public", "::ffff:104.18.0.1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			ip := net.ParseIP(tc.ip)
+			is.True(ip != nil)
+			refused, _ := Refuse(ip)
+			is.True(!refused) // must be allowed by range
+		})
+	}
+}
+
+// TestRefuse_NAT64Unwrap proves the NAT64-embedded IPv4 is extracted and that it
+// is the metadata endpoint — the load-bearing DNS64 defense (MUST-FIX 2).
+func TestRefuse_NAT64Unwrap(t *testing.T) {
+	is := is.New(t)
+	ip := net.ParseIP("64:ff9b::a9fe:a9fe")
+	is.True(ip != nil)
+	embedded := embeddedV4(ip)
+	is.True(embedded != nil)
+	is.Equal(embedded.To4().String(), "169.254.169.254") // unwraps to metadata IP
+	refused, reason := Refuse(ip)
+	is.True(refused)
+	is.Equal(reason, reasonNAT64)
+}
+
+func TestRefuse_NilAndEmpty(t *testing.T) {
+	is := is.New(t)
+	refused, _ := Refuse(nil)
+	is.True(refused)
+	refused, _ = Refuse(net.IP{})
+	is.True(refused)
+}
+
+// FuzzRefuse fuzzes the refused-range classifier over arbitrary 4- and 16-byte
+// address inputs. The invariant asserted: Refuse never panics, and any address
+// whose (possibly-unwrapped) IPv4 form is in a refused v4 range is refused —
+// i.e. an embedded-v4 encoding can never smuggle a private/metadata address past
+// the gate. (Design § Testing: "fuzz the refused-range classifier incl the
+// v4-mapped and NAT64 unwrap paths".)
+func FuzzRefuse(f *testing.F) {
+	seeds := [][]byte{
+		net.ParseIP("169.254.169.254").To4(),
+		net.ParseIP("::ffff:169.254.169.254").To16(),
+		net.ParseIP("64:ff9b::a9fe:a9fe").To16(),
+		net.ParseIP("2002:a9fe:a9fe::1").To16(),
+		net.ParseIP("8.8.8.8").To4(),
+		net.ParseIP("2606:4700::1").To16(),
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		var ip net.IP
+		switch len(raw) {
+		case net.IPv4len, net.IPv6len:
+			ip = net.IP(raw)
+		default:
+			return // only 4/16-byte inputs are valid net.IP
+		}
+		refused, _ := Refuse(ip) // must never panic
+
+		// Cross-check: if the address (or its embedded v4) lands in a refused v4
+		// range, the classifier MUST refuse it. This is the anti-SSRF invariant.
+		var v4 net.IP
+		if e := embeddedV4(ip); e != nil {
+			v4 = e.To4()
+		} else if t4 := ip.To4(); t4 != nil {
+			v4 = t4
+		}
+		if v4 != nil {
+			for _, r := range refusedV4 {
+				if r.net.Contains(v4) && !refused {
+					t.Fatalf("Refuse allowed %v whose v4 form %v is in refused range %v", ip, v4, r.net)
+				}
+			}
+		}
+	})
+}

--- a/pkg/plugin/processor/egress/ipguard_test.go
+++ b/pkg/plugin/processor/egress/ipguard_test.go
@@ -62,6 +62,13 @@ func TestRefuse_RefusedRanges(t *testing.T) {
 		{"Teredo", "2001::1"},
 		{"Teredo full", "2001:0:4136:e378:8000:63bf:3fff:fdd2"},
 		{"v4-compatible metadata", "::169.254.169.254"},
+		// Regression: red-team findings #1/#2 — the two encoding-gap ranges the
+		// classifier previously let through.
+		{"v4-translated metadata (::ffff:0:169.254.169.254)", "::ffff:0:169.254.169.254"},
+		{"v4-translated private", "::ffff:0:10.0.0.1"},
+		{"v4-translated prefix base", "::ffff:0:0:0"},
+		{"v6 site-local (deprecated fec0::/10)", "fec0::1"},
+		{"v6 site-local high", "fecf:ffff::1"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -133,6 +140,8 @@ func FuzzRefuse(f *testing.F) {
 		net.ParseIP("::ffff:169.254.169.254").To16(),
 		net.ParseIP("64:ff9b::a9fe:a9fe").To16(),
 		net.ParseIP("2002:a9fe:a9fe::1").To16(),
+		net.ParseIP("::ffff:0:169.254.169.254").To16(), // v4-translated (finding #1)
+		net.ParseIP("fec0::1").To16(),                  // deprecated site-local (finding #2)
 		net.ParseIP("8.8.8.8").To4(),
 		net.ParseIP("2606:4700::1").To16(),
 	}

--- a/pkg/plugin/processor/egress/policy.go
+++ b/pkg/plugin/processor/egress/policy.go
@@ -241,6 +241,19 @@ func ResolvePolicy(perProcessor Policy, ceiling Policy) (effective Policy, dropp
 		eff.MaxResponseBytes = DefaultMaxResponseBytes
 	}
 
+	// Ceiling caps are tightening-only: a positive ceiling Timeout/MaxResponseBytes
+	// is an operator-set upper bound no pipeline can exceed. A per-processor value
+	// larger than the ceiling is clamped down; a smaller one is kept. A zero
+	// ceiling value means "no cap" (the per-processor value / defaults stand).
+	// This runs before both the unrestricted and restricted branches below, so the
+	// cap holds regardless of allowlist shape.
+	if ceiling.Timeout > 0 && eff.Timeout > ceiling.Timeout {
+		eff.Timeout = ceiling.Timeout
+	}
+	if ceiling.MaxResponseBytes > 0 && eff.MaxResponseBytes > ceiling.MaxResponseBytes {
+		eff.MaxResponseBytes = ceiling.MaxResponseBytes
+	}
+
 	// Ceiling with no entries but enabled == unrestricted host set (single-tenant
 	// convenience). Secret refs pass through unclamped in that mode too — the
 	// operator has declared this instance unrestricted.

--- a/pkg/plugin/processor/egress/policy.go
+++ b/pkg/plugin/processor/egress/policy.go
@@ -241,10 +241,27 @@ func ResolvePolicy(perProcessor Policy, ceiling Policy) (effective Policy, dropp
 		eff.MaxResponseBytes = DefaultMaxResponseBytes
 	}
 
-	// Ceiling with no entries but enabled == unrestricted host set.
+	// Ceiling with no entries but enabled == unrestricted host set (single-tenant
+	// convenience). Secret refs pass through unclamped in that mode too — the
+	// operator has declared this instance unrestricted.
 	if len(ceiling.Allowlist) == 0 {
 		eff.Allowlist = perProcessor.Allowlist
 		return eff, nil
+	}
+
+	// Restricted (multi-tenant) ceiling: clamp SecretRefs to the ceiling's granted
+	// set exactly as the allowlist is clamped, so one tenant cannot name a secret
+	// the operator did not grant this instance. An ungranted ref is dropped here
+	// (defense in depth) and would additionally fail closed per-request in
+	// buildHTTPRequest. A ceiling that grants no secrets clamps to none.
+	if len(perProcessor.SecretRefs) > 0 {
+		clamped := make(map[string]struct{})
+		for ref := range perProcessor.SecretRefs {
+			if _, ok := ceiling.SecretRefs[ref]; ok {
+				clamped[ref] = struct{}{}
+			}
+		}
+		eff.SecretRefs = clamped
 	}
 
 	ceilingSet := make(map[string]struct{}, len(ceiling.Allowlist))

--- a/pkg/plugin/processor/egress/policy.go
+++ b/pkg/plugin/processor/egress/policy.go
@@ -1,0 +1,269 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package egress
+
+import (
+	"net"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+)
+
+// Supported egress URL schemes. https is the default; http is permitted only
+// for an explicitly-allowlisted private/loopback IP-literal target.
+const (
+	schemeHTTPS = "https"
+	schemeHTTP  = "http"
+)
+
+const (
+	// DefaultTimeout bounds dial + TLS + response-header + body read for a single
+	// egress call. Matches the parent AI-pipeline design's provider timeout.
+	DefaultTimeout = 30 * time.Second
+	// DefaultMaxResponseBytes caps the (decompressed) response body the host will
+	// buffer. Embedding responses are small JSON; this is a DoS bound, and it must
+	// stay comfortably below WASM32's 4 GiB linear-memory ceiling.
+	DefaultMaxResponseBytes int64 = 4 << 20 // 4 MiB
+)
+
+// AllowEntry is one resolved allowlist entry: a (scheme, host, port) triple.
+// Host is either a DNS hostname or an IP literal; an IP-literal entry is also
+// the (IP, port) carve-out that admits an otherwise-refused dial in Stage 2.
+type AllowEntry struct {
+	Scheme string // "https" or "http"
+	Host   string // lowercased hostname, or the canonical string form of IP
+	Port   string // explicit port (defaulted from scheme when omitted)
+
+	// IP is set iff the entry is an IP literal. Such an entry doubles as the
+	// explicit (IP, port) Stage-2 carve-out.
+	IP net.IP
+}
+
+// IsIP reports whether the entry is an IP literal (a carve-out candidate).
+func (e AllowEntry) IsIP() bool { return e.IP != nil }
+
+// Policy is the resolved, immutable per-processor egress policy. The zero value
+// is deny-all (Enabled == false): a Do call returns ErrHTTPEgressDisabled.
+//
+// A Policy is captured by value in a single Service's dialer Control closure and
+// is never shared across processor instances or held on a registry field, which
+// is what keeps one pipeline's allowlist from leaking into another's egress.
+type Policy struct {
+	Enabled bool
+
+	// Allowlist is the Stage-1 host:port pre-filter and the source of the
+	// Stage-2 (IP, port) carve-outs (its IP-literal entries).
+	Allowlist []AllowEntry
+
+	// SecretRefs is the set of secret names this processor may reference via
+	// HTTPRequest.AuthSecretRef for host-injected Authorization. A guest cannot
+	// reference a secret its pipeline was not granted.
+	SecretRefs map[string]struct{}
+
+	Timeout          time.Duration
+	MaxResponseBytes int64
+}
+
+// DenyAll returns an explicitly-disabled policy (deny-all). It is the policy for
+// every non-data-path NewProcessor call (existence checks, plugin inspection):
+// such a processor is torn down without ever processing records, so it needs no
+// egress, and defaulting it to deny-all keeps the boundary closed by default.
+func DenyAll() Policy { return Policy{} }
+
+// matchesCarveOut reports whether the exact (ip, port) pair is an explicit
+// IP-literal allowlist entry. The match is on the (IP, port) PAIR, never the IP
+// alone: allowlisting 127.0.0.1:11434 (Ollama) must not admit 127.0.0.1:6379.
+func (p Policy) matchesCarveOut(ip net.IP, port string) bool {
+	for _, e := range p.Allowlist {
+		if e.IsIP() && e.Port == port && e.IP.Equal(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchHostPort is Stage 1: the coarse scheme + host:port pre-filter. It reports
+// whether the parsed request target matches an allowlist entry. It is NOT the
+// security guarantee (a matched hostname can still resolve to a hostile IP); the
+// dial-time Guard.Refuse gate in Stage 2 is.
+func (p Policy) MatchHostPort(scheme, host, port string) bool {
+	host = strings.ToLower(host)
+	reqIP := net.ParseIP(host)
+	for _, e := range p.Allowlist {
+		if e.Scheme != scheme || e.Port != port {
+			continue
+		}
+		if e.IsIP() {
+			if reqIP != nil && e.IP.Equal(reqIP) {
+				return true
+			}
+			continue
+		}
+		if e.Host == host {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseAllowEntry parses a single allowlist entry. Accepted forms:
+//
+//	host                (scheme https, port 443)
+//	host:port           (scheme https)
+//	https://host[:port]
+//	http://ip[:port]    (http permitted ONLY for a private/loopback IP literal)
+//
+// Broad wildcards are rejected (a "*." prefix is a footgun); entries are exact
+// hosts. http is refused for anything but a private/loopback IP literal target.
+func ParseAllowEntry(raw string) (AllowEntry, error) {
+	s := strings.TrimSpace(strings.ToLower(raw))
+	if s == "" {
+		return AllowEntry{}, cerrors.New("empty allowlist entry")
+	}
+	if strings.Contains(s, "*") {
+		return AllowEntry{}, cerrors.Errorf("wildcard allowlist entries are not permitted: %q", raw)
+	}
+
+	scheme := schemeHTTPS
+	hostPort := s
+	if strings.Contains(s, "://") {
+		u, err := url.Parse(s)
+		if err != nil {
+			return AllowEntry{}, cerrors.Errorf("invalid allowlist entry %q: %w", raw, err)
+		}
+		if u.Scheme != schemeHTTP && u.Scheme != schemeHTTPS {
+			return AllowEntry{}, cerrors.Errorf("unsupported scheme %q in allowlist entry %q", u.Scheme, raw)
+		}
+		scheme = u.Scheme
+		hostPort = u.Host
+		if u.Path != "" && u.Path != "/" {
+			return AllowEntry{}, cerrors.Errorf("allowlist entry %q must not contain a path", raw)
+		}
+	}
+
+	host := hostPort
+	port := ""
+	if h, p, err := net.SplitHostPort(hostPort); err == nil {
+		host, port = h, p
+	} else if strings.Contains(hostPort, "]") {
+		// bracketed IPv6 without a port, e.g. "[::1]"
+		host = strings.TrimSuffix(strings.TrimPrefix(hostPort, "["), "]")
+	}
+	if host == "" {
+		return AllowEntry{}, cerrors.Errorf("allowlist entry %q has no host", raw)
+	}
+	if port == "" {
+		if scheme == schemeHTTPS {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+
+	ip := net.ParseIP(host)
+	if scheme == schemeHTTP {
+		if ip == nil {
+			return AllowEntry{}, cerrors.Errorf("http scheme in allowlist entry %q is only permitted for a private/loopback IP literal", raw)
+		}
+		if refused, _ := Refuse(ip); !refused {
+			return AllowEntry{}, cerrors.Errorf("http scheme in allowlist entry %q is only permitted for a private/loopback target", raw)
+		}
+	}
+
+	return AllowEntry{Scheme: scheme, Host: host, Port: port, IP: ip}, nil
+}
+
+// ParseAllowlist parses a comma/whitespace-separated list of entries.
+func ParseAllowlist(raw string) ([]AllowEntry, error) {
+	fields := strings.FieldsFunc(raw, func(r rune) bool { return r == ',' || r == ' ' || r == '\t' || r == '\n' })
+	out := make([]AllowEntry, 0, len(fields))
+	for _, f := range fields {
+		e, err := ParseAllowEntry(f)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+// entryKey is the identity used when intersecting a per-processor allowlist with
+// the engine ceiling.
+func entryKey(e AllowEntry) string { return e.Scheme + "|" + e.Host + "|" + e.Port }
+
+// ResolvePolicy computes the effective per-processor policy: the intersection of
+// the pipeline-author's per-processor allowlist with the operator's engine-level
+// ceiling. Entries a pipeline requests that the ceiling does not permit are
+// DROPPED (returned in dropped, for a startup warning) — never silently honored.
+//
+//   - If the ceiling is not enabled (the stock deny-all engine default), the
+//     result is deny-all regardless of what the pipeline requests: egress needs
+//     an affirmative operator action at the instance level too (defense in depth
+//     for shared/multi-tenant instances).
+//   - If ceiling.Allowlist is empty but ceiling.Enabled is true, the ceiling is
+//     "honor whatever the pipeline requests" (single-tenant / laptop convenience).
+//
+// The guest cannot widen its own policy: this runs host-side from operator-authored
+// config, and the result is bound per-instance and never re-read from guest input.
+func ResolvePolicy(perProcessor Policy, ceiling Policy) (effective Policy, dropped []AllowEntry) {
+	if !perProcessor.Enabled {
+		return DenyAll(), nil
+	}
+	if !ceiling.Enabled {
+		// Engine ceiling closed: the pipeline opt-in cannot override it.
+		return DenyAll(), perProcessor.Allowlist
+	}
+
+	eff := Policy{
+		Enabled:          true,
+		SecretRefs:       perProcessor.SecretRefs,
+		Timeout:          perProcessor.Timeout,
+		MaxResponseBytes: perProcessor.MaxResponseBytes,
+	}
+	if eff.Timeout <= 0 {
+		eff.Timeout = DefaultTimeout
+	}
+	if eff.MaxResponseBytes <= 0 {
+		eff.MaxResponseBytes = DefaultMaxResponseBytes
+	}
+
+	// Ceiling with no entries but enabled == unrestricted host set.
+	if len(ceiling.Allowlist) == 0 {
+		eff.Allowlist = perProcessor.Allowlist
+		return eff, nil
+	}
+
+	ceilingSet := make(map[string]struct{}, len(ceiling.Allowlist))
+	for _, e := range ceiling.Allowlist {
+		ceilingSet[entryKey(e)] = struct{}{}
+	}
+	for _, e := range perProcessor.Allowlist {
+		if _, ok := ceilingSet[entryKey(e)]; ok {
+			eff.Allowlist = append(eff.Allowlist, e)
+		} else {
+			dropped = append(dropped, e)
+		}
+	}
+	if len(eff.Allowlist) == 0 {
+		// Nothing survived the intersection: effectively deny-all, but keep
+		// Enabled=true so a Do returns a specific forbidden error per call rather
+		// than the "egress disabled" error — the operator DID opt in, the entries
+		// were just clamped away.
+		eff.Allowlist = nil
+	}
+	return eff, dropped
+}

--- a/pkg/plugin/processor/egress/policy_test.go
+++ b/pkg/plugin/processor/egress/policy_test.go
@@ -144,6 +144,42 @@ func TestResolvePolicy_Clamping(t *testing.T) {
 		is.Equal(len(eff.Allowlist), 1)
 		is.Equal(len(dropped), 0)
 	})
+
+	// Regression: red-team finding #3 — SecretRefs must be clamped to the ceiling
+	// on a restricted (multi-tenant) ceiling, mirroring the allowlist intersection,
+	// so a tenant cannot name a secret the operator did not grant this instance.
+	t.Run("secret refs clamped by restricted ceiling", func(t *testing.T) {
+		is := is.New(t)
+		perProc := mk("api.openai.com")
+		perProc.SecretRefs = map[string]struct{}{"openai_key": {}, "stolen_key": {}}
+		ceiling := mk("api.openai.com")
+		ceiling.SecretRefs = map[string]struct{}{"openai_key": {}} // only openai granted
+		eff, _ := ResolvePolicy(perProc, ceiling)
+		is.True(eff.Enabled)
+		_, granted := eff.SecretRefs["openai_key"]
+		is.True(granted) // granted ref survives
+		_, leaked := eff.SecretRefs["stolen_key"]
+		is.True(!leaked) // ungranted ref clamped away
+		is.Equal(len(eff.SecretRefs), 1)
+	})
+
+	t.Run("restricted ceiling granting no secrets clamps to none", func(t *testing.T) {
+		is := is.New(t)
+		perProc := mk("api.openai.com")
+		perProc.SecretRefs = map[string]struct{}{"openai_key": {}}
+		ceiling := mk("api.openai.com") // no SecretRefs granted
+		eff, _ := ResolvePolicy(perProc, ceiling)
+		is.Equal(len(eff.SecretRefs), 0) // nothing granted => nothing survives
+	})
+
+	t.Run("unrestricted ceiling passes secret refs through", func(t *testing.T) {
+		is := is.New(t)
+		perProc := mk("api.openai.com")
+		perProc.SecretRefs = map[string]struct{}{"openai_key": {}}
+		ceiling := Policy{Enabled: true} // unrestricted single-tenant mode
+		eff, _ := ResolvePolicy(perProc, ceiling)
+		is.Equal(len(eff.SecretRefs), 1) // convenience mode: no clamp
+	})
 }
 
 // FuzzParseAllowEntry fuzzes the allowlist-entry parser + Stage-1 matcher — a

--- a/pkg/plugin/processor/egress/policy_test.go
+++ b/pkg/plugin/processor/egress/policy_test.go
@@ -1,0 +1,218 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package egress
+
+import (
+	"net"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+func TestParseAllowEntry(t *testing.T) {
+	cases := []struct {
+		name       string
+		in         string
+		wantErr    bool
+		wantScheme string
+		wantHost   string
+		wantPort   string
+		wantIP     bool
+	}{
+		{"host only", "api.openai.com", false, "https", "api.openai.com", "443", false},
+		{"host:port", "api.openai.com:8443", false, "https", "api.openai.com", "8443", false},
+		{"https scheme", "https://api.voyageai.com", false, "https", "api.voyageai.com", "443", false},
+		{"http private ip ok (ollama)", "http://127.0.0.1:11434", false, "http", "127.0.0.1", "11434", true},
+		{"https loopback ip", "https://127.0.0.1:11434", false, "https", "127.0.0.1", "11434", true},
+		{"http public host rejected", "http://api.openai.com", true, "", "", "", false},
+		{"http public ip rejected", "http://8.8.8.8:80", true, "", "", "", false},
+		{"wildcard rejected", "*.openai.com", true, "", "", "", false},
+		{"bad scheme rejected", "ftp://host", true, "", "", "", false},
+		{"empty rejected", "", true, "", "", "", false},
+		{"path rejected", "https://host/v1/embeddings", true, "", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			e, err := ParseAllowEntry(tc.in)
+			if tc.wantErr {
+				is.True(err != nil)
+				return
+			}
+			is.NoErr(err)
+			is.Equal(e.Scheme, tc.wantScheme)
+			is.Equal(e.Host, tc.wantHost)
+			is.Equal(e.Port, tc.wantPort)
+			is.Equal(e.IsIP(), tc.wantIP)
+		})
+	}
+}
+
+func TestPolicy_MatchHostPort_Stage1(t *testing.T) {
+	is := is.New(t)
+	allow, err := ParseAllowlist("api.openai.com, https://api.voyageai.com:8443, http://127.0.0.1:11434")
+	is.NoErr(err)
+	p := Policy{Enabled: true, Allowlist: allow}
+
+	// allowed
+	is.True(p.MatchHostPort("https", "api.openai.com", "443"))
+	is.True(p.MatchHostPort("https", "api.voyageai.com", "8443"))
+	is.True(p.MatchHostPort("http", "127.0.0.1", "11434"))
+	// wrong port
+	is.True(!p.MatchHostPort("https", "api.openai.com", "8443"))
+	// wrong scheme
+	is.True(!p.MatchHostPort("http", "api.openai.com", "443"))
+	// host not listed
+	is.True(!p.MatchHostPort("https", "evil.example.com", "443"))
+	// voyage on default 443 not listed (only 8443)
+	is.True(!p.MatchHostPort("https", "api.voyageai.com", "443"))
+}
+
+// TestPolicy_CarveOut_IPPortScoped is MUST-FIX 3: the carve-out keys on the
+// (IP, port) PAIR, never the IP alone. 127.0.0.1:11434 must not admit
+// 127.0.0.1:6379.
+func TestPolicy_CarveOut_IPPortScoped(t *testing.T) {
+	is := is.New(t)
+	allow, err := ParseAllowlist("http://127.0.0.1:11434")
+	is.NoErr(err)
+	p := Policy{Enabled: true, Allowlist: allow}
+
+	loopback := net.ParseIP("127.0.0.1")
+	is.True(p.matchesCarveOut(loopback, "11434"))                  // the listed pair
+	is.True(!p.matchesCarveOut(loopback, "6379"))                  // Redis — same IP, different port
+	is.True(!p.matchesCarveOut(loopback, "5432"))                  // Postgres
+	is.True(!p.matchesCarveOut(net.ParseIP("127.0.0.2"), "11434")) // different IP
+}
+
+// TestResolvePolicy_Clamping is the config-clamping test (design § Testing): a
+// per-processor allowlist naming a host outside the engine ceiling yields the
+// intersection (excess dropped); a closed ceiling forces deny-all; a non-opted-in
+// processor stays deny-all.
+func TestResolvePolicy_Clamping(t *testing.T) {
+	is := is.New(t)
+
+	mk := func(spec string) Policy {
+		allow, err := ParseAllowlist(spec)
+		is.NoErr(err)
+		return Policy{Enabled: true, Allowlist: allow}
+	}
+
+	t.Run("deny-all when not opted in", func(t *testing.T) {
+		is := is.New(t)
+		eff, dropped := ResolvePolicy(DenyAll(), mk("api.openai.com"))
+		is.True(!eff.Enabled)
+		is.Equal(len(dropped), 0)
+	})
+
+	t.Run("closed ceiling forces deny-all", func(t *testing.T) {
+		is := is.New(t)
+		eff, dropped := ResolvePolicy(mk("api.openai.com"), DenyAll())
+		is.True(!eff.Enabled)
+		is.Equal(len(dropped), 1) // the requested entry is reported as dropped
+	})
+
+	t.Run("intersection drops excess", func(t *testing.T) {
+		is := is.New(t)
+		perProc := mk("api.openai.com, api.voyageai.com")
+		ceiling := mk("api.openai.com") // ceiling permits only openai
+		eff, dropped := ResolvePolicy(perProc, ceiling)
+		is.True(eff.Enabled)
+		is.Equal(len(eff.Allowlist), 1)
+		is.Equal(eff.Allowlist[0].Host, "api.openai.com")
+		is.Equal(len(dropped), 1)
+		is.Equal(dropped[0].Host, "api.voyageai.com") // excess dropped, not honored
+	})
+
+	t.Run("enabled ceiling with no entries is unrestricted", func(t *testing.T) {
+		is := is.New(t)
+		perProc := mk("api.openai.com")
+		ceiling := Policy{Enabled: true} // enabled, no entries => honor pipeline
+		eff, dropped := ResolvePolicy(perProc, ceiling)
+		is.True(eff.Enabled)
+		is.Equal(len(eff.Allowlist), 1)
+		is.Equal(len(dropped), 0)
+	})
+}
+
+// FuzzParseAllowEntry fuzzes the allowlist-entry parser + Stage-1 matcher — a
+// parser/decision boundary where an edge-case bug becomes an SSRF bypass (design
+// § Testing). Invariants: never panic; and any successfully-parsed entry that is
+// an http-scheme IP literal must classify as a refused (private/loopback) range
+// — the parser must never admit an http entry for a public target.
+func FuzzParseAllowEntry(f *testing.F) {
+	for _, s := range []string{
+		"api.openai.com", "api.openai.com:443", "https://a.b.c:8443",
+		"http://127.0.0.1:11434", "*.evil.com", "ftp://x", "", "http://8.8.8.8",
+		"[::1]:80", "https://[fc00::1]:443", "http://169.254.169.254",
+	} {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, in string) {
+		e, err := ParseAllowEntry(in) // must never panic
+		if err != nil {
+			return
+		}
+		if e.Scheme != "http" && e.Scheme != "https" {
+			t.Fatalf("parsed entry has invalid scheme %q from %q", e.Scheme, in)
+		}
+		if e.Scheme == "http" {
+			if e.IP == nil {
+				t.Fatalf("http entry %q admitted with non-IP host", in)
+			}
+			if refused, _ := Refuse(e.IP); !refused {
+				t.Fatalf("http entry %q admitted for non-private IP %v", in, e.IP)
+			}
+		}
+		// A successfully-parsed entry must self-match Stage 1.
+		p := Policy{Enabled: true, Allowlist: []AllowEntry{e}}
+		if !p.MatchHostPort(e.Scheme, e.Host, e.Port) {
+			t.Fatalf("entry %q does not self-match Stage 1", in)
+		}
+	})
+}
+
+func TestPolicyFromSettings(t *testing.T) {
+	is := is.New(t)
+
+	t.Run("no key => deny-all", func(t *testing.T) {
+		is := is.New(t)
+		p, err := PolicyFromSettings(map[string]string{"other": "x"})
+		is.NoErr(err)
+		is.True(!p.Enabled)
+	})
+
+	t.Run("full config", func(t *testing.T) {
+		is := is.New(t)
+		p, err := PolicyFromSettings(map[string]string{
+			ConfigKeyAllow:            "api.openai.com, http://127.0.0.1:11434",
+			ConfigKeyTimeout:          "10s",
+			ConfigKeyMaxResponseBytes: "1048576",
+			ConfigKeySecretRefs:       "openai_api_key, voyage_key",
+		})
+		is.NoErr(err)
+		is.True(p.Enabled)
+		is.Equal(len(p.Allowlist), 2)
+		is.Equal(p.Timeout.String(), "10s")
+		is.Equal(p.MaxResponseBytes, int64(1048576))
+		_, ok := p.SecretRefs["openai_api_key"]
+		is.True(ok)
+	})
+
+	t.Run("invalid allowlist fails", func(t *testing.T) {
+		is := is.New(t)
+		_, err := PolicyFromSettings(map[string]string{ConfigKeyAllow: "*.evil.com"})
+		is.True(err != nil)
+	})
+}

--- a/pkg/plugin/processor/egress/policy_test.go
+++ b/pkg/plugin/processor/egress/policy_test.go
@@ -17,6 +17,7 @@ package egress
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/matryer/is"
 )
@@ -179,6 +180,43 @@ func TestResolvePolicy_Clamping(t *testing.T) {
 		ceiling := Policy{Enabled: true} // unrestricted single-tenant mode
 		eff, _ := ResolvePolicy(perProc, ceiling)
 		is.Equal(len(eff.SecretRefs), 1) // convenience mode: no clamp
+	})
+
+	// Ceiling Timeout/MaxResponseBytes are tightening-only caps: a positive
+	// ceiling value is an upper bound no pipeline can exceed.
+	t.Run("ceiling caps timeout and size down", func(t *testing.T) {
+		is := is.New(t)
+		perProc := mk("api.openai.com")
+		perProc.Timeout = 60 * time.Second
+		perProc.MaxResponseBytes = 8 << 20
+		ceiling := mk("api.openai.com")
+		ceiling.Timeout = 5 * time.Second
+		ceiling.MaxResponseBytes = 1 << 20
+		eff, _ := ResolvePolicy(perProc, ceiling)
+		is.Equal(eff.Timeout, 5*time.Second)         // clamped down to the ceiling
+		is.Equal(eff.MaxResponseBytes, int64(1<<20)) // clamped down to the ceiling
+	})
+
+	t.Run("ceiling does not raise a smaller per-processor value", func(t *testing.T) {
+		is := is.New(t)
+		perProc := mk("api.openai.com")
+		perProc.Timeout = 2 * time.Second
+		perProc.MaxResponseBytes = 512 << 10
+		ceiling := mk("api.openai.com")
+		ceiling.Timeout = 30 * time.Second
+		ceiling.MaxResponseBytes = 4 << 20
+		eff, _ := ResolvePolicy(perProc, ceiling)
+		is.Equal(eff.Timeout, 2*time.Second)           // smaller per-processor value kept
+		is.Equal(eff.MaxResponseBytes, int64(512<<10)) // smaller per-processor value kept
+	})
+
+	t.Run("zero ceiling cap means no cap (defaults stand)", func(t *testing.T) {
+		is := is.New(t)
+		perProc := mk("api.openai.com") // no Timeout/MaxResponseBytes set
+		ceiling := mk("api.openai.com") // no cap set
+		eff, _ := ResolvePolicy(perProc, ceiling)
+		is.Equal(eff.Timeout, DefaultTimeout)                   // per-processor default stands
+		is.Equal(eff.MaxResponseBytes, DefaultMaxResponseBytes) // per-processor default stands
 	})
 }
 

--- a/pkg/plugin/processor/egress/service.go
+++ b/pkg/plugin/processor/egress/service.go
@@ -30,6 +30,26 @@ import (
 	"github.com/conduitio/conduit/pkg/foundation/log"
 )
 
+// Header-name constants for names referenced in more than one place (the
+// reserved-request set and the hop-by-hop-response set overlap heavily). Kept as
+// constants so the two maps and their tests share one source of truth.
+const (
+	hdrHost               = "Host"
+	hdrAuthority          = ":authority"
+	hdrAuthorization      = "Authorization"
+	hdrAcceptEncoding     = "Accept-Encoding"
+	hdrConnection         = "Connection"
+	hdrProxyConnection    = "Proxy-Connection"
+	hdrProxyAuthorization = "Proxy-Authorization"
+	hdrProxyAuthenticate  = "Proxy-Authenticate"
+	hdrTransferEncoding   = "Transfer-Encoding"
+	hdrContentLength      = "Content-Length"
+	hdrUpgrade            = "Upgrade"
+	hdrKeepAlive          = "Keep-Alive"
+	hdrTE                 = "Te"
+	hdrTrailer            = "Trailer"
+)
+
 // reservedHeaders are host-controlled: a guest attempt to set any of them is
 // rejected with ErrHTTPInvalidRequest. Keys are canonical MIME form.
 //
@@ -42,19 +62,19 @@ import (
 //     guest-set Accept-Encoding would let a decompression bomb pass the cap).
 //   - Connection-control headers: never guest-settable.
 var reservedHeaders = map[string]struct{}{
-	"Host":                {},
-	":authority":          {}, // not canonicalizable, checked verbatim too
-	"Authorization":       {},
-	"Accept-Encoding":     {},
-	"Connection":          {},
-	"Proxy-Connection":    {},
-	"Proxy-Authorization": {},
-	"Transfer-Encoding":   {},
-	"Content-Length":      {},
-	"Upgrade":             {},
-	"Keep-Alive":          {},
-	"Te":                  {},
-	"Trailer":             {},
+	hdrHost:               {},
+	hdrAuthority:          {}, // not canonicalizable, checked verbatim too
+	hdrAuthorization:      {},
+	hdrAcceptEncoding:     {},
+	hdrConnection:         {},
+	hdrProxyConnection:    {},
+	hdrProxyAuthorization: {},
+	hdrTransferEncoding:   {},
+	hdrContentLength:      {},
+	hdrUpgrade:            {},
+	hdrKeepAlive:          {},
+	hdrTE:                 {},
+	hdrTrailer:            {},
 }
 
 // SecretResolver resolves a named secret to the value the host sets as the
@@ -412,7 +432,7 @@ func (s *Service) buildHTTPRequest(ctx context.Context, u *url.URL, method strin
 		if serr != nil {
 			return nil, egressErr(pprocutils.ErrHTTPInvalidRequest, "failed to resolve secret reference")
 		}
-		httpReq.Header.Set("Authorization", val)
+		httpReq.Header.Set(hdrAuthorization, val)
 	}
 
 	return httpReq, nil
@@ -489,15 +509,37 @@ func validHeaderValue(v string) bool {
 	return true
 }
 
+// hopByHopResponseHeaders are connection-scoped headers that are meaningless to
+// (and potentially confusing for) the guest: they describe the host<->origin
+// transport, not the response payload. Dropped on the way back. Canonical MIME form.
+var hopByHopResponseHeaders = map[string]struct{}{
+	hdrConnection:         {},
+	hdrProxyConnection:    {},
+	hdrKeepAlive:          {},
+	hdrTransferEncoding:   {},
+	hdrTE:                 {},
+	hdrTrailer:            {},
+	hdrUpgrade:            {},
+	hdrProxyAuthenticate:  {},
+	hdrProxyAuthorization: {},
+}
+
 // filterResponseHeaders copies response headers into a plain map, dropping
-// hop-by-hop headers. Authorization is a request header and never echoed here.
+// hop-by-hop (connection-scoped) headers so only end-to-end response headers
+// reach the guest. Authorization is a request header and never echoed here.
 func filterResponseHeaders(h http.Header) map[string][]string {
 	if len(h) == 0 {
 		return nil
 	}
 	out := make(map[string][]string, len(h))
 	for k, v := range h {
+		if _, hop := hopByHopResponseHeaders[textproto.CanonicalMIMEHeaderKey(k)]; hop {
+			continue
+		}
 		out[k] = append([]string(nil), v...)
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }

--- a/pkg/plugin/processor/egress/service.go
+++ b/pkg/plugin/processor/egress/service.go
@@ -1,0 +1,527 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package egress
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/conduitio/conduit-processor-sdk/pprocutils"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+)
+
+// reservedHeaders are host-controlled: a guest attempt to set any of them is
+// rejected with ErrHTTPInvalidRequest. Keys are canonical MIME form.
+//
+//   - Host / :authority: derived from the validated URL, so the guest cannot show
+//     one hostname to the allowlist and another to the server (Host/SNI confusion).
+//   - Authorization: host-injected from a secret ref; there is no guest-supplied
+//     credential path at all.
+//   - Accept-Encoding: host-controlled so Go's transparent gzip decompression
+//     stays on and the response-size cap measures the DECOMPRESSED stream (a
+//     guest-set Accept-Encoding would let a decompression bomb pass the cap).
+//   - Connection-control headers: never guest-settable.
+var reservedHeaders = map[string]struct{}{
+	"Host":                {},
+	":authority":          {}, // not canonicalizable, checked verbatim too
+	"Authorization":       {},
+	"Accept-Encoding":     {},
+	"Connection":          {},
+	"Proxy-Connection":    {},
+	"Proxy-Authorization": {},
+	"Transfer-Encoding":   {},
+	"Content-Length":      {},
+	"Upgrade":             {},
+	"Keep-Alive":          {},
+	"Te":                  {},
+	"Trailer":             {},
+}
+
+// SecretResolver resolves a named secret to the value the host sets as the
+// Authorization header. The concrete backend is out of scope for this slice
+// (Non-goals); the interface reserves the mechanism so no guest-supplied
+// credential path ever exists. A nil resolver means the secret store is not
+// wired: any AuthSecretRef use fails with a clear, non-silent error.
+type SecretResolver interface {
+	// Resolve returns the Authorization header value for the named secret.
+	Resolve(ctx context.Context, name string) (string, error)
+}
+
+// dialRefusedError is returned by the dial-time gate when a resolved IP is
+// refused. It carries the audit reason so Do can map it to ErrHTTPForbidden and
+// log the security-relevant denial.
+type dialRefusedError struct {
+	ip     net.IP
+	port   string
+	reason refusedReason
+}
+
+func (e *dialRefusedError) Error() string {
+	return "egress: dial to " + net.JoinHostPort(e.ip.String(), e.port) + " refused (" + string(e.reason) + ")"
+}
+
+// errRedirectBlocked is returned by CheckRedirect so a 3xx never becomes an
+// automatic hop out of the allowlist.
+var errRedirectBlocked = cerrors.New("egress: redirects are not followed")
+
+// dnsError marks a name-resolution failure so Do maps it to ErrHTTPDNS
+// (retryable-transient), distinct from a forbidden/allowlist error (permanent).
+type dnsError struct{ err error }
+
+func (e *dnsError) Error() string { return "egress: DNS resolution failed: " + e.err.Error() }
+func (e *dnsError) Unwrap() error { return e.err }
+
+// Resolver resolves a hostname to candidate IPs. Injectable so the DNS-rebinding
+// tests can return a public IP on one lookup and a private one on the next,
+// proving the Stage-2 gate runs at dial time against the actual address.
+type Resolver interface {
+	LookupIP(ctx context.Context, host string) ([]net.IP, error)
+}
+
+type netResolver struct{ r *net.Resolver }
+
+func (n netResolver) LookupIP(ctx context.Context, host string) ([]net.IP, error) {
+	addrs, err := n.r.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	ips := make([]net.IP, len(addrs))
+	for i, a := range addrs {
+		ips[i] = a.IP
+	}
+	return ips, nil
+}
+
+// Service is the per-processor host-side egress implementation. It satisfies
+// pprocutils.HTTPService. One Service is bound to exactly one processor
+// instance's Policy (captured here and in the dialer Control closure); Services
+// are never shared, so policies never leak between processors.
+type Service struct {
+	policy   Policy
+	logger   log.CtxLogger
+	resolver Resolver
+	secrets  SecretResolver
+	client   *http.Client
+}
+
+// Option configures a Service (test seams for resolver / secret backend).
+type Option func(*Service)
+
+// WithResolver overrides the DNS resolver (used by the rebinding tests).
+func WithResolver(r Resolver) Option { return func(s *Service) { s.resolver = r } }
+
+// WithSecretResolver wires the credential backend for AuthSecretRef.
+func WithSecretResolver(sr SecretResolver) Option { return func(s *Service) { s.secrets = sr } }
+
+// New builds a Service for one processor instance's resolved Policy.
+//
+// Security-critical transport configuration (design § Hardening):
+//   - Transport.Proxy is pinned nil so HTTP(S)_PROXY / ALL_PROXY cannot redirect
+//     the dial to a proxy the gate never validated (the complete-bypass the
+//     security review found).
+//   - DialContext runs the resolved-IP gate per candidate and dials the chosen
+//     IP through a base dialer whose Control hook re-applies the gate at the
+//     syscall level. No custom DialTLSContext exists, so the same gated dial
+//     serves https as well as http (Control governs TLS dials too).
+//   - CheckRedirect refuses every redirect.
+//   - Transparent decompression is left ON (DisableCompression false) so the
+//     size cap in Do measures the decompressed stream.
+func New(policy Policy, logger log.CtxLogger, opts ...Option) *Service {
+	s := &Service{
+		policy:   policy,
+		logger:   logger.WithComponent("egress.Service"),
+		resolver: netResolver{r: net.DefaultResolver},
+	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	base := &net.Dialer{
+		Timeout:   effectiveTimeout(policy),
+		KeepAlive: 30 * time.Second,
+		Control:   s.dialControl, // Invariant (Stage 2): syscall-level resolved-IP gate.
+	}
+
+	transport := &http.Transport{
+		Proxy:                 nil, // MUST-FIX 1: never ProxyFromEnvironment.
+		DialContext:           s.dialContext(base),
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          10,
+		IdleConnTimeout:       30 * time.Second,
+		TLSHandshakeTimeout:   effectiveTimeout(policy),
+		ExpectContinueTimeout: time.Second,
+		// DisableCompression stays false: transparent gzip decompression must be
+		// on so the io.LimitReader in Do caps the DECOMPRESSED stream.
+	}
+
+	s.client = &http.Client{
+		Transport: transport,
+		Timeout:   effectiveTimeout(policy),
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return errRedirectBlocked
+		},
+	}
+	return s
+}
+
+func effectiveTimeout(p Policy) time.Duration {
+	if p.Timeout > 0 {
+		return p.Timeout
+	}
+	return DefaultTimeout
+}
+
+func (s *Service) maxResponseBytes() int64 {
+	if s.policy.MaxResponseBytes > 0 {
+		return s.policy.MaxResponseBytes
+	}
+	return DefaultMaxResponseBytes
+}
+
+// dialControl is the net.Dialer.Control hook — Stage 2 at the syscall level. It
+// fires immediately before connect(2) for every candidate address, for http and
+// TLS dials alike, and refuses unless the resolved IP is allowed by range or the
+// exact (IP, port) pair is an explicit carve-out.
+func (s *Service) dialControl(_, address string, _ syscall.RawConn) error {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return &dialRefusedError{reason: reasonUnparseable, port: port}
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return &dialRefusedError{reason: reasonUnparseable, port: port}
+	}
+	if refused, reason := Refuse(ip); refused {
+		if s.policy.matchesCarveOut(ip, port) {
+			return nil // explicit (IP, port) carve-out (e.g. local Ollama).
+		}
+		return &dialRefusedError{ip: ip, port: port, reason: reason}
+	}
+	return nil
+}
+
+// dialContext resolves the host, applies the Stage-2 gate per candidate, and
+// dials the first admissible candidate through the base dialer (whose Control
+// re-checks). Doing resolution here (a) makes the gate testable with an injected
+// resolver, (b) classifies a resolution failure as ErrHTTPDNS, and (c) ensures
+// every candidate of a multi-answer / dual-stack result is checked, so a
+// public+private mixed answer cannot smuggle a private dial through.
+func (s *Service) dialContext(base *net.Dialer) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, &dialRefusedError{reason: reasonUnparseable}
+		}
+
+		var candidates []net.IP
+		if ip := net.ParseIP(host); ip != nil {
+			candidates = []net.IP{ip}
+		} else {
+			ips, rerr := s.resolver.LookupIP(ctx, host)
+			if rerr != nil {
+				return nil, &dnsError{err: rerr}
+			}
+			if len(ips) == 0 {
+				return nil, &dnsError{err: cerrors.Errorf("no addresses for %q", host)}
+			}
+			candidates = ips
+		}
+
+		var lastRefusal error
+		for _, ip := range candidates {
+			if refused, reason := Refuse(ip); refused && !s.policy.matchesCarveOut(ip, port) {
+				lastRefusal = &dialRefusedError{ip: ip, port: port, reason: reason}
+				continue // try the next candidate (public may follow private)
+			}
+			conn, derr := base.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+			if derr != nil {
+				lastRefusal = derr
+				continue
+			}
+			return conn, nil
+		}
+		if lastRefusal == nil {
+			lastRefusal = &dialRefusedError{reason: reasonUnparseable, port: port}
+		}
+		return nil, lastRefusal
+	}
+}
+
+// Do performs one host-mediated egress call under the processor's policy. It is
+// the pprocutils.HTTPService implementation the host module invokes.
+func (s *Service) Do(ctx context.Context, req pprocutils.HTTPRequest) (pprocutils.HTTPResponse, error) {
+	start := time.Now()
+
+	// Deny-all default: a non-opted-in processor never gets egress.
+	if !s.policy.Enabled {
+		return pprocutils.HTTPResponse{}, egressErr(pprocutils.ErrHTTPEgressDisabled,
+			"egress is not enabled for this processor; add an allowlist entry")
+	}
+
+	u, method, err := s.validateRequestLine(req)
+	if err != nil {
+		return pprocutils.HTTPResponse{}, err
+	}
+
+	scheme := u.Scheme
+	host := strings.ToLower(u.Hostname())
+	port := u.Port()
+	if port == "" {
+		if scheme == schemeHTTPS {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+
+	// Stage 1: coarse scheme + host:port pre-filter.
+	if !s.policy.MatchHostPort(scheme, host, port) {
+		s.logDeny(ctx, method, host, "allowlist_miss")
+		return pprocutils.HTTPResponse{}, egressErr(pprocutils.ErrHTTPForbidden,
+			"destination not in the processor's egress allowlist")
+	}
+
+	httpReq, err := s.buildHTTPRequest(ctx, u, method, req)
+	if err != nil {
+		return pprocutils.HTTPResponse{}, err
+	}
+
+	resp, err := s.client.Do(httpReq)
+	if err != nil {
+		return pprocutils.HTTPResponse{}, s.classifyDoError(ctx, method, host, err)
+	}
+	defer resp.Body.Close()
+
+	// Response-size cap on the DECOMPRESSED stream (Accept-Encoding is
+	// host-reserved, so the transport has already inflated any gzip body).
+	limit := s.maxResponseBytes()
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if int64(len(body)) > limit {
+		s.logDeny(ctx, method, host, "size_cap")
+		return pprocutils.HTTPResponse{}, egressErr(pprocutils.ErrHTTPResponseTooLarge,
+			"response body exceeded the host size cap")
+	}
+	if readErr != nil {
+		// A body read that trips the per-call deadline is a timeout, not a
+		// generic transport error.
+		if isTimeout(readErr) {
+			return pprocutils.HTTPResponse{}, egressErr(pprocutils.ErrHTTPTimeout, "egress call timed out reading response body")
+		}
+		return pprocutils.HTTPResponse{}, egressErr(pprocutils.ErrHTTPTransport, "failed reading response body")
+	}
+
+	s.logAllow(ctx, method, host, resp.StatusCode, len(body), time.Since(start))
+
+	return pprocutils.HTTPResponse{
+		StatusCode: resp.StatusCode,
+		Headers:    filterResponseHeaders(resp.Header),
+		Body:       body,
+	}, nil
+}
+
+// validateRequestLine parses and validates the method + URL. It rejects
+// non-http(s) schemes and unparseable URLs with ErrHTTPInvalidRequest.
+func (s *Service) validateRequestLine(req pprocutils.HTTPRequest) (*url.URL, string, error) {
+	method := strings.ToUpper(strings.TrimSpace(req.Method))
+	if method == "" {
+		method = http.MethodGet
+	}
+	if !validToken(method) {
+		return nil, "", egressErr(pprocutils.ErrHTTPInvalidRequest, "invalid HTTP method")
+	}
+
+	u, err := url.Parse(req.URL)
+	if err != nil {
+		return nil, "", egressErr(pprocutils.ErrHTTPInvalidRequest, "unparseable request URL")
+	}
+	if u.Scheme != schemeHTTPS && u.Scheme != schemeHTTP {
+		return nil, "", egressErr(pprocutils.ErrHTTPInvalidRequest, "unsupported URL scheme: "+u.Scheme)
+	}
+	if u.Hostname() == "" {
+		return nil, "", egressErr(pprocutils.ErrHTTPInvalidRequest, "request URL has no host")
+	}
+	return u, method, nil
+}
+
+// buildHTTPRequest constructs the *http.Request, enforcing the reserved-header
+// denylist, validating header names/values (CRLF/control rejection), and
+// injecting the host-resolved Authorization from AuthSecretRef.
+func (s *Service) buildHTTPRequest(ctx context.Context, u *url.URL, method string, req pprocutils.HTTPRequest) (*http.Request, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, method, u.String(), strings.NewReader(""))
+	if err != nil {
+		return nil, egressErr(pprocutils.ErrHTTPInvalidRequest, "could not build request")
+	}
+	if len(req.Body) > 0 {
+		httpReq.Body = io.NopCloser(strings.NewReader(string(req.Body)))
+		httpReq.ContentLength = int64(len(req.Body))
+	}
+
+	for name, values := range req.Headers {
+		if !validToken(name) {
+			return nil, egressErr(pprocutils.ErrHTTPInvalidRequest, "invalid header name")
+		}
+		canonical := textproto.CanonicalMIMEHeaderKey(name)
+		if _, reserved := reservedHeaders[canonical]; reserved {
+			return nil, egressErr(pprocutils.ErrHTTPInvalidRequest, "header is host-reserved and cannot be set by the guest: "+canonical)
+		}
+		if strings.EqualFold(name, ":authority") || strings.HasPrefix(name, ":") {
+			return nil, egressErr(pprocutils.ErrHTTPInvalidRequest, "pseudo-headers cannot be set by the guest")
+		}
+		for _, v := range values {
+			if !validHeaderValue(v) {
+				return nil, egressErr(pprocutils.ErrHTTPInvalidRequest, "invalid header value (control characters not allowed)")
+			}
+			httpReq.Header.Add(canonical, v)
+		}
+	}
+
+	// Host is derived from the validated URL — never guest-controlled.
+	httpReq.Host = u.Host
+
+	// Host-injected credentials: the guest names a secret; the host sets
+	// Authorization. There is no guest-supplied-credential path.
+	if req.AuthSecretRef != "" {
+		if _, granted := s.policy.SecretRefs[req.AuthSecretRef]; !granted {
+			return nil, egressErr(pprocutils.ErrHTTPForbidden, "secret reference not granted to this processor: "+req.AuthSecretRef)
+		}
+		if s.secrets == nil {
+			// Mechanism reserved; backend wiring deferred to a later slice.
+			return nil, egressErr(pprocutils.ErrHTTPInvalidRequest, "secret store is not wired on this instance; AuthSecretRef is not yet supported")
+		}
+		val, serr := s.secrets.Resolve(ctx, req.AuthSecretRef)
+		if serr != nil {
+			return nil, egressErr(pprocutils.ErrHTTPInvalidRequest, "failed to resolve secret reference")
+		}
+		httpReq.Header.Set("Authorization", val)
+	}
+
+	return httpReq, nil
+}
+
+func (s *Service) classifyDoError(ctx context.Context, method, host string, err error) error {
+	var refused *dialRefusedError
+	if cerrors.As(err, &refused) {
+		s.logDeny(ctx, method, host, "ip_refused_"+string(refused.reason))
+		return egressErr(pprocutils.ErrHTTPForbidden, "resolved IP refused by egress policy")
+	}
+	var dnsE *dnsError
+	if cerrors.As(err, &dnsE) {
+		s.logDeny(ctx, method, host, "dns_failure")
+		return egressErr(pprocutils.ErrHTTPDNS, "DNS resolution failed")
+	}
+	if cerrors.Is(err, errRedirectBlocked) {
+		s.logDeny(ctx, method, host, "redirect_blocked")
+		return egressErr(pprocutils.ErrHTTPForbidden, "redirects are not followed")
+	}
+	if isTimeout(err) {
+		s.logDeny(ctx, method, host, "timeout")
+		return egressErr(pprocutils.ErrHTTPTimeout, "egress call timed out")
+	}
+	s.logDeny(ctx, method, host, "transport_error")
+	return egressErr(pprocutils.ErrHTTPTransport, "transport error")
+}
+
+func isTimeout(err error) bool {
+	var nerr net.Error
+	if cerrors.As(err, &nerr) {
+		return nerr.Timeout()
+	}
+	return cerrors.Is(err, context.DeadlineExceeded)
+}
+
+// egressErr wraps a stable pprocutils ABI error code with a human-readable,
+// non-secret message. host_module maps the wrapped *pprocutils.Error to the
+// numeric code the guest receives.
+func egressErr(code *pprocutils.Error, msg string) error {
+	return cerrors.Errorf("%s: %w", msg, code)
+}
+
+// --- header helpers -------------------------------------------------------
+
+// validToken reports whether s is a valid HTTP token (method/header name):
+// no control chars, no separators, no CR/LF (header-injection defense).
+func validToken(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c <= 0x20 || c >= 0x7f {
+			return false
+		}
+		switch c {
+		case '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=', '{', '}':
+			return false
+		}
+	}
+	return true
+}
+
+// validHeaderValue rejects CR, LF, and NUL (header/response splitting). Other
+// bytes are permitted (values are less restricted than names).
+func validHeaderValue(v string) bool {
+	for i := 0; i < len(v); i++ {
+		switch v[i] {
+		case '\r', '\n', 0:
+			return false
+		}
+	}
+	return true
+}
+
+// filterResponseHeaders copies response headers into a plain map, dropping
+// hop-by-hop headers. Authorization is a request header and never echoed here.
+func filterResponseHeaders(h http.Header) map[string][]string {
+	if len(h) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(h))
+	for k, v := range h {
+		out[k] = append([]string(nil), v...)
+	}
+	return out
+}
+
+// --- audit logging (redaction mandatory: never log bodies or Authorization) --
+
+func (s *Service) logAllow(ctx context.Context, method, host string, status, respBytes int, latency time.Duration) {
+	s.logger.Info(ctx).
+		Str("decision", "allow").
+		Str("method", method).
+		Str("request_host", host).
+		Int("status", status).
+		Int("response_bytes", respBytes).
+		Dur("latency", latency).
+		Msg("egress call")
+}
+
+func (s *Service) logDeny(ctx context.Context, method, host, reason string) {
+	// Deny events are the audit trail for an attempted SSRF; log at Warn so they
+	// survive normal filtering.
+	s.logger.Warn(ctx).
+		Str("decision", "deny").
+		Str("method", method).
+		Str("request_host", host).
+		Str("reason", reason).
+		Msg("egress call denied")
+}

--- a/pkg/plugin/processor/egress/service_test.go
+++ b/pkg/plugin/processor/egress/service_test.go
@@ -100,6 +100,33 @@ func TestService_DenyAll(t *testing.T) {
 	is.True(cerrors.Is(err, pprocutils.ErrHTTPEgressDisabled))
 }
 
+// TestFilterResponseHeaders_DropsHopByHop is the regression test for red-team
+// finding #4: connection-scoped (hop-by-hop) response headers must not be echoed
+// to the guest; end-to-end headers must pass through.
+func TestFilterResponseHeaders_DropsHopByHop(t *testing.T) {
+	is := is.New(t)
+	in := http.Header{
+		"Content-Type":      {"application/json"},
+		hdrConnection:       {"keep-alive"},
+		hdrTransferEncoding: {"chunked"},
+		hdrKeepAlive:        {"timeout=5"},
+		hdrTrailer:          {"Expires"},
+		hdrUpgrade:          {"h2c"},
+		"X-Request-Id":      {"abc123"},
+	}
+	out := filterResponseHeaders(in)
+	// End-to-end headers survive.
+	is.Equal(out["Content-Type"], []string{"application/json"})
+	is.Equal(out["X-Request-Id"], []string{"abc123"})
+	// Hop-by-hop headers are dropped.
+	for _, hop := range []string{hdrConnection, hdrTransferEncoding, hdrKeepAlive, hdrTrailer, hdrUpgrade} {
+		_, present := out[hop]
+		is.True(!present)
+	}
+	// A response of only hop-by-hop headers filters down to nil, not an empty map.
+	is.Equal(filterResponseHeaders(http.Header{hdrConnection: {"close"}}), nil)
+}
+
 func TestService_Stage1_Allowlist(t *testing.T) {
 	is := is.New(t)
 	s := New(mustAllow(t, "api.openai.com:443"), log.Nop())

--- a/pkg/plugin/processor/egress/service_test.go
+++ b/pkg/plugin/processor/egress/service_test.go
@@ -1,0 +1,490 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package egress
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-processor-sdk/pprocutils"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/matryer/is"
+)
+
+// --- test helpers ---------------------------------------------------------
+
+type funcResolver func(host string) ([]net.IP, error)
+
+func (f funcResolver) LookupIP(_ context.Context, host string) ([]net.IP, error) { return f(host) }
+
+func staticResolver(ips ...net.IP) Resolver {
+	return funcResolver(func(string) ([]net.IP, error) { return ips, nil })
+}
+
+// seqResolver returns a different answer on each successive lookup, to simulate
+// a DNS rebind (public answer first, private answer next). Guarded by a mutex
+// because the transport may resolve from more than one goroutine.
+type seqResolver struct {
+	mu      sync.Mutex
+	answers [][]net.IP
+	i       int
+}
+
+func (r *seqResolver) LookupIP(context.Context, string) ([]net.IP, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	a := r.answers[r.i]
+	if r.i < len(r.answers)-1 {
+		r.i++
+	}
+	return a, nil
+}
+
+func hostPort(t *testing.T, srv *httptest.Server) string {
+	t.Helper()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return u.Host
+}
+
+// trustTLS makes the egress client trust the httptest TLS server's self-signed
+// cert (white-box: reach into the transport). Only used for https tests.
+func trustTLS(t *testing.T, s *Service, srv *httptest.Server) {
+	t.Helper()
+	tr := s.client.Transport.(*http.Transport)
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+	tr.TLSClientConfig = &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
+}
+
+func mustAllow(t *testing.T, spec string) Policy {
+	t.Helper()
+	allow, err := ParseAllowlist(spec)
+	if err != nil {
+		t.Fatalf("parse allowlist %q: %v", spec, err)
+	}
+	return Policy{Enabled: true, Allowlist: allow, Timeout: 5 * time.Second, MaxResponseBytes: DefaultMaxResponseBytes}
+}
+
+// --- tests ----------------------------------------------------------------
+
+func TestService_DenyAll(t *testing.T) {
+	is := is.New(t)
+	s := New(DenyAll(), log.Nop())
+	_, err := s.Do(context.Background(), pprocutils.HTTPRequest{Method: "GET", URL: "https://api.openai.com/v1"})
+	is.True(cerrors.Is(err, pprocutils.ErrHTTPEgressDisabled))
+}
+
+func TestService_Stage1_Allowlist(t *testing.T) {
+	is := is.New(t)
+	s := New(mustAllow(t, "api.openai.com:443"), log.Nop())
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		url  string
+		want *pprocutils.Error
+	}{
+		{"host not allowlisted", "https://evil.example.com/x", pprocutils.ErrHTTPForbidden},
+		{"port not allowlisted", "https://api.openai.com:8443/x", pprocutils.ErrHTTPForbidden},
+		{"scheme rejected (ftp)", "ftp://api.openai.com/x", pprocutils.ErrHTTPInvalidRequest},
+		{"scheme rejected (file)", "file:///etc/passwd", pprocutils.ErrHTTPInvalidRequest},
+		{"http to https-only host", "http://api.openai.com/x", pprocutils.ErrHTTPForbidden},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			_, err := s.Do(ctx, pprocutils.HTTPRequest{Method: "GET", URL: tc.url})
+			is.True(cerrors.Is(err, tc.want))
+		})
+	}
+}
+
+// TestService_Rebinding_HTTPS is the headline DNS-rebinding test (MUST-FIX 4),
+// run against a real https target: an allowlisted HOSTNAME (Stage 1 passes) that
+// resolves to loopback is refused at the dial-time gate, even though a live TLS
+// server is listening there. A custom-DialTLSContext bypass would connect and
+// return 200; asserting ErrHTTPForbidden proves Control governs the TLS dial.
+func TestService_Rebinding_HTTPS(t *testing.T) {
+	is := is.New(t)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("SHOULD NOT REACH"))
+	}))
+	defer srv.Close()
+
+	_, port, _ := net.SplitHostPort(hostPort(t, srv))
+	// Allowlist the HOSTNAME (not an IP carve-out), so loopback is not admitted.
+	p := mustAllow(t, "https://rebind.test:"+port)
+	s := New(p, log.Nop(), WithResolver(staticResolver(srv.Listener.Addr().(*net.TCPAddr).IP)))
+	trustTLS(t, s, srv)
+
+	_, err := s.Do(context.Background(), pprocutils.HTTPRequest{Method: "GET", URL: "https://rebind.test:" + port + "/v1"})
+	is.True(cerrors.Is(err, pprocutils.ErrHTTPForbidden)) // gate refused the loopback dial on https
+}
+
+// TestService_Rebinding_TOCTOU proves the gate re-evaluates per call at dial
+// time: the SAME allowlisted hostname is allowed-by-gate when it resolves public
+// and refused when it later resolves private.
+func TestService_Rebinding_TOCTOU(t *testing.T) {
+	is := is.New(t)
+	p := mustAllow(t, "https://rebind.test:443")
+	p.Timeout = 300 * time.Millisecond
+	res := &seqResolver{answers: [][]net.IP{
+		{net.ParseIP("203.0.113.10")}, // public (TEST-NET-3): gate allows, connect fails/times out
+		{net.ParseIP("10.0.0.1")},     // private: gate refuses
+	}}
+	s := New(p, log.Nop(), WithResolver(res))
+	ctx := context.Background()
+
+	_, err1 := s.Do(ctx, pprocutils.HTTPRequest{Method: "GET", URL: "https://rebind.test:443/"})
+	is.True(!cerrors.Is(err1, pprocutils.ErrHTTPForbidden)) // gate ALLOWED public; failure is transport/timeout
+
+	_, err2 := s.Do(ctx, pprocutils.HTTPRequest{Method: "GET", URL: "https://rebind.test:443/"})
+	is.True(cerrors.Is(err2, pprocutils.ErrHTTPForbidden)) // same host now refused (rebind defended)
+}
+
+// TestService_CarveOut_HTTPS_Positive proves the explicit (IP, port) carve-out
+// admits a loopback https target end-to-end through the gate (the local-Ollama /
+// private-VPC-endpoint case), and that the gated dial serves TLS.
+func TestService_CarveOut_HTTPS_Positive(t *testing.T) {
+	is := is.New(t)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	s := New(mustAllow(t, "https://"+hostPort(t, srv)), log.Nop())
+	trustTLS(t, s, srv)
+
+	resp, err := s.Do(context.Background(), pprocutils.HTTPRequest{Method: "GET", URL: srv.URL + "/v1"})
+	is.NoErr(err)
+	is.Equal(resp.StatusCode, 200)
+	is.Equal(string(resp.Body), "ok")
+}
+
+// TestService_CarveOut_PortScoped is the live (IP, port) carve-out scoping check
+// (MUST-FIX 3): an allowlisted loopback:P is reachable, but the same IP on a
+// different port is refused (it is not the listed pair).
+func TestService_CarveOut_PortScoped(t *testing.T) {
+	is := is.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ollama"))
+	}))
+	defer srv.Close()
+
+	hp := hostPort(t, srv)
+	_, port, _ := net.SplitHostPort(hp)
+	s := New(mustAllow(t, "http://"+hp), log.Nop()) // only 127.0.0.1:<port>
+
+	// listed pair works
+	resp, err := s.Do(context.Background(), pprocutils.HTTPRequest{Method: "GET", URL: srv.URL})
+	is.NoErr(err)
+	is.Equal(resp.StatusCode, 200)
+
+	// same IP, a DIFFERENT port (Redis-like) is refused
+	otherPort := "6379"
+	if port == "6379" {
+		otherPort = "6380"
+	}
+	_, err = s.Do(context.Background(), pprocutils.HTTPRequest{Method: "GET", URL: "http://127.0.0.1:" + otherPort})
+	is.True(cerrors.Is(err, pprocutils.ErrHTTPForbidden))
+}
+
+// TestService_ProxyEnv_Ignored is MUST-FIX 1: HTTP_PROXY/HTTPS_PROXY/ALL_PROXY
+// are ignored (Transport.Proxy pinned nil), so the client dials — and gates —
+// the real destination instead of a proxy the gate never validated.
+func TestService_ProxyEnv_Ignored(t *testing.T) {
+	is := is.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("direct"))
+	}))
+	defer srv.Close()
+
+	// A bogus proxy that would break the call if honored.
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:1")
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:1")
+	t.Setenv("ALL_PROXY", "socks5://127.0.0.1:1")
+
+	s := New(mustAllow(t, "http://"+hostPort(t, srv)), log.Nop())
+	resp, err := s.Do(context.Background(), pprocutils.HTTPRequest{Method: "GET", URL: srv.URL})
+	is.NoErr(err) // proxy env ignored; real destination reached
+	is.Equal(string(resp.Body), "direct")
+}
+
+// TestService_Redirect_Blocked: a 3xx to any Location is not followed.
+func TestService_Redirect_Blocked(t *testing.T) {
+	is := is.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/redir" {
+			http.Redirect(w, r, "http://169.254.169.254/latest/meta-data/", http.StatusFound)
+			return
+		}
+		_, _ = w.Write([]byte("landing"))
+	}))
+	defer srv.Close()
+
+	s := New(mustAllow(t, "http://"+hostPort(t, srv)), log.Nop())
+	_, err := s.Do(context.Background(), pprocutils.HTTPRequest{Method: "GET", URL: srv.URL + "/redir"})
+	is.True(cerrors.Is(err, pprocutils.ErrHTTPForbidden)) // redirect not followed -> no hop to metadata
+}
+
+func TestService_HeaderHardening(t *testing.T) {
+	is := is.New(t)
+	s := New(mustAllow(t, "api.openai.com:443"), log.Nop())
+	ctx := context.Background()
+
+	cases := []struct {
+		name    string
+		headers map[string][]string
+	}{
+		{"CRLF in value", map[string][]string{"X-Test": {"a\r\nInjected: 1"}}},
+		{"CRLF in name", map[string][]string{"X-Test\r\nEvil": {"v"}}},
+		{"guest Host override", map[string][]string{"Host": {"evil.example.com"}}},
+		{"guest Authorization", map[string][]string{"Authorization": {"Bearer stolen"}}},
+		{"guest Accept-Encoding", map[string][]string{"Accept-Encoding": {"gzip"}}},
+		{"guest Content-Length", map[string][]string{"Content-Length": {"0"}}},
+		{"guest pseudo-header", map[string][]string{":authority": {"evil"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			_, err := s.Do(ctx, pprocutils.HTTPRequest{
+				Method:  "POST",
+				URL:     "https://api.openai.com/v1",
+				Headers: tc.headers,
+			})
+			is.True(cerrors.Is(err, pprocutils.ErrHTTPInvalidRequest))
+		})
+	}
+}
+
+// TestService_CredentialInjection is the mandatory host-injected-credential path:
+// the guest names a secret, the host resolves and sets Authorization, and there
+// is no guest-supplied-credential path.
+func TestService_CredentialInjection(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	t.Run("host injects Authorization the guest never supplied", func(t *testing.T) {
+		is := is.New(t)
+		gotAuth = ""
+		p := mustAllow(t, "http://"+hostPort(t, srv))
+		p.SecretRefs = map[string]struct{}{"openai_api_key": {}}
+		s := New(p, log.Nop(), WithSecretResolver(fakeSecrets{"openai_api_key": "Bearer SECRET-XYZ"}))
+		resp, err := s.Do(context.Background(), pprocutils.HTTPRequest{
+			Method: "GET", URL: srv.URL, AuthSecretRef: "openai_api_key",
+		})
+		is.NoErr(err)
+		is.Equal(resp.StatusCode, 200)
+		is.Equal(gotAuth, "Bearer SECRET-XYZ") // host set it from the secret ref
+	})
+
+	t.Run("ungranted secret ref is forbidden", func(t *testing.T) {
+		is := is.New(t)
+		p := mustAllow(t, "http://"+hostPort(t, srv)) // no SecretRefs granted
+		s := New(p, log.Nop(), WithSecretResolver(fakeSecrets{"openai_api_key": "Bearer x"}))
+		_, err := s.Do(context.Background(), pprocutils.HTTPRequest{
+			Method: "GET", URL: srv.URL, AuthSecretRef: "openai_api_key",
+		})
+		is.True(cerrors.Is(err, pprocutils.ErrHTTPForbidden))
+	})
+
+	t.Run("secret ref with no backend wired fails non-silently", func(t *testing.T) {
+		is := is.New(t)
+		p := mustAllow(t, "http://"+hostPort(t, srv))
+		p.SecretRefs = map[string]struct{}{"openai_api_key": {}}
+		s := New(p, log.Nop()) // no WithSecretResolver
+		_, err := s.Do(context.Background(), pprocutils.HTTPRequest{
+			Method: "GET", URL: srv.URL, AuthSecretRef: "openai_api_key",
+		})
+		is.True(cerrors.Is(err, pprocutils.ErrHTTPInvalidRequest))
+	})
+}
+
+type fakeSecrets map[string]string
+
+func (f fakeSecrets) Resolve(_ context.Context, name string) (string, error) {
+	v, ok := f[name]
+	if !ok {
+		return "", cerrors.New("no such secret")
+	}
+	return v, nil
+}
+
+// TestService_DecompressionBomb is MUST-FIX 5: with Accept-Encoding host-reserved,
+// transparent decompression stays on and the size cap measures the DECOMPRESSED
+// stream, so a small gzip body that inflates hugely trips the cap.
+func TestService_DecompressionBomb(t *testing.T) {
+	is := is.New(t)
+	// ~200 KiB decompressed, tiny compressed.
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, _ = gz.Write(bytes.Repeat([]byte("A"), 200*1024))
+	_ = gz.Close()
+	bomb := buf.Bytes()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		_, _ = w.Write(bomb)
+	}))
+	defer srv.Close()
+
+	p := mustAllow(t, "http://"+hostPort(t, srv))
+	p.MaxResponseBytes = 4096 // cap well below the 200 KiB decompressed size
+	s := New(p, log.Nop())
+
+	_, err := s.Do(context.Background(), pprocutils.HTTPRequest{Method: "GET", URL: srv.URL})
+	is.True(cerrors.Is(err, pprocutils.ErrHTTPResponseTooLarge)) // cap on decompressed stream
+}
+
+func TestService_OversizedResponse(t *testing.T) {
+	is := is.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(bytes.Repeat([]byte("x"), 100*1024))
+	}))
+	defer srv.Close()
+
+	p := mustAllow(t, "http://"+hostPort(t, srv))
+	p.MaxResponseBytes = 1024
+	s := New(p, log.Nop())
+	_, err := s.Do(context.Background(), pprocutils.HTTPRequest{Method: "GET", URL: srv.URL})
+	is.True(cerrors.Is(err, pprocutils.ErrHTTPResponseTooLarge))
+}
+
+func TestService_Timeout(t *testing.T) {
+	is := is.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		_, _ = w.Write([]byte("late"))
+	}))
+	defer srv.Close()
+
+	p := mustAllow(t, "http://"+hostPort(t, srv))
+	p.Timeout = 100 * time.Millisecond
+	s := New(p, log.Nop())
+	_, err := s.Do(context.Background(), pprocutils.HTTPRequest{Method: "GET", URL: srv.URL})
+	is.True(cerrors.Is(err, pprocutils.ErrHTTPTimeout))
+}
+
+// TestService_MultiTenantIsolation is MUST-FIX 6: two Services with two different
+// allowlists on one host each refuse the OTHER's destination and admit only their
+// own — the concrete proof that egress policy is per-Service (per-processor)
+// state, not shared. Neither can reach the other's granted host.
+func TestService_MultiTenantIsolation(t *testing.T) {
+	is := is.New(t)
+	srvA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("A")) }))
+	defer srvA.Close()
+	srvB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("B")) }))
+	defer srvB.Close()
+
+	sA := New(mustAllow(t, "http://"+hostPort(t, srvA)), log.Nop())
+	sB := New(mustAllow(t, "http://"+hostPort(t, srvB)), log.Nop())
+	ctx := context.Background()
+
+	// each reaches only its own host
+	rA, err := sA.Do(ctx, pprocutils.HTTPRequest{Method: "GET", URL: srvA.URL})
+	is.NoErr(err)
+	is.Equal(string(rA.Body), "A")
+	rB, err := sB.Do(ctx, pprocutils.HTTPRequest{Method: "GET", URL: srvB.URL})
+	is.NoErr(err)
+	is.Equal(string(rB.Body), "B")
+
+	// cross access is forbidden — no policy leakage between tenants
+	_, err = sA.Do(ctx, pprocutils.HTTPRequest{Method: "GET", URL: srvB.URL})
+	is.True(cerrors.Is(err, pprocutils.ErrHTTPForbidden))
+	_, err = sB.Do(ctx, pprocutils.HTTPRequest{Method: "GET", URL: srvA.URL})
+	is.True(cerrors.Is(err, pprocutils.ErrHTTPForbidden))
+}
+
+// TestService_MultiAnswerDNS proves per-candidate gating (design scenario 6): a
+// mixed answer set (one private, one admissible) skips the private candidate and
+// dials only the admissible one — a private dial cannot be smuggled through on a
+// fallback attempt.
+func TestService_MultiAnswerDNS(t *testing.T) {
+	is := is.New(t)
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	is.NoErr(err)
+	defer ln.Close()
+	go func() {
+		for {
+			c, e := ln.Accept()
+			if e != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+	_, port, _ := net.SplitHostPort(ln.Addr().String())
+
+	// carve-out the loopback:port so 127.0.0.1 is admissible on Stage 2.
+	s := New(mustAllow(t, "http://127.0.0.1:"+port), log.Nop(),
+		WithResolver(staticResolver(net.ParseIP("10.0.0.1"), net.ParseIP("127.0.0.1"))))
+	base := &net.Dialer{Control: s.dialControl}
+
+	conn, err := s.dialContext(base)(context.Background(), "tcp", "multi.test:"+port)
+	is.NoErr(err) // private 10.0.0.1 skipped, admissible 127.0.0.1 dialed
+	remoteIP := conn.RemoteAddr().(*net.TCPAddr).IP
+	is.True(remoteIP.IsLoopback()) // dialed the loopback candidate, not the private one
+	_ = conn.Close()
+
+	// with NO admissible candidate, every private candidate is refused.
+	s2 := New(Policy{Enabled: true, Allowlist: nil}, log.Nop(),
+		WithResolver(staticResolver(net.ParseIP("10.0.0.1"), net.ParseIP("192.168.1.1"))))
+	base2 := &net.Dialer{Control: s2.dialControl}
+	_, err = s2.dialContext(base2)(context.Background(), "tcp", "multi.test:"+port)
+	is.True(err != nil)
+	var refused *dialRefusedError
+	is.True(cerrors.As(err, &refused))
+}
+
+func TestService_DNSFailure(t *testing.T) {
+	is := is.New(t)
+	p := mustAllow(t, "https://noexist.test:443")
+	s := New(p, log.Nop(), WithResolver(funcResolver(func(string) ([]net.IP, error) {
+		return nil, cerrors.New("no such host")
+	})))
+	_, err := s.Do(context.Background(), pprocutils.HTTPRequest{Method: "GET", URL: "https://noexist.test:443/"})
+	is.True(cerrors.Is(err, pprocutils.ErrHTTPDNS))
+}
+
+// TestService_MetadataIPLiteral is scenario 2: a direct request to the metadata
+// IP literal is refused (Stage 1 miss, and Stage 2 would refuse it too).
+func TestService_MetadataIPLiteral(t *testing.T) {
+	is := is.New(t)
+	s := New(mustAllow(t, "api.openai.com:443"), log.Nop())
+	_, err := s.Do(context.Background(), pprocutils.HTTPRequest{
+		Method: "GET", URL: "http://169.254.169.254/latest/meta-data/",
+	})
+	// Stage 1 rejects (not allowlisted) before we even dial.
+	is.True(cerrors.Is(err, pprocutils.ErrHTTPForbidden))
+}

--- a/pkg/plugin/processor/mock/registry.go
+++ b/pkg/plugin/processor/mock/registry.go
@@ -15,6 +15,7 @@ import (
 
 	sdk "github.com/conduitio/conduit-processor-sdk"
 	plugin "github.com/conduitio/conduit/pkg/plugin"
+	egress "github.com/conduitio/conduit/pkg/plugin/processor/egress"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -81,18 +82,18 @@ func (c *RegistryListCall) DoAndReturn(f func() map[plugin.FullName]sdk.Specific
 }
 
 // NewProcessor mocks base method.
-func (m *Registry) NewProcessor(ctx context.Context, fullName plugin.FullName, id string) (sdk.Processor, error) {
+func (m *Registry) NewProcessor(ctx context.Context, fullName plugin.FullName, id string, egressPolicy egress.Policy) (sdk.Processor, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewProcessor", ctx, fullName, id)
+	ret := m.ctrl.Call(m, "NewProcessor", ctx, fullName, id, egressPolicy)
 	ret0, _ := ret[0].(sdk.Processor)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewProcessor indicates an expected call of NewProcessor.
-func (mr *RegistryMockRecorder) NewProcessor(ctx, fullName, id any) *RegistryNewProcessorCall {
+func (mr *RegistryMockRecorder) NewProcessor(ctx, fullName, id, egressPolicy any) *RegistryNewProcessorCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewProcessor", reflect.TypeOf((*Registry)(nil).NewProcessor), ctx, fullName, id)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewProcessor", reflect.TypeOf((*Registry)(nil).NewProcessor), ctx, fullName, id, egressPolicy)
 	return &RegistryNewProcessorCall{Call: call}
 }
 
@@ -108,13 +109,13 @@ func (c *RegistryNewProcessorCall) Return(arg0 sdk.Processor, arg1 error) *Regis
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *RegistryNewProcessorCall) Do(f func(context.Context, plugin.FullName, string) (sdk.Processor, error)) *RegistryNewProcessorCall {
+func (c *RegistryNewProcessorCall) Do(f func(context.Context, plugin.FullName, string, egress.Policy) (sdk.Processor, error)) *RegistryNewProcessorCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *RegistryNewProcessorCall) DoAndReturn(f func(context.Context, plugin.FullName, string) (sdk.Processor, error)) *RegistryNewProcessorCall {
+func (c *RegistryNewProcessorCall) DoAndReturn(f func(context.Context, plugin.FullName, string, egress.Policy) (sdk.Processor, error)) *RegistryNewProcessorCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -182,18 +183,18 @@ func (c *StandaloneRegistryListCall) DoAndReturn(f func() map[plugin.FullName]sd
 }
 
 // NewProcessor mocks base method.
-func (m *StandaloneRegistry) NewProcessor(ctx context.Context, fullName plugin.FullName, id string) (sdk.Processor, error) {
+func (m *StandaloneRegistry) NewProcessor(ctx context.Context, fullName plugin.FullName, id string, egressPolicy egress.Policy) (sdk.Processor, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewProcessor", ctx, fullName, id)
+	ret := m.ctrl.Call(m, "NewProcessor", ctx, fullName, id, egressPolicy)
 	ret0, _ := ret[0].(sdk.Processor)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewProcessor indicates an expected call of NewProcessor.
-func (mr *StandaloneRegistryMockRecorder) NewProcessor(ctx, fullName, id any) *StandaloneRegistryNewProcessorCall {
+func (mr *StandaloneRegistryMockRecorder) NewProcessor(ctx, fullName, id, egressPolicy any) *StandaloneRegistryNewProcessorCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewProcessor", reflect.TypeOf((*StandaloneRegistry)(nil).NewProcessor), ctx, fullName, id)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewProcessor", reflect.TypeOf((*StandaloneRegistry)(nil).NewProcessor), ctx, fullName, id, egressPolicy)
 	return &StandaloneRegistryNewProcessorCall{Call: call}
 }
 
@@ -209,13 +210,13 @@ func (c *StandaloneRegistryNewProcessorCall) Return(arg0 sdk.Processor, arg1 err
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *StandaloneRegistryNewProcessorCall) Do(f func(context.Context, plugin.FullName, string) (sdk.Processor, error)) *StandaloneRegistryNewProcessorCall {
+func (c *StandaloneRegistryNewProcessorCall) Do(f func(context.Context, plugin.FullName, string, egress.Policy) (sdk.Processor, error)) *StandaloneRegistryNewProcessorCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *StandaloneRegistryNewProcessorCall) DoAndReturn(f func(context.Context, plugin.FullName, string) (sdk.Processor, error)) *StandaloneRegistryNewProcessorCall {
+func (c *StandaloneRegistryNewProcessorCall) DoAndReturn(f func(context.Context, plugin.FullName, string, egress.Policy) (sdk.Processor, error)) *StandaloneRegistryNewProcessorCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/pkg/plugin/processor/service.go
+++ b/pkg/plugin/processor/service.go
@@ -23,10 +23,11 @@ import (
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/plugin"
+	"github.com/conduitio/conduit/pkg/plugin/processor/egress"
 )
 
 type registry interface {
-	NewProcessor(ctx context.Context, fullName plugin.FullName, id string) (sdk.Processor, error)
+	NewProcessor(ctx context.Context, fullName plugin.FullName, id string, egressPolicy egress.Policy) (sdk.Processor, error)
 	List() map[plugin.FullName]sdk.Specification
 }
 
@@ -54,20 +55,20 @@ func (s *PluginService) Check(context.Context) error {
 	return nil
 }
 
-func (s *PluginService) NewProcessor(ctx context.Context, pluginName string, id string) (sdk.Processor, error) {
+func (s *PluginService) NewProcessor(ctx context.Context, pluginName string, id string, egressPolicy egress.Policy) (sdk.Processor, error) {
 	fullName := plugin.FullName(pluginName)
 	switch fullName.PluginType() {
 	// standalone processors take precedence
 	// over built-in processors with the same name
 	case plugin.PluginTypeStandalone:
-		return s.standaloneReg.NewProcessor(ctx, fullName, id)
+		return s.standaloneReg.NewProcessor(ctx, fullName, id, egressPolicy)
 	case plugin.PluginTypeBuiltin:
-		return s.builtinReg.NewProcessor(ctx, fullName, id)
+		return s.builtinReg.NewProcessor(ctx, fullName, id, egressPolicy)
 	case plugin.PluginTypeAny:
-		d, err := s.standaloneReg.NewProcessor(ctx, fullName, id)
+		d, err := s.standaloneReg.NewProcessor(ctx, fullName, id, egressPolicy)
 		if err != nil {
 			s.logger.Debug(ctx).Err(err).Msg("could not find standalone plugin dispenser, falling back to builtin plugin")
-			d, err = s.builtinReg.NewProcessor(ctx, fullName, id)
+			d, err = s.builtinReg.NewProcessor(ctx, fullName, id, egressPolicy)
 		}
 		return d, err
 	default:

--- a/pkg/plugin/processor/service_test.go
+++ b/pkg/plugin/processor/service_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/plugin"
+	"github.com/conduitio/conduit/pkg/plugin/processor/egress"
 	"github.com/conduitio/conduit/pkg/plugin/processor/mock"
 	"github.com/matryer/is"
 	"go.uber.org/mock/gomock"
@@ -36,13 +37,13 @@ func TestPluginService_GetBuiltin_NotFound(t *testing.T) {
 
 	br := mock.NewRegistry(ctrl)
 	br.EXPECT().
-		NewProcessor(gomock.Any(), plugin.FullName(name), id).
+		NewProcessor(gomock.Any(), plugin.FullName(name), id, gomock.Any()).
 		Return(nil, plugin.ErrPluginNotFound)
 
 	sr := mock.NewStandaloneRegistry(ctrl)
 
 	underTest := NewPluginService(log.Nop(), br, sr)
-	got, err := underTest.NewProcessor(ctx, name, id)
+	got, err := underTest.NewProcessor(ctx, name, id, egress.DenyAll())
 	is.True(cerrors.Is(err, plugin.ErrPluginNotFound))
 	is.True(got == nil)
 }
@@ -58,11 +59,11 @@ func TestPluginService_GetStandalone_NotFound(t *testing.T) {
 	br := mock.NewRegistry(ctrl)
 	sr := mock.NewStandaloneRegistry(ctrl)
 	sr.EXPECT().
-		NewProcessor(gomock.Any(), plugin.FullName(name), id).
+		NewProcessor(gomock.Any(), plugin.FullName(name), id, gomock.Any()).
 		Return(nil, plugin.ErrPluginNotFound)
 
 	underTest := NewPluginService(log.Nop(), br, sr)
-	got, err := underTest.NewProcessor(ctx, name, id)
+	got, err := underTest.NewProcessor(ctx, name, id, egress.DenyAll())
 	is.True(cerrors.Is(err, plugin.ErrPluginNotFound))
 	is.True(got == nil)
 }
@@ -76,7 +77,7 @@ func TestPluginService_InvalidPluginType(t *testing.T) {
 	sr := mock.NewStandaloneRegistry(ctrl)
 	underTest := NewPluginService(log.Nop(), br, sr)
 
-	got, err := underTest.NewProcessor(ctx, "crunchy:test-processor", "test-id")
+	got, err := underTest.NewProcessor(ctx, "crunchy:test-processor", "test-id", egress.DenyAll())
 	is.True(err != nil)
 	is.Equal("invalid plugin name prefix \"crunchy\"", err.Error())
 	is.True(got == nil)
@@ -95,7 +96,7 @@ func TestPluginService_Get(t *testing.T) {
 			procName: "builtin:test-processor",
 			setup: func(br *mock.Registry, sr *mock.StandaloneRegistry, proc *mock.Processor) {
 				br.EXPECT().
-					NewProcessor(gomock.Any(), plugin.FullName("builtin:test-processor"), "test-id").
+					NewProcessor(gomock.Any(), plugin.FullName("builtin:test-processor"), "test-id", gomock.Any()).
 					Return(proc, nil)
 			},
 		},
@@ -104,7 +105,7 @@ func TestPluginService_Get(t *testing.T) {
 			procName: "standalone:test-processor",
 			setup: func(br *mock.Registry, sr *mock.StandaloneRegistry, proc *mock.Processor) {
 				sr.EXPECT().
-					NewProcessor(gomock.Any(), plugin.FullName("standalone:test-processor"), "test-id").
+					NewProcessor(gomock.Any(), plugin.FullName("standalone:test-processor"), "test-id", gomock.Any()).
 					Return(proc, nil)
 			},
 		},
@@ -113,7 +114,7 @@ func TestPluginService_Get(t *testing.T) {
 			procName: "test-processor",
 			setup: func(br *mock.Registry, sr *mock.StandaloneRegistry, proc *mock.Processor) {
 				sr.EXPECT().
-					NewProcessor(gomock.Any(), plugin.FullName("test-processor"), "test-id").
+					NewProcessor(gomock.Any(), plugin.FullName("test-processor"), "test-id", gomock.Any()).
 					Return(proc, nil)
 			},
 		},
@@ -130,7 +131,7 @@ func TestPluginService_Get(t *testing.T) {
 			tc.setup(br, sr, want)
 
 			underTest := NewPluginService(log.Nop(), br, sr)
-			got, err := underTest.NewProcessor(ctx, tc.procName, "test-id")
+			got, err := underTest.NewProcessor(ctx, tc.procName, "test-id", egress.DenyAll())
 			is.NoErr(err)
 			is.Equal(want, got)
 		})

--- a/pkg/plugin/processor/standalone/embedding_bundle_e2e_test.go
+++ b/pkg/plugin/processor/standalone/embedding_bundle_e2e_test.go
@@ -1,0 +1,378 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standalone
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/conduitio/conduit-commons/config"
+	"github.com/conduitio/conduit-commons/opencdc"
+	sdk "github.com/conduitio/conduit-processor-sdk"
+	"github.com/conduitio/conduit-processor-sdk/schema"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/plugin/processor/egress"
+	"github.com/goccy/go-json"
+	"github.com/matryer/is"
+	"github.com/tetratelabs/wazero"
+)
+
+// conduitProcessorAIDirEnv names the checkout of ConduitIO/conduit-processor-ai
+// this test builds the real ai.embed standalone-WASM guest from. This is a
+// cross-repo test by nature (the bundle's guest lives in a sibling repo, not
+// this one) — see the TODO(bundle-merge) comments in both repos' go.mod
+// files. It is set explicitly rather than assumed at a relative path because
+// no merged/monorepo layout exists yet; a follow-up wires this into a bundle
+// CI job that checks out both repos side by side and sets it there.
+const conduitProcessorAIDirEnv = "CONDUIT_PROCESSOR_AI_DIR"
+
+// buildEmbeddingWASM builds the REAL ai.embed processor binary
+// (cmd/embedding in conduit-processor-ai) for wasip1/wasm from the checkout
+// named by CONDUIT_PROCESSOR_AI_DIR, and returns the compiled bytes.
+//
+// This is not a fixture, a stub, or a purpose-built minimal guest: it is the
+// literal artifact conduit-processor-ai's own build instructions produce
+// (README.md: `GOOS=wasip1 GOARCH=wasm go build -tags wasm -o embedding.wasm
+// ./cmd/embedding`), which in turn embeds the real embed.Processor —
+// including the ollama Provider this task adds — running through the real
+// SDK (github.com/conduitio/conduit-processor-sdk), including its real
+// wasm-tagged egress.HTTPService wiring (sdk/wasm/util.go's InitUtils), not
+// a test double.
+//
+// The test SKIPS (does not fail) when CONDUIT_PROCESSOR_AI_DIR is unset or
+// doesn't look like a conduit-processor-ai checkout — see this package's
+// e2e report for why: until the two repos are merged or a bundle CI job
+// checks both out side by side, this test cannot run unconditionally in
+// every CI context that runs this repo's own test suite alone.
+func buildEmbeddingWASM(ctx context.Context, t *testing.T) []byte {
+	t.Helper()
+
+	dir := os.Getenv(conduitProcessorAIDirEnv)
+	if dir == "" {
+		t.Skipf("%s not set: skipping the real-embedding-guest bundle e2e test "+
+			"(requires a sibling checkout of ConduitIO/conduit-processor-ai with cmd/embedding)",
+			conduitProcessorAIDirEnv)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "cmd", "embedding")); err != nil {
+		t.Skipf("%s=%q does not look like a conduit-processor-ai checkout (no cmd/embedding): %v",
+			conduitProcessorAIDirEnv, dir, err)
+	}
+
+	out := filepath.Join(t.TempDir(), "embedding.wasm")
+	cmd := exec.CommandContext(ctx, "go", "build", "-tags", "wasm", "-o", out, "./cmd/embedding")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOOS=wasip1", "GOARCH=wasm")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("building real embedding.wasm from %s failed: %v\n%s", dir, err, stderr.String())
+	}
+
+	bin, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("reading built embedding.wasm: %v", err)
+	}
+	return bin
+}
+
+// newEmbeddingProcessor instantiates the compiled ai.embed guest against
+// this package's real host module (the same newWASMProcessor path every
+// standalone WASM processor in production goes through — see
+// processor.go), bound to policy.
+func newEmbeddingProcessor(ctx context.Context, t *testing.T, mod wazero.CompiledModule, policy egress.Policy) *wasmProcessor {
+	t.Helper()
+	logger := log.Test(t)
+	p, err := newWASMProcessor(ctx, TestRuntime, mod, CompiledHostModule, schema.NewInMemoryService(), policy, t.Name(), logger)
+	if err != nil {
+		t.Fatalf("instantiate embedding wasm processor: %v", err)
+	}
+	return p
+}
+
+// ollamaEmbeddingsHandlerRequest mirrors conduit-processor-ai's
+// ollamaEmbeddingRequest wire shape (model, prompt) — duplicated here
+// deliberately rather than imported, since this test only needs to decode
+// the request the real guest sends, not share code with it.
+type ollamaEmbeddingsHandlerRequest struct {
+	Model  string `json:"model"`
+	Prompt string `json:"prompt"`
+}
+
+// TestEmbeddingWASM_HostEgressBundle_EndToEnd is the host-egress bundle's
+// acceptance test: config-enabled egress -> the REAL ai.embed WASM guest
+// (built from conduit-processor-ai, configured for the ollama provider) ->
+// egress.Do -> this package's host module -> the host-side SSRF gate
+// (pkg/plugin/processor/egress) -> a local httptest server standing in for
+// Ollama.
+//
+// What this proves, precisely: every hop in that chain is the real,
+// production code path — the real compiled embed.Processor (not a fake or
+// a purpose-built stub guest), the real host module (hostModuleInstance,
+// the same type host_module_egress_test.go exercises), and the real
+// per-processor egress.Service gate (pkg/plugin/processor/egress). The only
+// non-production stand-in is the destination server itself (a local
+// httptest.Server playing Ollama's /api/embeddings, not a real Ollama
+// install) — acceptable because the property under test is the host-side
+// gate and the guest's own request/response handling, neither of which
+// cares whether the JSON on the other end came from Ollama or a fixture
+// that speaks its wire shape.
+func TestEmbeddingWASM_HostEgressBundle_EndToEnd(t *testing.T) {
+	ctx := context.Background()
+	wasmBytes := buildEmbeddingWASM(ctx, t)
+
+	mod, err := TestRuntime.CompileModule(ctx, wasmBytes)
+	if err != nil {
+		t.Fatalf("compile real embedding.wasm: %v", err)
+	}
+	defer func() { _ = mod.Close(ctx) }()
+
+	t.Run("HappyPath_RealGuestThroughHostToLocalServer", func(t *testing.T) {
+		testEmbeddingHappyPath(t, ctx, mod)
+	})
+	t.Run("SSRF_HostNotAllowlisted_BlockedEndToEndThroughRealGuest", func(t *testing.T) {
+		testEmbeddingSSRFBlocked(t, ctx, mod)
+	})
+	t.Run("ProviderError_Invariant1And3_NoPlaceholderEmbedding", func(t *testing.T) {
+		testEmbeddingProviderErrorInvariant(t, ctx, mod)
+	})
+}
+
+// testEmbeddingHappyPath proves the full chain works for real: config ->
+// guest -> egress.Do -> host gate -> local server -> guest -> two output
+// records each carrying the real embedding vector from the response the
+// local server sent back for THAT record's own prompt (proving the guest's
+// one-egress-call-per-record sub-batching, MaxBatchSize()==1 for ollama,
+// keeps the record<->response mapping correct rather than scrambling or
+// reusing the first call's result).
+func testEmbeddingHappyPath(t *testing.T, ctx context.Context, mod wazero.CompiledModule) {
+	is := is.New(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		is.NoErr(err)
+		var req ollamaEmbeddingsHandlerRequest
+		is.NoErr(json.Unmarshal(body, &req))
+		is.Equal(req.Model, "test-embed-model")
+
+		// Deterministic, per-prompt vector so the test can assert each
+		// output record got back the vector for ITS OWN input, not a
+		// neighbor's.
+		vec := []float32{float32(len(req.Prompt)), 1, 2}
+		w.Header().Set("Content-Type", "application/json")
+		is.NoErr(json.NewEncoder(w).Encode(map[string]any{"embedding": vec}))
+	}))
+	defer srv.Close()
+
+	policy := allowPolicy(t, "http://"+hp(t, srv))
+	underTest := newEmbeddingProcessor(ctx, t, mod, policy)
+
+	is.NoErr(underTest.Configure(ctx, config.Config{
+		"provider":       "ollama",
+		"model":          "test-embed-model",
+		"ollama.baseURL": srv.URL,
+		"requestTimeout": "5s",
+		"maxRetries":     "0",
+	}))
+	is.NoErr(underTest.Open(ctx))
+
+	records := []opencdc.Record{
+		{Operation: opencdc.OperationCreate, Payload: opencdc.Change{After: opencdc.RawData("short")}},
+		{Operation: opencdc.OperationCreate, Payload: opencdc.Change{After: opencdc.RawData("a much longer chunk of text")}},
+	}
+	processed := underTest.Process(ctx, records)
+	is.Equal(len(processed), 2)
+
+	wantLens := []int{len("short"), len("a much longer chunk of text")}
+	for i, pr := range processed {
+		single, ok := pr.(sdk.SingleRecord)
+		if !ok {
+			t.Fatalf("record %d: want sdk.SingleRecord, got %T (%+v)", i, pr, pr)
+		}
+		rec := opencdc.Record(single)
+
+		is.Equal(rec.Metadata["ai.embedding.provider"], "ollama")
+		is.Equal(rec.Metadata["ai.embedding.model"], "test-embed-model")
+		is.Equal(rec.Metadata["ai.embedding.dimension"], "3")
+		// Ollama reports no token usage — the tokensUsed/tokensUsedScope
+		// metadata must be ABSENT, never a fabricated "0" (design doc §2
+		// "never estimated"; embed/ollama.go's parseOllamaEmbeddingResponse).
+		_, hasTokens := rec.Metadata["ai.embedding.tokensUsed"]
+		is.True(!hasTokens)
+		_, hasScope := rec.Metadata["ai.embedding.tokensUsedScope"]
+		is.True(!hasScope)
+
+		raw, ok := rec.Payload.After.(opencdc.RawData)
+		if !ok {
+			t.Fatalf("record %d: want opencdc.RawData output payload, got %T", i, rec.Payload.After)
+		}
+		var vec []float32
+		is.NoErr(json.Unmarshal(raw.Bytes(), &vec))
+		is.Equal(len(vec), 3)
+		is.Equal(int(vec[0]), wantLens[i])
+	}
+
+	is.NoErr(underTest.Teardown(ctx))
+}
+
+// testEmbeddingSSRFBlocked is the bundle's highest-value assertion: the
+// SSRF gate proven end-to-end through the REAL compiled guest, not a host-
+// module unit test in isolation. The pipeline is configured to reach a real
+// local server, but that server's (IP,port) was never granted by the
+// egress policy (only an unrelated decoy server's was) — the same
+// (IP,port)-exact-match invariant policy.go's matchesCarveOut/MatchHostPort
+// enforce (allowlisting 127.0.0.1:11434 must not admit 127.0.0.1:6379).
+//
+// Expected outcome: the guest's egress.Do call is refused by the host gate
+// (ErrForbidden), embed/ollama.go's classifyOllamaEgressError wraps it as a
+// coded ai.embedding_provider_error, and the record comes back as an
+// sdk.ErrorRecord — never a passthrough, never a placeholder vector, and
+// the decoy target is never contacted (proving no confusion between the
+// two policy entries).
+func testEmbeddingSSRFBlocked(t *testing.T, ctx context.Context, mod wazero.CompiledModule) {
+	is := is.New(t)
+
+	reachedTarget := false
+	targetSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reachedTarget = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"embedding":[9,9,9]}`))
+	}))
+	defer targetSrv.Close()
+
+	decoySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"embedding":[0,0,0]}`))
+	}))
+	defer decoySrv.Close()
+
+	// Policy grants ONLY the decoy's (IP,port) — the pipeline config below
+	// points at targetSrv instead, an unauthorized host from the policy's
+	// point of view (an operator misconfiguration, or a compromised config
+	// value; either way the gate must hold).
+	policy := allowPolicy(t, "http://"+hp(t, decoySrv))
+	underTest := newEmbeddingProcessor(ctx, t, mod, policy)
+
+	is.NoErr(underTest.Configure(ctx, config.Config{
+		"provider":       "ollama",
+		"model":          "test-embed-model",
+		"ollama.baseURL": targetSrv.URL,
+		"requestTimeout": "5s",
+		"maxRetries":     "0",
+	}))
+	is.NoErr(underTest.Open(ctx))
+
+	processed := underTest.Process(ctx, []opencdc.Record{
+		{Operation: opencdc.OperationCreate, Payload: opencdc.Change{After: opencdc.RawData("ssrf-attempt")}},
+	})
+	is.Equal(len(processed), 1)
+
+	errRecord, ok := processed[0].(sdk.ErrorRecord)
+	if !ok {
+		t.Fatalf("want sdk.ErrorRecord for a non-allowlisted target, got %T (%+v)", processed[0], processed[0])
+	}
+	is.True(errRecord.Error != nil)
+	msg := errRecord.Error.Error()
+	// The coded error and the host gate's own reason both survive the
+	// guest -> host proto boundary as message text (see
+	// conduit-processor-sdk's run.go protoConverter.error: Message =
+	// err.Error(), which for *embed.Error is "<code>: <message> ...").
+	is.True(strings.Contains(msg, "ai.embedding_provider_error"))
+	is.True(strings.Contains(msg, "not in the pipeline's egress allowlist") ||
+		strings.Contains(msg, "forbidden"))
+	is.True(!reachedTarget) // the gate refused the call before it ever reached the target server
+
+	is.NoErr(underTest.Teardown(ctx))
+}
+
+// testEmbeddingProviderErrorInvariant proves invariants 1/3
+// (CLAUDE.md: never acknowledge/deliver a record as successfully processed
+// without a durable, real result) end to end for this provider: a local
+// server that fails for one record's prompt and succeeds for another's
+// must produce exactly one ErrorRecord and one embedded SingleRecord — the
+// failure must never widen into losing the good record, and the good
+// record must never regress into a placeholder/error, and the bad record
+// must never come back embedded with a fabricated vector.
+func testEmbeddingProviderErrorInvariant(t *testing.T, ctx context.Context, mod wazero.CompiledModule) {
+	is := is.New(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		is.NoErr(err)
+		var req ollamaEmbeddingsHandlerRequest
+		is.NoErr(json.Unmarshal(body, &req))
+
+		if req.Prompt == "trigger-error" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"synthetic provider failure"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		is.NoErr(json.NewEncoder(w).Encode(map[string]any{"embedding": []float32{1, 2, 3}}))
+	}))
+	defer srv.Close()
+
+	policy := allowPolicy(t, "http://"+hp(t, srv))
+	underTest := newEmbeddingProcessor(ctx, t, mod, policy)
+
+	is.NoErr(underTest.Configure(ctx, config.Config{
+		"provider":       "ollama",
+		"model":          "test-embed-model",
+		"ollama.baseURL": srv.URL,
+		"requestTimeout": "5s",
+		"maxRetries":     "0", // fail fast: this test asserts failure shape, not retry behavior
+	}))
+	is.NoErr(underTest.Open(ctx))
+
+	processed := underTest.Process(ctx, []opencdc.Record{
+		{Operation: opencdc.OperationCreate, Payload: opencdc.Change{After: opencdc.RawData("trigger-error")}},
+		{Operation: opencdc.OperationCreate, Payload: opencdc.Change{After: opencdc.RawData("this one succeeds")}},
+	})
+	is.Equal(len(processed), 2)
+
+	errRecord, ok := processed[0].(sdk.ErrorRecord)
+	if !ok {
+		t.Fatalf("record 0: want sdk.ErrorRecord (provider failure), got %T (%+v)", processed[0], processed[0])
+	}
+	is.True(errRecord.Error != nil)
+	is.True(strings.Contains(errRecord.Error.Error(), "ai.embedding_provider_error"))
+	// The exact vendor status/message must survive too, proving this isn't
+	// a generic catch-all: the guest actually parsed the local server's
+	// response.
+	is.True(strings.Contains(errRecord.Error.Error(), "500") ||
+		strings.Contains(errRecord.Error.Error(), "synthetic provider failure"))
+
+	single, ok := processed[1].(sdk.SingleRecord)
+	if !ok {
+		t.Fatalf("record 1: want sdk.SingleRecord (independent success), got %T (%+v)", processed[1], processed[1])
+	}
+	rec := opencdc.Record(single)
+	raw, ok := rec.Payload.After.(opencdc.RawData)
+	if !ok {
+		t.Fatalf("record 1: want opencdc.RawData output payload, got %T", rec.Payload.After)
+	}
+	var vec []float32
+	is.NoErr(json.Unmarshal(raw.Bytes(), &vec))
+	is.Equal(vec, []float32{1, 2, 3})
+
+	is.NoErr(underTest.Teardown(ctx))
+}

--- a/pkg/plugin/processor/standalone/host_module.go
+++ b/pkg/plugin/processor/standalone/host_module.go
@@ -37,6 +37,7 @@ var hostModule wazergo.HostModule[*hostModuleInstance] = hostModuleFunctions{
 	"command_response": wazergo.F1((*hostModuleInstance).commandResponse),
 	"create_schema":    wazergo.F1((*hostModuleInstance).createSchema),
 	"get_schema":       wazergo.F1((*hostModuleInstance).getSchema),
+	"http_request":     wazergo.F1((*hostModuleInstance).httpRequest),
 }
 
 // hostModuleFunctions type implements HostModule, providing the module name,
@@ -51,7 +52,7 @@ func (f hostModuleFunctions) Name() string {
 
 // Functions is a helper that returns the exported functions of the module.
 func (f hostModuleFunctions) Functions() wazergo.Functions[*hostModuleInstance] {
-	return (wazergo.Functions[*hostModuleInstance])(f)
+	return wazergo.Functions[*hostModuleInstance](f)
 }
 
 // Instantiate creates a new instance of the module. This is called by the
@@ -78,12 +79,14 @@ func hostModuleOptions(
 	requests <-chan *processorv1.CommandRequest,
 	responses chan<- tuple[*processorv1.CommandResponse, error],
 	schemaService pprocutils.SchemaService,
+	httpService pprocutils.HTTPService,
 ) hostModuleOption {
 	return wazergo.OptionFunc(func(m *hostModuleInstance) {
 		m.logger = logger
 		m.commandRequests = requests
 		m.commandResponses = responses
 		m.schemaService = schemaService
+		m.httpService = httpService
 	})
 }
 
@@ -93,6 +96,11 @@ type hostModuleInstance struct {
 	commandRequests  <-chan *processorv1.CommandRequest
 	commandResponses chan<- tuple[*processorv1.CommandResponse, error]
 	schemaService    pprocutils.SchemaService
+	// httpService is the per-processor egress capability, bound host-side to this
+	// instance's resolved egress policy. It is genuinely per-instance state — never
+	// a shared registry field — so one processor's allowlist cannot leak to
+	// another. A nil httpService means egress was not wired (deny-all).
+	httpService pprocutils.HTTPService
 
 	parkedCommandRequest *processorv1.CommandRequest
 	parkedResponses      map[string]proto.Message
@@ -261,4 +269,39 @@ func (m *hostModuleInstance) getSchema(ctx context.Context, buf types.Bytes) typ
 	}
 
 	return m.handleWasmRequest(ctx, buf, "get_schema", serviceFunc)
+}
+
+// httpRequest is the exported host function that performs a host-mediated,
+// allowlisted, security-gated outbound HTTP call on behalf of the WASM guest and
+// writes the buffered response back into the guest-owned buffer. It mirrors
+// create_schema/get_schema exactly (same park/resize protocol, same numeric
+// error-code band); the guest never gets a socket.
+//
+// The security boundary (allowlist + resolved-IP dial-time gate, no-proxy
+// transport, redirect suppression, per-call timeout, response-size cap,
+// host-injected credentials) lives entirely in the per-instance httpService,
+// which is bound to this processor's egress policy. See package egress.
+func (m *hostModuleInstance) httpRequest(ctx context.Context, buf types.Bytes) types.Uint32 {
+	m.logger.Trace(ctx).Msg("executing http_request")
+
+	// A nil httpService means egress was never wired for this processor: deny-all.
+	if m.httpService == nil {
+		return pprocutils.ErrorCodeHTTPEgressDisabled
+	}
+
+	serviceFunc := func(ctx context.Context, buf types.Bytes) (proto.Message, error) {
+		var req procutilsv1.HTTPRequest
+		err := proto.Unmarshal(buf, &req)
+		if err != nil {
+			m.logger.Err(ctx, err).Msg("failed unmarshalling protobuf http request")
+			return nil, err
+		}
+		resp, err := m.httpService.Do(ctx, fromproto.HTTPRequest(&req))
+		if err != nil {
+			return nil, err
+		}
+		return toproto.HTTPResponse(resp), nil
+	}
+
+	return m.handleWasmRequest(ctx, buf, "http_request", serviceFunc)
 }

--- a/pkg/plugin/processor/standalone/host_module_egress_test.go
+++ b/pkg/plugin/processor/standalone/host_module_egress_test.go
@@ -1,0 +1,161 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standalone
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/conduitio/conduit-processor-sdk/pprocutils"
+	"github.com/conduitio/conduit-processor-sdk/pprocutils/v1/toproto"
+	procutilsv1 "github.com/conduitio/conduit-processor-sdk/proto/procutils/v1"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/plugin/processor/egress"
+	"github.com/matryer/is"
+	"github.com/stealthrocket/wazergo/types"
+	"google.golang.org/protobuf/proto"
+)
+
+// newEgressTestInstance builds a bare hostModuleInstance wired only with the
+// per-instance egress service, so http_request can be exercised at the host-ABI
+// layer without a compiled WASM guest.
+func newEgressTestInstance(policy egress.Policy) *hostModuleInstance {
+	return &hostModuleInstance{
+		logger:           log.Nop(),
+		httpService:      egress.New(policy, log.Nop()),
+		parkedResponses:  make(map[string]proto.Message),
+		lastRequestBytes: make(map[string][]byte),
+	}
+}
+
+// callHTTPRequest drives the exact two-try park/resize protocol the guest uses
+// (wasm/caller.go): first call with a tight buffer, resize once on the returned
+// size, second call fills it. Returns either the decoded response or the numeric
+// error code the guest would receive.
+func callHTTPRequest(t *testing.T, m *hostModuleInstance, req *procutilsv1.HTTPRequest) (*procutilsv1.HTTPResponse, uint32) {
+	t.Helper()
+	reqBytes, err := proto.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := types.Bytes(append([]byte(nil), reqBytes...))
+	ctx := context.Background()
+
+	for i := 0; i < 2; i++ {
+		size := uint32(m.httpRequest(ctx, buf))
+		switch {
+		case size >= pprocutils.ErrorCodeStart:
+			return nil, size
+		case int(size) > len(buf) && i == 0:
+			// resize, preserving the request prefix so handleWasmRequest sees the
+			// same request and returns the parked response.
+			buf = types.Bytes(append([]byte(buf), make([]byte, int(size)-len(buf))...))
+			continue
+		default:
+			var resp procutilsv1.HTTPResponse
+			if err := proto.Unmarshal(buf[:size], &resp); err != nil {
+				t.Fatalf("unmarshal response: %v", err)
+			}
+			return &resp, 0
+		}
+	}
+	t.Fatal("buffer not resized correctly")
+	return nil, 0
+}
+
+func hp(t *testing.T, srv *httptest.Server) string {
+	t.Helper()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return u.Host
+}
+
+func allowPolicy(t *testing.T, spec string) egress.Policy {
+	t.Helper()
+	al, err := egress.ParseAllowlist(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return egress.Policy{Enabled: true, Allowlist: al, MaxResponseBytes: egress.DefaultMaxResponseBytes}
+}
+
+// TestHostModule_HTTPRequest_RoundTrip proves the http_request host export
+// marshals/unmarshals the HTTPRequest/HTTPResponse proto pair over the existing
+// park/resize protocol and performs the gated call.
+func TestHostModule_HTTPRequest_RoundTrip(t *testing.T) {
+	is := is.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Echo", r.Method)
+		_, _ = w.Write([]byte("hello-guest"))
+	}))
+	defer srv.Close()
+
+	m := newEgressTestInstance(allowPolicy(t, "http://"+hp(t, srv)))
+	resp, errCode := callHTTPRequest(t, m, toproto.HTTPRequest(pprocutils.HTTPRequest{
+		Method: "GET", URL: srv.URL,
+	}))
+	is.Equal(errCode, uint32(0))
+	is.Equal(int(resp.StatusCode), 200)
+	is.Equal(string(resp.Body), "hello-guest")
+}
+
+// TestHostModule_HTTPRequest_Disabled proves a nil httpService (egress never
+// wired) yields the deny-all ABI code, not a panic.
+func TestHostModule_HTTPRequest_Disabled(t *testing.T) {
+	is := is.New(t)
+	m := &hostModuleInstance{
+		logger:           log.Nop(),
+		parkedResponses:  make(map[string]proto.Message),
+		lastRequestBytes: make(map[string][]byte),
+	}
+	_, errCode := callHTTPRequest(t, m, toproto.HTTPRequest(pprocutils.HTTPRequest{Method: "GET", URL: "https://api.openai.com/v1"}))
+	is.Equal(errCode, uint32(pprocutils.ErrorCodeHTTPEgressDisabled))
+}
+
+// TestHostModule_HTTPRequest_MultiTenantIsolation is MUST-FIX 6 at the host-module
+// binding layer: two instances with two different per-processor policies, each
+// bound to its own httpService. Neither instance can reach the other's granted
+// host — proving the policy is per-hostModuleInstance state (bound at
+// newWASMProcessor / hostModuleOptions), never a shared Registry field.
+func TestHostModule_HTTPRequest_MultiTenantIsolation(t *testing.T) {
+	is := is.New(t)
+	srvA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("A")) }))
+	defer srvA.Close()
+	srvB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("B")) }))
+	defer srvB.Close()
+
+	mA := newEgressTestInstance(allowPolicy(t, "http://"+hp(t, srvA)))
+	mB := newEgressTestInstance(allowPolicy(t, "http://"+hp(t, srvB)))
+
+	// each instance reaches only its own granted host
+	rA, ec := callHTTPRequest(t, mA, toproto.HTTPRequest(pprocutils.HTTPRequest{Method: "GET", URL: srvA.URL}))
+	is.Equal(ec, uint32(0))
+	is.Equal(string(rA.Body), "A")
+
+	rB, ec := callHTTPRequest(t, mB, toproto.HTTPRequest(pprocutils.HTTPRequest{Method: "GET", URL: srvB.URL}))
+	is.Equal(ec, uint32(0))
+	is.Equal(string(rB.Body), "B")
+
+	// cross-tenant access is forbidden: no leakage of A's allowlist into B or vice versa
+	_, ec = callHTTPRequest(t, mA, toproto.HTTPRequest(pprocutils.HTTPRequest{Method: "GET", URL: srvB.URL}))
+	is.Equal(ec, uint32(pprocutils.ErrorCodeHTTPForbidden))
+	_, ec = callHTTPRequest(t, mB, toproto.HTTPRequest(pprocutils.HTTPRequest{Method: "GET", URL: srvA.URL}))
+	is.Equal(ec, uint32(pprocutils.ErrorCodeHTTPForbidden))
+}

--- a/pkg/plugin/processor/standalone/processor.go
+++ b/pkg/plugin/processor/standalone/processor.go
@@ -27,6 +27,7 @@ import (
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/plugin"
+	"github.com/conduitio/conduit/pkg/plugin/processor/egress"
 	"github.com/stealthrocket/wazergo"
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
@@ -80,6 +81,7 @@ func newWASMProcessor(
 	processorModule wazero.CompiledModule,
 	hostModule *wazergo.CompiledModule[*hostModuleInstance],
 	schemaService pprocutils.SchemaService,
+	egressPolicy egress.Policy,
 
 	id string,
 	logger log.CtxLogger,
@@ -92,6 +94,13 @@ func newWASMProcessor(
 	commandResponses := make(chan tuple[*processorv1.CommandResponse, error])
 	moduleStopped := make(chan struct{})
 
+	// Build the per-processor egress capability from the resolved policy. The
+	// policy is bound here, per instance — never on the shared Registry — so one
+	// processor's allowlist cannot leak into another's (a tested isolation
+	// invariant). A deny-all policy still yields a Service that refuses every
+	// call with ErrHTTPEgressDisabled.
+	httpService := egress.New(egressPolicy, logger)
+
 	// instantiate conduit host module and inject it into the context
 	logger.Debug(ctx).Msg("instantiating conduit host module")
 	ins, err := hostModule.Instantiate(
@@ -101,6 +110,7 @@ func newWASMProcessor(
 			commandRequests,
 			commandResponses,
 			schemaService,
+			httpService,
 		),
 	)
 	if err != nil {

--- a/pkg/plugin/processor/standalone/processor_test.go
+++ b/pkg/plugin/processor/standalone/processor_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/plugin"
+	"github.com/conduitio/conduit/pkg/plugin/processor/egress"
 	"github.com/google/go-cmp/cmp"
 	"github.com/matryer/is"
 )
@@ -34,7 +35,7 @@ func TestWASMProcessor_Specification_Success(t *testing.T) {
 	ctx := context.Background()
 	logger := log.Test(t)
 
-	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), "test-processor", logger)
+	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), egress.DenyAll(), "test-processor", logger)
 	is.NoErr(err)
 
 	gotSpec, err := underTest.Specification()
@@ -51,7 +52,7 @@ func TestWASMProcessor_Specification_Error(t *testing.T) {
 	ctx := context.Background()
 	logger := log.Test(t)
 
-	underTest, err := newWASMProcessor(ctx, TestRuntime, SpecifyErrorModule, CompiledHostModule, schema.NewInMemoryService(), "test-processor", logger)
+	underTest, err := newWASMProcessor(ctx, TestRuntime, SpecifyErrorModule, CompiledHostModule, schema.NewInMemoryService(), egress.DenyAll(), "test-processor", logger)
 	is.NoErr(err)
 
 	_, err = underTest.Specification()
@@ -66,7 +67,7 @@ func TestWASMProcessor_Configure_Success(t *testing.T) {
 	ctx := context.Background()
 	logger := log.Test(t)
 
-	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), "test-processor", logger)
+	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), egress.DenyAll(), "test-processor", logger)
 	is.NoErr(err)
 
 	err = underTest.Configure(ctx, nil)
@@ -80,7 +81,7 @@ func TestWASMProcessor_Configure_Error(t *testing.T) {
 	ctx := context.Background()
 	logger := log.Test(t)
 
-	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), "test-processor", logger)
+	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), egress.DenyAll(), "test-processor", logger)
 	is.NoErr(err)
 
 	err = underTest.Configure(ctx, map[string]string{"configure": "error"})
@@ -95,7 +96,7 @@ func TestWASMProcessor_Configure_Panic(t *testing.T) {
 	ctx := context.Background()
 	logger := log.Test(t)
 
-	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), "test-processor", logger)
+	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), egress.DenyAll(), "test-processor", logger)
 	is.NoErr(err)
 
 	err = underTest.Configure(ctx, map[string]string{"configure": "panic"})
@@ -111,7 +112,7 @@ func TestWASMProcessor_Open_Success(t *testing.T) {
 	ctx := context.Background()
 	logger := log.Test(t)
 
-	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), "test-processor", logger)
+	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), egress.DenyAll(), "test-processor", logger)
 	is.NoErr(err)
 
 	err = underTest.Open(ctx)
@@ -125,7 +126,7 @@ func TestWASMProcessor_Open_Error(t *testing.T) {
 	ctx := context.Background()
 	logger := log.Test(t)
 
-	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), "test-processor", logger)
+	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), egress.DenyAll(), "test-processor", logger)
 	is.NoErr(err)
 
 	err = underTest.Configure(ctx, map[string]string{"open": "error"})
@@ -143,7 +144,7 @@ func TestWASMProcessor_Open_Panic(t *testing.T) {
 	ctx := context.Background()
 	logger := log.Test(t)
 
-	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), "test-processor", logger)
+	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), egress.DenyAll(), "test-processor", logger)
 	is.NoErr(err)
 
 	err = underTest.Configure(ctx, map[string]string{"open": "panic"})
@@ -162,7 +163,7 @@ func TestWASMProcessor_Process_Success(t *testing.T) {
 	ctx := context.Background()
 	logger := log.Test(t)
 
-	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), "test-processor", logger)
+	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), egress.DenyAll(), "test-processor", logger)
 	is.NoErr(err)
 
 	is.NoErr(underTest.Configure(ctx, map[string]string{"process.prefix": "hello!\n\n"}))
@@ -199,7 +200,7 @@ func TestWASMProcessor_Process_Error(t *testing.T) {
 	ctx := context.Background()
 	logger := log.Test(t)
 
-	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), "test-processor", logger)
+	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), egress.DenyAll(), "test-processor", logger)
 	is.NoErr(err)
 
 	is.NoErr(underTest.Configure(ctx, map[string]string{"process": "error"}))
@@ -220,7 +221,7 @@ func TestWASMProcessor_Process_Panic(t *testing.T) {
 	ctx := context.Background()
 	logger := log.Test(t)
 
-	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), "test-processor", logger)
+	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), egress.DenyAll(), "test-processor", logger)
 	is.NoErr(err)
 
 	is.NoErr(underTest.Configure(ctx, map[string]string{"process": "panic"}))
@@ -242,7 +243,7 @@ func TestWASMProcessor_Configure_Schema_Success(t *testing.T) {
 	ctx := context.Background()
 	logger := log.Test(t)
 
-	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), "test-processor", logger)
+	underTest, err := newWASMProcessor(ctx, TestRuntime, ChaosProcessorModule, CompiledHostModule, schema.NewInMemoryService(), egress.DenyAll(), "test-processor", logger)
 	is.NoErr(err)
 
 	err = underTest.Configure(ctx, map[string]string{"configure": "create_and_get_schema"})

--- a/pkg/plugin/processor/standalone/registry.go
+++ b/pkg/plugin/processor/standalone/registry.go
@@ -28,6 +28,7 @@ import (
 	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/plugin"
+	"github.com/conduitio/conduit/pkg/plugin/processor/egress"
 	"github.com/stealthrocket/wazergo"
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
@@ -120,7 +121,13 @@ func NewRegistry(logger log.CtxLogger, pluginDir string, schemaService pprocutil
 	return r, nil
 }
 
-func (r *Registry) NewProcessor(ctx context.Context, fullName plugin.FullName, id string) (sdk.Processor, error) {
+// NewProcessor builds a standalone (WASM) processor. egressPolicy is the
+// resolved, per-processor egress policy the engine computed from this instance's
+// config; it is threaded per-call (never stored on the Registry, which is a
+// process-global singleton shared across all processors — a policy field there
+// would leak one pipeline's allowlist to another) down to newWASMProcessor,
+// where it is bound to the per-instance host module.
+func (r *Registry) NewProcessor(ctx context.Context, fullName plugin.FullName, id string, egressPolicy egress.Policy) (sdk.Processor, error) {
 	r.m.RLock()
 	defer r.m.RUnlock()
 
@@ -151,7 +158,7 @@ func (r *Registry) NewProcessor(ctx context.Context, fullName plugin.FullName, i
 		return nil, err
 	}
 
-	p, err := newWASMProcessor(ctx, r.runtime, bp.module, r.hostModule, r.schemaService, id, r.logger)
+	p, err := newWASMProcessor(ctx, r.runtime, bp.module, r.hostModule, r.schemaService, egressPolicy, id, r.logger)
 	if err != nil {
 		return nil, cerrors.Errorf("failed to create a new WASM processor: %w", err)
 	}
@@ -273,7 +280,9 @@ func (r *Registry) loadBlueprint(ctx context.Context, path string) (blueprint, e
 		}
 	}()
 
-	p, err := newWASMProcessor(ctx, r.runtime, module, r.hostModule, r.schemaService, "init-processor", r.logger)
+	// Spec extraction only: a throwaway processor that never processes records, so
+	// it gets deny-all egress.
+	p, err := newWASMProcessor(ctx, r.runtime, module, r.hostModule, r.schemaService, egress.DenyAll(), "init-processor", r.logger)
 	if err != nil {
 		return blueprint{}, fmt.Errorf("failed to create a new WASM processor: %w", err)
 	}

--- a/pkg/plugin/processor/standalone/registry_test.go
+++ b/pkg/plugin/processor/standalone/registry_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/plugin"
+	"github.com/conduitio/conduit/pkg/plugin/processor/egress"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/matryer/is"
@@ -76,7 +77,7 @@ func TestRegistry_ChaosProcessor(t *testing.T) {
 	t.Run("NewProcessor", func(t *testing.T) {
 		is := is.New(t)
 
-		p, err := underTest.NewProcessor(ctx, standaloneProcessorName, "test-processor")
+		p, err := underTest.NewProcessor(ctx, standaloneProcessorName, "test-processor", egress.DenyAll())
 		is.NoErr(err)
 
 		got, err := p.Specification()
@@ -100,7 +101,7 @@ func TestRegistry_ChaosProcessor(t *testing.T) {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()
-				p, err := underTest.NewProcessor(ctx, "standalone:chaos-processor@v1.3.5", fmt.Sprintf("test-processor-%d", i))
+				p, err := underTest.NewProcessor(ctx, "standalone:chaos-processor@v1.3.5", fmt.Sprintf("test-processor-%d", i), egress.DenyAll())
 				is.NoErr(err)
 
 				err = p.Configure(ctx, map[string]string{"process.prefix": fmt.Sprintf("%d", i)})

--- a/pkg/processor/mock/plugin_service.go
+++ b/pkg/processor/mock/plugin_service.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	sdk "github.com/conduitio/conduit-processor-sdk"
+	egress "github.com/conduitio/conduit/pkg/plugin/processor/egress"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -42,18 +43,18 @@ func (m *PluginService) EXPECT() *PluginServiceMockRecorder {
 }
 
 // NewProcessor mocks base method.
-func (m *PluginService) NewProcessor(ctx context.Context, pluginName, id string) (sdk.Processor, error) {
+func (m *PluginService) NewProcessor(ctx context.Context, pluginName, id string, egressPolicy egress.Policy) (sdk.Processor, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewProcessor", ctx, pluginName, id)
+	ret := m.ctrl.Call(m, "NewProcessor", ctx, pluginName, id, egressPolicy)
 	ret0, _ := ret[0].(sdk.Processor)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewProcessor indicates an expected call of NewProcessor.
-func (mr *PluginServiceMockRecorder) NewProcessor(ctx, pluginName, id any) *PluginServiceNewProcessorCall {
+func (mr *PluginServiceMockRecorder) NewProcessor(ctx, pluginName, id, egressPolicy any) *PluginServiceNewProcessorCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewProcessor", reflect.TypeOf((*PluginService)(nil).NewProcessor), ctx, pluginName, id)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewProcessor", reflect.TypeOf((*PluginService)(nil).NewProcessor), ctx, pluginName, id, egressPolicy)
 	return &PluginServiceNewProcessorCall{Call: call}
 }
 
@@ -69,13 +70,13 @@ func (c *PluginServiceNewProcessorCall) Return(arg0 sdk.Processor, arg1 error) *
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *PluginServiceNewProcessorCall) Do(f func(context.Context, string, string) (sdk.Processor, error)) *PluginServiceNewProcessorCall {
+func (c *PluginServiceNewProcessorCall) Do(f func(context.Context, string, string, egress.Policy) (sdk.Processor, error)) *PluginServiceNewProcessorCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *PluginServiceNewProcessorCall) DoAndReturn(f func(context.Context, string, string) (sdk.Processor, error)) *PluginServiceNewProcessorCall {
+func (c *PluginServiceNewProcessorCall) DoAndReturn(f func(context.Context, string, string, egress.Policy) (sdk.Processor, error)) *PluginServiceNewProcessorCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/pkg/processor/service.go
+++ b/pkg/processor/service.go
@@ -27,10 +27,11 @@ import (
 	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/foundation/metrics/measure"
+	"github.com/conduitio/conduit/pkg/plugin/processor/egress"
 )
 
 type PluginService interface {
-	NewProcessor(ctx context.Context, pluginName string, id string) (sdk.Processor, error)
+	NewProcessor(ctx context.Context, pluginName string, id string, egressPolicy egress.Policy) (sdk.Processor, error)
 }
 
 type Service struct {
@@ -39,16 +40,55 @@ type Service struct {
 	registry  PluginService
 	instances map[string]*Instance
 	store     *Store
+
+	// egressCeiling is the operator-set engine-level ceiling that clamps every
+	// processor's per-pipeline egress opt-in (the intersection). Its zero value
+	// is deny-all, so on a stock instance egress stays off until the operator
+	// affirmatively opens the ceiling — defense in depth for shared instances.
+	egressCeiling egress.Policy
+}
+
+// ServiceOption configures a Service at construction.
+type ServiceOption func(*Service)
+
+// WithEgressCeiling sets the engine-level egress ceiling (from the Conduit
+// instance config). Omitting it leaves the ceiling at deny-all.
+func WithEgressCeiling(ceiling egress.Policy) ServiceOption {
+	return func(s *Service) { s.egressCeiling = ceiling }
 }
 
 // NewService creates a new processor plugin service.
-func NewService(logger log.CtxLogger, db database.DB, registry PluginService) *Service {
-	return &Service{
+func NewService(logger log.CtxLogger, db database.DB, registry PluginService, opts ...ServiceOption) *Service {
+	s := &Service{
 		logger:    logger.WithComponent("processor.Service"),
 		registry:  registry,
 		instances: make(map[string]*Instance),
 		store:     NewStore(db),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
+}
+
+// resolveEgressPolicy computes the effective, engine-clamped egress policy for a
+// processor instance from its current config. It is called at every processor
+// open (cold start and live reconfigure), so a reconfigure necessarily rebinds
+// the policy to the then-current config. A malformed egress config fails the
+// build rather than silently disabling egress.
+func (s *Service) resolveEgressPolicy(i *Instance) (egress.Policy, error) {
+	requested, err := egress.PolicyFromSettings(i.Config.Settings)
+	if err != nil {
+		return egress.DenyAll(), err
+	}
+	effective, dropped := egress.ResolvePolicy(requested, s.egressCeiling)
+	if len(dropped) > 0 {
+		s.logger.Warn(context.Background()).
+			Str("processor_id", i.ID).
+			Int("dropped_entries", len(dropped)).
+			Msg("egress allowlist entries dropped: outside the engine-level egress ceiling")
+	}
+	return effective, nil
 }
 
 // Init fetches instances from the store.
@@ -111,7 +151,12 @@ func (s *Service) MakeRunnableProcessor(ctx context.Context, i *Instance) (*Runn
 		return nil, ErrProcessorRunning
 	}
 
-	p, err := s.registry.NewProcessor(ctx, i.Plugin, i.ID)
+	egressPolicy, err := s.resolveEgressPolicy(i)
+	if err != nil {
+		i.running.Store(false)
+		return nil, err
+	}
+	p, err := s.registry.NewProcessor(ctx, i.Plugin, i.ID, egressPolicy)
 	if err != nil {
 		i.running.Store(false)
 		return nil, err
@@ -134,7 +179,14 @@ func (s *Service) MakeRunnableProcessor(ctx context.Context, i *Instance) (*Runn
 // is dropped. It dispenses a new plugin from the instance's current (already
 // updated) config, exactly as MakeRunnableProcessor does for a fresh start.
 func (s *Service) MakeRunnableProcessorForReconfigure(ctx context.Context, i *Instance) (*RunnableProcessor, error) {
-	p, err := s.registry.NewProcessor(ctx, i.Plugin, i.ID)
+	// Invariant (design § reconfigure rebinds policy): resolving the egress policy
+	// here from the instance's already-updated config means the reconfigure swap
+	// binds the NEW policy to the rebuilt processor, by construction.
+	egressPolicy, err := s.resolveEgressPolicy(i)
+	if err != nil {
+		return nil, err
+	}
+	p, err := s.registry.NewProcessor(ctx, i.Plugin, i.ID, egressPolicy)
 	if err != nil {
 		return nil, err
 	}
@@ -162,8 +214,9 @@ func (s *Service) Create(
 		cfg.Workers = 1
 	}
 
-	// check if the processor plugin exists
-	p, err := s.registry.NewProcessor(ctx, plugin, id)
+	// check if the processor plugin exists — a throwaway processor torn down
+	// immediately below, so it gets deny-all egress (it never processes records).
+	p, err := s.registry.NewProcessor(ctx, plugin, id, egress.DenyAll())
 	if err != nil {
 		return nil, cerrors.Errorf("could not get processor: %w", err)
 	}

--- a/pkg/processor/service_test.go
+++ b/pkg/processor/service_test.go
@@ -157,7 +157,7 @@ func TestService_Init_PluginNotFound(t *testing.T) {
 
 	procGetter := mock.NewPluginService(gomock.NewController(t))
 	procGetter.EXPECT().
-		NewProcessor(gomock.Any(), gomock.Any(), gomock.Any()).
+		NewProcessor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, plugin.ErrPluginNotFound)
 	service := NewService(log.Nop(), db, procGetter)
 
@@ -182,7 +182,7 @@ func TestService_Create_BuilderFail(t *testing.T) {
 
 	procGetter := mock.NewPluginService(gomock.NewController(t))
 	procGetter.EXPECT().
-		NewProcessor(gomock.Any(), gomock.Any(), gomock.Any()).
+		NewProcessor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, wantErr)
 	service := NewService(log.Nop(), db, procGetter)
 
@@ -625,7 +625,7 @@ func newPluginService(t *testing.T, processors map[string]sdk.Processor) *mock.P
 	pg := mock.NewPluginService(gomock.NewController(t))
 	for name, proc := range processors {
 		pg.EXPECT().
-			NewProcessor(gomock.Any(), name, gomock.Any()).AnyTimes().
+			NewProcessor(gomock.Any(), name, gomock.Any(), gomock.Any()).AnyTimes().
 			Return(proc, nil)
 	}
 	return pg

--- a/pkg/processor/service_test.go
+++ b/pkg/processor/service_test.go
@@ -28,12 +28,88 @@ import (
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/plugin"
 	proc_plugin "github.com/conduitio/conduit/pkg/plugin/processor"
+	"github.com/conduitio/conduit/pkg/plugin/processor/egress"
 	proc_mock "github.com/conduitio/conduit/pkg/plugin/processor/mock"
 	"github.com/conduitio/conduit/pkg/processor/mock"
 	"github.com/google/uuid"
 	"github.com/matryer/is"
 	"go.uber.org/mock/gomock"
 )
+
+// TestService_resolveEgressPolicy_DefaultDenyAll is the end-to-end proof of the
+// security default: a Service with NO WithEgressCeiling option (the stock engine
+// wiring) has a zero-value/deny-all ceiling, so a processor that explicitly
+// requests egress via sdk.egress.allow still resolves to DenyAll. This closes
+// red-team finding #4 in the safe direction — the default stays fully closed.
+func TestService_resolveEgressPolicy_DefaultDenyAll(t *testing.T) {
+	is := is.New(t)
+	db := &inmemory.DB{}
+	registry := newPluginService(t, map[string]sdk.Processor{})
+
+	// No WithEgressCeiling => egressCeiling is the zero value (Enabled=false).
+	service := NewService(log.Nop(), db, registry)
+
+	inst := &Instance{
+		ID: uuid.NewString(),
+		Config: Config{Settings: map[string]string{
+			egress.ConfigKeyAllow: "api.openai.com", // the pipeline DOES opt in
+		}},
+	}
+
+	eff, err := service.resolveEgressPolicy(inst)
+	is.NoErr(err)
+	is.True(!eff.Enabled) // closed engine ceiling wins: effective policy is deny-all
+}
+
+// TestService_resolveEgressPolicy_EnabledIntersection verifies that an operator
+// ceiling (set via WithEgressCeiling, as runtime.go wires it from config) clamps
+// the per-processor request to the intersection.
+func TestService_resolveEgressPolicy_EnabledIntersection(t *testing.T) {
+	is := is.New(t)
+	db := &inmemory.DB{}
+	registry := newPluginService(t, map[string]sdk.Processor{})
+
+	ceiling := egress.Policy{
+		Enabled: true,
+		Allowlist: []egress.AllowEntry{
+			{Scheme: "https", Host: "api.openai.com", Port: "443"},
+		},
+	}
+	service := NewService(log.Nop(), db, registry, WithEgressCeiling(ceiling))
+
+	inst := &Instance{
+		ID: uuid.NewString(),
+		Config: Config{Settings: map[string]string{
+			egress.ConfigKeyAllow: "api.openai.com, api.voyageai.com", // one in, one out
+		}},
+	}
+
+	eff, err := service.resolveEgressPolicy(inst)
+	is.NoErr(err)
+	is.True(eff.Enabled)
+	is.Equal(len(eff.Allowlist), 1) // intersection: only the in-ceiling host survives
+	is.Equal(eff.Allowlist[0].Host, "api.openai.com")
+}
+
+// TestService_resolveEgressPolicy_MalformedFails verifies a malformed
+// per-processor egress config surfaces as an error (which fails the processor
+// build) rather than silently disabling egress.
+func TestService_resolveEgressPolicy_MalformedFails(t *testing.T) {
+	is := is.New(t)
+	db := &inmemory.DB{}
+	registry := newPluginService(t, map[string]sdk.Processor{})
+	service := NewService(log.Nop(), db, registry, WithEgressCeiling(egress.Policy{Enabled: true}))
+
+	inst := &Instance{
+		ID: uuid.NewString(),
+		Config: Config{Settings: map[string]string{
+			egress.ConfigKeyAllow: "*.evil.com", // wildcard is rejected
+		}},
+	}
+
+	_, err := service.resolveEgressPolicy(inst)
+	is.True(err != nil)
+}
 
 func TestService_Init_Success(t *testing.T) {
 	is := is.New(t)


### PR DESCRIPTION
## What & why

Implements the **WASM host-egress capability** — bounded, allowlisted outbound HTTP for standalone (WASM) processors — the host half of the bundle whose SDK ABI merged in conduit-processor-sdk#162 and whose first consumer (the embedding processor) merged in conduit-processor-ai#1. Advances **v0.20 WS8 (AI-pipeline components)**; design: `docs/design-documents/20260726-wasm-host-egress-capability.md` (signed off #2696) + AI-pipeline §1.

Contents:
- **`pkg/plugin/processor/egress/`** — the SSRF gate: `http_request` policy, `ipguard.go` refused-range classifier, `service.go` (the gated `http.Client` + `Do`), per-processor `Policy` + `ResolvePolicy` ceiling intersection.
- **`pkg/plugin/processor/standalone/host_module.go`** — the wazero `http_request` host function, per-processor policy threading through `newWASMProcessor` (no shared-registry field).
- **`pkg/conduit/` config wiring** — `processors.egress` operator config (`enabled` default **false**), `WithEgressCeiling`.
- **`embedding_bundle_e2e_test.go`** + `.github/workflows/bundle-e2e.yml` — the cross-repo acceptance test.

## Risk tier: **Tier-1** (new security boundary + on the record path)

Human sign-off required; not merging on automated review alone.

## Security review

A fresh adversarial red-team pass (instructed to *break* the gate) returned **block-pending-fixes**; all four findings are fixed in this branch with regression tests + fuzz seeds:
1. **[Med/High]** RFC 6052 IPv4-Translated `::ffff:0:0:0/96` let `::ffff:0:169.254.169.254` (metadata) through (`To4()` doesn't unwrap it) → now refused wholesale + unwrapped in the audit path.
2. **[Low/Med]** deprecated site-local `fec0::/10` added to the v6 floor.
3. **[Med, forward-looking]** `SecretRefs` now clamped by the engine ceiling (mirrors the allowlist intersection) so a tenant can't name an ungranted secret.
4. **[cosmetic]** `filterResponseHeaders` now actually drops hop-by-hop headers.

Claims the red-team attacked and could **not** break: dial-time resolved-IP gate covers http + TLS + HTTP/2 (no un-hooked `DialTLSContext`); DNS-rebinding TOCTOU closed (checked IP == dialed IP + syscall `Control` re-check); `Transport.Proxy=nil` (proxy-env ignored); redirects not followed; header/CRLF/Host hardening; decompression cap on the decompressed stream; per-processor policy isolation (no shared mutable state); deny-all defaults.

## Failure-mode analysis

- *Guest reaches private/metadata IP* → dial-time gate refuses (full family incl. v4-mapped/v4-translated/NAT64/6to4/Teredo/site-local/ULA/CGNAT). Signal: `decision=deny` egress audit log with reason.
- *Egress enabled by accident* → **default is deny-all**, proven by `TestService_resolveEgressPolicy_DefaultDenyAll` (stock `NewService`, no ceiling, an opt-in processor still resolves to `Enabled=false`). Requires explicit operator config **and** a per-processor allowlist. A malformed egress config fails startup (validated even when disabled) rather than silently disabling.
- *Embedding/provider partial-batch failure* → invariant 1/3: never passthrough-with-placeholder, per-record 1:1, `ErrorRecord`→DLQ. Proven end-to-end in the bundle e2e.
- *Secret leak* → no guest `Authorization` path; `AuthSecretRef` requires a granted ref **and** a wired resolver, both of which currently fail closed (the resolver backend is a deliberate later slice).
- *Rollback* → the capability is inert unless an operator opts in; SDK dependency is a released pseudo-version (local `replace` removed); no existing pipeline is affected.

## Acceptance bar — the cross-repo e2e (CI-enforced by this PR)

`.github/workflows/bundle-e2e.yml` checks out `conduit-processor-ai@main`, builds the **real** `embedding.wasm`, and drives it through this repo's standalone host module + gate. Three assertions, all against the compiled guest: happy path (config→guest→`egress.Do`→gate→local Ollama stand-in→vector back), **SSRF blocked end-to-end through the real guest** (un-allowlisted target → `ErrForbidden`, target never reached), and **invariant-1/3 end-to-end** (provider error → `ErrorRecord`, sibling succeeds, no placeholder). Verified locally in two independent runs (4/4). Scoped to the bundle's paths; making it a branch-protection-required check is a follow-up repo-settings change (noted, not silently assumed).

## Adversarial self-review

Re-read the gate for an un-hooked dial path (none — `Control` on the base dialer governs http + TLS; custom `DialContext` re-checks the resolved IP), for default-open config (none — ceiling zero-value is `DenyAll`, validated-when-disabled), and the per-processor policy for shared mutable state (none — `Policy` captured by value per `Service`). No open uncertainty about behavior under failure.

## Not in this slice

The `SecretResolver` backend (host-injected credentials — OpenAI/Voyage/Cohere can't authenticate end-to-end until it lands; Ollama needs no key, hence the e2e uses it); making bundle-e2e a required branch-protection check; the full RAG e2e (needs chunking + pgvector slice 2).
