### PR TITLE
feat(egress): env-backed SecretResolver — host-inject AuthSecretRef credentials

### DIFF
--- a/pkg/plugin/processor/egress/policy.go
+++ b/pkg/plugin/processor/egress/policy.go
@@ -205,6 +205,21 @@ func ParseAllowlist(raw string) ([]AllowEntry, error) {
 // the engine ceiling.
 func entryKey(e AllowEntry) string { return e.Scheme + "|" + e.Host + "|" + e.Port }
 
+// intersectRefs returns the secret-ref names present in BOTH the per-processor
+// request and the ceiling grant. It is the secret-scope analog of the allowlist
+// intersection: a pipeline can only end up with a secret ref its instance-level
+// ceiling also granted. A nil/empty ceiling yields an empty result (grant
+// nothing), never a pass-through.
+func intersectRefs(requested, ceiling map[string]struct{}) map[string]struct{} {
+	out := make(map[string]struct{}, len(requested))
+	for ref := range requested {
+		if _, ok := ceiling[ref]; ok {
+			out[ref] = struct{}{}
+		}
+	}
+	return out
+}
+
 // ResolvePolicy computes the effective per-processor policy: the intersection of
 // the pipeline-author's per-processor allowlist with the operator's engine-level
 // ceiling. Entries a pipeline requests that the ceiling does not permit are
@@ -254,11 +269,17 @@ func ResolvePolicy(perProcessor Policy, ceiling Policy) (effective Policy, dropp
 		eff.MaxResponseBytes = ceiling.MaxResponseBytes
 	}
 
-	// Ceiling with no entries but enabled == unrestricted host set (single-tenant
-	// convenience). Secret refs pass through unclamped in that mode too — the
-	// operator has declared this instance unrestricted.
+	// Ceiling with no allowlist entries but enabled == unrestricted host set
+	// (single-tenant convenience). Secrets still honor an explicit ceiling scope:
+	// if the operator granted a specific secret-refs set, clamp to it even here —
+	// otherwise a ceiling that restricts secrets but not hosts would leak
+	// ungranted refs. With no ceiling secret-refs, this stays a pass-through
+	// (nothing to enforce).
 	if len(ceiling.Allowlist) == 0 {
 		eff.Allowlist = perProcessor.Allowlist
+		if len(ceiling.SecretRefs) > 0 {
+			eff.SecretRefs = intersectRefs(perProcessor.SecretRefs, ceiling.SecretRefs)
+		}
 		return eff, nil
 	}
 
@@ -266,16 +287,9 @@ func ResolvePolicy(perProcessor Policy, ceiling Policy) (effective Policy, dropp
 	// set exactly as the allowlist is clamped, so one tenant cannot name a secret
 	// the operator did not grant this instance. An ungranted ref is dropped here
 	// (defense in depth) and would additionally fail closed per-request in
-	// buildHTTPRequest. A ceiling that grants no secrets clamps to none.
-	if len(perProcessor.SecretRefs) > 0 {
-		clamped := make(map[string]struct{})
-		for ref := range perProcessor.SecretRefs {
-			if _, ok := ceiling.SecretRefs[ref]; ok {
-				clamped[ref] = struct{}{}
-			}
-		}
-		eff.SecretRefs = clamped
-	}
+	// buildHTTPRequest. A restricted ceiling that grants no secrets clamps to none
+	// (explicit-grants-only).
+	eff.SecretRefs = intersectRefs(perProcessor.SecretRefs, ceiling.SecretRefs)
 
 	ceilingSet := make(map[string]struct{}, len(ceiling.Allowlist))
 	for _, e := range ceiling.Allowlist {

--- a/pkg/plugin/processor/egress/policy_test.go
+++ b/pkg/plugin/processor/egress/policy_test.go
@@ -173,13 +173,33 @@ func TestResolvePolicy_Clamping(t *testing.T) {
 		is.Equal(len(eff.SecretRefs), 0) // nothing granted => nothing survives
 	})
 
-	t.Run("unrestricted ceiling passes secret refs through", func(t *testing.T) {
+	t.Run("unrestricted ceiling with no secret refs passes secret refs through", func(t *testing.T) {
 		is := is.New(t)
 		perProc := mk("api.openai.com")
 		perProc.SecretRefs = map[string]struct{}{"openai_key": {}}
-		ceiling := Policy{Enabled: true} // unrestricted single-tenant mode
+		ceiling := Policy{Enabled: true} // unrestricted, no secret scope declared
 		eff, _ := ResolvePolicy(perProc, ceiling)
-		is.Equal(len(eff.SecretRefs), 1) // convenience mode: no clamp
+		is.Equal(len(eff.SecretRefs), 1) // convenience mode: nothing to enforce
+	})
+
+	// Regression: the empty-allowlist + secret-refs gap. An operator that scopes
+	// secrets on the ceiling must have that honored even when the ceiling leaves
+	// the host allowlist unrestricted — otherwise an ungranted ref leaks through
+	// the single-tenant convenience branch.
+	t.Run("unrestricted ceiling still clamps secret refs when the operator scoped them", func(t *testing.T) {
+		is := is.New(t)
+		perProc := mk("api.openai.com")
+		perProc.SecretRefs = map[string]struct{}{"openai_key": {}, "stolen_key": {}}
+		ceiling := Policy{Enabled: true}                           // empty allowlist (unrestricted hosts)...
+		ceiling.SecretRefs = map[string]struct{}{"openai_key": {}} // ...but scoped secrets
+		eff, _ := ResolvePolicy(perProc, ceiling)
+		is.True(eff.Enabled)
+		is.Equal(len(eff.Allowlist), 1) // hosts still unrestricted (pipeline's own list)
+		_, granted := eff.SecretRefs["openai_key"]
+		is.True(granted)
+		_, leaked := eff.SecretRefs["stolen_key"]
+		is.True(!leaked) // ungranted ref clamped even under an unrestricted host ceiling
+		is.Equal(len(eff.SecretRefs), 1)
 	})
 
 	// Ceiling Timeout/MaxResponseBytes are tightening-only caps: a positive

--- a/pkg/plugin/processor/egress/secret.go
+++ b/pkg/plugin/processor/egress/secret.go
@@ -1,0 +1,80 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package egress
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+)
+
+// EnvSecretPrefix namespaces the process environment variables from which
+// EnvSecretResolver reads egress credentials. A granted secret name maps to
+// EnvSecretPrefix + the normalized (uppercased, non-alphanumerics → '_') name:
+// e.g. "openai_key" → "CONDUIT_SECRET_OPENAI_KEY".
+const EnvSecretPrefix = "CONDUIT_SECRET_"
+
+// EnvSecretResolver resolves a granted secret name to an Authorization header
+// value from a namespaced process environment variable (see EnvSecretPrefix).
+//
+// The namespace is the security boundary: a guest can only ever cause a lookup
+// of names the operator granted via the egress secret-refs allowlist (the grant
+// check in buildHTTPRequest runs BEFORE Resolve), and even a granted name can
+// only read the deliberately-exported CONDUIT_SECRET_* set — never an arbitrary
+// process environment variable. The resolved value is used verbatim as the
+// Authorization header, so the operator must set the COMPLETE header value,
+// including any scheme, e.g.:
+//
+//	CONDUIT_SECRET_OPENAI_KEY="Bearer sk-..."
+//
+// This is host-side only: the credential is read in the engine process and
+// injected into the outbound request; it is never placed in processor config
+// (which would reach the WASM guest) and the guest never sees the value.
+type EnvSecretResolver struct{}
+
+// Resolve returns the Authorization header value for the named secret, read
+// from EnvSecretPrefix+normalize(name). A missing or empty variable is a
+// non-silent error (the request fails closed rather than sending an empty or
+// unauthenticated Authorization header).
+func (EnvSecretResolver) Resolve(_ context.Context, name string) (string, error) {
+	envName := EnvSecretPrefix + normalizeSecretName(name)
+	v, ok := os.LookupEnv(envName)
+	if !ok || v == "" {
+		// Deliberately does not echo the value; names the expected variable so
+		// the operator can fix the deployment.
+		return "", cerrors.Errorf("egress secret %q is not set in the environment (expected %s)", name, envName)
+	}
+	return v, nil
+}
+
+// normalizeSecretName maps a secret-ref name to the environment-variable suffix:
+// uppercased, with every character outside [A-Z0-9] replaced by '_'. This keeps
+// the pipeline-facing name (e.g. "openai.key" or "openai-key") a stable,
+// filesystem/env-safe identifier regardless of punctuation.
+func normalizeSecretName(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range strings.ToUpper(name) {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}

--- a/pkg/plugin/processor/egress/secret_test.go
+++ b/pkg/plugin/processor/egress/secret_test.go
@@ -1,0 +1,79 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package egress
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+func TestEnvSecretResolver_Resolve(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("resolves a granted name from the namespaced env var", func(t *testing.T) {
+		is := is.New(t)
+		t.Setenv("CONDUIT_SECRET_OPENAI_KEY", "Bearer sk-live-123")
+		got, err := EnvSecretResolver{}.Resolve(ctx, "openai_key")
+		is.NoErr(err)
+		is.Equal(got, "Bearer sk-live-123") // value used verbatim as the Authorization header
+	})
+
+	t.Run("normalizes punctuation in the name to underscores", func(t *testing.T) {
+		is := is.New(t)
+		t.Setenv("CONDUIT_SECRET_OPENAI_API_KEY", "Bearer x")
+		// "openai.api-key" and "openai_api_key" both normalize to OPENAI_API_KEY.
+		g1, err := EnvSecretResolver{}.Resolve(ctx, "openai.api-key")
+		is.NoErr(err)
+		is.Equal(g1, "Bearer x")
+		g2, err := EnvSecretResolver{}.Resolve(ctx, "OpenAI_API_Key")
+		is.NoErr(err)
+		is.Equal(g2, "Bearer x")
+	})
+
+	t.Run("missing var is a non-silent error, not an empty value", func(t *testing.T) {
+		is := is.New(t)
+		// Ensure the var is absent.
+		v, err := EnvSecretResolver{}.Resolve(ctx, "definitely_absent_secret")
+		is.True(err != nil) // fails closed
+		is.Equal(v, "")     // never returns an empty credential to send
+	})
+
+	t.Run("present-but-empty var is a non-silent error", func(t *testing.T) {
+		is := is.New(t)
+		t.Setenv("CONDUIT_SECRET_EMPTY_ONE", "")
+		v, err := EnvSecretResolver{}.Resolve(ctx, "empty_one")
+		is.True(err != nil) // an empty env value must not become an empty Authorization
+		is.Equal(v, "")
+	})
+
+	t.Run("error names the expected env var but never echoes a value", func(t *testing.T) {
+		is := is.New(t)
+		_, err := EnvSecretResolver{}.Resolve(ctx, "some_key")
+		is.True(err != nil)
+		// Operator-actionable: tells them which var to set.
+		is.True(strings.Contains(err.Error(), "CONDUIT_SECRET_SOME_KEY"))
+	})
+}
+
+func TestNormalizeSecretName(t *testing.T) {
+	is := is.New(t)
+	is.Equal(normalizeSecretName("openai_key"), "OPENAI_KEY")
+	is.Equal(normalizeSecretName("openai.api-key"), "OPENAI_API_KEY")
+	is.Equal(normalizeSecretName("Voyage Key!"), "VOYAGE_KEY_")
+	is.Equal(normalizeSecretName("k8s-secret/3"), "K8S_SECRET_3")
+}

--- a/pkg/plugin/processor/standalone/host_module_egress_test.go
+++ b/pkg/plugin/processor/standalone/host_module_egress_test.go
@@ -159,3 +159,59 @@ func TestHostModule_HTTPRequest_MultiTenantIsolation(t *testing.T) {
 	_, ec = callHTTPRequest(t, mB, toproto.HTTPRequest(pprocutils.HTTPRequest{Method: "GET", URL: srvA.URL}))
 	is.Equal(ec, uint32(pprocutils.ErrorCodeHTTPForbidden))
 }
+
+// TestHostModule_HTTPRequest_EnvSecretInjection proves the host-injected
+// credential path end-to-end at the host-ABI layer with the real
+// EnvSecretResolver: the guest names a granted secret (AuthSecretRef) and sets
+// NO Authorization header itself; the host reads the value from the namespaced
+// process env and injects it, and the destination server receives it. This is
+// the wiring newWASMProcessor uses in production (egress.New(..., WithSecretResolver(EnvSecretResolver{}))).
+func TestHostModule_HTTPRequest_EnvSecretInjection(t *testing.T) {
+	is := is.New(t)
+	t.Setenv("CONDUIT_SECRET_TEST_KEY", "Bearer sk-injected-by-host")
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	// Policy grants the secret ref AND allowlists the local server. The resolver
+	// is the real env-backed one, exactly as newWASMProcessor wires it.
+	al, err := egress.ParseAllowlist("http://" + hp(t, srv))
+	is.NoErr(err)
+	policy := egress.Policy{
+		Enabled:          true,
+		Allowlist:        al,
+		SecretRefs:       map[string]struct{}{"test_key": {}},
+		MaxResponseBytes: egress.DefaultMaxResponseBytes,
+	}
+	m := &hostModuleInstance{
+		logger:           log.Nop(),
+		httpService:      egress.New(policy, log.Nop(), egress.WithSecretResolver(egress.EnvSecretResolver{})),
+		parkedResponses:  make(map[string]proto.Message),
+		lastRequestBytes: make(map[string][]byte),
+	}
+
+	// The guest supplies AuthSecretRef and NO Authorization header of its own.
+	resp, ec := callHTTPRequest(t, m, toproto.HTTPRequest(pprocutils.HTTPRequest{
+		Method:        "POST",
+		URL:           srv.URL,
+		AuthSecretRef: "test_key",
+	}))
+	is.Equal(ec, uint32(0))
+	is.Equal(int(resp.StatusCode), 200)
+	// The server saw the env-sourced credential, injected host-side.
+	is.Equal(gotAuth, "Bearer sk-injected-by-host")
+
+	// An ungranted ref is refused before any resolution (defense in depth), even
+	// if its env var happens to exist.
+	t.Setenv("CONDUIT_SECRET_UNGRANTED", "Bearer nope")
+	_, ec = callHTTPRequest(t, m, toproto.HTTPRequest(pprocutils.HTTPRequest{
+		Method:        "POST",
+		URL:           srv.URL,
+		AuthSecretRef: "ungranted",
+	}))
+	is.Equal(ec, uint32(pprocutils.ErrorCodeHTTPForbidden))
+}

--- a/pkg/plugin/processor/standalone/processor.go
+++ b/pkg/plugin/processor/standalone/processor.go
@@ -99,7 +99,14 @@ func newWASMProcessor(
 	// processor's allowlist cannot leak into another's (a tested isolation
 	// invariant). A deny-all policy still yields a Service that refuses every
 	// call with ErrHTTPEgressDisabled.
-	httpService := egress.New(egressPolicy, logger)
+	//
+	// The secret resolver is host-side and namespaced (CONDUIT_SECRET_*): it is
+	// safe to wire unconditionally because it is only consulted for an
+	// AuthSecretRef the per-processor policy already granted, and only on an
+	// enabled policy (a deny-all Do never reaches the credential path). The
+	// resolver is stateless process-env, so a single value serves every
+	// processor; per-processor scope is enforced by the policy's granted refs.
+	httpService := egress.New(egressPolicy, logger, egress.WithSecretResolver(egress.EnvSecretResolver{}))
 
 	// instantiate conduit host module and inject it into the context
 	logger.Debug(ctx).Msg("instantiating conduit host module")


### PR DESCRIPTION
## What & why

Fills the deliberately-reserved `SecretResolver` seam from the host-egress bundle (#2699), so a standalone WASM processor can authenticate to a hosted embedding provider (OpenAI/Voyage/Cohere) **without the credential ever entering the guest**. Turns the shipped-but-inert `AuthSecretRef` mechanism into a working host-injected path. Advances **v0.20 WS8**; follow-up to #2699.

## Risk tier: **Tier-1** (credential path on the egress security boundary)

Human sign-off required.

## What it does

- **`egress.EnvSecretResolver`** resolves a **granted** secret name → an `Authorization` header value from a namespaced env var: `CONDUIT_SECRET_<NORMALIZED_NAME>` (`openai_key` → `CONDUIT_SECRET_OPENAI_KEY`). The namespace is the boundary — a granted name can only read the operator's deliberately-exported egress secrets, never arbitrary process env. Missing/empty var **fails closed** (no empty/unauthenticated credential is ever sent). Value is used verbatim as the header, so the operator sets the complete `"Bearer ..."` value.
- **Wired into `newWASMProcessor`** (host-side only, never via guest-reachable config). Stateless process-env, so one resolver serves every processor; per-processor scope stays enforced by the policy's granted refs — the grant check runs **before** `Resolve`.
- **Closed the empty-allowlist secret-refs gap** in `ResolvePolicy`: an operator that scopes `secret-refs` on the ceiling now has it honored even under an unrestricted (empty-allowlist) host ceiling. This was the non-exploitable wart flagged at bundle merge (nil resolver failed closed); it becomes live with a real resolver, so it's fixed here.

## Why no design doc

Investigated Conduit's secret handling: there is **no** secret store — the only mechanism is env-var expansion at YAML parse time, and built-in AI processors take the key as a plain config field (fine in-process, but that path would leak the key to an untrusted guest — exactly what the egress design forbids). This reuses the **existing env-as-secret-source convention**, adds no config schema and no subsystem, and fills a seam the design explicitly reserved (host-egress design Non-goals scoped the *store* out, the *mechanism* in). So it doesn't trip CLAUDE.md's design-doc trigger. A richer store (file/Vault/KMS) later *would* need a doc.

## DECISION FOR YOUR VETO

The `CONDUIT_SECRET_<NAME>` **namespacing** (vs. `name == env var directly`) is the security-conscious choice — a guest-referenceable name can't probe arbitrary process env, only the deliberately-exported set. Flagging explicitly since it's the one externally-visible contract detail (operators must set `CONDUIT_SECRET_*` to supply keys). Easy to change pre-merge if you'd prefer the direct-name mapping or a different prefix.

## Tests

- `EnvSecretResolver`: resolve, punctuation normalization, missing/empty → non-silent error, error names the expected var without echoing a value.
- `ResolvePolicy`: the empty-allowlist + secret-refs regression (ungranted ref clamped even under unrestricted hosts) + the existing restricted-ceiling clamps.
- **Host-module end-to-end** `TestHostModule_HTTPRequest_EnvSecretInjection`: the guest supplies `AuthSecretRef` and **no** `Authorization`; the real env-backed resolver injects host-side; the destination server receives the credential; an **ungranted** ref is refused before any resolution (defense in depth) even though its env var exists.
- 423 tests `-race` across 8 pkgs; gofumpt + golangci-lint (v2.12.2) clean.

## Adversarial self-review

Re-read for: a guest path to supply/read the credential (none — `Authorization` is a reserved header, `AuthSecretRef` only names a ref, value injected host-side and never returned to the guest); resolving an ungranted or arbitrary env var (grant check precedes `Resolve`; namespace prefix bounds the readable set); empty-value injection (fails closed). No open uncertainty.

## Not in this slice

A non-env secret backend (file/Vault/KMS — would need a design doc); end-to-end secret auth through the embedding processor's *OpenAI* provider (its URL isn't yet overridable to a test server — the bundle e2e proves the guest→gate path via keyless Ollama; this PR proves the credential-injection path at the host-module boundary with a real server).
