### PR TITLE
fix(standalone): convert MultiRecord processor responses host-side

### DIFF
--- a/pkg/plugin/processor/standalone/proto.go
+++ b/pkg/plugin/processor/standalone/proto.go
@@ -87,6 +87,8 @@ func (c protoConverter) processedRecord(in *processorv1.Process_ProcessedRecord)
 	switch v := in.Record.(type) {
 	case *processorv1.Process_ProcessedRecord_SingleRecord:
 		return c.singleRecord(v)
+	case *processorv1.Process_ProcessedRecord_MultiRecord:
+		return c.multiRecord(v)
 	case *processorv1.Process_ProcessedRecord_FilterRecord:
 		return c.filterRecord(v)
 	case *processorv1.Process_ProcessedRecord_ErrorRecord:
@@ -108,6 +110,33 @@ func (c protoConverter) singleRecord(in *processorv1.Process_ProcessedRecord_Sin
 	}
 
 	return sdk.SingleRecord(rec), nil
+}
+
+// multiRecord converts a guest's Process_ProcessedRecord_MultiRecord response
+// into an sdk.MultiRecord — the fan-out shape a processor uses to turn one
+// input record into zero, one, or many output records (e.g. the ai.chunk
+// standalone processor splitting a source record into N chunk records). Prior
+// to this fix, processedRecord's switch had no case for this oneof variant at
+// all: any standalone WASM processor returning sdk.MultiRecord from Process
+// would have every such response rejected host-side as "unknown processed
+// record type", regardless of what the guest itself did correctly. A nil
+// MultiRecord (matching the zero-element sdk.MultiRecord{} the SDK documents
+// as a filter-equivalent, empty response) converts to an empty, non-nil
+// slice — never nil — for the same "no records survives the guest boundary
+// as a real empty fan-out, not an absent one" reasoning singleRecord's own
+// nil-guard follows.
+func (c protoConverter) multiRecord(in *processorv1.Process_ProcessedRecord_MultiRecord) (sdk.MultiRecord, error) {
+	if in == nil || in.MultiRecord == nil {
+		return sdk.MultiRecord{}, nil
+	}
+
+	recs := make([]opencdc.Record, len(in.MultiRecord.Records))
+	for i, r := range in.MultiRecord.Records {
+		if err := recs[i].FromProto(r); err != nil {
+			return nil, fmt.Errorf("failed to convert multi-record entry %d: %w", i, err)
+		}
+	}
+	return sdk.MultiRecord(recs), nil
 }
 
 func (c protoConverter) filterRecord(_ *processorv1.Process_ProcessedRecord_FilterRecord) (sdk.FilterRecord, error) {

--- a/pkg/plugin/processor/standalone/proto_test.go
+++ b/pkg/plugin/processor/standalone/proto_test.go
@@ -1,0 +1,93 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standalone
+
+import (
+	"testing"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	opencdcv1 "github.com/conduitio/conduit-commons/proto/opencdc/v1"
+	sdk "github.com/conduitio/conduit-processor-sdk"
+	processorv1 "github.com/conduitio/conduit-processor-sdk/proto/processor/v1"
+	"github.com/matryer/is"
+)
+
+// TestProtoConverter_ProcessedRecord_MultiRecord is the regression test for a
+// gap found while building the RAG pipeline e2e (rag_e2e_test.go): before this
+// fix, protoConverter.processedRecord's switch had no case for
+// *processorv1.Process_ProcessedRecord_MultiRecord at all, so ANY standalone
+// WASM processor returning sdk.MultiRecord from Process (fan-out — one input
+// record producing zero, one, or many output records, e.g. a chunking
+// processor) would have that response rejected host-side as "unknown
+// processed record type: *processorv1.Process_ProcessedRecord_MultiRecord",
+// regardless of what the guest itself did correctly. This exercises the fix
+// directly against the proto conversion layer, without needing a compiled
+// WASM guest.
+func TestProtoConverter_ProcessedRecord_MultiRecord(t *testing.T) {
+	is := is.New(t)
+	c := protoConverter{}
+
+	rec1 := opencdc.Record{Key: opencdc.RawData("doc-1:0"), Payload: opencdc.Change{After: opencdc.RawData("chunk 0")}}
+	rec2 := opencdc.Record{Key: opencdc.RawData("doc-1:1"), Payload: opencdc.Change{After: opencdc.RawData("chunk 1")}}
+
+	protoRec1, protoRec2 := &opencdcv1.Record{}, &opencdcv1.Record{}
+	is.NoErr(rec1.ToProto(protoRec1))
+	is.NoErr(rec2.ToProto(protoRec2))
+
+	in := &processorv1.Process_ProcessedRecord{
+		Record: &processorv1.Process_ProcessedRecord_MultiRecord{
+			MultiRecord: &processorv1.Process_MultiRecord{
+				Records: []*opencdcv1.Record{protoRec1, protoRec2},
+			},
+		},
+	}
+
+	out, err := c.processedRecord(in)
+	is.NoErr(err)
+
+	multi, ok := out.(sdk.MultiRecord)
+	if !ok {
+		t.Fatalf("want sdk.MultiRecord, got %T (%+v)", out, out)
+	}
+	is.Equal(len(multi), 2)
+	is.Equal(multi[0].Key, opencdc.RawData("doc-1:0"))
+	is.Equal(multi[1].Key, opencdc.RawData("doc-1:1"))
+}
+
+// TestProtoConverter_ProcessedRecord_MultiRecord_Empty proves the empty
+// fan-out case (a processor's documented "filter" equivalent — see
+// sdk.MultiRecord's own doc comment) converts to a real, non-nil, zero-length
+// sdk.MultiRecord — not a nil slice and not an error — mirroring
+// singleRecord's own nil-guard behavior for a nil inner message.
+func TestProtoConverter_ProcessedRecord_MultiRecord_Empty(t *testing.T) {
+	is := is.New(t)
+	c := protoConverter{}
+
+	in := &processorv1.Process_ProcessedRecord{
+		Record: &processorv1.Process_ProcessedRecord_MultiRecord{
+			MultiRecord: &processorv1.Process_MultiRecord{},
+		},
+	}
+
+	out, err := c.processedRecord(in)
+	is.NoErr(err)
+
+	multi, ok := out.(sdk.MultiRecord)
+	if !ok {
+		t.Fatalf("want sdk.MultiRecord, got %T (%+v)", out, out)
+	}
+	is.True(multi != nil)
+	is.Equal(len(multi), 0)
+}


### PR DESCRIPTION
## What & why

The host-side `protoConverter.processedRecord` switch had no case for `Process_ProcessedRecord_MultiRecord` — so any standalone WASM processor returning `sdk.MultiRecord` (the fan-out shape: one input record → zero/one/many outputs) had every such response rejected host-side as "unknown processed record type". This blocked standalone **fan-out processors entirely**, independent of any specific pipeline. The `ai.chunk` processor (source record → N chunks) is the motivating case.

## Fix

Add the `MultiRecord` case + a `multiRecord` converter, mirroring `singleRecord`'s nil-guard (nil MultiRecord → empty, non-nil slice: a real empty fan-out, not absent). Regression test (`proto_test.go`) covers a populated fan-out + the empty case, verified fail-without / pass-with.

## Risk tier: Tier-1-adjacent (host-side record conversion, processor data path)

## How found

Surfaced building the RAG e2e (chunk → embed → pgvector) — the chunking processor's fan-out runs through the real host module there for the first time, exposing the missing conversion.

## Tests

Full `standalone` package `go test -race` (25 pass), gofumpt + golangci-lint clean.

## Self-review

Mirrors the existing `singleRecord`/`filterRecord`/`errorRecord` converter pattern; nil-guard reasoning matches `singleRecord`. No behavior change for non-MultiRecord responses (pure addition of a previously-missing case).