### PR TITLE
feat(pipelines): postgres-pgvector-rag gallery template + scoped non-builtin exception

### DIFF
--- a/cmd/conduit/root/pipelines/init.go
+++ b/cmd/conduit/root/pipelines/init.go
@@ -88,6 +88,19 @@ type InitResult struct {
 	// from (see --template), or empty when scaffolded via the generic
 	// --source/--destination path.
 	Template string `json:"template,omitempty"`
+	// Prerequisites lists preflight steps (plugin installs, or — where no
+	// install command exists yet — manual build/placement steps) that must
+	// be completed before `conduit run` will succeed against this
+	// scaffolded pipeline. Populated only for templates that reference
+	// plugins not built into this binary (GalleryTemplate.Prerequisites,
+	// docs/design-documents/20260724-ai-pipeline-components.md §8) — empty
+	// for the generic --source/--destination path and for every
+	// built-in-only template, which is self-sufficient the moment it's
+	// written. Surfaced here (not only in the template's README) so
+	// `pipelines init --template <name>` never emits a bare YAML that
+	// fails opaquely on first `conduit run` because a plugin isn't
+	// present.
+	Prerequisites []string `json:"prerequisites,omitempty"`
 }
 
 // InitSummary is `pipelines init`'s --json summary payload
@@ -528,14 +541,15 @@ func (c *InitCommand) executeTemplateScaffold(ctx context.Context) (cecdysis.Out
 		OK:      true,
 		Summary: InitSummary{Written: written},
 		Result: InitResult{
-			Path:         c.configFilePath,
-			PipelineName: c.pipelineName,
-			Source:       c.sourceConnector,
-			Destination:  c.destinationConnector,
-			DryRun:       c.flags.DryRun,
-			Forced:       c.flags.Force,
-			Config:       tmpl.YAML,
-			Template:     tmpl.Name,
+			Path:          c.configFilePath,
+			PipelineName:  c.pipelineName,
+			Source:        c.sourceConnector,
+			Destination:   c.destinationConnector,
+			DryRun:        c.flags.DryRun,
+			Forced:        c.flags.Force,
+			Config:        tmpl.YAML,
+			Template:      tmpl.Name,
+			Prerequisites: tmpl.Prerequisites,
 		},
 	}, nil
 }
@@ -543,19 +557,40 @@ func (c *InitCommand) executeTemplateScaffold(ctx context.Context) (cecdysis.Out
 // Render returns the human-readable rendering of a successful init run: the
 // original "your pipeline has been initialized" message when a file was
 // written, or the rendered config plus a "nothing was written" notice under
-// --dry-run.
+// --dry-run — followed by a prerequisites section whenever the scaffolded
+// template names one (renderPrerequisites), so a template whose plugins
+// aren't built into this binary never prints a plain "run `conduit run`"
+// that would fail opaquely.
 func (c *InitCommand) Render(outcome cecdysis.Outcome) string {
 	if list, ok := outcome.Result.(TemplateListResult); ok {
 		return renderTemplateList(list)
 	}
 
 	result, _ := outcome.Result.(InitResult)
+	prereq := renderPrerequisites(result.Prerequisites)
 
 	if result.DryRun {
 		return fmt.Sprintf("Dry run: the following pipeline configuration would be written to %q "+
-			"(nothing was written):\n\n%s", result.Path, result.Config)
+			"(nothing was written):\n\n%s%s", result.Path, result.Config, prereq)
 	}
 
 	return fmt.Sprintf("Your pipeline has been initialized and created at %q.\n"+
-		"To run the pipeline, simply run `conduit run`.\n", result.Path)
+		"To run the pipeline, simply run `conduit run`.\n%s", result.Path, prereq)
+}
+
+// renderPrerequisites renders InitResult.Prerequisites as a "before you can
+// run this" section, or "" when there are none (the common case: the
+// generic scaffold path and every built-in-only template).
+func renderPrerequisites(prerequisites []string) string {
+	if len(prerequisites) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("\nBefore `conduit run` will work, complete these steps " +
+		"(this template references plugins not built into this binary):\n\n")
+	for _, p := range prerequisites {
+		fmt.Fprintf(&b, "  - %s\n", p)
+	}
+	return b.String()
 }

--- a/cmd/conduit/root/pipelines/template_gallery.go
+++ b/cmd/conduit/root/pipelines/template_gallery.go
@@ -33,6 +33,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -40,6 +41,7 @@ import (
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/plugin"
 	"github.com/conduitio/conduit/pkg/plugin/connector/builtin"
 	provconfig "github.com/conduitio/conduit/pkg/provisioning/config"
 	yamlparser "github.com/conduitio/conduit/pkg/provisioning/config/yaml"
@@ -77,6 +79,41 @@ type GalleryTemplate struct {
 	// YAML is the literal, embedded pipeline configuration this template
 	// scaffolds.
 	YAML string
+	// AllowedNonBuiltin is a SCOPED exception to the built-in-only invariant
+	// above: the plugin names (Specification.Name / connector-plugin name)
+	// this ONE template is explicitly permitted to reference as its Source
+	// or Destination even though they are not in
+	// builtin.DefaultBuiltinConnectors. This is the registry-backed
+	// template extension point named (but not built) by
+	// docs/design-documents/20260723-templates-gallery.md §7's "a future
+	// template author proposes one needing a non-built-in connector" row,
+	// exercised for the first time by
+	// docs/design-documents/20260724-ai-pipeline-components.md §8's
+	// postgres-pgvector-rag template. Nil for every other template: leaving
+	// this empty is what keeps AC-5 ("zero templates require a non-built-in
+	// connector") a hard, package-init-enforced invariant for the rest of
+	// the catalog — validateGalleryCatalog and
+	// validateGalleryTemplateConnectors both consult this field per-template
+	// rather than relaxing the check globally, so granting the exception to
+	// one entry can never silently authorize it for another (see
+	// TestValidateGalleryCatalog_RejectsNonBuiltinConnector_ScopedToOneTemplate).
+	AllowedNonBuiltin []string
+	// Prerequisites are preflight steps (registry plugin installs, or —
+	// where no install command exists yet — manual build/placement steps)
+	// that must be completed before `conduit run` will succeed against this
+	// template's scaffolded YAML. `pipelines init --template <name>`
+	// surfaces these directly in its result (both --json and
+	// human-readable) rather than only documenting them in the template's
+	// README, mirroring `conduit migrate kafka-connect`'s "never silently
+	// drop config it can't translate" spirit — applied here as "never emit
+	// a bare YAML that fails opaquely on first `conduit run` because a
+	// plugin isn't present" (design doc §8). Nil for every template whose
+	// Source/Destination are both built in (AllowedNonBuiltin is also nil
+	// for those, structurally: a template with prerequisites necessarily
+	// has a non-empty AllowedNonBuiltin, though the converse — an allowed
+	// non-builtin plugin the user is assumed to already have installed —
+	// isn't required to hold).
+	Prerequisites []string
 }
 
 //go:embed templates/generator-log/pipeline.yaml
@@ -91,21 +128,30 @@ var galleryYAMLPostgresS3 string
 //go:embed templates/postgres-cdc-kafka/pipeline.yaml
 var galleryYAMLPostgresCDCKafka string
 
+//go:embed templates/postgres-pgvector-rag/pipeline.yaml
+var galleryYAMLPostgresPgvectorRAG string
+
 // Template names (GalleryTemplate.Name / --template values) and built-in
 // connector names used more than once below — named so golangci-lint's
 // goconst check doesn't flag repeated string literals, and so the E2E test
 // file (template_gallery_e2e_test.go) can reference the same names rather
 // than re-typing them.
 const (
-	templateNameGeneratorLog     = "generator-log"
-	templateNameGeneratorFile    = "generator-file"
-	templateNamePostgresS3       = "postgres-s3"
-	templateNamePostgresCDCKafka = "postgres-cdc-kafka"
+	templateNameGeneratorLog        = "generator-log"
+	templateNameGeneratorFile       = "generator-file"
+	templateNamePostgresS3          = "postgres-s3"
+	templateNamePostgresCDCKafka    = "postgres-cdc-kafka"
+	templateNamePostgresPgvectorRAG = "postgres-pgvector-rag"
 
 	connNamePostgres = "postgres"
 	connNameS3       = "s3"
 	connNameKafka    = "kafka"
 	connNameFile     = "file"
+	// connNamePgvector is NOT in builtin.DefaultBuiltinConnectors — it is
+	// the one registry-installed, non-built-in destination the
+	// postgres-pgvector-rag template is scoped-exception-permitted to name
+	// (GalleryTemplate.AllowedNonBuiltin).
+	connNamePgvector = "pgvector"
 )
 
 // galleryCatalogSpec is the MVP template set (
@@ -156,6 +202,45 @@ func galleryCatalogSpec() []GalleryTemplate {
 				"\"logrepl\" — refuses to run rather than silently degrading to polling.",
 			YAML: galleryYAMLPostgresCDCKafka,
 		},
+		{
+			// postgres-pgvector-rag is the RAG-sync template
+			// (docs/design-documents/20260724-ai-pipeline-components.md
+			// §8): Postgres CDC -> chunk -> embed -> pgvector. It is the
+			// FIRST (and, deliberately, only) entry naming a non-built-in
+			// destination — AllowedNonBuiltin below is the scoped
+			// exception that makes validateGalleryCatalog and
+			// validateGalleryTemplateConnectors permit it without
+			// weakening AC-5 for every other template.
+			Name: templateNamePostgresPgvectorRAG,
+			Description: "Sync a Postgres table into a RAG-ready vector store: chunk each row's text, " +
+				"embed it, and upsert the vectors into pgvector.",
+			Source:            connNamePostgres,
+			Destination:       connNamePgvector,
+			AllowedNonBuiltin: []string{connNamePgvector},
+			DeliverySemantics: "At-least-once, not exactly-once; a row is only acknowledged upstream " +
+				"once pgvector has durably upserted every chunk derived from it. Deletes remove all " +
+				"chunks ever derived from a source row (matched by source_key), even across a chunk-count " +
+				"change, so no orphaned vectors survive an update or delete.",
+			YAML: galleryYAMLPostgresPgvectorRAG,
+			// Prerequisites: this template's pipeline.yaml references three
+			// plugins none of which are built into this binary (postgres
+			// is the only built-in participant). Surfaced directly in
+			// `pipelines init --template postgres-pgvector-rag`'s result
+			// (init.go's InitResult.Prerequisites / Render) so the command
+			// never emits a bare YAML that fails opaquely on first
+			// `conduit run` — see this field's doc comment.
+			Prerequisites: []string{
+				"Install the pgvector destination connector: `conduit connectors install pgvector@<version>` " +
+					"(run `conduit connectors search pgvector` to see available versions).",
+				"conduit-processor-ai's chunking (ai.chunk) and embedding (ai.embed) processors are WASM " +
+					"processor plugins. There is no `conduit processor-plugins install` command in this " +
+					"build — that install path does not exist yet. Until it does: build them yourself from " +
+					"a github.com/conduitio/conduit-processor-ai checkout with " +
+					"`GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-chunk.wasm ./cmd/chunking` and " +
+					"`GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-embed.wasm ./cmd/embedding`, then " +
+					"place both .wasm files in the directory configured as --processors.path.",
+			},
+		},
 	}
 }
 
@@ -178,13 +263,21 @@ func mustBuildGalleryCatalog() []GalleryTemplate {
 // template must hold (
 // docs/design-documents/20260723-templates-gallery.md §6 AC-5, §7's reserved-name row): unique,
 // non-empty names; never the reserved "list" sentinel; a non-empty
-// description; source/destination that both resolve to a built-in
-// connector; non-empty embedded YAML. It does NOT check individual setting
-// keys against the connector's parameter spec — that is
-// validateGalleryTemplateSettings's job, run per-template at scaffold time
-// (not at package init, so a synthetic "stale fixture" can be asserted
-// against directly in a test without crashing the whole test binary via a
-// package-level panic).
+// description; source/destination that either resolve to a built-in
+// connector OR are named in that specific template's own AllowedNonBuiltin
+// (the scoped registry-backed-template exception,
+// docs/design-documents/20260724-ai-pipeline-components.md §8 — see
+// GalleryTemplate's doc comment); non-empty embedded YAML. Because the
+// exception is checked per-template (t.AllowedNonBuiltin), a connector named
+// in one template's allowlist grants NO permission to any other template —
+// every other entry's empty AllowedNonBuiltin keeps AC-5 exactly as hard as
+// before (see
+// TestValidateGalleryCatalog_RejectsNonBuiltinConnector_ScopedToOneTemplate).
+// This does NOT check individual setting keys against the connector's
+// parameter spec — that is validateGalleryTemplateSettings's job, run
+// per-template at scaffold time (not at package init, so a synthetic "stale
+// fixture" can be asserted against directly in a test without crashing the
+// whole test binary via a package-level panic).
 func validateGalleryCatalog(catalog []GalleryTemplate) error {
 	seen := make(map[string]bool, len(catalog))
 	for _, t := range catalog {
@@ -208,12 +301,16 @@ func validateGalleryCatalog(catalog []GalleryTemplate) error {
 		if strings.TrimSpace(t.DeliverySemantics) == "" {
 			return cerrors.Errorf("embedded template gallery: template %q has an empty delivery-semantics summary", t.Name)
 		}
-		if !isBuiltinConnectorName(t.Source) {
-			return cerrors.Errorf("embedded template gallery: template %q: source %q is not a built-in connector",
+		if !isBuiltinConnectorName(t.Source) && !slices.Contains(t.AllowedNonBuiltin, t.Source) {
+			return cerrors.Errorf(
+				"embedded template gallery: template %q: source %q is not a built-in connector "+
+					"and is not in this template's AllowedNonBuiltin allowlist",
 				t.Name, t.Source)
 		}
-		if !isBuiltinConnectorName(t.Destination) {
-			return cerrors.Errorf("embedded template gallery: template %q: destination %q is not a built-in connector",
+		if !isBuiltinConnectorName(t.Destination) && !slices.Contains(t.AllowedNonBuiltin, t.Destination) {
+			return cerrors.Errorf(
+				"embedded template gallery: template %q: destination %q is not a built-in connector "+
+					"and is not in this template's AllowedNonBuiltin allowlist",
 				t.Name, t.Destination)
 		}
 		if strings.TrimSpace(t.YAML) == "" {
@@ -302,7 +399,7 @@ func validateGalleryTemplateSettings(ctx context.Context, tmpl GalleryTemplate) 
 	}
 
 	for _, p := range pipelineCfgs {
-		if err := validateGalleryTemplateConnectors(tmpl.Name, p.Connectors); err != nil {
+		if err := validateGalleryTemplateConnectors(tmpl, p.Connectors); err != nil {
 			return err
 		}
 	}
@@ -330,15 +427,38 @@ func configParamRecognized(params config.Parameters, key string) bool {
 	return false
 }
 
-func validateGalleryTemplateConnectors(templateName string, connectors []provconfig.Connector) error {
+// validateGalleryTemplateConnectors checks tmpl's parsed connectors against
+// this build's actual connector param specs, with one scoped exception: a
+// connector plugin named in tmpl.AllowedNonBuiltin (see GalleryTemplate's doc
+// comment and validateGalleryCatalog) skips the builtin-spec lookup entirely
+// — builtinConnectorSpecParams would legitimately return not-found for it
+// (its spec isn't compiled into this binary at all), so treating that as a
+// "does not exist" error would be wrong for a template deliberately
+// referencing a registry-installed plugin. The allowlist is consulted
+// per-connector against THIS tmpl only, so it grants no permission to any
+// other catalog entry.
+func validateGalleryTemplateConnectors(tmpl GalleryTemplate, connectors []provconfig.Connector) error {
 	for _, c := range connectors {
-		pluginName := strings.TrimPrefix(c.Plugin, "builtin:")
+		pluginName := plugin.FullName(c.Plugin).PluginName()
+
+		if slices.Contains(tmpl.AllowedNonBuiltin, pluginName) {
+			// Scoped exception (design doc §8 / GalleryTemplate.AllowedNonBuiltin):
+			// this plugin's parameter spec is not compiled into this
+			// binary, so there is nothing to validate setting keys
+			// against here — a registry-installed plugin's own
+			// install/startup validation is where a real mismatch would
+			// surface. Do NOT build a parallel spec-fetching subsystem for
+			// this; see the task scope note in this package's design doc
+			// citation.
+			continue
+		}
 
 		params, ok := builtinConnectorSpecParams(pluginName, c.Type)
 		if !ok {
 			ce := conduiterr.New(CodeTemplateVersionMismatch, fmt.Sprintf(
 				"embedded template %q references %s connector %q, which does not exist in this build's "+
-					"built-in connector set", templateName, c.Type, pluginName,
+					"built-in connector set and is not in this template's AllowedNonBuiltin allowlist",
+				tmpl.Name, c.Type, pluginName,
 			))
 			ce.Suggestion = "this is a packaging bug in the vendored template, not a user config error " +
 				"— please file an issue against ConduitIO/conduit"
@@ -351,7 +471,7 @@ func validateGalleryTemplateConnectors(templateName string, connectors []provcon
 			}
 			ce := conduiterr.New(CodeTemplateVersionMismatch, fmt.Sprintf(
 				"embedded template %q sets %s connector %q's parameter %q, which is not recognized by "+
-					"the %q connector built into this binary", templateName, c.Type, c.ID, key, pluginName,
+					"the %q connector built into this binary", tmpl.Name, c.Type, c.ID, key, pluginName,
 			))
 			ce.Suggestion = "the vendored template is pinned against an older connector parameter shape " +
 				"than the one built into this binary — this is a packaging bug, not a user config error; " +

--- a/cmd/conduit/root/pipelines/template_gallery_test.go
+++ b/cmd/conduit/root/pipelines/template_gallery_test.go
@@ -39,6 +39,7 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -64,17 +65,24 @@ func TestGalleryCatalog_Valid(t *testing.T) {
 	is := is.New(t)
 
 	is.NoErr(validateGalleryCatalog(galleryTemplates))
-	is.Equal(len(galleryTemplates), 4)
+	is.Equal(len(galleryTemplates), 5)
 
 	wantNames := map[string]bool{
 		"generator-log": true, "generator-file": true,
 		"postgres-s3": true, "postgres-cdc-kafka": true,
+		"postgres-pgvector-rag": true,
 	}
 	for _, tmpl := range galleryTemplates {
 		is.True(wantNames[tmpl.Name])
 		is.True(tmpl.Name != templateListSentinel)
-		is.True(isBuiltinConnectorName(tmpl.Source))
-		is.True(isBuiltinConnectorName(tmpl.Destination))
+		// AC-5 ("zero templates require a non-built-in connector") holds
+		// for source/destination that are EITHER a built-in connector OR
+		// explicitly allowlisted by that same template's own
+		// AllowedNonBuiltin — postgres-pgvector-rag is the one entry that
+		// exercises the second branch (its Destination is "pgvector",
+		// which isBuiltinConnectorName alone would reject).
+		is.True(isBuiltinConnectorName(tmpl.Source) || slices.Contains(tmpl.AllowedNonBuiltin, tmpl.Source))
+		is.True(isBuiltinConnectorName(tmpl.Destination) || slices.Contains(tmpl.AllowedNonBuiltin, tmpl.Destination))
 		is.True(strings.TrimSpace(tmpl.Description) != "")
 		is.True(strings.TrimSpace(tmpl.DeliverySemantics) != "")
 		is.True(strings.TrimSpace(tmpl.YAML) != "")
@@ -113,6 +121,51 @@ func TestValidateGalleryCatalog_RejectsNonBuiltinConnector(t *testing.T) {
 	err := validateGalleryCatalog(bad)
 	is.True(err != nil)
 	is.True(strings.Contains(err.Error(), "not-a-real-connector"))
+}
+
+// TestValidateGalleryCatalog_RejectsNonBuiltinConnector_ScopedToOneTemplate
+// is the load-bearing safety property of the postgres-pgvector-rag
+// exception (GalleryTemplate.AllowedNonBuiltin,
+// docs/design-documents/20260724-ai-pipeline-components.md §8): granting
+// ONE template permission to reference a non-built-in connector must not
+// leak that permission to any OTHER template. This builds a synthetic
+// catalog with two entries — one that legitimately allowlists
+// "not-a-real-connector" (mirroring the real postgres-pgvector-rag entry's
+// shape) and a second, unrelated template that references the SAME
+// connector name WITHOUT itself being on any allowlist — and asserts the
+// first passes while the second still fails validation. If the exception
+// were checked catalog-wide instead of per-template, this test would fail
+// (the second entry would wrongly pass once the first legitimized the
+// name).
+func TestValidateGalleryCatalog_RejectsNonBuiltinConnector_ScopedToOneTemplate(t *testing.T) {
+	is := is.New(t)
+
+	catalog := []GalleryTemplate{
+		{
+			Name: "legitimately-allowlisted", Description: "x", DeliverySemantics: "x",
+			Source: "generator", Destination: "not-a-real-connector",
+			AllowedNonBuiltin: []string{"not-a-real-connector"},
+			YAML:              "version: \"2.2\"\n",
+		},
+		{
+			Name: "not-allowlisted", Description: "x", DeliverySemantics: "x",
+			Source: "generator", Destination: "not-a-real-connector",
+			// No AllowedNonBuiltin: this template never opted into the
+			// exception, even though a sibling entry's allowlist happens
+			// to name the exact same connector.
+			YAML: "version: \"2.2\"\n",
+		},
+	}
+
+	err := validateGalleryCatalog(catalog)
+	is.True(err != nil)
+	is.True(strings.Contains(err.Error(), "not-allowlisted"))
+	is.True(strings.Contains(err.Error(), "not-a-real-connector"))
+
+	// Isolate: the first entry alone (with its own allowlist) must pass on
+	// its own — proving the failure above is really about the SECOND
+	// entry's missing allowlist, not some other defect in the fixture.
+	is.NoErr(validateGalleryCatalog(catalog[:1]))
 }
 
 // TestValidateGalleryCatalog_RejectsDuplicateName and
@@ -235,6 +288,56 @@ pipelines:
 	is.Equal(ce.Code.Reason(), CodeTemplateVersionMismatch.Reason())
 }
 
+// TestValidateGalleryTemplateConnectors_AllowedNonBuiltin_SkipsSpecCheck_ScopedToTemplate
+// is validateGalleryTemplateConnectors's own half of the scoped-exception
+// safety property (the catalog-level half is
+// TestValidateGalleryCatalog_RejectsNonBuiltinConnector_ScopedToOneTemplate):
+// a connector plugin named in THIS template's AllowedNonBuiltin skips the
+// builtin-spec/parameter check entirely — even one setting a nonsense key,
+// since there's no compiled-in spec to check it against — while the exact
+// same plugin/settings pair on a DIFFERENT template (no allowlist) still
+// fails with CodeTemplateVersionMismatch.
+func TestValidateGalleryTemplateConnectors_AllowedNonBuiltin_SkipsSpecCheck_ScopedToTemplate(t *testing.T) {
+	is := is.New(t)
+
+	yaml := `version: "2.2"
+pipelines:
+  - id: uses-pgvector
+    status: running
+    name: uses-pgvector
+    connectors:
+      - id: src
+        type: source
+        plugin: "builtin:generator"
+      - id: dst
+        type: destination
+        plugin: "standalone:pgvector"
+        settings:
+          anySettingAtAll: "not checked against a compiled-in spec"
+`
+
+	allowed := GalleryTemplate{
+		Name: "allowed", Description: "x", DeliverySemantics: "x",
+		Source: "generator", Destination: "pgvector",
+		AllowedNonBuiltin: []string{"pgvector"},
+		YAML:              yaml,
+	}
+	is.NoErr(validateGalleryTemplateSettings(context.Background(), allowed))
+
+	notAllowed := GalleryTemplate{
+		Name: "not-allowed", Description: "x", DeliverySemantics: "x",
+		Source: "generator", Destination: "pgvector",
+		// No AllowedNonBuiltin — the identical connector reference must
+		// still be refused for THIS template.
+		YAML: yaml,
+	}
+	err := validateGalleryTemplateSettings(context.Background(), notAllowed)
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code.Reason(), CodeTemplateVersionMismatch.Reason())
+}
+
 func newTemplateGalleryEcdysis() *ecdysis.Ecdysis {
 	return ecdysis.New(ecdysis.WithDecorators(cecdysis.CommandWithResultDecorator{}))
 }
@@ -271,6 +374,73 @@ func TestGalleryTemplates_ScaffoldParseableYAML(t *testing.T) {
 	}
 }
 
+// TestInitCommand_TemplateScaffold_PgvectorRAG_EmitsPrerequisites is the
+// preflight-note requirement from design doc §8 ("never emit a bare YAML
+// that fails opaquely on first `conduit run` because a plugin isn't
+// present"): scaffolding postgres-pgvector-rag must surface its
+// GalleryTemplate.Prerequisites in BOTH the --json result and the
+// human-readable Render output, naming the exact `conduit connectors
+// install pgvector@<version>` command and stating plainly that no
+// `conduit processor-plugins install` equivalent exists yet for the two
+// WASM processors.
+func TestInitCommand_TemplateScaffold_PgvectorRAG_EmitsPrerequisites(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+
+	cmd := newTemplateGalleryEcdysis().MustBuildCobraCommand(&InitCommand{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--pipelines.path=" + dir, "--template=postgres-pgvector-rag", "--json"})
+	is.NoErr(cmd.Execute())
+
+	var got cecdysis.Result
+	is.NoErr(json.Unmarshal(out.Bytes(), &got))
+	is.True(got.OK)
+
+	resultBytes, err := json.Marshal(got.Result)
+	is.NoErr(err)
+	var result InitResult
+	is.NoErr(json.Unmarshal(resultBytes, &result))
+	is.True(len(result.Prerequisites) >= 2)
+
+	joined := strings.Join(result.Prerequisites, "\n")
+	is.True(strings.Contains(joined, "conduit connectors install pgvector@"))
+	is.True(strings.Contains(joined, "no `conduit processor-plugins install` command"))
+
+	// The human-readable Render path must surface the same note, not just
+	// the --json payload.
+	cmd2 := newTemplateGalleryEcdysis().MustBuildCobraCommand(&InitCommand{})
+	var out2 bytes.Buffer
+	cmd2.SetOut(&out2)
+	cmd2.SetArgs([]string{"--pipelines.path=" + dir, "--template=postgres-pgvector-rag", "--force"})
+	is.NoErr(cmd2.Execute())
+	is.True(strings.Contains(out2.String(), "conduit connectors install pgvector@"))
+}
+
+// TestInitCommand_TemplateScaffold_BuiltinOnlyTemplate_NoPrerequisites is
+// the converse: a built-in-only template (generator-log) must never carry a
+// prerequisites note — it's self-sufficient the moment it's scaffolded, and
+// the field should stay empty rather than print a vacuous "no steps needed"
+// section.
+func TestInitCommand_TemplateScaffold_BuiltinOnlyTemplate_NoPrerequisites(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+
+	cmd := newTemplateGalleryEcdysis().MustBuildCobraCommand(&InitCommand{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--pipelines.path=" + dir, "--template=generator-log", "--json"})
+	is.NoErr(cmd.Execute())
+
+	var got cecdysis.Result
+	is.NoErr(json.Unmarshal(out.Bytes(), &got))
+	resultBytes, err := json.Marshal(got.Result)
+	is.NoErr(err)
+	var result InitResult
+	is.NoErr(json.Unmarshal(resultBytes, &result))
+	is.Equal(len(result.Prerequisites), 0)
+}
+
 // TestTemplateList_JSON_EnvelopeShape is AC-2: --template list --json must
 // conform to the Family A envelope and enumerate all four templates with a
 // non-empty description each.
@@ -296,7 +466,7 @@ func TestTemplateList_JSON_EnvelopeShape(t *testing.T) {
 	is.NoErr(err)
 	var result TemplateListResult
 	is.NoErr(json.Unmarshal(resultBytes, &result))
-	is.Equal(len(result.Templates), 4)
+	is.Equal(len(result.Templates), 5)
 	for _, entry := range result.Templates {
 		is.True(entry.Name != "")
 		is.True(entry.Description != "")
@@ -351,7 +521,9 @@ func TestInitCommand_UnknownTemplate_HardFailure(t *testing.T) {
 	is.True(!got.OK)
 	is.True(got.Error != nil)
 	is.Equal(got.Error.Code, CodeUnknownTemplate.Reason())
-	for _, name := range []string{"generator-log", "generator-file", "postgres-s3", "postgres-cdc-kafka"} {
+	for _, name := range []string{
+		"generator-log", "generator-file", "postgres-s3", "postgres-cdc-kafka", "postgres-pgvector-rag",
+	} {
 		is.True(strings.Contains(got.Error.Suggestion, name))
 	}
 

--- a/cmd/conduit/root/pipelines/templates/postgres-pgvector-rag/README.md
+++ b/cmd/conduit/root/pipelines/templates/postgres-pgvector-rag/README.md
@@ -1,0 +1,109 @@
+# Template: postgres-pgvector-rag
+
+Scaffold with:
+
+```shell
+conduit pipelines init --template postgres-pgvector-rag
+```
+
+Unlike every other template in this gallery, this one prints a **prerequisite note** —
+`conduit pipelines init --template postgres-pgvector-rag`'s result (`--json`'s
+`result.prerequisites`, or the human-readable output) names the exact installs you need before
+`conduit run` will do anything useful. This template is the first in the gallery to reference
+plugins that are not built into `conduit` (see [Non-built-in dependencies](#non-built-in-dependencies) below) —
+`conduit pipelines init` still writes the pipeline YAML, but it will not run until those plugins
+are in place.
+
+## What it does
+
+Syncs a Postgres table — an initial full-table snapshot, then ongoing change data capture — into a
+RAG-ready vector store: each row's text is **chunked**, **embedded**, and **upserted into
+pgvector**, keyed so redelivery and in-place updates converge to one row per chunk and a source-row
+delete removes every chunk ever derived from it. This is the canonical RAG-sync pipeline shape from
+`docs/design-documents/20260724-ai-pipeline-components.md` (CDC → chunk → embed → vector store).
+
+## Non-built-in dependencies
+
+Three of this pipeline's four plugins are **not** compiled into `conduit` (only `builtin:postgres`
+is):
+
+| Plugin | Kind | Install |
+| --- | --- | --- |
+| `standalone:pgvector` (destination) | Registry-installed Go connector (`conduit-connector-pgvector`) | `conduit connectors install pgvector@<version>` |
+| `standalone:ai.chunk` (processor) | Standalone WASM processor (`conduit-processor-ai`) | **No install command exists yet.** Build `./cmd/chunking` from a `conduit-processor-ai` checkout (`GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-chunk.wasm ./cmd/chunking`) and place the `.wasm` file under your `--processors.path` directory. |
+| `standalone:ai.embed` (processor) | Standalone WASM processor (`conduit-processor-ai`) | Same gap as above: build `./cmd/embedding` (`GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-embed.wasm ./cmd/embedding`) and place it under `--processors.path`. |
+
+This gap — `conduit processor-plugins install` not existing — is stated here plainly rather than
+invented around; `conduit pipelines init --template postgres-pgvector-rag` names it in its
+prerequisite note every time this template is scaffolded.
+
+You'll also need the pgvector target table created ahead of time, matching the `dimension` you
+configure (768 for the template's default `nomic-embed-text` model):
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE TABLE document_chunks (
+    id text PRIMARY KEY,
+    embedding vector(768),
+    metadata jsonb,
+    source_key text
+);
+CREATE INDEX ON document_chunks (source_key);
+```
+
+## Config reference
+
+| Component | Setting | Meaning |
+| --- | --- | --- |
+| `builtin:postgres` (source) | `url` | Postgres connection string. **Placeholder — must be replaced.** |
+| | `tables` | Comma-separated table name(s), or `*` for all tables. **Placeholder — must be replaced.** |
+| | `snapshotMode` | `initial` — sync existing rows immediately, not just future changes. |
+| | `cdcMode` | `auto` — logical replication if available, otherwise long-polling. |
+| `standalone:ai.chunk` (processor) | `strategy` | `recursive` — try progressively finer separators until each chunk fits `chunkSize`. |
+| | `chunkSize` / `overlap` | Target chunk size and overlap, in Unicode runes. |
+| | `inputField` | The record field read as chunk-input text. **Placeholder (`.Payload.After.content`) — point this at your table's actual text column.** |
+| | `outputField` | Left at its default (`.Payload.After.text`) — composes with `ai.embed`'s default `inputField` with zero configuration. |
+| `standalone:ai.embed` (processor) | `provider` | `ollama` — local, keyless, no cloud credentials needed to try this template. |
+| | `model` | `nomic-embed-text` (768-dimensional). Change this and `dimension` below together. |
+| | `ollama.baseURL` | Ollama's default local address. |
+| `standalone:pgvector` (destination) | `url` | Connection string for the pgvector-enabled Postgres instance — can be the same database as the source, or a dedicated one. **Placeholder — must be replaced.** |
+| | `table` | Target table for embedding rows. Must already exist (see the `CREATE TABLE` above). |
+| | `dimension` | **Must match the embedding model's output dimension** (768 for `nomic-embed-text`). Validated at connector startup; a mismatch refuses to run. |
+| | `vectorColumn` / `keyColumn` / `metadataColumn` | Database column names (defaults: `embedding`, `id`, `metadata`). |
+| | `vectorField` | The record **payload field** (not a DB column) carrying the vector — default `vector`, matching `ai.embed`'s default `outputField` basename. |
+| | `sourceKeyColumn` / `sourceKeyMetadataKey` | What makes a source-row delete remove every chunk ever derived from it, even across a chunk-count change — do not disable for a RAG-sync pipeline. |
+
+## Runnable example
+
+The exact bytes above (minus the placeholder values) are what
+`conduit pipelines init --template postgres-pgvector-rag` writes (module:
+`cmd/conduit/root/pipelines/templates/postgres-pgvector-rag/pipeline.yaml`). The chunk → embed →
+pgvector leg of this pipeline is proven end to end against real WASM processor guests, a real
+egress-allowlist host module, and a real out-of-process `conduit-connector-pgvector` binary talking
+to real Postgres in `pkg/plugin/processor/standalone/rag_e2e_test.go` (build tag `rag_e2e`) — that
+suite is what validates the exact record shape this template's processors/destination compose
+around (chunk's `.Payload.After.text` → embed's `.Payload.After.vector` → pgvector's `vectorField`).
+A full template-gallery end-to-end job (this template scaffolded via `conduit pipelines init` and
+run as a real `conduit` pipeline against Postgres CDC + pgvector) is tracked as follow-up work; see
+this template's addition PR for the current state of that harness.
+
+## Delivery semantics
+
+- **At-least-once (Invariant 3), not exactly-once.** A source row is only acknowledged upstream
+  (advancing the Postgres source's position) once pgvector has durably upserted every chunk
+  derived from it (Invariant 1) — the embedding processor's `Process` call does not return until
+  every chunk it was handed is embedded or definitively failed, so there is no window where a
+  record is acked while still waiting on an embedding call.
+- **Idempotent upserts.** Each chunk's `id` (`{source_row_key}:{chunk_index}`) is deterministic, and
+  the pgvector write is a single `ON CONFLICT ... DO UPDATE` statement — a retried/redelivered chunk
+  converges to the same row rather than duplicating it.
+- **No orphaned chunks on update or delete.** Deletes (and a source row's delete tombstone) remove
+  every chunk row matching that row's `source_key`, not just the chunk IDs the current chunk count
+  would guess — so a document that shrinks (fewer chunks after an edit) doesn't leave stale rows
+  behind, and a row delete removes all of its chunks regardless of how the chunk count has changed
+  over time.
+- **Invariant 6 (schema handling):** the chunking/embedding processors do not coerce or drop
+  content; an unrecognized `inputField` path or a provider error surfaces as a processor error
+  (routed through the pipeline's configured DLQ/error policy), never silent truncation.
+- Ordering is per-table (Postgres CDC), then per-chunk-index within a source row's fan-out; chunks
+  from different source rows are not ordered relative to each other.

--- a/cmd/conduit/root/pipelines/templates/postgres-pgvector-rag/pipeline.yaml
+++ b/cmd/conduit/root/pipelines/templates/postgres-pgvector-rag/pipeline.yaml
@@ -1,0 +1,117 @@
+version: "2.2"
+pipelines:
+  - id: postgres-pgvector-rag
+    description: >
+      Vendored template "postgres-pgvector-rag": syncs a Postgres table
+      (initial snapshot, then ongoing change data capture) into a RAG-ready
+      vector store — each row's text is chunked, embedded, and upserted into
+      pgvector, keyed so redelivery and updates converge cleanly and deletes
+      remove every chunk ever derived from a row. Scaffolded by
+      `conduit pipelines init --template postgres-pgvector-rag`. This
+      template's non-postgres connector/processors are NOT built into
+      `conduit` — run the preflight steps this command printed (or see
+      README.md in this template's directory) before `conduit run`, and
+      fill in the placeholder connection values below.
+    status: running
+    name: postgres-pgvector-rag
+    connectors:
+      - id: postgres-pgvector-rag-source
+        type: source
+        plugin: "builtin:postgres"
+        settings:
+          # Postgres connection string, e.g.
+          # postgres://user:password@localhost:5432/dbname?sslmode=disable
+          url: postgres://user:password@localhost:5432/dbname?sslmode=disable
+          # Comma-separated table names, or "*" for all tables. Each row's
+          # text-bearing column is read by the chunking processor's
+          # inputField setting below — update BOTH together.
+          tables: my_table
+          # Take a full snapshot on first run (so existing rows are synced
+          # into the vector store immediately), then keep syncing ongoing
+          # changes — this is the "sync," not "CDC-only," shape. See
+          # README.md's delivery-semantics note.
+          snapshotMode: initial
+          # Use logical replication if available, otherwise fall back to
+          # long-polling. Set to "logrepl" if you need a hard guarantee
+          # (matching the postgres-cdc-kafka template's stance).
+          cdcMode: auto
+      - id: postgres-pgvector-rag-destination
+        type: destination
+        # pgvector (conduit-connector-pgvector): NOT a built-in connector —
+        # see this template's preflight note / README for the install
+        # command. Field shape verified against
+        # conduit-connector-pgvector's destination.Config.
+        plugin: "standalone:pgvector"
+        settings:
+          # Connection string for the Postgres instance running the
+          # pgvector extension — can be the same database as the source
+          # above, or a dedicated vector store.
+          url: postgres://user:password@localhost:5432/vectordb?sslmode=disable
+          # Target table for the embedding rows. Must already exist with
+          # the shape: id text PRIMARY KEY, embedding vector(<dimension>),
+          # metadata jsonb, source_key text (indexed) — see README.md for
+          # the exact CREATE TABLE statement.
+          table: document_chunks
+          # MUST match the embedding model's output dimension configured
+          # below (nomic-embed-text is 768). Validated at connector
+          # startup — a mismatch refuses to run rather than silently
+          # truncating.
+          dimension: "768"
+          # vectorColumn is the pgvector `vector` column name on the target
+          # table (distinct from vectorField below, which is the record's
+          # payload field, not a database column).
+          vectorColumn: embedding
+          keyColumn: id
+          # vectorField is the record payload field carrying the embedding
+          # — the default "vector" is exactly ai.embed's default
+          # outputField basename below.
+          vectorField: vector
+          metadataColumn: metadata
+          # source_key population is what lets a source-row delete remove
+          # every chunk ever derived from it (design doc §5) — do not
+          # disable this for a RAG-sync pipeline.
+          sourceKeyColumn: source_key
+          sourceKeyMetadataKey: ai.chunk.source_key
+          idMetadataKey: ai.chunk.id
+    processors:
+      # ai.chunk (conduit-processor-ai): splits each row's text into N chunk
+      # records. NOT a built-in processor — see this template's preflight
+      # note / README for the install gap. Field shape verified against
+      # conduit-processor-ai's chunk.Config.
+      - id: chunk
+        plugin: "standalone:ai.chunk"
+        settings:
+          strategy: recursive
+          chunkSize: "1000"
+          overlap: "100"
+          # The record field holding the text to chunk. Point this at your
+          # table's actual text-bearing column — "content" is a placeholder
+          # matching the "tables: my_table" placeholder above.
+          inputField: ".Payload.After.content"
+          # outputField is left at its default (".Payload.After.text"),
+          # which is exactly ai.embed's default inputField below — this
+          # composable, zero-config handoff is the RAG contract the two
+          # processors share (conduit-processor-ai design doc §3/§4).
+      # ai.embed (conduit-processor-ai): calls an embedding provider for
+      # each chunk's text. NOT a built-in processor — see this template's
+      # preflight note / README. Field shape verified against
+      # conduit-processor-ai's embed.Config. Provider is "ollama" (local,
+      # keyless) so this template runs with zero cloud credentials; swap in
+      # "openai" (openai.authSecretRef + openai.baseURL) or another
+      # supported provider for production use.
+      - id: embed
+        plugin: "standalone:ai.embed"
+        settings:
+          provider: ollama
+          # nomic-embed-text is a common local Ollama embedding model,
+          # 768-dimensional — the pgvector destination's "dimension"
+          # setting above MUST match whatever model you actually use.
+          model: nomic-embed-text
+          ollama.baseURL: http://localhost:11434
+          requestTimeout: 30s
+          maxRetries: "5"
+          # inputField/outputField are left at their defaults
+          # (".Payload.After.text" / ".Payload.After.vector") — matching
+          # ai.chunk's default output and the pgvector destination's
+          # default vectorField respectively, with zero field configuration
+          # needed between all three components.


### PR DESCRIPTION
## What & why

Adds the `postgres-pgvector-rag` templates-gallery template — the one-command RAG scaffold (Postgres CDC → chunk → embed → pgvector) that ROADMAP.md line 143 commits to — plus a **scoped exception** to the gallery's built-in-only enforcement so this one template may declare its non-built-in deps while the rule stays strict for every other template. Completes the v0.20 WS8 AI-pipeline body of work's distribution layer.

## Risk tier: **Tier-1-adjacent** (changes a shipped subsystem's enforcement, run at package init)

## The scoped exception (the delicate part)

`GalleryTemplate.AllowedNonBuiltin []string` names the exact non-built-in plugins ONE template may reference. Gated at both enforcement sites **per-entry**:
- `validateGalleryCatalog` (package-init): `!isBuiltinConnectorName(t.Source) && !slices.Contains(t.AllowedNonBuiltin, t.Source)` (same for Destination).
- `validateGalleryTemplateConnectors` (scaffold-time): a plugin in `tmpl.AllowedNonBuiltin` skips the built-in spec check.

Only the pgvector template carries `AllowedNonBuiltin: []string{"pgvector"}`. Because the check is per-entry, a template with an empty allowlist naming a non-built-in **still fails** — the invariant stays as hard as before for everyone else.

**Proof the scoping holds** (non-tautological): `TestValidateGalleryCatalog_RejectsNonBuiltinConnector_ScopedToOneTemplate` builds a catalog where two entries name the *same* non-built-in connector, only one allowlisted — asserts the non-allowlisted entry still fails (error names it), and that the allowlisted entry passes in isolation. Plus the scaffold-time analog. The original hard-reject baseline test is unchanged.

## Template

`templates/postgres-pgvector-rag/{pipeline.yaml,README.md}`: `builtin:postgres` → `standalone:ai.chunk` → `standalone:ai.embed` → `standalone:pgvector`. Field shapes verified against the real components (not guessed): chunk `.Payload.After.text` → embed reads it, writes `.Payload.After.vector` → pgvector `vectorField: vector`, delete-by-`source_key` — zero inter-stage field config, matching what `rag-e2e` proves. `dimension: 768` matches the `nomic-embed-text` Ollama model in the template.

## init preflight note

`conduit pipelines init --template postgres-pgvector-rag` emits the YAML **and** a prerequisites note (both `--json` and human), naming `conduit connectors install pgvector@<version>` and stating **plainly that no `conduit processor-plugins install` command exists in this build** — with the manual `GOOS=wasip1 GOARCH=wasm go build` + `--processors.path` placement steps. Never a bare YAML that fails opaquely. A converse test asserts built-in-only templates get no such note.

## Gallery e2e — honestly deferred, not faked

Design §8 wants the template validated by *running* it. No test in the repo drives the full `pkg/conduit` engine with a standalone WASM processor **and** a standalone external connector loaded together — `rag_e2e_test.go` proves the exact chunk→embed→pgvector shape but at the package level (hand-instantiating the guest + connector, bypassing engine discovery + YAML). A true template-gallery-e2e needs a materially new harness (engine boot + `--processors.path`/`--connectors.path` discovery + mock Ollama + docker pgvector). Per "don't hack this," I did **not** build a fake/no-op e2e; `rag-e2e` is the component-level proof in the meantime. Flagged as the follow-up.

## ROADMAP

I did **not** check off ROADMAP.md line 143 — the connector/processor deps aren't installable through any shipped command in this build (the gap the preflight note states). That call is yours.

## Tests / checks

`go build ./...`, `go test -race ./cmd/conduit/root/pipelines/...`, golangci-lint (v2.12.2) + gofumpt — all clean.
