### PR TITLE
fix(processor): strip host-reserved sdk.egress.* keys before guest Configure

### DIFF
--- a/pkg/plugin/processor/egress/config.go
+++ b/pkg/plugin/processor/egress/config.go
@@ -39,6 +39,31 @@ const (
 	ConfigKeySecretRefs = "sdk.egress.secretRefs" //nolint:gosec // config key name, not a credential value
 )
 
+// reservedKeyPrefix is the host-reserved processor-config namespace. Every key
+// under it is consumed HOST-SIDE by PolicyFromSettings at processor-open time
+// and is never meant to reach guest code — the design mandates egress config be
+// "host-reserved ... immutable from guest code"
+// (docs/design-documents/20260726-wasm-host-egress-capability.md). StripReservedKeys
+// removes the whole namespace so a standalone processor that strictly validates
+// its declared parameters does not reject the operator's egress opt-in as an
+// "unrecognized parameter".
+const reservedKeyPrefix = "sdk.egress."
+
+// StripReservedKeys deletes every host-reserved egress config key (the
+// sdk.egress.* namespace) from settings, mutating it in place. Call it on the
+// clone of a processor's Settings handed to Configure, AFTER PolicyFromSettings
+// has consumed the same keys host-side (they are read from the instance's own
+// Settings, not from this stripped clone, so removing them here does not affect
+// policy resolution). Stripping by prefix — rather than the four known
+// constants — keeps a future sdk.egress.* sub-key host-reserved automatically.
+func StripReservedKeys(settings map[string]string) {
+	for k := range settings {
+		if strings.HasPrefix(k, reservedKeyPrefix) {
+			delete(settings, k)
+		}
+	}
+}
+
 // splitList splits a comma/whitespace-separated config value into trimmed,
 // non-empty tokens.
 func splitList(raw string) []string {

--- a/pkg/processor/runnable_processor.go
+++ b/pkg/processor/runnable_processor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/conduitio/conduit-commons/opencdc"
 	sdk "github.com/conduitio/conduit-processor-sdk"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/plugin/processor/egress"
 )
 
 // RunnableProcessor is a stream.Processor which has been
@@ -44,7 +45,16 @@ func newRunnableProcessor(
 }
 
 func (p *RunnableProcessor) Open(ctx context.Context) error {
-	err := p.proc.Configure(ctx, maps.Clone(p.Config.Settings))
+	// Host-reserved sdk.egress.* keys are consumed host-side by
+	// Service.resolveEgressPolicy (from the instance's own Settings); strip them
+	// from the clone handed to the guest so a processor that strictly validates
+	// its declared parameters does not reject the operator's egress opt-in as an
+	// "unrecognized parameter". The guest must never see host-reserved config
+	// (design: 20260726-wasm-host-egress-capability.md).
+	settings := maps.Clone(p.Config.Settings)
+	egress.StripReservedKeys(settings)
+
+	err := p.proc.Configure(ctx, settings)
 	if err != nil {
 		return cerrors.Errorf("failed configuring processor: %w", err)
 	}

--- a/pkg/processor/runnable_processor_test.go
+++ b/pkg/processor/runnable_processor_test.go
@@ -20,15 +20,66 @@ import (
 	"time"
 
 	"github.com/conduitio/conduit-commons/cchan"
+	"github.com/conduitio/conduit-commons/config"
 	"github.com/conduitio/conduit-commons/opencdc"
 	sdk "github.com/conduitio/conduit-processor-sdk"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/inspector"
+	"github.com/conduitio/conduit/pkg/plugin/processor/egress"
 	"github.com/conduitio/conduit/pkg/plugin/processor/mock"
 	"github.com/matryer/is"
 	"go.uber.org/mock/gomock"
 )
+
+// TestRunnableProcessor_Open_StripsHostReservedEgressKeys is the regression test
+// for the bug the engine-level RAG template e2e surfaced: the host-reserved
+// sdk.egress.* config keys (consumed host-side by Service.resolveEgressPolicy)
+// were passed through to the guest's Configure, where a standalone processor
+// that strictly validates its declared parameters rejected them as
+// "unrecognized parameter" — so no pipeline could opt a WASM processor into
+// egress via YAML. Open must strip the sdk.egress.* namespace from the settings
+// handed to Configure while leaving the instance's own Settings (and every
+// non-reserved key) intact.
+func TestRunnableProcessor_Open_StripsHostReservedEgressKeys(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	inst := &Instance{
+		Config: Config{
+			Settings: config.Config{
+				"model":                    "nomic-embed-text",
+				egress.ConfigKeyAllow:      "http://127.0.0.1:11434",
+				egress.ConfigKeyTimeout:    "30s",
+				egress.ConfigKeySecretRefs: "openai-key",
+			},
+		},
+	}
+
+	var gotSettings config.Config
+	proc := mock.NewProcessor(gomock.NewController(t))
+	proc.EXPECT().
+		Configure(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, s config.Config) error {
+			gotSettings = s
+			return nil
+		})
+	proc.EXPECT().Open(gomock.Any()).Return(nil)
+
+	underTest := newRunnableProcessor(proc, nil, inst)
+	is.NoErr(underTest.Open(ctx))
+
+	// No host-reserved sdk.egress.* key reaches the guest.
+	for _, k := range []string{egress.ConfigKeyAllow, egress.ConfigKeyTimeout, egress.ConfigKeySecretRefs} {
+		_, present := gotSettings[k]
+		is.True(!present)
+	}
+	// Non-reserved settings are preserved.
+	is.Equal(gotSettings["model"], "nomic-embed-text")
+	// The instance's own Settings are untouched — resolveEgressPolicy reads them.
+	_, instanceStillHasAllow := inst.Config.Settings[egress.ConfigKeyAllow]
+	is.True(instanceStillHasAllow)
+}
 
 func TestRunnableProcessor_Open(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## What & why

The engine reads the host-reserved `sdk.egress.*` config keys **host-side** (`Service.resolveEgressPolicy` → `egress.PolicyFromSettings`) to build a processor's egress policy, but `RunnableProcessor.Open` then passed the **same** settings map — egress keys included — to the guest's `Configure`. A standalone WASM processor that strictly validates its declared parameters (e.g. `conduit-processor-ai`'s `ai.embed`) rejects `sdk.egress.allow` as an `"unrecognized parameter"`, so **no pipeline could opt a WASM processor into egress via YAML**.

The shipped host-egress design mandates these keys be *"host-reserved … immutable from guest code"* (`docs/design-documents/20260726-wasm-host-egress-capability.md`); the guest must never see them.

**Fix:** `egress.StripReservedKeys` removes the whole `sdk.egress.*` namespace from the settings clone handed to `Configure`, after policy resolution has consumed the same keys from the instance's own (unmodified) `Settings`. Policy resolution is unaffected.

## How it was found

Surfaced by the new engine-level RAG template e2e (`test/rag-template-engine-e2e`). The component-level `rag_e2e` / `embedding_bundle_e2e` tests inject the egress policy directly into the processor constructor and never exercised the YAML settings path, so they missed it.

## Risk tier: **1** (egress is a security boundary)

Change is in the **safe direction** — the guest sees strictly *less* config; the host-side policy resolution (the actual security control) is untouched, still reading the instance's own `Settings`.

### Failure-mode analysis
- **What could this break?** If a processor legitimately declared a param literally named `sdk.egress.*`, it would no longer receive it. No processor does (the namespace is reserved by design); `sdk.egress.*` is consumed exclusively host-side.
- **Could it weaken egress?** No. `resolveEgressPolicy` reads `i.Config.Settings` (the instance's own map), not the stripped clone — the allowlist/policy is derived from the original, unmodified settings. Stripping only affects what reaches the guest's `Configure`.
- **Which signal would show a regression?** A processor failing to open with a config-validation error, or (hypothetically) an egress allowlist not taking effect — covered by the new `TestRunnableProcessor_Open_StripsHostReservedEgressKeys` and the RAG e2e's create path (embed reaches the mock provider only when the policy resolves correctly).
- **Rollback:** revert the commit; behavior returns to passing all keys through (the broken state).

### Tests
- Ships the regression test that would have caught it: `TestRunnableProcessor_Open_StripsHostReservedEgressKeys` (asserts `sdk.egress.*` never reaches `Configure`, non-reserved keys preserved, instance `Settings` untouched).
- Verified locally: `go test -race ./pkg/processor/... ./pkg/plugin/processor/egress/...` green; `go vet` + `golangci-lint` (v2.12.2, CI-exact) clean.
- End-to-end: with this fix the RAG template e2e's **create path** passes (embed opts into egress via YAML and reaches the provider).

### Sign-off
Tier-1 human sign-off received from DeVaris (maintainer) for this change.

Roadmap: WS8 (AI-pipeline components), unblocks per-processor egress opt-in via pipeline YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD