### PR TITLE
feat(registry): index schema carries WASM-processor artifacts + ADR/design (Tier-1, PR-A)

### DIFF
--- a/docs/architecture-decision-records/20260727-processors-ride-connector-registry.md
+++ b/docs/architecture-decision-records/20260727-processors-ride-connector-registry.md
@@ -1,0 +1,153 @@
+# Standalone WASM processors ride the connector registry trust core
+
+## Summary
+
+**Status: proposed — pending ratification and DeVaris (Tier-1) sign-off. Not yet binding.** An ADR
+takes effect only once merged; until then the direction below is proposed, not in force.
+
+Standalone WASM processors (`conduit-processor-ai`'s `ai.chunk`, `ai.embed`, and future AI-pipeline
+components) have no install path today: an operator must hand-build the `.wasm`
+(`GOOS=wasip1 GOARCH=wasm go build ...`) and drop it into `--processors.path` by hand. The shipped
+`postgres-pgvector-rag` template README says so in as many words
+(`cmd/conduit/root/pipelines/templates/postgres-pgvector-rag/README.md:33-36`, "No install command
+exists yet.").
+
+**Decision:** processors are distributed through the **same signed connector registry and the same
+`pkg/registry` install pipeline** — one supply-chain trust core, not a second one — extended to
+carry a WASM-processor artifact kind. We do **not** build a parallel processor-only registry or a
+second signature/provenance verifier. The index-schema extension that makes this possible is a
+signed, frozen public-contract change specified in its companion design doc
+([20260727-registry-processor-artifacts](../design-documents/20260727-registry-processor-artifacts.md));
+this ADR records the _decision_ (one trust core) that the design doc's schema work implements.
+
+## Context
+
+The connector supply chain is production-hardened and is the security-critical core of the registry:
+`conduit connectors install <name>[@version]` resolves a name/version against a **signed** index,
+downloads the host-platform artifact, verifies its signature + SLSA provenance against the
+connector's pinned publisher identity, and atomically places the binary into `--connectors.path`
+(`cmd/conduit/root/connectors/install.go`, `pkg/registry/install.go`). Integrity (sha256 vs the
+index's declared digest) and trust (signature + provenance vs pinned identity) are deliberately
+separate gates; the unsigned-install escape hatch is a single gated `policy.Decide` call, guarded by
+a `depguard` rule so it can never be bypassed by a copy.
+
+Three facts frame the decision:
+
+1. **The registry is connector-only today.** `index.Payload` carries exactly one artifact-bearing
+   collection, `Connectors []Connector` (`pkg/registry/index/schema_v1.go:36-40`); resolution
+   iterates `payload.Connectors` by exact name (`pkg/registry/resolve.go:97-107`); the install
+   pipeline recognizes exactly one artifact `Kind`, `StandaloneArtifactKind = "standalone"`
+   (`pkg/registry/platform.go:26-31`). A processor artifact kind was _anticipated_ — `platform.go`
+   comments that "a future kind (e.g. a WASM processor-shaped artifact) is skipped, not treated as
+   an error, by `SelectArtifact`" — but never implemented. Publish tooling (which signs an artifact
+   and adds its entry to the index) lives in the separate `conduit-connector-registry` repo and
+   emits no processors.
+
+2. **The runtime already discovers standalone processors from a directory.**
+   `proc_standalone.NewRegistry(logger, Config.Processors.Path, schemaService)` at engine startup
+   (`pkg/conduit/runtime.go:390`) scans every non-directory file in `--processors.path`, compiles
+   each as a WASM module, and registers it under the name+version from the module's own
+   `Specification()` — **not** from the filename (`pkg/plugin/processor/standalone/registry.go:296-306`).
+   Discovery is startup-only. So the install target is simply "place a verified `.wasm` under
+   `--processors.path`"; the runtime side needs no change.
+
+3. **WASM is arch-neutral.** A processor builds once as `GOOS=wasip1 GOARCH=wasm` and runs on any
+   host wazero supports. The connector path's host-`(GOOS,GOARCH)` artifact selection
+   (`platform.go:38-47`) is therefore _wrong_ for processors — matching the host platform would find
+   nothing on a `darwin/arm64` machine. A processor has exactly one artifact, selected by a fixed
+   `(wasip1, wasm)` rule.
+
+The WASM Component Model packaging move is deferred
+([20260722-wasm-component-model-deferred](20260722-wasm-component-model-deferred.md)); processors
+ship as today's core WASM modules on wazero, and this command installs exactly those.
+
+## Decision
+
+1. **One trust core.** Standalone processors are fetched, verified, and placed by the **same**
+   `pkg/registry` pipeline that serves connectors. Signature verification, SLSA provenance,
+   pinned-identity checks, the `policy.Decide` unsigned gate, index freeze/rollback protection, and
+   the fail-closed-by-construction guarantee are reused verbatim, never forked. This follows the
+   CLAUDE.md rule that CLI and MCP surfaces share code paths with "no divergent logic" — a duplicate
+   of a supply-chain security core is exactly the divergence that grows a second, weaker
+   implementation.
+
+2. **The registry index carries a processor artifact kind.** The signed index gains a way to
+   describe a WASM-processor artifact (a separate top-level `processors[]` collection is the
+   recommended shape — see the design doc for why it beats a unified list with a new `kind`). This is
+   a signed, frozen, public-contract change and is gated on its own design doc + this ADR + DeVaris
+   Tier-1 sign-off. It is the load-bearing 80%; the CLI command is the easy 20%.
+
+3. **The install pipeline becomes artifact-type-generic.** `pkg/registry`'s
+   download → verify → atomic-rename → manifest machinery is parameterized by target directory,
+   filename prefix, artifact kind, and audit label, with a WASM-aware `SelectArtifact` that matches
+   the fixed `(wasip1, wasm)` key. The default parameters preserve today's connector behavior
+   exactly — the unchanged connector test suite is the regression guard.
+
+4. **Install-time WASM validation.** The fetched artifact is wazero-compiled and its
+   `Specification()` extracted before the final atomic rename; a module that will not compile, or
+   whose spec `Name`/`Version` disagrees with the resolved index `name@version`, is refused at
+   install time rather than silently failing at the next `conduit run`. This closes the gap between
+   "index name" and "the name the runtime will actually register" (fact 2 above).
+
+5. **Discovery stays startup-time.** Installing a processor does not hot-load it into a running
+   engine; the contract is "install, then `conduit run`." (`run --dev` hot-reload is a future
+   ergonomic, not a requirement.)
+
+6. **Two-tranche rollout.** Tranche A ships an interim offline path (`--index-file`, `--bundle`, and
+   the _same_ gated `--allow-unsigned` local install connectors already have) so the RAG template is
+   unblocked before the hosted index serves processors. Tranche B is the north-star ergonomic —
+   `conduit processor-plugins install ai.embed` against the live signed index — and goes live once
+   the schema extension and the out-of-repo publish path land.
+
+### Alternatives considered
+
+- **A parallel processor-only registry / a `pkg/procregistry` that bypasses `pkg/registry`
+  (rejected).** Forks the trust core: signature verification, provenance, identity pinning, the
+  unsigned gate, and freeze/rollback protection would all be duplicated. The whole value of the
+  registry is one trust core; a second one is a second, weaker attack surface.
+- **Fetch-only from a URL / GitHub release, unsigned, no index entry (rejected as the durable
+  answer).** The WASM runs in-process under wazero with host-function egress, so an unsigned
+  arbitrary-URL install is a real supply-chain hole; it also cannot express `@version` resolution or
+  compatibility gates. A _gated, explicit_ local-unsigned install is retained only as part of
+  Tranche A, through the exact same `policy.Decide` gate connectors use — never a silent bypass.
+- **`--bundle`-only, defer online entirely (partial — adopted as Tranche A, not the whole answer).**
+  The connector path already has a fully-offline signed `--bundle` install; generalizing it to
+  processors unblocks the template first. But bundles still need publish/sign tooling to _produce_,
+  and the product ergonomic is `install ai.embed` against the live registry — so `--bundle` is the
+  interim, not the destination.
+
+## Consequences
+
+- **Positive.** One supply-chain trust core with real signing + provenance + identity pinning for
+  processors, at the same bar as connectors. Full CLI parity (`--json`, stable error codes,
+  `@version` resolution, `--dry-run`, idempotent re-install, gated `--allow-unsigned`). The runtime
+  side is untouched — discovery already works from `--processors.path`. The `postgres-pgvector-rag`
+  template's "init → install → run" story closes, unblocking `ROADMAP.md:142-143`.
+- **Negative / cost.** The prerequisite is a **Tier-1 signed-format change** to a frozen public
+  contract (the index schema), with its own design doc, upgrade test, golden-fixture regeneration,
+  and index-CI append-only-rule update — it cannot be short-cut. Until it and the out-of-repo publish
+  path land, only the Tranche-A offline install works; an online `install <name>` against the live
+  index must return an actionable `registry.processor_not_found` that points at the interim path, and
+  must never claim success against an index with no processor entries.
+- **Doc updates this ADR triggers.** The `postgres-pgvector-rag` README's "No install command exists
+  yet" note is replaced with the real commands once Tranche A lands; the AI-pipeline components design
+  doc's assumption that a processor-install path "already ships (v0.18)" is corrected by an errata note
+  (it is false — the registry is connector-only); `ROADMAP.md:137` "Community publishing" advances
+  when the out-of-repo publish path lands.
+
+## Related
+
+- [20260727-registry-processor-artifacts](../design-documents/20260727-registry-processor-artifacts.md)
+  — the companion design doc: the index-schema extension (the signed-format public-contract change
+  this ADR's decision depends on)
+- [20260714-connector-registry-index-schema](../design-documents/20260714-connector-registry-index-schema.md)
+  — the frozen connector index schema + trust model this extends
+- [20260713-connector-registry-mvp](../design-documents/20260713-connector-registry-mvp.md) — the
+  registry epic
+- [20260722-wasm-component-model-deferred](20260722-wasm-component-model-deferred.md) — why processors
+  ship as core WASM modules on wazero (the artifact this command installs)
+- `cmd/conduit/root/connectors/install.go`, `pkg/registry/install.go` — the connector install
+  precedent reused
+- `conduit-connector-registry` — where the out-of-repo publish path (Tranche B prerequisite) lands
+- `ROADMAP.md:135-138, 142-143` — registry / public-publishing and the `postgres-pgvector-rag`
+  gallery item this unblocks

--- a/docs/design-documents/20260727-registry-processor-artifacts.md
+++ b/docs/design-documents/20260727-registry-processor-artifacts.md
@@ -1,0 +1,249 @@
+# Registry index: carrying WASM-processor artifacts
+
+## Summary
+
+This design doc extends the frozen connector-registry index schema
+([20260714-connector-registry-index-schema](20260714-connector-registry-index-schema.md)) to carry
+**standalone WASM-processor artifacts**, so `conduit processor-plugins install` can fetch, verify,
+and place them through the same signed trust core connectors use. The decision that processors ride
+that one trust core (rather than a parallel registry) is recorded in the companion ADR
+([20260727-processors-ride-connector-registry](../architecture-decision-records/20260727-processors-ride-connector-registry.md));
+this doc covers the _schema_ change — a signed, frozen, public-contract format — its failure modes,
+and its upgrade/rollback story.
+
+**Recommended shape:** add a top-level `processors []Processor` collection to `index.Payload`,
+mirroring `connectors[]` and reusing the `Publisher` / `Revocation` / `YankReason` shapes, with a
+single arch-neutral artifact per version selected by a fixed `(wasip1, wasm)` rule — **additive under
+`schemaVersion` 1** (forward-compatible: older clients ignore it and keep installing connectors).
+The load-bearing decision for DeVaris is forward-compat-vs-fail-closed (§ Upgrade/rollback, OQ-1).
+
+This is a design artifact, not running code. It invents no CLI surface beyond what the ADR and the
+`processor-plugins install` plan already name.
+
+## Problem
+
+The signed index is connector-only:
+
+- `index.Payload{ SchemaVersion, Index, Connectors []Connector }` — one artifact-bearing collection,
+  no processors (`pkg/registry/index/schema_v1.go:36-40`).
+- Resolution iterates `payload.Connectors` by exact name (`pkg/registry/resolve.go:97-107`).
+- The install pipeline recognizes one artifact `Kind`, `StandaloneArtifactKind = "standalone"`, and
+  selects the artifact matching the host `(runtime.GOOS, runtime.GOARCH)`
+  (`pkg/registry/platform.go:26-31, 38-47`).
+
+A WASM processor cannot be described by any of that. It is arch-neutral (one `GOOS=wasip1
+GOARCH=wasm` build runs everywhere), so host-platform selection would find nothing; and there is no
+collection to resolve its name against. The runtime side is already fine — the standalone processor
+registry discovers any `.wasm` placed under `--processors.path` and registers it under the name from
+its own `Specification()` (`pkg/plugin/processor/standalone/registry.go:296-306`) — so the entire gap
+is on the _index/publish_ side. Until it is closed, the `postgres-pgvector-rag` template's
+`ai.chunk` / `ai.embed` processors have no verified install path
+(`cmd/conduit/root/pipelines/templates/postgres-pgvector-rag/README.md:33-36`).
+
+## Constraints (inherited from the frozen trust model — non-negotiable)
+
+The extension must not weaken any property frozen by the R-1 schema doc:
+
+1. **Everything a client trusts lives inside the signed `payload`.** The processor collection,
+   including every artifact `url` / `sha256` / `signature` / `slsaProvenance` and every publisher
+   identity, must be _inside_ `payload`, covered by the signature — no unsigned mirror.
+2. **Verify-before-parse, on the generic untyped payload.** Signature verification canonicalizes
+   (JCS / RFC 8785) and verifies the _whole_ `payload` object's bytes before any schema-version-typed
+   unmarshal (R-1 §a). This is what makes the additive change forward-compatible (see below): an older
+   client canonicalizes and verifies the exact bytes it received — including `processors[]` — even
+   though it will not unmarshal that field into its typed struct.
+3. **`schemaVersion` is inside the signed payload** precisely to prevent a schema-confusion downgrade
+   (R-1 §a). Any change to how `schemaVersion` gates parsing is security-relevant.
+4. **Append-only, tamper-evident.** index-CI rejects a PR mutating any field of an already-published
+   version other than `deprecated` / `yanked` (R-1 §d item 4). The processor collection must inherit
+   the same append-only rule and the same registration-vs-version-bump review split.
+5. **Root vs freshness key split.** The reviewer-gated **root** key authorizes content; the
+   unattended **freshness** key may only re-sign when the _content subtree_ is byte-identical to the
+   last root-signed content (R-1 §a, OQ3). Today "content subtree" means `connectors[]`; it must be
+   redefined to `connectors[]` **and** `processors[]`, or a freshness re-sign could silently authorize
+   a changed processor tree.
+6. **One trust core.** No new verifier, no forked signature/provenance/identity path (the ADR's
+   decision 1).
+
+## Decision
+
+### D1 — A separate `processors []Processor` collection (recommended over a unified `kind`)
+
+Add to `index.Payload`:
+
+```go
+type Payload struct {
+    SchemaVersion int         `json:"schemaVersion"`
+    Index         IndexMeta   `json:"index"`
+    Connectors    []Connector `json:"connectors"`
+    Processors    []Processor `json:"processors,omitempty"` // NEW
+}
+
+// Processor is one registered standalone-WASM-processor name's entry. It
+// reuses Publisher/Revocation identity-pinning exactly as Connector does.
+type Processor struct {
+    Name        string             `json:"name"`
+    DisplayName string             `json:"displayName,omitempty"`
+    Description string             `json:"description,omitempty"`
+    Repository  string             `json:"repository,omitempty"`
+    Publisher   Publisher          `json:"publisher"`
+    Versions    []ProcessorVersion `json:"versions"`
+}
+
+// ProcessorVersion is one published release. Unlike ConnectorVersion it has
+// exactly one arch-neutral artifact (wasip1/wasm), not a per-(os,arch) list.
+type ProcessorVersion struct {
+    Version            string      `json:"version"`
+    ReleasedAt         *time.Time  `json:"releasedAt,omitempty"`
+    MinConduitVersion  string      `json:"minConduitVersion"`
+    MinProtocolVersion string      `json:"minProtocolVersion"`
+    Artifact           Artifact    `json:"artifact"` // single, kind:"wasm-processor"
+    SLSAProvenance     *ProvenanceRef `json:"slsaProvenance,omitempty"`
+    Deprecated         bool        `json:"deprecated"`
+    Yanked             *YankReason `json:"yanked,omitempty"`
+}
+```
+
+The `Artifact` struct is reused as-is; a processor artifact sets `Kind: "wasm-processor"`,
+`OS: "wasip1"`, `Arch: "wasm"`. `Publisher`, `Revocation`, `YankReason`, `Artifact`,
+`SignatureRef`, `ProvenanceRef` are shared verbatim — identity pinning, revocation, yank, and the
+per-artifact Sigstore-bundle signature all behave identically to connectors.
+
+**Why a separate collection rather than a unified artifact list with a new `kind`:** it keeps
+`SelectArtifact`'s host-`(GOOS,GOARCH)` logic (correct for connectors) completely untouched and
+isolates the "single arch-neutral artifact" selection in a dedicated `ProcessorVersion.Artifact`
+field, so a wasm processor structurally _cannot_ accidentally acquire a per-platform artifact list or
+be host-matched. A unified list forces `SelectArtifact` to branch on `kind` and keeps the arch-neutral
+special case live inside the connector path. Fewer types is not worth reintroducing that coupling into
+a security-critical selector.
+
+### D2 — Arch-neutral selection
+
+A processor version has exactly one artifact. A `SelectProcessorArtifact` returns
+`ProcessorVersion.Artifact` after asserting `Kind == "wasm-processor"` and
+`(OS, Arch) == (wasip1, wasm)` — it never consults `runtime.GOOS`/`runtime.GOARCH`. `SelectArtifact`
+(connectors) is unchanged. A malformed processor entry carrying a per-host artifact list, or a host
+os/arch, is a schema/validation error, not a silent skip.
+
+### D3 — Resolution and the install pipeline
+
+`Resolve` gains a processor path that iterates `payload.Processors` by exact name (anti-typosquat, no
+fuzzy match), newest-non-yanked-compatible when `@version` is omitted, refusing revoked publisher /
+yanked pinned version / incompatible min-versions — the _same_ logic as connectors, over the
+processor collection. The install pipeline is parameterized (target dir `--processors.path`, filename
+prefix `conduit-processor-`, artifact kind, audit label `processor_install`) per the ADR; the
+download → verify → atomic-rename → manifest core is shared. See the `processor-plugins install` plan
+for the pipeline generalization and install-time WASM validation.
+
+### D4 — Freshness "content subtree" redefinition
+
+The freshness-key acceptance rule (R-1 §a, OQ3) is extended: a `freshness`-only signature is accepted
+only when **both** `connectors[]` and `processors[]` are byte-identical to what was last verified
+under a `root` signature. Implementation: the freshness re-sign's byte-identical comparison covers the
+full content subtree, not just `connectors[]`. Without this, the unattended freshness key could
+re-sign a mutated processor tree — a content-authorization escalation.
+
+## Alternatives considered
+
+- **Unified artifact list + new `kind:"wasm-processor"` (rejected — see D1).** Fewer types, but
+  forces the security-critical `SelectArtifact` to branch on kind and keeps arch-neutral handling
+  inside the connector selector. Rejected to keep the connector path untouched.
+- **Bump `schemaVersion` to 2 for the additive change (rejected as the default — see Upgrade).**
+  Correct-feeling but costly: every already-deployed client has `MaxSupportedSchemaVersion = 1`
+  (`schema_v1.go:23`) and would refuse the _entire_ index with `CodeSchemaTooNew` — breaking
+  _connector_ installs for everyone until they upgrade, for a purely additive field they could safely
+  ignore. Reserve a version bump for a genuinely non-additive change.
+- **Separate processor-only index document served at a different URL (rejected).** Two indexes, two
+  fetch/verify pipelines, two freshness stories, two rollback high-water marks. Doubles the trust
+  surface for no benefit; contradicts the ADR's one-trust-core decision.
+- **A second trust core / unsigned URL fetch (rejected in the ADR).** See the ADR's Alternatives.
+
+## Failure modes
+
+1. **Older client fetches an index that now contains `processors[]`.**
+   With the additive-under-v1 choice: the client canonicalizes and verifies the whole payload
+   (signature still valid), unmarshals
+   into its `schemaVersion:1` struct, and Go silently ignores the unknown `processors` field. It keeps
+   installing connectors normally; it simply has no processor-install command and never sees the field.
+   _This is the forward-compat behavior — and the exact thing OQ-1 asks DeVaris to confirm is desired
+   (vs. fail-closed)._ If instead we want old clients to _reject_ a processor-bearing index, that
+   requires a `schemaVersion` bump and its breakage cost (above).
+2. **Freshness key re-signs a mutated processor tree.** Prevented by D4 (content subtree covers
+   `processors[]`). A test must assert a freshness signature is rejected when only `processors[]`
+   differs from the last root-signed content.
+3. **Processor entry carries a host-platform artifact list (malformed / spoofed).** `SelectProcessor
+   Artifact` asserts the single arch-neutral artifact and `(wasip1, wasm)`; a per-host list or a host
+   os/arch is a validation error, not a silent skip (contrast the connector path's deliberate
+   skip-unknown-kind). Prevents a processor entry from smuggling host-targeted selection.
+4. **Name collision across collections** (`connectors[]` and `processors[]` both have `foo`).
+   Legitimate — they are different plugin types resolved by different commands
+   (`conduit connectors install foo` vs `conduit processor-plugins install foo`) and land in different
+   directories. No cross-collection uniqueness constraint; but index-CI should warn on a cross-collection
+   name clash to reduce operator confusion.
+5. **Duplicate `name` within `processors[]`.** Same rejection as duplicate connector names — a
+   parse-time / index-CI error. The R-1 parse-time duplicate-_key_ rejection (a signature-bypass
+   primitive) is unchanged and already covers duplicate JSON keys at any nesting level.
+6. **Golden round-trip fixture drift.** Adding `processors[]` (even `omitempty`) changes the canonical
+   bytes of any index that includes it. The `index/testdata` golden fixtures and `sample-index.json`
+   must be regenerated with at least one processor entry, and the round-trip / canonicalization tests
+   updated in the same PR. An `omitempty` empty `processors` must NOT appear for a connector-only index
+   (so existing connector-only golden fixtures stay byte-identical) — verify this explicitly, because
+   the `Deprecated bool` field's history shows omitempty/default choices are load-bearing for the
+   golden tests (`schema_v1.go:98-102`).
+7. **index-CI routing gap.** Registering a _processor_ publisher identity (e.g. `conduit-processor-ai`)
+   must route to the human-reviewed registration bucket; adding a processor _version_ from an
+   already-pinned identity is auto-mergeable only after index-CI re-fetches the artifact, recomputes
+   sha256, and re-runs cosign verify/verify-attestation against the _currently committed_ identity —
+   the exact §d split, extended to `processors[]`. A routing rule that only inspects `connectors[]`
+   would let a processor identity change bypass human review. Must be updated in lockstep.
+8. **`predicateType` / provenance shape for wasm.** The publish Action (out-of-repo, Tranche B) emits
+   the processor's Sigstore bundle + SLSA provenance; the subject-digest binding (R-1 §c step 7) must
+   match the `.wasm` artifact digest. No schema change — `Artifact`/`ProvenanceRef` are reused — but
+   flagged so the Action's output shape is confirmed against this, not discovered later.
+
+## Upgrade / rollback
+
+- **Serialized-format change, Tier-1.** The signed index schema gains a collection. **Recommended:
+  additive under `schemaVersion` 1**, forward-compatible — older clients ignore `processors[]` and
+  keep verifying/installing connectors (failure mode 1). `MaxSupportedSchemaVersion` stays `1`. The
+  freeze/canonicalization rules (`pkg/registry/index/freeze.go`, `canonicalize.go`) need no algorithm
+  change (JCS already canonicalizes the whole payload), but the golden fixtures and
+  `sample-index.json` are regenerated (failure mode 6), and the index-CI append-only + routing rules
+  are extended to `processors[]` (failure modes 5, 7). **Ships with an upgrade test:** an older-schema
+  client verifies and reads a processor-bearing index without error and still installs a connector
+  from it; a current client installs a processor from it.
+- **Rollback of the schema change** is the hard part (removing the field after clients have written
+  processor manifests) — which is why it lands as its own reviewed, upgrade-tested PR (PR-A in the
+  plan) _before_ the CLI, and why the field is additive (an additive field is far cheaper to freeze
+  correctly than a structural change).
+- **The processor install manifest** reuses `ManifestSchemaVersion = 1` unchanged — a new file at a
+  new path (`<processors.path>/.registry/manifest.json`), no migration of existing connector
+  manifests.
+
+## Observability
+
+- No new index-side observability surface; the index is a static signed document. Client-side, the
+  processor `install`/`uninstall` emit structured `--json` results and `processor_install` /
+  `processor_uninstall` audit events (per the plan), mirroring connectors — so a processor's
+  provenance/identity/digest is auditable exactly as a connector's is via `conduit connectors audit`'s
+  processor-aware sibling.
+- index-CI logs the routing decision (registration vs version-bump) and the re-verification result for
+  each processor PR, the same as connectors — so a processor identity change is visible in the merge
+  trail.
+
+## Open questions for DeVaris
+
+1. **Forward-compat vs fail-closed (the load-bearing one).** Additive under `schemaVersion` 1 —
+   recommended — means older clients silently ignore `processors[]` and keep working (they have no
+   processor command anyway). The alternative — an older client should _reject_ a processor-bearing
+   index — requires a `schemaVersion` bump and breaks _connector_ installs for every un-upgraded client
+   until they upgrade. Recommend additive/forward-compat. Confirm.
+2. **Schema shape:** separate `processors []Processor` collection (recommended, D1) vs unified list
+   with `kind`. Confirm the separate collection.
+3. **Cross-collection name clash** (failure mode 4): warn-only in index-CI (recommended) vs hard-reject
+   a name present in both `connectors[]` and `processors[]`.
+4. **Publish tooling home:** confirm processor publish belongs in `conduit-connector-registry`
+   alongside connector publish (one publish pipeline, two artifact kinds) — this doc assumes yes.
+5. **`slsaProvenance` level** for a single-artifact processor version: version-level `SLSAProvenance`
+   (there is only one artifact, so per-artifact vs per-version collapses) — confirm the publish Action
+   emits it at the version level.

--- a/docs/design-documents/registry-index/index-schema.json
+++ b/docs/design-documents/registry-index/index-schema.json
@@ -49,6 +49,11 @@
           "type": "array",
           "description": "One entry per registered connector name. Names are unique within the index (index-CI enforces this; JSON Schema alone cannot express cross-array uniqueness on a subfield, see r1-spec.md).",
           "items": { "$ref": "#/$defs/connector" }
+        },
+        "processors": {
+          "type": "array",
+          "description": "One entry per registered standalone-WASM-processor name. Added additively under schemaVersion 1 (see docs/design-documents/20260727-registry-processor-artifacts.md, D1): a client built before this field existed verifies the whole payload (this array included) and then silently ignores it, still installing connectors. NOT in payload.required -- a connector-only index omits the key entirely, keeping its bytes identical to the pre-processor schema. Names are unique within processors[] (index-CI enforces this, same as connectors[]); a name may legitimately appear in BOTH connectors[] and processors[] (different plugin types, different install commands, different directories).",
+          "items": { "$ref": "#/$defs/processor" }
         }
       }
     },
@@ -111,6 +116,40 @@
           "type": "array",
           "description": "Published versions for this connector, newest-first by convention (not schema-enforced). Entries are append-only once published: index-CI must reject a PR that mutates any field of an already-present version other than `deprecated`, `yanked`, or `yanked.reason`/`yanked.yankedAt` (see r1-spec.md §(d)).",
           "items": { "$ref": "#/$defs/connectorVersion" }
+        }
+      }
+    },
+
+    "processor": {
+      "type": "object",
+      "description": "One registered standalone-WASM-processor name. Mirrors `connector` and reuses `publisher` (identity pinning) and `yankReason`/`revocation` verbatim -- a processor's root-of-trust decision behaves identically to a connector's. Deliberately a SEPARATE collection rather than a `connector` with a new artifact kind, so the connector's host-(os,arch) artifact selection stays untouched (see docs/design-documents/20260727-registry-processor-artifacts.md, D1).",
+      "additionalProperties": false,
+      "required": ["name", "publisher", "versions"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+          "description": "Unique registry name for the processor, e.g. \"conduit-processor-ai\". Same naming rule as a connector. Resolution by `install` is exact-match only. The runtime registers the processor under the name from its own Specification(), NOT this index name -- install-time validation (PR-B) binds the two."
+        },
+        "displayName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-friendly name for the web UI. Not used in any trust decision."
+        },
+        "description": {
+          "type": "string",
+          "description": "Short description for the web UI / `list`. Not used in any trust decision."
+        },
+        "repository": {
+          "type": "string",
+          "format": "uri",
+          "description": "Source repository URL, for the web UI and human review context. Not itself a trust input -- the trust input is `publisher.expectedIdentityPattern`."
+        },
+        "publisher": { "$ref": "#/$defs/publisher" },
+        "versions": {
+          "type": "array",
+          "description": "Published versions for this processor, newest-first by convention (not schema-enforced). Append-only once published, same rule as connectors[].versions (index-CI rejects mutating any field of an already-present version other than `deprecated`/`yanked`).",
+          "items": { "$ref": "#/$defs/processorVersion" }
         }
       }
     },
@@ -230,6 +269,99 @@
         "yanked": {
           "$ref": "#/$defs/yankReason",
           "description": "If present, this specific version is yanked (e.g. bad build, discovered vulnerability, accidental publish). `install` refuses selecting it (naming the reason); `conduit connectors audit` flags it if already installed. Does not affect sibling versions of the same connector."
+        }
+      }
+    },
+
+    "processorVersion": {
+      "type": "object",
+      "description": "One published processor release. Mirrors `connectorVersion` but carries a SINGLE arch-neutral `artifact` object (not an `artifacts` array): a WASM processor builds once as wasip1/wasm and runs everywhere, so there is exactly one artifact and no per-(os,arch) list (see docs/design-documents/20260727-registry-processor-artifacts.md, D1/D2).",
+      "additionalProperties": false,
+      "required": ["version", "minConduitVersion", "minProtocolVersion", "artifact"],
+      "properties": {
+        "version": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z.-]+)?(\\+[0-9A-Za-z.-]+)?$",
+          "description": "Semver version string of this processor release, e.g. \"0.1.0\". Immutable once published (append-only; see `processors[].versions` description)."
+        },
+        "releasedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When this version was published to the index. Used for web UI ordering and audit context; not itself a trust input."
+        },
+        "minConduitVersion": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+$",
+          "description": "Minimum Conduit engine version this processor version requires."
+        },
+        "minProtocolVersion": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+$",
+          "description": "Minimum conduit-processor-sdk/protocol version this processor version requires."
+        },
+        "artifact": {
+          "$ref": "#/$defs/processorArtifact",
+          "description": "The single arch-neutral (wasip1/wasm) WASM build for this version. Not an array: a processor has exactly one artifact, selected by a fixed (wasip1, wasm) rule that NEVER consults the host platform (D2). A per-host artifact list cannot even be expressed here -- that is the point of the separate collection."
+        },
+        "slsaProvenance": {
+          "$ref": "#/$defs/provenanceRef",
+          "description": "OPTIONAL SLSA provenance attestation for this version's single artifact. Version-level and per-artifact collapse here (there is only one artifact), so it is declared once at the version level."
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false,
+          "description": "Soft signal: still installable, but flagged (e.g. superseded, unmaintained). Same semantics as connectorVersion.deprecated."
+        },
+        "yanked": {
+          "$ref": "#/$defs/yankReason",
+          "description": "If present, this specific processor version is yanked. `install` refuses selecting it (naming the reason). Does not affect sibling versions of the same processor."
+        }
+      }
+    },
+
+    "processorArtifact": {
+      "type": "object",
+      "description": "One standalone-WASM-processor build. Structurally like `artifact` but pinned to the arch-neutral WASM target: os/arch/kind are fixed constants, so a host os/arch or a non-WASM kind is a schema violation, not a valid-but-skipped entry (D2, failure mode 3). Kept a SEPARATE def from `artifact` -- rather than widening the connector artifact's os/arch/kind enums -- so connector artifact validation stays byte-for-byte unchanged.",
+      "additionalProperties": false,
+      "required": ["os", "arch", "kind", "url", "sha256", "size", "signature"],
+      "properties": {
+        "os": {
+          "type": "string",
+          "const": "wasip1",
+          "description": "GOOS value, fixed to the WASI preview-1 target. A processor is arch-neutral; a host GOOS here is a malformed/spoofed entry."
+        },
+        "arch": {
+          "type": "string",
+          "const": "wasm",
+          "description": "GOARCH value, fixed to wasm. A host GOARCH here is a malformed/spoofed entry."
+        },
+        "kind": {
+          "type": "string",
+          "const": "wasm-processor",
+          "description": "Artifact kind for a standalone WASM processor module (wazero runtime). SelectProcessorArtifact asserts exactly this value."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Scarf-gatewayed download URL of the `.wasm` module. Inside the signed payload; the digest is always recomputed from the received bytes, so a compromised gateway can only cause a failed verification, never a wrong-artifact install."
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$",
+          "description": "Expected SHA-256 of the `.wasm` bytes. Corruption detection; the trust boundary is `signature` verified against the processor's pinned identity."
+        },
+        "size": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Expected artifact size in bytes."
+        },
+        "signature": {
+          "$ref": "#/$defs/signatureRef",
+          "description": "Reference to the Sigstore bundle covering THIS `.wasm` module's own digest. Required, same as a connector artifact."
+        },
+        "slsaProvenance": {
+          "$ref": "#/$defs/provenanceRef",
+          "description": "OPTIONAL per-artifact SLSA provenance. For a single-artifact processor version this is equivalent to processorVersion.slsaProvenance; the version-level field is preferred."
         }
       }
     },

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -614,7 +614,7 @@ Author: Meroxa, Inc.
 | `sdk.schema.extract.key.enabled` | bool | true | no | Whether to extract and decode the record key with a schema. |  |
 | `sdk.schema.extract.payload.enabled` | bool | true | no | Whether to extract and decode the record payload with a schema. |  |
 
-## 3. Error codes (83)
+## 3. Error codes (84)
 
 | Reason | gRPC status | Description |
 | --- | --- | --- |
@@ -678,6 +678,7 @@ Author: Meroxa, Inc.
 | `registry.index_too_large` | ResourceExhausted | CodeIndexTooLarge is raised when a fetched index exceeds the P0-2 size cap (plan-v2 §2.4 item 1). ResourceExhausted already carries a defined pkg/conduit/exitcode bucket (Environment) — see fetch.go's doc comment for the footnote this resolves. |
 | `registry.index_unreachable` | Unavailable | CodeIndexUnreachable is raised when fetching the index fails at the network/HTTP layer (distinct from a fetch that succeeds but is too large, stale, or rolled back). |
 | `registry.install_locked` | Unavailable | CodeInstallLocked is raised when the per-target install lock is not acquired within --lock-timeout. |
+| `registry.invalid_processor_artifact` | FailedPrecondition | CodeInvalidProcessorArtifact is raised by SelectProcessorArtifact when a processor version's single artifact is not the required arch-neutral WASM shape — Kind != "wasm-processor", or (OS, Arch) != ("wasip1", "wasm"). Unlike the connector path's SelectArtifact, which deliberately SKIPS an unrecognized kind ("no matching artifact"), a malformed processor artifact is a hard validation error, never a silent skip (design doc D2, failure mode 3): a processor has exactly one artifact and it must be the WASM one, so anything else is a malformed or spoofed index entry. FailedPrecondition — the index entry as published does not meet the precondition for install. |
 | `registry.no_platform_artifact` | NotFound | CodeNoPlatformArtifact is raised when no artifact exists for the host (os, arch). |
 | `registry.provenance_invalid` | PermissionDenied | CodeProvenanceInvalid is raised when the SLSA provenance's subject-digest match or builder.id/configSource.uri binding fails (trust.ErrProvenanceInvalid). |
 | `registry.schema_too_new` | FailedPrecondition | CodeSchemaTooNew is raised when payload.schemaVersion exceeds the highest this build was compiled to understand. |

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@
 (6 built-in connectors; full parameters in llms-full.txt)
 
 ## Error codes
-- 83 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
+- 84 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
 
 ## MCP tools
 - Read: deploy, doctor, dry_run, inspect, lint, repair, validate

--- a/pkg/registry/codes.go
+++ b/pkg/registry/codes.go
@@ -93,4 +93,14 @@ var (
 	// key not among them. Verification never proceeds when this is raised —
 	// it can only make installs fail closed, never open.
 	CodeTrustAnchorsUnavailable = conduiterr.Register("registry.trust_anchors_unavailable", codes.Internal)
+	// CodeInvalidProcessorArtifact is raised by SelectProcessorArtifact when a
+	// processor version's single artifact is not the required arch-neutral WASM
+	// shape — Kind != "wasm-processor", or (OS, Arch) != ("wasip1", "wasm").
+	// Unlike the connector path's SelectArtifact, which deliberately SKIPS an
+	// unrecognized kind ("no matching artifact"), a malformed processor artifact
+	// is a hard validation error, never a silent skip (design doc D2, failure
+	// mode 3): a processor has exactly one artifact and it must be the WASM one,
+	// so anything else is a malformed or spoofed index entry. FailedPrecondition
+	// — the index entry as published does not meet the precondition for install.
+	CodeInvalidProcessorArtifact = conduiterr.Register("registry.invalid_processor_artifact", codes.FailedPrecondition)
 )

--- a/pkg/registry/index/hash.go
+++ b/pkg/registry/index/hash.go
@@ -23,27 +23,46 @@ import (
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 )
 
-// HashConnectors returns "sha256:<hex>" over the JCS-canonicalized
-// connectors[] array — the value persisted in State.LastVerifiedConnectorsHash
-// and compared by Verify's freshness-only acceptance path (R-1 §a.2.c): a
-// freshness signature may only extend index.timestamp/index.version over
-// BYTE-IDENTICAL connectors[] content, never authorize different content on
-// its own. Hashing (rather than comparing raw canonical bytes directly) keeps
-// State small and gives a stable, loggable value for diagnostics.
+// HashContentSubtree returns "sha256:<hex>" over the JCS-canonicalized
+// CONTENT SUBTREE of the index — the {connectors[], processors[]} pair — the
+// value persisted in State.LastVerifiedContentHash and compared by Verify's
+// freshness-only acceptance path (R-1 §a.2.c; design doc
+// 20260727-registry-processor-artifacts, D4): a freshness signature may only
+// extend index.timestamp/index.version over BYTE-IDENTICAL content, never
+// authorize different content on its own. Hashing (rather than comparing raw
+// canonical bytes directly) keeps State small and gives a stable, loggable
+// value for diagnostics.
 //
-// The hash is computed over the canonicalized connectors array alone (not the
-// full payload, which also carries index.version/timestamp that legitimately
-// change on every heartbeat re-sign) — hashing the whole payload would make
-// every nightly freshness re-sign look like new content and defeat the
-// byte-identical check this function exists to support.
-func HashConnectors(connectors []Connector) (string, error) {
-	raw, err := json.Marshal(connectors)
+// The "content subtree" spans BOTH the connectors[] and processors[]
+// collections. It was widened from connectors[]-alone when processors[] was
+// added (design doc D4): if the subtree covered only connectors[], the
+// unattended freshness key could re-sign an index whose processors[] tree was
+// mutated while connectors[] stayed byte-identical — silently authorizing a
+// changed processor tree, a content-authorization escalation. Covering both is
+// the fix, and TestVerify_FreshnessSignatureWithMutatedProcessorsRequiresRoot
+// is its regression guard.
+//
+// The hash is computed over the two content collections only, NOT the full
+// payload (which also carries index.version/timestamp that legitimately change
+// on every heartbeat re-sign) — hashing the whole payload would make every
+// nightly freshness re-sign look like new content and defeat the byte-identical
+// check this function exists to support. The collections are wrapped in a fixed
+// {"connectors":...,"processors":...} object before canonicalization so the two
+// arrays can never be confused for one another (e.g. moving an entry between
+// them changes the hash), and so producer and verifier — which both call this
+// one function — agree byte-for-byte.
+func HashContentSubtree(connectors []Connector, processors []Processor) (string, error) {
+	subtree := struct {
+		Connectors []Connector `json:"connectors"`
+		Processors []Processor `json:"processors"`
+	}{Connectors: connectors, Processors: processors}
+	raw, err := json.Marshal(subtree)
 	if err != nil {
-		return "", cerrors.Errorf("could not marshal connectors for hashing: %w", err)
+		return "", cerrors.Errorf("could not marshal content subtree for hashing: %w", err)
 	}
 	canonical, err := Canonicalize(raw)
 	if err != nil {
-		return "", cerrors.Errorf("could not canonicalize connectors for hashing: %w", err)
+		return "", cerrors.Errorf("could not canonicalize content subtree for hashing: %w", err)
 	}
 	sum := sha256.Sum256(canonical)
 	return "sha256:" + hex.EncodeToString(sum[:]), nil

--- a/pkg/registry/index/schema_v1.go
+++ b/pkg/registry/index/schema_v1.go
@@ -37,6 +37,20 @@ type Payload struct {
 	SchemaVersion int         `json:"schemaVersion"`
 	Index         IndexMeta   `json:"index"`
 	Connectors    []Connector `json:"connectors"`
+	// Processors is the standalone-WASM-processor collection, added additively
+	// under schemaVersion 1 (design doc 20260727-registry-processor-artifacts,
+	// D1). It is forward-compatible: a client built before this field existed
+	// canonicalizes and signature-verifies the WHOLE payload it received —
+	// processors[] included — and then, unmarshalling into its older typed
+	// Payload, silently ignores the unknown field while still reading
+	// connectors[]. MaxSupportedSchemaVersion therefore STAYS 1.
+	//
+	// The `omitempty` is load-bearing, not cosmetic: a connector-only index
+	// (Processors nil/empty) must marshal to bytes byte-identical to the
+	// pre-processor schema, so existing connector-only golden fixtures and any
+	// persisted content-subtree hash over them do not drift (design doc failure
+	// mode 6). Enforced by TestConnectorOnlyIndex_OmitemptyKeepsBytesIdentical.
+	Processors []Processor `json:"processors,omitempty"`
 }
 
 // IndexMeta is the freeze/rollback-protection metadata (R-1 §b): Version is
@@ -99,6 +113,51 @@ type ConnectorVersion struct {
 	// and the frozen sample index writes it explicitly even when false —
 	// dropping it on marshal would fail the golden round-trip test against
 	// that fixture.
+	Deprecated bool        `json:"deprecated"`
+	Yanked     *YankReason `json:"yanked,omitempty"`
+}
+
+// Processor is one registered standalone-WASM-processor name's entry. It
+// reuses the exact Publisher/Revocation identity-pinning shapes Connector
+// does — a processor's root-of-trust decision behaves identically to a
+// connector's (design doc D1). It is deliberately a SEPARATE top-level
+// collection rather than a Connector with a new artifact kind, so the
+// connector selector (registry.SelectArtifact, host-(GOOS,GOARCH)-matched)
+// stays untouched and a WASM processor structurally cannot acquire a
+// per-platform artifact list (design doc D1, "why a separate collection").
+type Processor struct {
+	Name        string             `json:"name"`
+	DisplayName string             `json:"displayName,omitempty"`
+	Description string             `json:"description,omitempty"`
+	Repository  string             `json:"repository,omitempty"`
+	Publisher   Publisher          `json:"publisher"`
+	Versions    []ProcessorVersion `json:"versions"`
+}
+
+// ProcessorVersion is one published processor release. Unlike ConnectorVersion
+// it carries exactly ONE arch-neutral Artifact (a single GOOS=wasip1
+// GOARCH=wasm build runs on every host wazero supports), not a per-(os,arch)
+// Artifacts list — so a processor entry cannot smuggle host-targeted artifact
+// selection (design doc D2, failure mode 3). Entries are append-only once
+// published, exactly like ConnectorVersion: index-CI rejects a PR mutating any
+// field of an already-present version other than Deprecated / Yanked.
+//
+// The Artifact must be selected via registry.SelectProcessorArtifact, which
+// asserts Kind == "wasm-processor" and (OS, Arch) == ("wasip1", "wasm") and
+// never consults runtime.GOOS/GOARCH.
+type ProcessorVersion struct {
+	Version            string     `json:"version"`
+	ReleasedAt         *time.Time `json:"releasedAt,omitempty"`
+	MinConduitVersion  string     `json:"minConduitVersion"`
+	MinProtocolVersion string     `json:"minProtocolVersion"`
+	// Artifact is the single arch-neutral (wasip1/wasm) build for this version,
+	// with Kind == "wasm-processor". Not a list: see the type doc.
+	Artifact       Artifact       `json:"artifact"`
+	SLSAProvenance *ProvenanceRef `json:"slsaProvenance,omitempty"`
+	// Deprecated has no omitempty for the same reason ConnectorVersion.Deprecated
+	// does not (see above): the schema's documented default is false, the frozen
+	// sample index writes it explicitly even when false, and dropping it on
+	// marshal would fail the golden round-trip against that fixture.
 	Deprecated bool        `json:"deprecated"`
 	Yanked     *YankReason `json:"yanked,omitempty"`
 }

--- a/pkg/registry/index/schema_v1_test.go
+++ b/pkg/registry/index/schema_v1_test.go
@@ -15,8 +15,10 @@
 package index_test
 
 import (
+	"bytes"
 	"os"
 	"testing"
+	"time"
 
 	json "github.com/goccy/go-json"
 	"github.com/google/go-cmp/cmp"
@@ -70,6 +72,23 @@ func TestGoldenRoundTrip_SampleIndex(t *testing.T) {
 	is.True(vs.Publisher.Revoked != nil)
 	is.True(vs.Publisher.Revoked.Reason != "")
 
+	// Processors[] is the additive schemaVersion-1 collection (design doc D1).
+	// Assert the processor entry survives at every nesting level: entry ->
+	// publisher/versions -> the SINGLE arch-neutral artifact (not an artifacts
+	// list) -> signature/provenance.
+	is.Equal(len(payload.Processors), 1)
+	proc := payload.Processors[0]
+	is.Equal(proc.Name, "conduit-processor-ai")
+	is.Equal(proc.Publisher.ExpectedOIDCIssuer, "https://token.actions.githubusercontent.com")
+	is.Equal(len(proc.Versions), 1)
+	pv := proc.Versions[0]
+	is.Equal(pv.Version, "0.1.0")
+	is.Equal(pv.Artifact.Kind, "wasm-processor")
+	is.Equal(pv.Artifact.OS, "wasip1")
+	is.Equal(pv.Artifact.Arch, "wasm")
+	is.True(pv.Artifact.Signature.BundleURL != "")
+	is.True(pv.SLSAProvenance != nil)
+
 	// Full structural round trip: unmarshal original raw payload generically,
 	// marshal the typed struct, unmarshal THAT generically too, and diff the
 	// two generic representations — this catches a field this package's
@@ -92,6 +111,78 @@ func TestGoldenRoundTrip_SampleIndex(t *testing.T) {
 	if diff := cmp.Diff(wantGeneric, gotGeneric); diff != "" {
 		t.Fatalf("golden round-trip mismatch (-want +got):\n%s", diff)
 	}
+}
+
+// TestConnectorOnlyIndex_OmitemptyKeepsBytesIdentical is the security- and
+// compat-critical proof for design doc failure mode 6: adding
+// Payload.Processors with `omitempty` must NOT change the serialized bytes of a
+// connector-only index. If it did, every existing connector-only golden fixture
+// would drift AND — worse — the freshness content-subtree hash over a
+// connector-only index would change, forcing spurious root re-verifications.
+//
+// Two independent assertions:
+//
+//  1. The frozen connectors-only fixture round-trips (parse -> re-marshal
+//     payload) to a payload byte-identical to the original — i.e. an absent
+//     processors[] never reappears as `"processors":null` or `"processors":[]`.
+//  2. A Payload constructed in-code with Processors left nil marshals with no
+//     "processors" key at all, exactly as a pre-processor Payload would.
+func TestConnectorOnlyIndex_OmitemptyKeepsBytesIdentical(t *testing.T) {
+	is := is.New(t)
+
+	// (1) Round-trip the frozen connectors-only fixture through the real
+	// production parse, then re-marshal the typed payload and compare to the
+	// fixture's own payload bytes (canonicalized on both sides to neutralize
+	// insignificant whitespace/key-order — the signature-relevant comparison).
+	raw, err := os.ReadFile("testdata/sample-index-connectors-only.json")
+	is.NoErr(err)
+
+	payload, err := index.ParseUnverified(raw)
+	is.NoErr(err)
+	is.Equal(len(payload.Processors), 0) // absent in the fixture => nil/empty
+
+	var envelope struct {
+		Payload json.RawMessage `json:"payload"`
+	}
+	is.NoErr(json.Unmarshal(raw, &envelope))
+	wantCanonical, err := index.Canonicalize(envelope.Payload)
+	is.NoErr(err)
+
+	reMarshaled, err := json.Marshal(payload)
+	is.NoErr(err)
+	gotCanonical, err := index.Canonicalize(reMarshaled)
+	is.NoErr(err)
+
+	is.Equal(string(gotCanonical), string(wantCanonical)) // byte-identical, no processors[] introduced
+
+	// The re-marshaled connector-only payload must contain no processors key.
+	is.True(!bytes.Contains(reMarshaled, []byte(`"processors"`)))
+
+	// (2) A Payload value with Processors nil marshals identically to the
+	// pre-processor shape — no "processors" key emitted.
+	p := index.Payload{
+		SchemaVersion: 1,
+		Index:         index.IndexMeta{Version: 1, Timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+		Connectors: []index.Connector{{
+			Name: "postgres",
+			Publisher: index.Publisher{
+				ExpectedOIDCIssuer:      "https://token.actions.githubusercontent.com",
+				ExpectedIdentityPattern: "^.+$",
+			},
+			Versions: []index.ConnectorVersion{{
+				Version: "1.0.0", MinConduitVersion: "0.1.0", MinProtocolVersion: "0.1.0",
+				Artifacts: []index.Artifact{{
+					OS: "linux", Arch: "amd64", Kind: "standalone",
+					URL: "https://example/x.tar.gz", SHA256: "deadbeef", Size: 1,
+					Signature: index.SignatureRef{BundleURL: "https://example/x.sigstore.json"},
+				}},
+			}},
+		}},
+		// Processors intentionally left nil.
+	}
+	out, err := json.Marshal(p)
+	is.NoErr(err)
+	is.True(!bytes.Contains(out, []byte(`"processors"`)))
 }
 
 // TestParseUnverified_SchemaTooNew proves the schema-too-new refusal runs

--- a/pkg/registry/index/schema_validation_test.go
+++ b/pkg/registry/index/schema_validation_test.go
@@ -1,0 +1,146 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+
+	json "github.com/goccy/go-json"
+	"github.com/matryer/is"
+)
+
+// frozenSchemaPath resolves docs/design-documents/registry-index/index-schema.json
+// relative to THIS source file (via runtime.Caller), not the test binary's cwd —
+// the same pattern cmd/conduit/internal/testutils/envelope.go uses to load a
+// fixture living outside the calling package's own tree. The frozen JSON Schema
+// is the on-disk/served-shape contract (index-CI linting + fixture testing); the
+// R-1 schema doc claims "sample-index.json validates against index-schema.json"
+// but nothing in-repo enforced it until this test. PR-A adds processors[] to
+// both, so this is now a live regression guard that the two stay in lockstep.
+func frozenSchemaPath(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	is.New(t).True(ok)
+	// pkg/registry/index -> repo root is three parents up.
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "..",
+		"docs", "design-documents", "registry-index", "index-schema.json")
+}
+
+func compileFrozenSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	is := is.New(t)
+	c := jsonschema.NewCompiler()
+	sch, err := c.Compile(frozenSchemaPath(t))
+	is.NoErr(err)
+	return sch
+}
+
+func validateAgainstFrozenSchema(t *testing.T, sch *jsonschema.Schema, raw []byte) error {
+	t.Helper()
+	inst, err := jsonschema.UnmarshalJSON(bytes.NewReader(raw))
+	is.New(t).NoErr(err)
+	return sch.Validate(inst)
+}
+
+// TestFrozenSchema_ValidatesSampleIndex is the R-1-doc-promised check, now
+// automated: the processor-bearing sample envelope validates against the frozen
+// Draft 2020-12 schema. If a future edit adds a field to sample-index.json the
+// schema doesn't declare (additionalProperties:false everywhere), or a processor
+// entry that violates the arch-neutral (wasip1/wasm/wasm-processor) constraint,
+// this fails.
+func TestFrozenSchema_ValidatesSampleIndex(t *testing.T) {
+	is := is.New(t)
+	sch := compileFrozenSchema(t)
+
+	raw, err := os.ReadFile("testdata/sample-index.json")
+	is.NoErr(err)
+
+	is.NoErr(validateAgainstFrozenSchema(t, sch, raw))
+}
+
+// TestFrozenSchema_ValidatesConnectorOnlyIndex proves the additive change is
+// backward-compatible at the schema level: an index with NO processors[] key at
+// all (the pre-processor shape) still validates, because processors[] is not in
+// payload.required.
+func TestFrozenSchema_ValidatesConnectorOnlyIndex(t *testing.T) {
+	is := is.New(t)
+	sch := compileFrozenSchema(t)
+
+	raw, err := os.ReadFile("testdata/sample-index-connectors-only.json")
+	is.NoErr(err)
+
+	is.NoErr(validateAgainstFrozenSchema(t, sch, raw))
+}
+
+// TestFrozenSchema_RejectsHostTargetedProcessorArtifact is the schema-level
+// counterpart to SelectProcessorArtifact's runtime refusal (design doc D2,
+// failure mode 3): a processor artifact carrying a host os/arch instead of the
+// fixed wasip1/wasm must be a schema violation, not a valid-but-skipped entry.
+// This is what makes "a host os/arch is a malformed/spoofed entry" enforceable
+// by index-CI linting, not only at install time.
+func TestFrozenSchema_RejectsHostTargetedProcessorArtifact(t *testing.T) {
+	is := is.New(t)
+	sch := compileFrozenSchema(t)
+
+	raw, err := os.ReadFile("testdata/sample-index.json")
+	is.NoErr(err)
+
+	// Rewrite the single processor artifact's os/arch to a host platform.
+	var env map[string]any
+	is.NoErr(json.Unmarshal(raw, &env))
+	payload := env["payload"].(map[string]any)
+	procs := payload["processors"].([]any)
+	art := procs[0].(map[string]any)["versions"].([]any)[0].(map[string]any)["artifact"].(map[string]any)
+	art["os"] = "linux"
+	art["arch"] = "amd64"
+
+	mutated, err := json.Marshal(env)
+	is.NoErr(err)
+
+	// Must now FAIL: processorArtifact.os is const "wasip1", arch const "wasm".
+	is.True(validateAgainstFrozenSchema(t, sch, mutated) != nil)
+}
+
+// TestFrozenSchema_RejectsProcessorArtifactsList proves a processor version
+// cannot smuggle a connector-shaped per-host "artifacts" array in place of the
+// single arch-neutral "artifact" object (design doc D1/D2). additionalProperties
+// is false on processorVersion, and "artifact" is required, so an "artifacts"
+// key is rejected.
+func TestFrozenSchema_RejectsProcessorArtifactsList(t *testing.T) {
+	is := is.New(t)
+	sch := compileFrozenSchema(t)
+
+	raw, err := os.ReadFile("testdata/sample-index.json")
+	is.NoErr(err)
+
+	var env map[string]any
+	is.NoErr(json.Unmarshal(raw, &env))
+	payload := env["payload"].(map[string]any)
+	ver := payload["processors"].([]any)[0].(map[string]any)["versions"].([]any)[0].(map[string]any)
+	// Replace the single "artifact" with a connector-style "artifacts" list.
+	ver["artifacts"] = []any{ver["artifact"]}
+	delete(ver, "artifact")
+
+	mutated, err := json.Marshal(env)
+	is.NoErr(err)
+
+	is.True(validateAgainstFrozenSchema(t, sch, mutated) != nil)
+}

--- a/pkg/registry/index/state.go
+++ b/pkg/registry/index/state.go
@@ -25,20 +25,30 @@ import (
 
 // State is the locally persisted rollback high-water mark (R-1 §b item 1):
 // the highest payload.index.version this client has successfully verified,
-// plus the sha256 of the JCS-canonicalized connectors[] array from the last
-// ROOT-verified (not freshness-only) index (PR-2, R-1 §a.2.c) — the value
-// Verify's freshness-only acceptance path compares against, so a freshness
-// signature can only ever extend timestamp/version over byte-identical
-// content, never authorize new content on its own.
+// plus the sha256 of the JCS-canonicalized CONTENT SUBTREE (connectors[] and
+// processors[]) from the last ROOT-verified (not freshness-only) index (PR-2,
+// R-1 §a.2.c; design doc 20260727-registry-processor-artifacts, D4) — the
+// value Verify's freshness-only acceptance path compares against, so a
+// freshness signature can only ever extend timestamp/version over
+// byte-identical content, never authorize new content on its own.
 type State struct {
 	Version int64 `json:"version"`
-	// LastVerifiedConnectorsHash is "sha256:<hex>" over the JCS-canonicalized
-	// connectors[] array from the last root-verified index, or "" if no
-	// index has ever been root-verified yet (see HashConnectors). Additive
-	// field: a State persisted by PR-0/PR-1 (before this field existed)
-	// unmarshals with this empty, matching "no root-verified content on
-	// record" — Verify's freshness path then correctly requires root.
-	LastVerifiedConnectorsHash string `json:"lastVerifiedConnectorsHash,omitempty"`
+	// LastVerifiedContentHash is "sha256:<hex>" over the JCS-canonicalized
+	// content subtree (connectors[] AND processors[]) from the last
+	// root-verified index, or "" if no index has ever been root-verified yet
+	// (see HashContentSubtree).
+	//
+	// This field's JSON key was renamed from "lastVerifiedConnectorsHash" when
+	// the content subtree was widened to include processors[] (design doc D4):
+	// the old key is now unknown and ignored on load, leaving this empty. That
+	// is fail-safe, not fail-open — an empty hash matches "no root-verified
+	// content on record", so Verify's freshness path REQUIRES a root signature
+	// on the next fetch (a routine, non-destructive, self-healing one-time
+	// event after upgrade), and can never accept a freshness-only index against
+	// a stale connectors-only hash. Same additive behavior as the PR-0/PR-1 ->
+	// PR-2 transition that first introduced the hash. Regression guard:
+	// TestLoadState_LegacyConnectorsHashKeyIsIgnoredFailSafe.
+	LastVerifiedContentHash string `json:"lastVerifiedContentHash,omitempty"`
 }
 
 // LoadState reads the persisted high-water mark from path. A missing file

--- a/pkg/registry/index/state_test.go
+++ b/pkg/registry/index/state_test.go
@@ -74,3 +74,26 @@ func TestLoadState_CorruptFileIsAnError(t *testing.T) {
 	_, err := index.LoadState(path)
 	is.True(err != nil)
 }
+
+// TestLoadState_LegacyConnectorsHashKeyIsIgnoredFailSafe is the upgrade
+// regression guard for the content-subtree widening (design doc D4): a state
+// file written by an older build — carrying the pre-widening JSON key
+// "lastVerifiedConnectorsHash" — must load with LastVerifiedContentHash EMPTY
+// (the old key is now unknown and ignored). That is fail-safe: an empty hash
+// means "no root-verified content on record", so Verify's freshness path
+// requires a fresh root signature on the next fetch rather than accepting a
+// freshness-only index against a stale connectors-only hash. Version, a stable
+// key, still loads normally, so rollback protection is preserved across the
+// upgrade — only the (self-healing) content hash resets.
+func TestLoadState_LegacyConnectorsHashKeyIsIgnoredFailSafe(t *testing.T) {
+	is := is.New(t)
+	path := filepath.Join(t.TempDir(), "state.json")
+
+	legacy := []byte(`{"version": 7, "lastVerifiedConnectorsHash": "sha256:deadbeef"}`)
+	is.NoErr(os.WriteFile(path, legacy, 0o600))
+
+	got, err := index.LoadState(path)
+	is.NoErr(err)
+	is.Equal(got.Version, int64(7))           // stable key preserved: rollback floor intact
+	is.Equal(got.LastVerifiedContentHash, "") // old key ignored => fail-safe to "requires root"
+}

--- a/pkg/registry/index/testdata/sample-index-connectors-only.json
+++ b/pkg/registry/index/testdata/sample-index-connectors-only.json
@@ -137,43 +137,6 @@
           }
         ]
       }
-    ],
-    "processors": [
-      {
-        "name": "conduit-processor-ai",
-        "displayName": "Conduit AI Processors",
-        "description": "Standalone WASM processors for AI pipelines: chunking (ai.chunk) and embedding (ai.embed).",
-        "repository": "https://github.com/ConduitIO/conduit-processor-ai",
-        "publisher": {
-          "expectedOIDCIssuer": "https://token.actions.githubusercontent.com",
-          "expectedIdentityPattern": "^https://github\\.com/ConduitIO/conduit-processor-ai/\\.github/workflows/publish\\.yml@refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+$"
-        },
-        "versions": [
-          {
-            "version": "0.1.0",
-            "releasedAt": "2026-07-20T12:00:00Z",
-            "minConduitVersion": "0.19.0",
-            "minProtocolVersion": "0.14.0",
-            "artifact": {
-              "os": "wasip1",
-              "arch": "wasm",
-              "kind": "wasm-processor",
-              "url": "https://conduit.gateway.scarf.sh/conduitio/conduit-processor-ai/releases/download/v0.1.0/conduit-processor-ai_0.1.0_wasip1_wasm.wasm",
-              "sha256": "b1946ac92492d2347c6235b4d2611184a1c9e7f2d3a4b5c6d7e8f90112233445",
-              "size": 6291456,
-              "signature": {
-                "bundleURL": "https://conduit.gateway.scarf.sh/conduitio/conduit-processor-ai/releases/download/v0.1.0/conduit-processor-ai_0.1.0_wasip1_wasm.wasm.sigstore.json",
-                "rekorLogIndex": 120553001
-              }
-            },
-            "slsaProvenance": {
-              "bundleURL": "https://conduit.gateway.scarf.sh/conduitio/conduit-processor-ai/releases/download/v0.1.0/conduit-processor-ai_0.1.0.intoto.jsonl",
-              "predicateType": "https://slsa.dev/provenance/v1"
-            },
-            "deprecated": false
-          }
-        ]
-      }
     ]
   },
   "signatures": [

--- a/pkg/registry/index/testdata/sample-index.json
+++ b/pkg/registry/index/testdata/sample-index.json
@@ -137,6 +137,43 @@
           }
         ]
       }
+    ],
+    "processors": [
+      {
+        "name": "conduit-processor-ai",
+        "displayName": "Conduit AI Processors",
+        "description": "Standalone WASM processors for AI pipelines: chunking (ai.chunk) and embedding (ai.embed).",
+        "repository": "https://github.com/ConduitIO/conduit-processor-ai",
+        "publisher": {
+          "expectedOIDCIssuer": "https://token.actions.githubusercontent.com",
+          "expectedIdentityPattern": "^https://github\\.com/ConduitIO/conduit-processor-ai/\\.github/workflows/publish\\.yml@refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+        "versions": [
+          {
+            "version": "0.1.0",
+            "releasedAt": "2026-07-20T12:00:00Z",
+            "minConduitVersion": "0.19.0",
+            "minProtocolVersion": "0.14.0",
+            "artifact": {
+              "os": "wasip1",
+              "arch": "wasm",
+              "kind": "wasm-processor",
+              "url": "https://conduit.gateway.scarf.sh/conduitio/conduit-processor-ai/releases/download/v0.1.0/conduit-processor-ai_0.1.0_wasip1_wasm.wasm",
+              "sha256": "b1946ac92492d2347c6235b4d2611184a1c9e7f2d3a4b5c6d7e8f90112233445",
+              "size": 6291456,
+              "signature": {
+                "bundleURL": "https://conduit.gateway.scarf.sh/conduitio/conduit-processor-ai/releases/download/v0.1.0/conduit-processor-ai_0.1.0_wasip1_wasm.wasm.sigstore.json",
+                "rekorLogIndex": 120553001
+              }
+            },
+            "slsaProvenance": {
+              "bundleURL": "https://conduit.gateway.scarf.sh/conduitio/conduit-processor-ai/releases/download/v0.1.0/conduit-processor-ai_0.1.0.intoto.jsonl",
+              "predicateType": "https://slsa.dev/provenance/v1"
+            },
+            "deprecated": false
+          }
+        ]
+      }
     ]
   },
   "signatures": [

--- a/pkg/registry/index/verify.go
+++ b/pkg/registry/index/verify.go
@@ -37,9 +37,10 @@ type VerifiedIndex struct {
 	Verified bool
 	// RootVerified is true only when acceptance came from a role:"root"
 	// signature — as opposed to a role:"freshness" signature accepted
-	// because connectors[] was byte-identical to the last root-verified
-	// content (R-1 §a.2.c). Callers persisting State.LastVerifiedConnectorsHash
-	// (via HashConnectors) should only update it when RootVerified is true:
+	// because the content subtree (connectors[] and processors[]) was
+	// byte-identical to the last root-verified content (R-1 §a.2.c; design
+	// doc D4). Callers persisting State.LastVerifiedContentHash (via
+	// HashContentSubtree) should only update it when RootVerified is true:
 	// a freshness-only acceptance by construction already matches the
 	// existing persisted hash, so re-deriving it is a no-op at best and,
 	// if ever wrong, must never widen what freshness alone can authorize.
@@ -83,11 +84,12 @@ func ParseUnverified(raw []byte) (*Payload, error) {
 //     anchors for that entry's declared role ("root" or "freshness") and
 //     verify the ed25519 signature over the canonical bytes.
 //  4. Accept if any role:"root" signature verifies. Otherwise, accept if a
-//     role:"freshness" signature verifies AND the payload's connectors[]
-//     (canonicalized, hashed via HashConnectors) is byte-identical to
-//     lastVerifiedConnectorsHash — the last root-verified content on
-//     record (persisted in State, R-1 §a.2.c: "a freshness signature may
-//     extend freshness, never authorize content").
+//     role:"freshness" signature verifies AND the payload's content subtree
+//     — connectors[] and processors[], canonicalized, hashed via
+//     HashContentSubtree — is byte-identical to lastVerifiedContentHash —
+//     the last root-verified content on record (persisted in State, R-1
+//     §a.2.c: "a freshness signature may extend freshness, never authorize
+//     content"; design doc D4 widened the subtree to include processors[]).
 //  5. Only once accepted, peek schemaVersion and unmarshal into the typed
 //     Payload (shared with ParseUnverified, via decodeTypedPayload).
 //
@@ -102,15 +104,15 @@ func ParseUnverified(raw []byte) (*Payload, error) {
 //     recognized, but no recognized signature both verified cryptographically
 //     AND was sufficient to authorize this content (a root signature that
 //     fails crypto; a freshness signature that verifies crypto but doesn't
-//     match lastVerifiedConnectorsHash; a duplicate key; malformed
+//     match lastVerifiedContentHash; a duplicate key; malformed
 //     signature bytes) — tampering/corruption, refuse and report loudly.
 //
-// lastVerifiedConnectorsHash is the caller's persisted
-// State.LastVerifiedConnectorsHash (empty string if no index has ever been
+// lastVerifiedContentHash is the caller's persisted
+// State.LastVerifiedContentHash (empty string if no index has ever been
 // root-verified on this machine — R-1 §b's documented first-fetch gap: a
 // freshness-only index can never be the FIRST index a client ever accepts,
 // by construction, since an empty hash can never equal a real one).
-func Verify(raw []byte, anchors TrustAnchors, lastVerifiedConnectorsHash string) (*VerifiedIndex, error) {
+func Verify(raw []byte, anchors TrustAnchors, lastVerifiedContentHash string) (*VerifiedIndex, error) {
 	env, err := decodeEnvelope(raw)
 	if err != nil {
 		return nil, err
@@ -149,8 +151,8 @@ func Verify(raw []byte, anchors TrustAnchors, lastVerifiedConnectorsHash string)
 	}
 
 	freshnessVerified := freshnessCryptoVerified &&
-		lastVerifiedConnectorsHash != "" &&
-		matchesLastVerifiedConnectors(env.Payload, lastVerifiedConnectorsHash)
+		lastVerifiedContentHash != "" &&
+		matchesLastVerifiedContent(env.Payload, lastVerifiedContentHash)
 
 	if !rootVerified && !freshnessVerified {
 		if !anyKeyRecognized {
@@ -185,19 +187,23 @@ func resolveAnchor(anchors TrustAnchors, role, keyID string) (ed25519.PublicKey,
 	}
 }
 
-// matchesLastVerifiedConnectors reports whether payloadRaw's connectors[]
-// field, canonicalized and hashed, equals want. A malformed payload here
-// (connectors[] doesn't even unmarshal) is treated as a mismatch, not a
-// separate error: the caller's fall-through to CodeIndexIntegrity already
-// covers "freshness signature verified crypto but content doesn't match".
-func matchesLastVerifiedConnectors(payloadRaw json.RawMessage, want string) bool {
+// matchesLastVerifiedContent reports whether payloadRaw's CONTENT SUBTREE —
+// its connectors[] AND processors[] fields — canonicalized and hashed, equals
+// want. Both collections are covered (design doc D4): a freshness re-sign that
+// mutated processors[] while leaving connectors[] byte-identical must NOT be
+// accepted on the freshness key alone. A malformed payload here (a collection
+// doesn't even unmarshal) is treated as a mismatch, not a separate error: the
+// caller's fall-through to CodeIndexIntegrity already covers "freshness
+// signature verified crypto but content doesn't match".
+func matchesLastVerifiedContent(payloadRaw json.RawMessage, want string) bool {
 	var probe struct {
 		Connectors []Connector `json:"connectors"`
+		Processors []Processor `json:"processors"`
 	}
 	if err := json.Unmarshal(payloadRaw, &probe); err != nil {
 		return false
 	}
-	got, err := HashConnectors(probe.Connectors)
+	got, err := HashContentSubtree(probe.Connectors, probe.Processors)
 	if err != nil {
 		return false
 	}

--- a/pkg/registry/index/verify_test.go
+++ b/pkg/registry/index/verify_test.go
@@ -62,11 +62,40 @@ func (b *testIndexBuilder) anchors(t *testing.T) index.TrustAnchors {
 	}
 }
 
-// payload is a minimal but schema-shaped connectors-index payload.
+// payload is a minimal but schema-shaped connectors-index payload. Processors
+// carries `omitempty` so the many tests that leave it nil sign byte-identical
+// bytes to the pre-processor shape (mirrors index.Payload's own omitempty).
 type testPayload struct {
 	SchemaVersion int               `json:"schemaVersion"`
 	Index         index.IndexMeta   `json:"index"`
 	Connectors    []index.Connector `json:"connectors"`
+	Processors    []index.Processor `json:"processors,omitempty"`
+}
+
+// withProcessor returns a copy of p carrying one minimal, schema-shaped
+// processor entry — used by the freshness content-subtree (D4) and
+// forward-compat tests.
+func withProcessor(p testPayload) testPayload {
+	p.Processors = []index.Processor{
+		{
+			Name: "example-processor",
+			Publisher: index.Publisher{
+				ExpectedOIDCIssuer:      "https://token.actions.githubusercontent.com",
+				ExpectedIdentityPattern: `^https://github\.com/ExampleOrg/conduit-processor-example/\.github/workflows/publish\.yml@refs/tags/v.*$`,
+			},
+			Versions: []index.ProcessorVersion{
+				{
+					Version: "0.1.0", MinConduitVersion: "0.19.0", MinProtocolVersion: "0.14.0",
+					Artifact: index.Artifact{
+						OS: "wasip1", Arch: "wasm", Kind: "wasm-processor",
+						URL: "https://example/proc_0.1.0_wasip1_wasm.wasm", SHA256: "abc123", Size: 4096,
+						Signature: index.SignatureRef{BundleURL: "https://example/proc.wasm.sigstore.json"},
+					},
+				},
+			},
+		},
+	}
+	return p
 }
 
 func defaultTestPayload() testPayload {
@@ -151,10 +180,10 @@ func TestVerify_ValidFreshnessSignatureWithMatchingConnectors(t *testing.T) {
 	b := newTestIndexBuilder(t)
 	payload := defaultTestPayload()
 
-	lastHash, err := index.HashConnectors(payload.Connectors)
+	lastHash, err := index.HashContentSubtree(payload.Connectors, payload.Processors)
 	is.NoErr(err)
 
-	// A "heartbeat" re-sign: same connectors[], bumped version/timestamp,
+	// A "heartbeat" re-sign: same content subtree, bumped version/timestamp,
 	// freshness-signed only (no root signature present at all).
 	payload.Index.Version = 2
 	payload.Index.Timestamp = time.Now().UTC()
@@ -171,7 +200,7 @@ func TestVerify_FreshnessSignatureWithMismatchedConnectorsRequiresRoot(t *testin
 	b := newTestIndexBuilder(t)
 	payload := defaultTestPayload()
 
-	lastHash, err := index.HashConnectors(payload.Connectors)
+	lastHash, err := index.HashContentSubtree(payload.Connectors, payload.Processors)
 	is.NoErr(err)
 
 	// Freshness key re-signs DIFFERENT connectors content — must be refused:
@@ -184,6 +213,62 @@ func TestVerify_FreshnessSignatureWithMismatchedConnectorsRequiresRoot(t *testin
 	ce, ok := conduiterr.Get(err)
 	is.True(ok)
 	is.Equal(ce.Code.Reason(), index.CodeIndexIntegrity.Reason())
+}
+
+// TestVerify_FreshnessSignatureWithMutatedProcessorsRequiresRoot is the D4
+// regression guard (design doc 20260727-registry-processor-artifacts, failure
+// mode 2): the freshness content subtree covers processors[] too, so a
+// freshness re-sign that mutates ONLY processors[] — leaving connectors[]
+// byte-identical to the last root-verified content — must be REFUSED. Without
+// the subtree widening (HashConnectors over connectors[] alone), this attack
+// would have silently authorized a changed processor tree on the unattended
+// freshness key: a content-authorization escalation. This test fails on the
+// pre-D4 code and passes only with the widened HashContentSubtree.
+func TestVerify_FreshnessSignatureWithMutatedProcessorsRequiresRoot(t *testing.T) {
+	is := is.New(t)
+	b := newTestIndexBuilder(t)
+	payload := withProcessor(defaultTestPayload())
+
+	// The last root-verified content hash covers BOTH collections.
+	lastHash, err := index.HashContentSubtree(payload.Connectors, payload.Processors)
+	is.NoErr(err)
+
+	// Connectors[] stays byte-identical; ONLY the processor artifact URL is
+	// swapped (e.g. repointed at an attacker-controlled .wasm). A subtree that
+	// covered connectors[] alone would accept this on freshness; it must not.
+	payload.Processors[0].Versions[0].Artifact.URL = "https://attacker.example/evil.wasm"
+	payload.Index.Version = 2
+	raw := b.sign(t, payload, "freshness")
+
+	_, err = index.Verify(raw, b.anchors(t), lastHash)
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code.Reason(), index.CodeIndexIntegrity.Reason())
+}
+
+// TestVerify_FreshnessSignatureWithMatchingProcessorsAccepted is the positive
+// half of D4: a genuine heartbeat re-sign of a processor-bearing index (both
+// collections byte-identical, only version/timestamp bumped) is still accepted
+// on the freshness key alone — the widening refuses mutation, not legitimate
+// freshness.
+func TestVerify_FreshnessSignatureWithMatchingProcessorsAccepted(t *testing.T) {
+	is := is.New(t)
+	b := newTestIndexBuilder(t)
+	payload := withProcessor(defaultTestPayload())
+
+	lastHash, err := index.HashContentSubtree(payload.Connectors, payload.Processors)
+	is.NoErr(err)
+
+	payload.Index.Version = 2
+	payload.Index.Timestamp = time.Now().UTC()
+	raw := b.sign(t, payload, "freshness")
+
+	vi, err := index.Verify(raw, b.anchors(t), lastHash)
+	is.NoErr(err)
+	is.True(vi.Verified)
+	is.True(!vi.RootVerified)
+	is.Equal(len(vi.Payload.Processors), 1)
 }
 
 func TestVerify_UnrecognizedKeyID(t *testing.T) {
@@ -295,4 +380,65 @@ func TestVerify_NoSignaturesAtAll(t *testing.T) {
 	ce, ok := conduiterr.Get(err)
 	is.True(ok)
 	is.Equal(ce.Code.Reason(), index.CodeTrustAnchorExpired.Reason())
+}
+
+// legacyPayload is the schemaVersion-1 payload shape as it existed BEFORE
+// processors[] was added — a faithful stand-in for an older Conduit build's
+// typed struct. It has no Processors field at all.
+type legacyPayload struct {
+	SchemaVersion int               `json:"schemaVersion"`
+	Index         index.IndexMeta   `json:"index"`
+	Connectors    []index.Connector `json:"connectors"`
+}
+
+// TestVerify_ForwardCompat_OlderClientIgnoresProcessors is the design doc's
+// required upgrade test (Upgrade/rollback; failure mode 1). It proves the
+// additive-under-schemaVersion-1 promise from both ends:
+//
+//   - The signature is computed over the WHOLE payload bytes (processors[]
+//     included), so an older client — which canonicalizes and verifies those
+//     exact bytes — still verifies successfully. Adding processors[] does NOT
+//     invalidate the signature for anyone.
+//   - An older typed struct (legacyPayload, no Processors field) unmarshals the
+//     same payload fine: Go silently ignores the unknown "processors" key,
+//     reads connectors[] normally, and sees schemaVersion 1 (NOT
+//     CodeSchemaTooNew — MaxSupportedSchemaVersion stays 1).
+//   - A current build (index.Verify) sees and reads processors[].
+func TestVerify_ForwardCompat_OlderClientIgnoresProcessors(t *testing.T) {
+	is := is.New(t)
+	b := newTestIndexBuilder(t)
+
+	payload := withProcessor(defaultTestPayload())
+	raw := b.sign(t, payload, "root")
+
+	// (a) Current build verifies and SEES processors[].
+	vi, err := index.Verify(raw, b.anchors(t), "")
+	is.NoErr(err)
+	is.True(vi.Verified)
+	is.Equal(vi.Payload.SchemaVersion, 1) // schemaVersion stays 1
+	is.Equal(len(vi.Payload.Connectors), 1)
+	is.Equal(len(vi.Payload.Processors), 1)
+	is.Equal(vi.Payload.Processors[0].Name, "example-processor")
+
+	// (b) Older client: extract the exact payload bytes the client received and
+	// unmarshal into the pre-processor typed struct. connectors[] reads fine;
+	// processors[] is silently ignored; no error; schemaVersion still 1.
+	var env struct {
+		Payload json.RawMessage `json:"payload"`
+	}
+	is.NoErr(json.Unmarshal(raw, &env))
+
+	var legacy legacyPayload
+	is.NoErr(json.Unmarshal(env.Payload, &legacy))
+	is.Equal(legacy.SchemaVersion, 1)
+	is.Equal(len(legacy.Connectors), 1)
+	is.Equal(legacy.Connectors[0].Name, "example")
+
+	// (c) And the signature still verifies over those whole bytes — the older
+	// client's crypto check is unaffected by the field it will ignore. (We
+	// re-run Verify here to stand in for the older client's identical
+	// canonicalize+verify of the bytes it holds; the point is the SAME raw
+	// bytes both verify AND legacy-parse.)
+	_, err = index.Verify(raw, b.anchors(t), "")
+	is.NoErr(err)
 }

--- a/pkg/registry/procplatform.go
+++ b/pkg/registry/procplatform.go
@@ -1,0 +1,78 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"fmt"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry/index"
+)
+
+// WASMProcessorArtifactKind is the artifact kind for a standalone WASM
+// processor build. It is arch-neutral: a single GOOS=wasip1 GOARCH=wasm module
+// runs on every host wazero supports, so — unlike a connector's per-(os, arch)
+// StandaloneArtifactKind builds — a processor version has exactly ONE artifact
+// of this kind (design doc 20260727-registry-processor-artifacts, D1/D2).
+const WASMProcessorArtifactKind = "wasm-processor"
+
+// wasmProcessorOS and wasmProcessorArch are the fixed (GOOS, GOARCH) pair every
+// standalone WASM processor artifact must declare. They are the wazero/WASI
+// target, deliberately NOT the host's runtime.GOOS/runtime.GOARCH.
+const (
+	wasmProcessorOS   = "wasip1"
+	wasmProcessorArch = "wasm"
+)
+
+// SelectProcessorArtifact returns the single arch-neutral WASM artifact of a
+// processor version. It is the processor analogue of SelectArtifact, but it
+// NEVER consults runtime.GOOS/runtime.GOARCH: a WASM processor is arch-neutral,
+// so there is exactly one artifact and it is selected by a fixed
+// (wasip1, wasm) rule, not by matching the host platform (design doc D2; ADR
+// 20260727-processors-ride-connector-registry, fact 3).
+//
+// A processor artifact that is not Kind == WASMProcessorArtifactKind, or whose
+// (OS, Arch) is not exactly (wasip1, wasm), is refused with
+// CodeInvalidProcessorArtifact — a hard validation error, NOT a silent skip.
+// This is the deliberate contrast with the connector path (design doc D2,
+// failure mode 3): SelectArtifact skips an unrecognized artifact kind because a
+// connector version legitimately carries many artifacts of different shapes and
+// picks the host match; a processor version carries exactly one artifact, which
+// must be the WASM one, so a host os/arch (or any other malformed shape) is a
+// malformed or spoofed index entry that must be surfaced, never quietly
+// ignored into "nothing to install". The single-Artifact field on
+// ProcessorVersion means a per-host artifact list cannot even be expressed —
+// this function closes the remaining "wrong single artifact" gap.
+//
+// The returned pointer aliases a copy of the version's Artifact; callers must
+// not assume it points into v.
+func SelectProcessorArtifact(procName string, v index.ProcessorVersion) (*index.Artifact, error) {
+	a := v.Artifact
+	if a.Kind != WASMProcessorArtifactKind {
+		err := conduiterr.New(CodeInvalidProcessorArtifact, fmt.Sprintf(
+			"processor %q version %s has artifact kind %q, but a processor artifact must be %q",
+			procName, v.Version, a.Kind, WASMProcessorArtifactKind))
+		err.Suggestion = "the registry index entry for this processor version is malformed; it should declare a single arch-neutral " + WASMProcessorArtifactKind + " artifact"
+		return nil, err
+	}
+	if a.OS != wasmProcessorOS || a.Arch != wasmProcessorArch {
+		err := conduiterr.New(CodeInvalidProcessorArtifact, fmt.Sprintf(
+			"processor %q version %s declares os/arch %s/%s, but a WASM processor artifact must be %s/%s",
+			procName, v.Version, a.OS, a.Arch, wasmProcessorOS, wasmProcessorArch))
+		err.Suggestion = "a standalone WASM processor is arch-neutral and must be built for " + wasmProcessorOS + "/" + wasmProcessorArch + "; a host os/arch here is a malformed or spoofed index entry"
+		return nil, err
+	}
+	return &a, nil
+}

--- a/pkg/registry/procplatform_test.go
+++ b/pkg/registry/procplatform_test.go
@@ -1,0 +1,75 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry"
+	"github.com/conduitio/conduit/pkg/registry/index"
+)
+
+func wasmProcessorVersion() index.ProcessorVersion {
+	return index.ProcessorVersion{
+		Version: "0.1.0",
+		Artifact: index.Artifact{
+			OS: "wasip1", Arch: "wasm", Kind: "wasm-processor",
+			URL: "http://x/proc.wasm",
+		},
+	}
+}
+
+func TestSelectProcessorArtifact_Match(t *testing.T) {
+	a, err := registry.SelectProcessorArtifact("conduit-processor-ai", wasmProcessorVersion())
+	require.NoError(t, err)
+	assert.Equal(t, "http://x/proc.wasm", a.URL)
+	assert.Equal(t, registry.WASMProcessorArtifactKind, a.Kind)
+}
+
+// TestSelectProcessorArtifact_WrongKindIsHardError proves the contrast with the
+// connector path (design doc D2): an unexpected kind is a HARD validation
+// error, never a silent skip.
+func TestSelectProcessorArtifact_WrongKindIsHardError(t *testing.T) {
+	v := wasmProcessorVersion()
+	v.Artifact.Kind = "standalone"
+
+	_, err := registry.SelectProcessorArtifact("conduit-processor-ai", v)
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeInvalidProcessorArtifact, ce.Code)
+}
+
+// TestSelectProcessorArtifact_HostOSArchIsHardError proves a processor artifact
+// carrying a host os/arch (instead of the fixed wasip1/wasm) is rejected, not
+// silently skipped — the anti-spoofing guard (D2, failure mode 3). It also
+// confirms the selector NEVER consults runtime.GOOS/GOARCH: a linux/amd64
+// artifact is refused even when the test host is linux/amd64.
+func TestSelectProcessorArtifact_HostOSArchIsHardError(t *testing.T) {
+	v := wasmProcessorVersion()
+	v.Artifact.OS = "linux"
+	v.Artifact.Arch = "amd64"
+
+	_, err := registry.SelectProcessorArtifact("conduit-processor-ai", v)
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeInvalidProcessorArtifact, ce.Code)
+	assert.Contains(t, ce.Suggestion, "wasip1/wasm")
+}

--- a/pkg/registry/trustverifier.go
+++ b/pkg/registry/trustverifier.go
@@ -121,7 +121,7 @@ func (v *TrustedVerifier) VerifyIndex(_ context.Context, raw []byte) (*index.Ver
 		return nil, conduiterr.Wrap(conduiterr.CodeInternal, "could not load persisted index state", err)
 	}
 
-	verified, err := index.Verify(raw, v.Anchors, state.LastVerifiedConnectorsHash)
+	verified, err := index.Verify(raw, v.Anchors, state.LastVerifiedContentHash)
 	if err != nil {
 		return nil, err
 	}
@@ -137,13 +137,13 @@ func (v *TrustedVerifier) VerifyIndex(_ context.Context, raw []byte) (*index.Ver
 		return nil, err
 	}
 
-	newState := index.State{Version: verified.Payload.Index.Version, LastVerifiedConnectorsHash: state.LastVerifiedConnectorsHash}
+	newState := index.State{Version: verified.Payload.Index.Version, LastVerifiedContentHash: state.LastVerifiedContentHash}
 	if verified.RootVerified {
-		hash, err := index.HashConnectors(verified.Payload.Connectors)
+		hash, err := index.HashContentSubtree(verified.Payload.Connectors, verified.Payload.Processors)
 		if err != nil {
-			return nil, conduiterr.Wrap(conduiterr.CodeInternal, "could not hash verified connectors for state persistence", err)
+			return nil, conduiterr.Wrap(conduiterr.CodeInternal, "could not hash verified content subtree for state persistence", err)
 		}
-		newState.LastVerifiedConnectorsHash = hash
+		newState.LastVerifiedContentHash = hash
 	}
 	fireChaos(chaosPointIndexStateBeforeWrite)
 	if err := index.SaveState(v.StatePath, newState); err != nil {


### PR DESCRIPTION
## Risk tier: **1** (signed, frozen public-contract format — the registry trust core). **Requires DeVaris explicit sign-off before merge.**

WS8 Plan #1, **PR-A** — the index-schema extension that lets `conduit processor-plugins install` fetch WASM processors through the same signed trust core connectors use. Bundles the gating **ADR + design doc** with the schema implementation so the decision + code are reviewed together.

- ADR: `docs/architecture-decision-records/20260727-processors-ride-connector-registry.md`
- Design doc: `docs/design-documents/20260727-registry-processor-artifacts.md`

## Decisions embodied (please confirm/correct at sign-off)
- **Additive under `schemaVersion` 1, forward-compatible** — `MaxSupportedSchemaVersion` stays 1; older clients ignore `processors[]` and keep installing connectors. (The load-bearing forward-compat-vs-fail-closed call — implemented as forward-compat, my recommendation.)
- **Separate top-level `processors []Processor` collection** (not a unified list + `kind`).

## What it adds (signed-format change only; resolution/install is PR-B)
- `Payload.Processors` + `Processor`/`ProcessorVersion` types (single **arch-neutral** `artifact`, not a per-`(os,arch)` list). Reuses `Publisher`/`Revocation`/`YankReason`/`Artifact`/`ProvenanceRef` verbatim.
- `SelectProcessorArtifact` (asserts `kind:"wasm-processor"`, `(wasip1,wasm)`; never consults host GOOS/GOARCH). Connector `SelectArtifact` untouched.
- Frozen JSON schema + `sample-index.json` gain a processor entry; connector artifact def unchanged.

## The security-critical bit — D4 freshness content-subtree (was a real hole, now fixed)
The freshness-key acceptance check hashed **connectors[] alone**, so `processors[]` was **not** covered — the unattended freshness key could re-sign an index whose processor tree was mutated while connectors[] stayed byte-identical, silently authorizing changed content. Widened `HashConnectors` → `HashContentSubtree(connectors, processors)` (fixed `{connectors,processors}` wrapper, excludes version/timestamp so heartbeats still validate). **Proven a genuine guard:** reverting to connectors-only makes `TestVerify_FreshnessSignatureWithMutatedProcessorsRequiresRoot` fail (freshness accepts the mutated tree); the widening refuses it (`CodeIndexIntegrity`).

## Failure-mode analysis
- **Older client, processor-bearing index:** verifies (signature covers the whole payload bytes it received) and reads connectors[] fine; ignores processors[]; `schemaVersion` still 1, no `CodeSchemaTooNew`. (`TestVerify_ForwardCompat_OlderClientIgnoresProcessors`.)
- **Freshness re-sign mutates processors[]:** refused, requires root (D4 test above).
- **State-file upgrade:** the persisted key renamed `lastVerifiedConnectorsHash` → `lastVerifiedContentHash`; an old-format file's key is unknown → loads empty → next fetch **requires a root signature** (fail-safe, self-healing). `Version` still loads → rollback protection intact. (`TestLoadState_LegacyConnectorsHashKeyIsIgnoredFailSafe`.)
- **Root-verify persists the new content hash** (`trustverifier.go`), only on `RootVerified`, under the state lock — so freshness always compares against root-established content.
- **Connector-only index stays byte-identical** (`omitempty` on `Processors`) — proven against the pre-processor fixture (`TestConnectorOnlyIndex_OmitemptyKeepsBytesIdentical` + a byte-identical preserved fixture).

## Deviations from the plan (flagged)
1. **Did NOT add `wasm-processor` to the shared connector `artifact.kind` enum** — that would loosen connector-artifact validation. Instead a dedicated `processorArtifact` schema def with `os`/`arch`/`kind` as **consts** — stricter (makes "a host os/arch is a validation error" schema-enforceable) and leaves the connector def byte-for-byte unchanged.
2. **State key rename** (beyond pure index schema) — the direct realization of D4; ships with its fail-safe upgrade test.
3. **index-CI is out-of-repo** — the append-only / registration-routing extension to `processors[]` is noted as a **PR-D follow-up**, not invented here.

## Verification
- `go build ./...` clean; `go test -race ./pkg/registry/...` GREEN (connector tests unchanged + green — the regression guard for the refactor); `cmd/conduit/root/connectors/...` green.
- Frozen schema validates both samples (santhosh-tekuri/jsonschema/v6); negative cases (host-targeted processor artifact) rejected.
- `go vet` + `golangci-lint` v2.12.2 (CI-exact) clean.

## Reviewer note
Reviewed line-by-line in a separate session from authorship — trust-core files (`hash.go`, `verify.go`, `state.go`, `trustverifier.go`), the omitempty byte-identity, the persist-on-root path, and the connector-def-untouched property specifically. No divergence from the frozen R-1 trust model.

Next: PR-B (generalize the install pipeline), PR-C (the CLI + Tranche-A offline install), PR-D (out-of-repo publish + index-CI), PR-E (template + ROADMAP-143 closeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD