### PR TITLE
feat(registry): generalize install pipeline for WASM-processor artifacts (Tier-1, PR-B)

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -614,7 +614,7 @@ Author: Meroxa, Inc.
 | `sdk.schema.extract.key.enabled` | bool | true | no | Whether to extract and decode the record key with a schema. |  |
 | `sdk.schema.extract.payload.enabled` | bool | true | no | Whether to extract and decode the record payload with a schema. |  |
 
-## 3. Error codes (84)
+## 3. Error codes (85)
 
 | Reason | gRPC status | Description |
 | --- | --- | --- |
@@ -680,6 +680,7 @@ Author: Meroxa, Inc.
 | `registry.install_locked` | Unavailable | CodeInstallLocked is raised when the per-target install lock is not acquired within --lock-timeout. |
 | `registry.invalid_processor_artifact` | FailedPrecondition | CodeInvalidProcessorArtifact is raised by SelectProcessorArtifact when a processor version's single artifact is not the required arch-neutral WASM shape — Kind != "wasm-processor", or (OS, Arch) != ("wasip1", "wasm"). Unlike the connector path's SelectArtifact, which deliberately SKIPS an unrecognized kind ("no matching artifact"), a malformed processor artifact is a hard validation error, never a silent skip (design doc D2, failure mode 3): a processor has exactly one artifact and it must be the WASM one, so anything else is a malformed or spoofed index entry. FailedPrecondition — the index entry as published does not meet the precondition for install. |
 | `registry.no_platform_artifact` | NotFound | CodeNoPlatformArtifact is raised when no artifact exists for the host (os, arch). |
+| `registry.processor_not_found` | NotFound | CodeProcessorNotFound is raised when an exact-match name lookup in the index's processors[] collection fails. Distinct from CodeConnectorNotFound so an operator/agent can tell which collection was searched (a name may legitimately exist in one and not the other); codes.NotFound, exactly like its connector sibling. Same anti-typosquat stance as findConnector: exact-match only, never a fuzzy suggestion. |
 | `registry.provenance_invalid` | PermissionDenied | CodeProvenanceInvalid is raised when the SLSA provenance's subject-digest match or builder.id/configSource.uri binding fails (trust.ErrProvenanceInvalid). |
 | `registry.schema_too_new` | FailedPrecondition | CodeSchemaTooNew is raised when payload.schemaVersion exceeds the highest this build was compiled to understand. |
 | `registry.trust_anchor_expired` | FailedPrecondition | CodeTrustAnchorExpired is raised when no keyId in signatures[] matches any of this build's compiled-in trust anchors at all — the "upgrade Conduit" case, distinct from CodeIndexIntegrity's "recognized key, verification failed". |

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@
 (6 built-in connectors; full parameters in llms-full.txt)
 
 ## Error codes
-- 84 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
+- 85 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
 
 ## MCP tools
 - Read: deploy, doctor, dry_run, inspect, lint, repair, validate

--- a/pkg/plugin/processor/standalone/inspect.go
+++ b/pkg/plugin/processor/standalone/inspect.go
@@ -1,0 +1,92 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standalone
+
+import (
+	"context"
+
+	sdk "github.com/conduitio/conduit-processor-sdk"
+	"github.com/conduitio/conduit-processor-sdk/schema"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/stealthrocket/wazergo"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+)
+
+// InspectSpecification compiles the WASM module at path with the SAME wazero
+// runtime and Conduit host module the standalone processor registry uses at
+// load time (it reuses loadBlueprint verbatim), instantiates it once with
+// deny-all egress and a throwaway in-memory schema service, and returns its
+// self-declared Specification.
+//
+// It is the install-time validation primitive pkg/registry uses to confirm a
+// fetched processor artifact (a) compiles under wazero at all and (b) declares
+// the name the runtime will actually register it under — closing the gap
+// between the registry index name and Specification().Name, which is what
+// NewRegistry keys a discovered plugin on (see registry.go's loadBlueprint),
+// NOT the on-disk filename.
+//
+// It builds and tears down its OWN throwaway runtime; it never scans a
+// directory and never registers anything into a live Registry. Because it
+// reuses loadBlueprint, install-time validation can never diverge from runtime
+// discovery: if this returns a spec for a file, a NewRegistry over that same
+// file will register exactly that spec.
+//
+// Concurrency: safe to call concurrently — each call owns an independent
+// runtime (a wazero.Runtime is not itself goroutine-safe, but nothing here is
+// shared across calls).
+//
+// This lives here, in the standalone package, rather than in pkg/registry, so
+// there is a single WASM loader: pkg/registry importing this creates no import
+// cycle (standalone does not import pkg/registry).
+func InspectSpecification(ctx context.Context, logger log.CtxLogger, path string) (sdk.Specification, error) {
+	logger = logger.WithComponentFromType(Registry{})
+
+	// Use the package-level newRuntime hook so this honors the interpreter
+	// runtime tests swap in (standalone_test.go's TestMain), and the compiler
+	// runtime in production — exactly as NewRegistry does.
+	rt := newRuntime(ctx)
+	defer func() { _ = rt.Close(ctx) }()
+
+	if _, err := wasi_snapshot_preview1.Instantiate(ctx, rt); err != nil {
+		return sdk.Specification{}, cerrors.Errorf("failed to instantiate WASI: %w", err)
+	}
+	compiledHostModule, err := wazergo.Compile(ctx, rt, hostModule)
+	if err != nil {
+		return sdk.Specification{}, cerrors.Errorf("failed to compile host module: %w", err)
+	}
+
+	// A minimal, directory-less Registry: loadBlueprint reads only these four
+	// fields. The schema service is a throwaway in-memory one — Specification()
+	// never exercises a schema host call, and the throwaway processor is torn
+	// down immediately inside loadBlueprint, so nothing is ever written to it.
+	r := &Registry{
+		logger:        logger,
+		runtime:       rt,
+		hostModule:    compiledHostModule,
+		schemaService: schema.NewInMemoryService(),
+	}
+
+	bp, err := r.loadBlueprint(ctx, path)
+	if err != nil {
+		return sdk.Specification{}, err
+	}
+	// loadBlueprint returns the compiled module still open (a live Registry
+	// keeps it for later NewProcessor calls). Here there is no Registry to own
+	// it, so close it before the runtime is torn down.
+	_ = bp.module.Close(ctx)
+
+	return bp.specification, nil
+}

--- a/pkg/plugin/processor/standalone/inspect_test.go
+++ b/pkg/plugin/processor/standalone/inspect_test.go
@@ -1,0 +1,70 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standalone
+
+import (
+	"context"
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/matryer/is"
+)
+
+// TestInspectSpecification_Chaos is the happy path: a real, compilable
+// standalone WASM processor's self-declared Specification is returned exactly
+// as a NewRegistry-loaded plugin's would be — proving install-time validation
+// (pkg/registry) reads the SAME name/version the runtime will register the
+// plugin under. The wasm is built by TestMain (standalone_test.go).
+func TestInspectSpecification_Chaos(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	spec, err := InspectSpecification(ctx, log.Nop(), testPluginChaosDir+"processor.wasm")
+	is.NoErr(err)
+	is.Equal("chaos-processor", spec.Name)
+	is.Equal("v1.3.5", spec.Version)
+}
+
+// TestInspectSpecification_CompileError refuses a file that is not a valid
+// WASM module at all (the malformed fixture is a plain .txt) — the compile step
+// fails and the error is surfaced, never a zero-value spec silently returned.
+func TestInspectSpecification_CompileError(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	_, err := InspectSpecification(ctx, log.Nop(), testPluginMalformedDir+"processor.txt")
+	is.True(err != nil)
+}
+
+// TestInspectSpecification_SpecifyError refuses a module that compiles but
+// whose Specification() returns an error ("boom") — the spec-extraction failure
+// propagates, exactly as it does in NewRegistry's discovery.
+func TestInspectSpecification_SpecifyError(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	_, err := InspectSpecification(ctx, log.Nop(), testPluginSpecifyErrorDir+"processor.wasm")
+	is.True(err != nil)
+}
+
+// TestInspectSpecification_MissingFile refuses a path that does not exist,
+// rather than panicking or returning a zero spec.
+func TestInspectSpecification_MissingFile(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	_, err := InspectSpecification(ctx, log.Nop(), testPluginChaosDir+"does-not-exist.wasm")
+	is.True(err != nil)
+}

--- a/pkg/registry/bundle.go
+++ b/pkg/registry/bundle.go
@@ -201,20 +201,28 @@ func Bundle(ctx context.Context, opts BundleOptions) (*BundleResult, error) {
 		return nil, err
 	}
 
-	// fetchArtifactRef's InstallOptions parameter carries no fields it
-	// actually reads (bundle fetches always go through boundedfetch's own
-	// http.DefaultClient) — passed as a zero value deliberately, not an
-	// oversight.
-	ref, err := fetchArtifactRef(ctx, InstallOptions{}, dl.Digest, resolved.Version, artifact)
+	// Collapse the connector resolution into the artifact-kind-neutral shape
+	// fetchArtifactRef now consumes. fetchArtifactRef's InstallOptions
+	// parameter carries no fields it actually reads (bundle fetches always go
+	// through boundedfetch's own http.DefaultClient) — passed as a zero value
+	// deliberately, not an oversight.
+	ra := resolvedArtifact{
+		name:    resolved.Connector.Name,
+		version: resolved.Version.Version,
+		identity: trust.PinnedIdentity{
+			OIDCIssuer:      resolved.Connector.Publisher.ExpectedOIDCIssuer,
+			IdentityPattern: resolved.Connector.Publisher.ExpectedIdentityPattern,
+		},
+		artifact:          artifact,
+		versionProvenance: resolved.Version.SLSAProvenance,
+		deprecated:        resolved.Version.Deprecated,
+	}
+	ref, err := fetchArtifactRef(ctx, InstallOptions{}, dl.Digest, ra)
 	if err != nil {
 		return nil, err
 	}
 
-	identity := trust.PinnedIdentity{
-		OIDCIssuer:      resolved.Connector.Publisher.ExpectedOIDCIssuer,
-		IdentityPattern: resolved.Connector.Publisher.ExpectedIdentityPattern,
-	}
-	verifyResult, err := opts.ArtifactVerifier.VerifyArtifact(ctx, ref, identity)
+	verifyResult, err := opts.ArtifactVerifier.VerifyArtifact(ctx, ref, ra.identity)
 	if err != nil {
 		return nil, err
 	}
@@ -511,8 +519,9 @@ func InstallFromBundle(ctx context.Context, opts InstallBundleOptions) (*Install
 		return nil, conduiterr.Wrap(CodeArchiveInvalid, "could not stage bundled artifact", err)
 	}
 
-	entryToSave, err := finalizeArtifactInstall(finalizeInstallOptions{
-		connectorsPath:     opts.ConnectorsPath,
+	entryToSave, err := finalizeArtifactInstall(ctx, finalizeInstallOptions{
+		targetDir:          opts.ConnectorsPath,
+		target:             connectorTarget(),
 		stagingDir:         stagingDir,
 		archivePath:        archivePath,
 		name:               resolved.Connector.Name,

--- a/pkg/registry/codes.go
+++ b/pkg/registry/codes.go
@@ -93,6 +93,13 @@ var (
 	// key not among them. Verification never proceeds when this is raised —
 	// it can only make installs fail closed, never open.
 	CodeTrustAnchorsUnavailable = conduiterr.Register("registry.trust_anchors_unavailable", codes.Internal)
+	// CodeProcessorNotFound is raised when an exact-match name lookup in the
+	// index's processors[] collection fails. Distinct from
+	// CodeConnectorNotFound so an operator/agent can tell which collection was
+	// searched (a name may legitimately exist in one and not the other);
+	// codes.NotFound, exactly like its connector sibling. Same anti-typosquat
+	// stance as findConnector: exact-match only, never a fuzzy suggestion.
+	CodeProcessorNotFound = conduiterr.Register("registry.processor_not_found", codes.NotFound)
 	// CodeInvalidProcessorArtifact is raised by SelectProcessorArtifact when a
 	// processor version's single artifact is not the required arch-neutral WASM
 	// shape — Kind != "wasm-processor", or (OS, Arch) != ("wasip1", "wasm").

--- a/pkg/registry/install.go
+++ b/pkg/registry/install.go
@@ -66,8 +66,16 @@ type InstallOptions struct {
 
 	// ConnectorsPath is the standalone connectors directory
 	// (--connectors.path) the binary is installed into, and under which
-	// .registry/ bookkeeping lives.
+	// .registry/ bookkeeping lives. Used by Install (connectors).
 	ConnectorsPath string
+
+	// ProcessorsPath is the standalone processors directory
+	// (--processors.path) a WASM processor artifact is installed into, and
+	// under which its OWN, SEPARATE .registry/ bookkeeping lives. Used by
+	// InstallProcessor (processors) exactly as ConnectorsPath is used by
+	// Install — never commingled: a processor install writes a distinct
+	// <processors.path>/.registry/manifest.json (plan edge case 15).
+	ProcessorsPath string
 
 	// IndexURL is the index to fetch over HTTP(S). Ignored if IndexFile is
 	// set.
@@ -246,19 +254,36 @@ func Install(ctx context.Context, opts InstallOptions) (*InstallResult, error) {
 		return nil, err
 	}
 
+	// Collapse the connector-specific resolution into the artifact-kind-neutral
+	// shape the shared install core (installArtifact) consumes — so connectors
+	// and processors funnel through ONE download/verify/rename/manifest path.
+	ra := resolvedArtifact{
+		name:    resolved.Connector.Name,
+		version: resolved.Version.Version,
+		identity: trust.PinnedIdentity{
+			OIDCIssuer:      resolved.Connector.Publisher.ExpectedOIDCIssuer,
+			IdentityPattern: resolved.Connector.Publisher.ExpectedIdentityPattern,
+		},
+		artifact:          artifact,
+		versionProvenance: resolved.Version.SLSAProvenance,
+		deprecated:        resolved.Version.Deprecated,
+	}
+
 	if opts.DryRun {
 		return &InstallResult{
-			Name: resolved.Connector.Name, Version: resolved.Version.Version,
+			Name: ra.name, Version: ra.version,
 			OS: artifact.OS, Arch: artifact.Arch,
-			Deprecated:  resolved.Version.Deprecated,
+			Deprecated:  ra.deprecated,
 			DryRun:      true,
 			ArtifactURL: artifact.URL,
 			Size:        artifact.Size,
 		}, nil
 	}
 
-	// 4-9: lock, download, verify, extract, atomically install, record.
-	return installResolved(ctx, opts, verified, resolved, artifact)
+	// 4-9: lock, download, verify, extract, atomically install, record — into
+	// ConnectorsPath, with the connector target's naming/mode/kind/audit
+	// (connectorTarget preserves today's connector behavior exactly).
+	return installArtifact(ctx, opts, opts.ConnectorsPath, connectorTarget(), verified, ra)
 }
 
 // resolveInstall runs steps 1-3: fetch+shape-check the index (via
@@ -292,19 +317,25 @@ func resolveInstall(ctx context.Context, opts InstallOptions) (*index.VerifiedIn
 	return verified, resolved, artifact, nil
 }
 
-// installResolved runs steps 4-9 of Install against an already-resolved
-// connector version and platform artifact: acquire the per-target lock,
-// short-circuit if already installed, download+verify+extract+atomically
-// install, then record the manifest entry and audit event.
-func installResolved(ctx context.Context, opts InstallOptions, verified *index.VerifiedIndex, resolved *ResolvedVersion, artifact *index.Artifact) (*InstallResult, error) {
-	key, err := ManifestKey(resolved.Connector.Name, resolved.Version.Version)
+// installArtifact runs steps 4-9 against an already-resolved, artifact-kind-
+// neutral resolvedArtifact: acquire the per-target lock, short-circuit if
+// already installed, download+verify+extract+atomically install into targetDir,
+// then record the manifest entry and audit event. Both Install (connectors)
+// and InstallProcessor (processors) funnel through here — the trust gate,
+// staging, atomic rename, manifest and audit discipline is IDENTICAL and never
+// forked (ADR 20260727-processors-ride-connector-registry, decision 1). target
+// carries the only artifact-kind-specific parameters (on-disk filename, file
+// mode, manifest Kind, audit label, and the optional install-time validation
+// hook); targetDir is --connectors.path or --processors.path.
+func installArtifact(ctx context.Context, opts InstallOptions, targetDir string, target installTarget, verified *index.VerifiedIndex, ra resolvedArtifact) (*InstallResult, error) {
+	key, err := ManifestKey(ra.name, ra.version)
 	if err != nil {
 		return nil, err
 	}
 
 	// 4. Per-target lock: serializes the ENTIRE remaining pipeline for two
-	// concurrent installs of the same connector name.
-	targetLock, err := AcquireTargetLock(opts.ConnectorsPath, resolved.Connector.Name, opts.lockTimeout())
+	// concurrent installs of the same name.
+	targetLock, err := AcquireTargetLock(targetDir, ra.name, opts.lockTimeout())
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +345,7 @@ func installResolved(ctx context.Context, opts InstallOptions, verified *index.V
 	// a concurrent install of the same name that started earlier may have
 	// just finished; reading the manifest before the lock could observe a
 	// write in flight and give a stale answer.
-	entry, alreadyInstalled, err := lookupManifestEntry(opts.ConnectorsPath, key)
+	entry, alreadyInstalled, err := lookupManifestEntry(targetDir, key)
 	if err != nil {
 		return nil, err
 	}
@@ -328,28 +359,31 @@ func installResolved(ctx context.Context, opts InstallOptions, verified *index.V
 		}, nil
 	}
 
-	entry, err = downloadVerifyAndInstall(ctx, opts, verified, resolved, artifact)
+	entry, err = downloadVerifyAndInstall(ctx, opts, targetDir, target, verified, ra)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := writeManifestEntry(opts.ConnectorsPath, key, entry, opts.lockTimeout()); err != nil {
+	if err := writeManifestEntry(targetDir, key, entry, opts.lockTimeout()); err != nil {
 		return nil, err
 	}
 
 	// 9. Audit event — appended only AFTER the rename and manifest write
 	// above have both succeeded (see AppendAuditEvent's invariant comment).
-	if err := AppendAuditEvent(auditLogPath(opts.ConnectorsPath), AuditEvent{
-		Event: "connector_install", Connector: entry.Name, Version: entry.Version,
+	// AuditEvent.Connector carries the artifact name for both kinds; the Event
+	// label (target.auditEvent) is what distinguishes a processor_install from
+	// a connector_install in the trail.
+	if err := AppendAuditEvent(auditLogPath(targetDir), AuditEvent{
+		Event: target.auditEvent, Connector: entry.Name, Version: entry.Version,
 		Digest: entry.Digest, Operator: opts.InstalledBy, Timestamp: entry.InstalledAt,
 		Signed: entry.Signed, VerifiedIdentity: entry.VerifiedIdentity, AllowUnsigned: entry.AllowUnsigned,
 	}); err != nil {
-		return nil, conduiterr.Wrap(conduiterr.CodeInternal, "connector installed but could not append the audit log entry", err)
+		return nil, conduiterr.Wrap(conduiterr.CodeInternal, "artifact installed but could not append the audit log entry", err)
 	}
 
 	return &InstallResult{
 		Name: entry.Name, Version: entry.Version, OS: entry.OS, Arch: entry.Arch,
-		Deprecated:         resolved.Version.Deprecated,
+		Deprecated:         ra.deprecated,
 		ArtifactFile:       entry.ArtifactFile,
 		Digest:             entry.Digest,
 		SourceIndexVersion: entry.SourceIndexVersion,
@@ -357,24 +391,28 @@ func installResolved(ctx context.Context, opts InstallOptions, verified *index.V
 }
 
 // downloadVerifyAndInstall runs steps 5-8: stage, download, corruption
-// check, the verification gate, extract, and the atomic rename — returning
-// the ManifestEntry to record (steps 8-9's write/audit stay in
-// installResolved, since they're identical regardless of how the entry was
-// produced).
-func downloadVerifyAndInstall(ctx context.Context, opts InstallOptions, verified *index.VerifiedIndex, resolved *ResolvedVersion, artifact *index.Artifact) (ManifestEntry, error) {
+// check, the verification gate, extract, (optionally) install-time-validate,
+// and the atomic rename — returning the ManifestEntry to record (steps 8-9's
+// write/audit stay in installArtifact, since they're identical regardless of
+// how the entry was produced).
+func downloadVerifyAndInstall(ctx context.Context, opts InstallOptions, targetDir string, target installTarget, verified *index.VerifiedIndex, ra resolvedArtifact) (ManifestEntry, error) {
 	// Best-effort, non-blocking cache housekeeping (step5 §5): sweep any
 	// orphaned ".tmp-populate-*" directory left by a crash mid-CachePopulate
 	// on a PRIOR install. Never fails or slows this install over a stale
 	// temp directory — errors are swallowed inside CacheSweepTmp itself.
-	CacheSweepTmp(opts.ConnectorsPath, cacheTmpMaxAge)
+	CacheSweepTmp(targetDir, cacheTmpMaxAge)
 
 	// 5. Staging directory: a private (0700), uniquely-named SUBDIRECTORY
-	// of ConnectorsPath — never the OS temp dir. This is required, not
+	// of targetDir — never the OS temp dir. This is required, not
 	// just tidy, so the final os.Rename below is a same-filesystem,
 	// therefore atomic, rename: a temp directory on a different volume
 	// would make that rename a non-atomic copy and could fail outright
-	// with EXDEV.
-	stagingRoot := stagingRootPath(opts.ConnectorsPath)
+	// with EXDEV. Invariant 5. For a processor install targetDir is
+	// --processors.path, so staging lives under
+	// <processors.path>/.registry/staging and the rename stays on the
+	// processors filesystem (plan edge case 7 — the single most important
+	// porting detail).
+	stagingRoot := stagingRootPath(targetDir)
 	if err := os.MkdirAll(stagingRoot, 0o700); err != nil {
 		return ManifestEntry{}, conduiterr.Wrap(CodeDownloadFailed, "could not create staging root directory", err)
 	}
@@ -395,7 +433,7 @@ func downloadVerifyAndInstall(ctx context.Context, opts InstallOptions, verified
 	}
 
 	archivePath := filepath.Join(stagingDir, "artifact.tar.gz")
-	dl, fromCache, err := stageArtifact(ctx, opts, artifact, archivePath)
+	dl, fromCache, err := stageArtifact(ctx, opts, targetDir, ra.artifact, archivePath)
 	if err != nil {
 		return ManifestEntry{}, err
 	}
@@ -405,7 +443,7 @@ func downloadVerifyAndInstall(ctx context.Context, opts InstallOptions, verified
 	// unconditionally regardless of fromCache: a cache hit still proves
 	// nothing about the bytes' trustworthiness on its own (see stageArtifact's
 	// doc comment) — it only short-circuits the network fetch.
-	if err := CheckCorruption(dl.Digest, artifact.SHA256); err != nil {
+	if err := CheckCorruption(dl.Digest, ra.artifact.SHA256); err != nil {
 		return ManifestEntry{}, err
 	}
 
@@ -418,23 +456,24 @@ func downloadVerifyAndInstall(ctx context.Context, opts InstallOptions, verified
 			// Best-effort: the cache is purely an optimization (step5 §5) —
 			// a populate failure must never fail an otherwise-successful
 			// install.
-			_ = CachePopulate(opts.ConnectorsPath, normalizeDigestHex(artifact.SHA256), data, artifact.URL)
+			_ = CachePopulate(targetDir, normalizeDigestHex(ra.artifact.SHA256), data, ra.artifact.URL)
 		}
 	}
 
-	verifyResult, err := runVerificationGate(ctx, opts, dl, resolved, artifact)
+	verifyResult, err := runVerificationGate(ctx, opts, dl, ra)
 	if err != nil {
 		return ManifestEntry{}, err
 	}
 
-	return finalizeArtifactInstall(finalizeInstallOptions{
-		connectorsPath:     opts.ConnectorsPath,
+	return finalizeArtifactInstall(ctx, finalizeInstallOptions{
+		targetDir:          targetDir,
+		target:             target,
 		stagingDir:         stagingDir,
 		archivePath:        archivePath,
-		name:               resolved.Connector.Name,
-		version:            resolved.Version.Version,
-		os:                 artifact.OS,
-		arch:               artifact.Arch,
+		name:               ra.name,
+		version:            ra.version,
+		os:                 ra.artifact.OS,
+		arch:               ra.artifact.Arch,
 		digest:             dl.Digest,
 		size:               dl.Size,
 		installedBy:        opts.InstalledBy,
@@ -449,9 +488,14 @@ func downloadVerifyAndInstall(ctx context.Context, opts InstallOptions, verified
 // archive whose bytes have ALREADY passed the corruption check and the full
 // verification gate.
 type finalizeInstallOptions struct {
-	connectorsPath string
-	stagingDir     string
-	archivePath    string
+	// targetDir is --connectors.path (connectors) or --processors.path
+	// (processors); the artifact is renamed into it and staging shares its
+	// filesystem.
+	targetDir string
+	// target carries the artifact-kind-specific naming/mode/kind/validate.
+	target      installTarget
+	stagingDir  string
+	archivePath string
 
 	name, version, os, arch string
 	digest                  [32]byte
@@ -469,42 +513,55 @@ type finalizeInstallOptions struct {
 }
 
 // finalizeArtifactInstall is steps 7-9's shared tail: extract the single
-// candidate binary, atomically rename it into connectorsPath, and build the
-// ManifestEntry to record — used by BOTH the online install pipeline
-// (downloadVerifyAndInstall, above) and the offline bundle-install path
-// (bundle.go's InstallFromBundle), so the two paths can never diverge on
-// the extract/rename/manifest-shape discipline. Manifest write + audit
-// event (steps 8-9's remaining parts) stay with each caller, since
-// InstallFromBundle's is otherwise identical to installResolved's but for
-// the ManifestEntry.Source/BundleIndexVersion fields.
-func finalizeArtifactInstall(o finalizeInstallOptions) (ManifestEntry, error) {
+// candidate artifact, run the target's optional install-time validation hook,
+// atomically rename it into o.targetDir, and build the ManifestEntry to record
+// — used by the online connector pipeline (downloadVerifyAndInstall, above),
+// the online processor pipeline (via the same path with a processor target),
+// and the offline bundle-install path (bundle.go's InstallFromBundle), so
+// those paths can never diverge on the extract/validate/rename/manifest-shape
+// discipline. Manifest write + audit event (steps 8-9's remaining parts) stay
+// with each caller, since InstallFromBundle's is otherwise identical to
+// installArtifact's but for the ManifestEntry.Source/BundleIndexVersion
+// fields.
+func finalizeArtifactInstall(ctx context.Context, o finalizeInstallOptions) (ManifestEntry, error) {
 	binaryPath, err := extractAndGuard(o.archivePath, o.stagingDir)
 	if err != nil {
 		return ManifestEntry{}, err
 	}
 
-	finalName := fmt.Sprintf("conduit-connector-%s_%s", o.name, o.version)
-	finalPath := filepath.Join(o.connectorsPath, finalName)
+	// Install-time validation hook (processors, ADR decision 4 / plan AC-9):
+	// runs on the extracted artifact — still inside the private staging dir —
+	// AFTER the corruption + trust gates and BEFORE the atomic rename, so a
+	// module that will not compile or whose spec name disagrees with the
+	// resolved index name never lands under targetDir. nil for connectors, so
+	// the connector path's behavior is preserved exactly.
+	if o.target.validate != nil {
+		if err := o.target.validate(ctx, binaryPath, o.name, o.version); err != nil {
+			return ManifestEntry{}, err
+		}
+	}
+
+	finalName := o.target.finalName(o.name, o.version)
+	finalPath := filepath.Join(o.targetDir, finalName)
 
 	// Invariant 5 (atomic state/checkpoint writes): os.Rename within one
 	// filesystem is a single atomic syscall — there is no OS-observable
 	// "mid-rename" state. A crash before it returns leaves the OLD binary
 	// (if any) untouched at finalPath; a crash after leaves the NEW binary
 	// fully present. This is exactly why staging must share a filesystem
-	// with connectorsPath — the guarantee does not hold across devices
-	// (EXDEV).
+	// with targetDir — the guarantee does not hold across devices (EXDEV).
 	if err := os.Rename(binaryPath, finalPath); err != nil {
 		return ManifestEntry{}, conduiterr.Wrap(CodeArchiveInvalid, fmt.Sprintf("could not install %q", finalName), err)
 	}
-	if err := os.Chmod(finalPath, 0o755); err != nil {
-		return ManifestEntry{}, conduiterr.Wrap(CodeArchiveInvalid, "could not set installed binary permissions", err)
+	if err := os.Chmod(finalPath, o.target.fileMode); err != nil {
+		return ManifestEntry{}, conduiterr.Wrap(CodeArchiveInvalid, "could not set installed artifact permissions", err)
 	}
 	fireChaos(chaosPointPostRenamePreManifest)
 
 	now := time.Now().UTC()
 	return ManifestEntry{
 		Name: o.name, Version: o.version,
-		Kind: StandaloneArtifactKind, OS: o.os, Arch: o.arch,
+		Kind: o.target.kind, OS: o.os, Arch: o.arch,
 		ArtifactFile: finalName, Digest: fmt.Sprintf("sha256:%x", o.digest), Size: o.size,
 		InstalledAt: now, InstalledBy: o.installedBy,
 		SourceIndexVersion: o.sourceIndexVersion, Source: o.source, BundleIndexVersion: o.bundleIndexVersion,
@@ -523,10 +580,10 @@ func finalizeArtifactInstall(o finalizeInstallOptions) (ManifestEntry, error) {
 // decision: the caller still runs CheckCorruption and the full verification
 // gate against the returned DownloadResult exactly as it would for a fresh
 // download; this function only ever decides where the BYTES come from.
-func stageArtifact(ctx context.Context, opts InstallOptions, artifact *index.Artifact, archivePath string) (DownloadResult, bool, error) {
+func stageArtifact(ctx context.Context, opts InstallOptions, targetDir string, artifact *index.Artifact, archivePath string) (DownloadResult, bool, error) {
 	digestHex := normalizeDigestHex(artifact.SHA256)
 	if digestHex != "" {
-		if cached, hit, cacheErr := CacheLookup(opts.ConnectorsPath, digestHex); cacheErr == nil && hit {
+		if cached, hit, cacheErr := CacheLookup(targetDir, digestHex); cacheErr == nil && hit {
 			if werr := os.WriteFile(archivePath, cached, 0o600); werr == nil {
 				sum := sha256.Sum256(cached)
 				var digest [32]byte
@@ -561,19 +618,16 @@ func stageArtifact(ctx context.Context, opts InstallOptions, artifact *index.Art
 // ErrVerificationNotConfigured. With the real TrustedVerifier (PR-2), a
 // non-Signed success without going through the AllowUnsigned+policy.Decide
 // path is a programming error refused below, never silently installed.
-func runVerificationGate(ctx context.Context, opts InstallOptions, dl DownloadResult, resolved *ResolvedVersion, artifact *index.Artifact) (VerifyResult, error) {
+func runVerificationGate(ctx context.Context, opts InstallOptions, dl DownloadResult, ra resolvedArtifact) (VerifyResult, error) {
 	if opts.AllowUnsigned {
-		return unsignedInstallGate(opts, dl, resolved)
+		return unsignedInstallGate(opts, dl, ra)
 	}
 
-	ref, err := fetchArtifactRef(ctx, opts, dl.Digest, resolved.Version, artifact)
+	ref, err := fetchArtifactRef(ctx, opts, dl.Digest, ra)
 	if err != nil {
 		return VerifyResult{}, err
 	}
-	identity := trust.PinnedIdentity{
-		OIDCIssuer:      resolved.Connector.Publisher.ExpectedOIDCIssuer,
-		IdentityPattern: resolved.Connector.Publisher.ExpectedIdentityPattern,
-	}
+	identity := ra.identity
 
 	verifyResult, err := opts.ArtifactVerifier.VerifyArtifact(ctx, ref, identity)
 	if err != nil {
@@ -601,7 +655,7 @@ func runVerificationGate(ctx context.Context, opts InstallOptions, dl DownloadRe
 // unsigned install to be logged, no exceptions — and returns
 // VerifyResult{Signed: false}, which downloadVerifyAndInstall records
 // verbatim into the manifest's Signed/AllowUnsigned fields.
-func unsignedInstallGate(opts InstallOptions, dl DownloadResult, resolved *ResolvedVersion) (VerifyResult, error) {
+func unsignedInstallGate(opts InstallOptions, dl DownloadResult, ra resolvedArtifact) (VerifyResult, error) {
 	dec, err := policy.Decide(policy.Context{
 		TTY:               opts.TTY,
 		CIEnv:             opts.CIEnv,
@@ -630,8 +684,8 @@ func unsignedInstallGate(opts InstallOptions, dl DownloadResult, resolved *Resol
 		logPath = unsignedInstallsLogPath(opts.ConnectorsPath)
 	}
 	if err := policy.AppendUnsignedInstallEvent(logPath, policy.UnsignedInstallEvent{
-		Connector:      resolved.Connector.Name,
-		Version:        resolved.Version.Version,
+		Connector:      ra.name,
+		Version:        ra.version,
 		ResolvedDigest: fmt.Sprintf("sha256:%x", dl.Digest),
 		Operator:       opts.InstalledBy,
 		Timestamp:      time.Now().UTC(),
@@ -690,8 +744,9 @@ func fetchIndexRaw(ctx context.Context, opts InstallOptions) ([]byte, error) {
 // whichever is present) into an ArtifactRef, bounded per MaxBundleBytes —
 // this package never hands ArtifactVerifier a bare URL; it fetches the
 // bytes itself so the interface stays crypto-library-agnostic.
-func fetchArtifactRef(ctx context.Context, opts InstallOptions, digest [32]byte, v index.ConnectorVersion, a *index.Artifact) (ArtifactRef, error) {
+func fetchArtifactRef(ctx context.Context, opts InstallOptions, digest [32]byte, ra resolvedArtifact) (ArtifactRef, error) {
 	ref := ArtifactRef{Digest: digest}
+	a := ra.artifact
 
 	if a.Signature.BundleURL != "" {
 		sig, err := fetchBundle(ctx, a.Signature.BundleURL)
@@ -703,7 +758,7 @@ func fetchArtifactRef(ctx context.Context, opts InstallOptions, digest [32]byte,
 
 	provRef := a.SLSAProvenance
 	if provRef == nil {
-		provRef = v.SLSAProvenance
+		provRef = ra.versionProvenance
 	}
 	if provRef != nil && provRef.BundleURL != "" {
 		prov, err := fetchBundle(ctx, provRef.BundleURL)

--- a/pkg/registry/installprocessor.go
+++ b/pkg/registry/installprocessor.go
@@ -1,0 +1,234 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	proc_standalone "github.com/conduitio/conduit/pkg/plugin/processor/standalone"
+	"github.com/conduitio/conduit/pkg/registry/trust"
+)
+
+// develGuestVersion is the version a standalone WASM processor reports from Go
+// build info when it was built with a plain `GOOS=wasip1 GOARCH=wasm go build`
+// (no release version stamped in) — Go's module-version default for anything
+// not built via `go install module@version`. The authoritative version for
+// such a build is the registry index's name@version (what lands on disk and in
+// the manifest), so install-time validation asserts the guest NAME but treats
+// a "(devel)" guest VERSION as an unversioned dev build and does NOT require it
+// to equal the index version. See validateProcessorWASM.
+const develGuestVersion = "(devel)"
+
+// wasmProcessorFileMode is 0644, not the connector path's 0755: a .wasm is read
+// by wazero, never exec'd, so the executable bit is meaningless (plan edge
+// case 14).
+const wasmProcessorFileMode os.FileMode = 0o644
+
+// ProcessorFileName builds the on-disk filename for an installed standalone
+// WASM processor: conduit-processor-<name>_<version>.wasm. The name is cosmetic
+// to discovery (the standalone registry registers a plugin under the module's
+// own Specification().Name, not the filename) but gives uninstall/audit a
+// predictable target and makes --processors.path human-legible; the .wasm
+// suffix tells an operator eyeballing the directory what the file is (plan edge
+// case 13). Exported for the PR-C CLI/uninstall, which must agree with this
+// pipeline's naming without duplicating it.
+func ProcessorFileName(name, version string) string {
+	return fmt.Sprintf("conduit-processor-%s_%s.wasm", name, version)
+}
+
+// InstallProcessor is the processor analogue of Install. It fetches +
+// shape-checks the signed index, resolves name/version against
+// payload.Processors (ResolveProcessor), selects the single arch-neutral
+// (wasip1/wasm) artifact (SelectProcessorArtifact — NEVER the host-platform
+// SelectArtifact), and runs the SAME download → corruption-check → trust gate →
+// atomic-rename → manifest → audit core Install uses (installArtifact). It
+// differs from Install only in:
+//
+//   - the target directory: --processors.path (opts.ProcessorsPath), with its
+//     own separate <processors.path>/.registry bookkeeping;
+//   - the on-disk filename (conduit-processor-<name>_<version>.wasm) and mode
+//     (0644);
+//   - the manifest Kind (WASMProcessorArtifactKind) and audit label
+//     ("processor_install"); and
+//   - an install-time WASM compile+spec validation step (validateProcessorWASM)
+//     run on the extracted artifact BEFORE the atomic rename.
+//
+// The trust core is reused verbatim, never forked (ADR decision 1): the same
+// IndexVerifier/ArtifactVerifier, the same RequireProvenance behavior, and the
+// same single policy.Decide unsigned gate (guarded by the PolicyBypass
+// depguard rule). Integrity (sha256) stays separate from trust, as for
+// connectors.
+func InstallProcessor(ctx context.Context, opts InstallOptions) (*InstallResult, error) {
+	if err := opts.validateProcessor(); err != nil {
+		return nil, err
+	}
+
+	// 1-3: fetch + shape-check the index, resolve name/version over the
+	// processor collection, select the single arch-neutral WASM artifact.
+	raw, err := fetchIndexRaw(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	verified, err := opts.IndexVerifier.VerifyIndex(ctx, raw)
+	if err != nil {
+		return nil, err
+	}
+
+	resolved, err := ResolveProcessor(verified.Payload, ResolveOptions{
+		Name:                   opts.Name,
+		Version:                opts.Version,
+		RunningConduitVersion:  opts.RunningConduitVersion,
+		RunningProtocolVersion: opts.RunningProtocolVersion,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	artifact, err := SelectProcessorArtifact(resolved.Processor.Name, resolved.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	ra := resolvedArtifact{
+		name:    resolved.Processor.Name,
+		version: resolved.Version.Version,
+		identity: trust.PinnedIdentity{
+			OIDCIssuer:      resolved.Processor.Publisher.ExpectedOIDCIssuer,
+			IdentityPattern: resolved.Processor.Publisher.ExpectedIdentityPattern,
+		},
+		artifact:          artifact,
+		versionProvenance: resolved.Version.SLSAProvenance,
+		deprecated:        resolved.Version.Deprecated,
+	}
+
+	if opts.DryRun {
+		return &InstallResult{
+			Name: ra.name, Version: ra.version,
+			OS: artifact.OS, Arch: artifact.Arch,
+			Deprecated:  ra.deprecated,
+			DryRun:      true,
+			ArtifactURL: artifact.URL,
+			Size:        artifact.Size,
+		}, nil
+	}
+
+	// 4-9: lock, download, verify, extract, WASM-validate, atomically install,
+	// record — into ProcessorsPath, with the processor target.
+	return installArtifact(ctx, opts, opts.ProcessorsPath, wasmProcessorTarget(), verified, ra)
+}
+
+// wasmProcessorTarget is the installTarget for a standalone WASM processor: the
+// conduit-processor-<name>_<version>.wasm filename, 0644 mode,
+// WASMProcessorArtifactKind manifest Kind, the "processor_install" audit label,
+// and validateProcessorWASM as the install-time validation hook.
+func wasmProcessorTarget() installTarget {
+	return installTarget{
+		kind:       WASMProcessorArtifactKind,
+		finalName:  ProcessorFileName,
+		fileMode:   wasmProcessorFileMode,
+		auditEvent: "processor_install",
+		validate:   validateProcessorWASM,
+	}
+}
+
+// validateProcessorWASM is the install-time validation gate (ADR decision 4 /
+// plan AC-9). It compiles the extracted .wasm with the SAME wazero runtime the
+// standalone processor registry uses at load time and extracts its
+// Specification — refusing, BEFORE the artifact is renamed into place:
+//
+//   - a module that will not compile or whose spec cannot be read; and
+//   - a module whose self-declared Specification().Name disagrees with the
+//     resolved index name (never install a file that would register under a
+//     different name than requested — closing the gap between the index name
+//     and the name the runtime actually keys discovery on).
+//
+// Version handling honors the "(devel)" dev-build sentinel: a plain
+// `GOOS=wasip1 GOARCH=wasm go build` stamps the module version as "(devel)",
+// and the authoritative version is the index's, so a "(devel)" (or empty)
+// guest version is accepted without an equality check; any OTHER concrete guest
+// version that disagrees with the index is refused as a mispublished artifact.
+//
+// It runs through proc_standalone.InspectSpecification — the one, shared WASM
+// loader — so install-time validation can never diverge from runtime
+// discovery. There is no import cycle: the standalone package does not import
+// pkg/registry (verified with `go list -deps`). A no-op logger is used; the
+// step is silent unless it refuses.
+//
+// All refusals use CodeInvalidProcessorArtifact (FailedPrecondition): the
+// fetched artifact, as published, does not meet the precondition for install.
+func validateProcessorWASM(ctx context.Context, wasmPath, name, version string) error {
+	spec, err := proc_standalone.InspectSpecification(ctx, log.Nop(), wasmPath)
+	if err != nil {
+		e := conduiterr.Wrap(CodeInvalidProcessorArtifact, fmt.Sprintf(
+			"processor artifact for %q@%s failed install-time WASM validation: could not compile the module or read its specification", name, version), err)
+		e.Suggestion = "the downloaded artifact is not a loadable standalone WASM processor; the registry index entry may point at a corrupt or wrong file"
+		return e
+	}
+
+	if spec.Name != name {
+		e := conduiterr.New(CodeInvalidProcessorArtifact, fmt.Sprintf(
+			"processor artifact declares name %q but the registry index resolved it as %q — refusing to install a file that would register under a different name than requested",
+			spec.Name, name))
+		e.Suggestion = "the index entry name and the WASM module's own Specification().Name must match; this is a mispublished or spoofed index entry"
+		return e
+	}
+
+	if spec.Version != develGuestVersion && spec.Version != "" && !processorVersionsAgree(spec.Version, version) {
+		e := conduiterr.New(CodeInvalidProcessorArtifact, fmt.Sprintf(
+			"processor artifact declares version %q but the registry index resolved version %q", spec.Version, version))
+		e.Suggestion = `the index entry version and the WASM module's own Specification().Version must match (a plain dev build reporting "(devel)" is exempt)`
+		return e
+	}
+
+	return nil
+}
+
+// processorVersionsAgree reports whether a guest-declared spec version matches
+// the resolved index version. It compares via NormalizeVersion (so "v1.2.0"
+// and "1.2.0" agree, matching the rest of the pipeline's version handling), and
+// falls back to exact string equality when either side does not parse as
+// semver.
+func processorVersionsAgree(guest, indexVersion string) bool {
+	gv, gerr := NormalizeVersion(guest)
+	iv, ierr := NormalizeVersion(indexVersion)
+	if gerr == nil && ierr == nil {
+		return gv.Equal(iv)
+	}
+	return guest == indexVersion
+}
+
+// validateProcessor is InstallProcessor's InstallOptions check — validate()'s
+// processor twin: it requires ProcessorsPath (not ConnectorsPath) and, like
+// validate(), fails closed on a nil verifier rather than nil-panicking deeper
+// in the pipeline.
+func (o *InstallOptions) validateProcessor() error {
+	if o.Name == "" {
+		return conduiterr.New(conduiterr.CodeInvalidArgument, "processor name is required")
+	}
+	if o.ProcessorsPath == "" {
+		return conduiterr.New(conduiterr.CodeInvalidArgument, "--processors.path is required")
+	}
+	if o.IndexURL == "" && o.IndexFile == "" {
+		return conduiterr.New(conduiterr.CodeInvalidArgument, "one of --index-url or --index-file is required")
+	}
+	if o.IndexVerifier == nil || o.ArtifactVerifier == nil {
+		return conduiterr.New(CodeVerificationUnavailable, "no verifier configured for this install")
+	}
+	return nil
+}

--- a/pkg/registry/installprocessor_test.go
+++ b/pkg/registry/installprocessor_test.go
@@ -1,0 +1,405 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	json "github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/registry"
+	"github.com/conduitio/conduit/pkg/registry/index"
+)
+
+// --- test wasm fixtures (built by pkg/plugin/processor/standalone's build
+// script, the same real fixtures its own tests use) ---
+
+var (
+	buildProcessorsOnce sync.Once
+	errBuildProcessors  error
+)
+
+// repoRootFromTest resolves the conduit module root from this test file's
+// location (pkg/registry/), independent of the test's working directory.
+func repoRootFromTest(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller failed")
+	return filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+}
+
+// buildTestProcessors builds the real standalone test WASM processors once per
+// test binary (the same build-test-processors.sh the standalone package's
+// TestMain runs). Requires the wasip1 toolchain + bash, exactly as the
+// standalone suite already does.
+func buildTestProcessors(t *testing.T) {
+	t.Helper()
+	root := repoRootFromTest(t)
+	script := filepath.Join(root, "pkg", "plugin", "processor", "standalone", "test", "build-test-processors.sh")
+	buildProcessorsOnce.Do(func() {
+		cmd := exec.CommandContext(context.Background(), "bash", script)
+		cmd.Stdout = os.Stderr
+		cmd.Stderr = os.Stderr
+		errBuildProcessors = cmd.Run()
+	})
+	require.NoError(t, errBuildProcessors, "building test wasm processors")
+}
+
+// readTestProcessorWASM returns the compiled bytes of one of the standalone
+// test processors (sub is "chaos" or "specify_error").
+func readTestProcessorWASM(t *testing.T, sub string) []byte {
+	t.Helper()
+	buildTestProcessors(t)
+	p := filepath.Join(repoRootFromTest(t), "pkg", "plugin", "processor", "standalone", "test", "wasm_processors", sub, "processor.wasm")
+	b, err := os.ReadFile(p)
+	require.NoError(t, err)
+	require.NotEmpty(t, b)
+	return b
+}
+
+// tarGzSingle wraps content as a single-root-file tar.gz — the archive shape
+// ExtractBinary expects (a processor artifact is a tar.gz carrying one .wasm,
+// exactly as a connector artifact carries one binary; the trust core and the
+// extract step are reused verbatim).
+func tarGzSingle(t *testing.T, name string, content []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(content))}))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+	return buf.Bytes()
+}
+
+// newProcessorInstallTestServer serves a schema-valid (unsigned-shape) index
+// carrying ONE processor at ONE version plus its artifact and fake sig/prov
+// bundles. mutate, if non-nil, is applied to the artifact after the arch-
+// neutral defaults (wasip1/wasm, kind wasm-processor) are set — the seam for
+// the malformed-artifact test.
+func newProcessorInstallTestServer(t *testing.T, name, version string, artifactTarGz []byte, mutate func(a *index.Artifact)) (srv *httptest.Server, indexURL string) {
+	t.Helper()
+	digest := sha256.Sum256(artifactTarGz)
+
+	mux := http.NewServeMux()
+	srv = httptest.NewServer(mux)
+
+	artifact := index.Artifact{
+		OS: "wasip1", Arch: "wasm", Kind: registry.WASMProcessorArtifactKind,
+		URL:       srv.URL + "/p.tar.gz",
+		SHA256:    hexEncode(digest),
+		Size:      int64(len(artifactTarGz)),
+		Signature: index.SignatureRef{BundleURL: srv.URL + "/sig.json"},
+	}
+	if mutate != nil {
+		mutate(&artifact)
+	}
+
+	payload := index.Payload{
+		SchemaVersion: 1,
+		Index:         index.IndexMeta{Version: 9, Timestamp: time.Now()},
+		Processors: []index.Processor{
+			{
+				Name: name,
+				Publisher: index.Publisher{
+					ExpectedOIDCIssuer:      "https://token.actions.githubusercontent.com",
+					ExpectedIdentityPattern: `^https://github\.com/conduitio/conduit-processor-ai/.*$`,
+				},
+				Versions: []index.ProcessorVersion{
+					{
+						Version: version, MinConduitVersion: "0.1.0", MinProtocolVersion: "0.1.0",
+						Artifact:       artifact,
+						SLSAProvenance: &index.ProvenanceRef{BundleURL: srv.URL + "/prov.json", PredicateType: "https://slsa.dev/provenance/v1"},
+					},
+				},
+			},
+		},
+	}
+
+	envelope := map[string]any{"payload": payload, "signatures": []any{}}
+	indexBytes, err := json.Marshal(envelope)
+	require.NoError(t, err)
+
+	mux.HandleFunc("/index.json", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write(indexBytes) })
+	mux.HandleFunc("/p.tar.gz", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write(artifactTarGz) })
+	mux.HandleFunc("/sig.json", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(`{"sig":"fake-test-bundle"}`)) })
+	mux.HandleFunc("/prov.json", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(`{"prov":"fake-test-bundle"}`)) })
+
+	return srv, srv.URL + "/index.json"
+}
+
+func assertNoInstalledProcessor(t *testing.T, processorsPath string) {
+	t.Helper()
+	entries, err := os.ReadDir(processorsPath)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), "conduit-processor-",
+			"no processor artifact should be visible under --processors.path")
+	}
+}
+
+// TestInstallProcessor_FullPipeline is the processor twin of
+// TestInstall_FullPipeline: resolve (processors[]) -> arch-neutral select ->
+// download -> corruption -> (test) verification -> extract -> install-time
+// WASM validation -> atomic rename -> manifest -> audit, using the REAL chaos
+// processor wasm so install-time validation runs against a genuine module.
+func TestInstallProcessor_FullPipeline(t *testing.T) {
+	wasm := readTestProcessorWASM(t, "chaos")
+	artifact := tarGzSingle(t, "processor.wasm", wasm)
+	srv, indexURL := newProcessorInstallTestServer(t, "chaos-processor", "1.3.5", artifact, nil)
+	defer srv.Close()
+
+	processorsPath := t.TempDir()
+
+	res, err := registry.InstallProcessor(context.Background(), registry.InstallOptions{
+		Name: "chaos-processor", ProcessorsPath: processorsPath, IndexURL: indexURL,
+		IndexVerifier: passThroughVerifier{}, ArtifactVerifier: passThroughVerifier{},
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+		InstalledBy: "test-operator",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, "chaos-processor", res.Name)
+	assert.Equal(t, "1.3.5", res.Version)
+	assert.Equal(t, "wasip1", res.OS)
+	assert.Equal(t, "wasm", res.Arch)
+	assert.Equal(t, "conduit-processor-chaos-processor_1.3.5.wasm", res.ArtifactFile)
+
+	// Installed file present, complete, and 0644 (NOT 0755 — no exec bit).
+	installedPath := filepath.Join(processorsPath, "conduit-processor-chaos-processor_1.3.5.wasm")
+	data, err := os.ReadFile(installedPath)
+	require.NoError(t, err)
+	assert.Equal(t, wasm, data)
+	info, err := os.Stat(installedPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+
+	// Manifest under the PROCESSORS path (separate from any connector manifest),
+	// Kind == wasm-processor, keyed name@version.
+	m, err := registry.LoadManifest(filepath.Join(processorsPath, ".registry", "manifest.json"))
+	require.NoError(t, err)
+	entry, ok := m.Installs["chaos-processor@1.3.5"]
+	require.True(t, ok)
+	assert.Equal(t, registry.WASMProcessorArtifactKind, entry.Kind)
+	assert.True(t, entry.Signed)
+
+	// Audit log carries a processor_install event, not connector_install.
+	auditData, err := os.ReadFile(filepath.Join(processorsPath, ".registry", "audit.jsonl"))
+	require.NoError(t, err)
+	assert.Contains(t, string(auditData), `"event":"processor_install"`)
+	assert.NotContains(t, string(auditData), `"event":"connector_install"`)
+
+	// Staging (a subdir of the PROCESSORS path — same filesystem, so the rename
+	// is atomic) is cleaned up.
+	stagingEntries, err := os.ReadDir(filepath.Join(processorsPath, ".registry", "staging"))
+	require.NoError(t, err)
+	assert.Empty(t, stagingEntries)
+}
+
+// TestInstallProcessor_Idempotent re-installs the same name@version and gets a
+// no-op AlreadyInstalled success (mirrors TestInstall_AlreadyInstalled).
+func TestInstallProcessor_Idempotent(t *testing.T) {
+	wasm := readTestProcessorWASM(t, "chaos")
+	artifact := tarGzSingle(t, "processor.wasm", wasm)
+	srv, indexURL := newProcessorInstallTestServer(t, "chaos-processor", "1.3.5", artifact, nil)
+	defer srv.Close()
+
+	processorsPath := t.TempDir()
+	opts := registry.InstallOptions{
+		Name: "chaos-processor", ProcessorsPath: processorsPath, IndexURL: indexURL,
+		IndexVerifier: passThroughVerifier{}, ArtifactVerifier: passThroughVerifier{},
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+	}
+
+	first, err := registry.InstallProcessor(context.Background(), opts)
+	require.NoError(t, err)
+	assert.False(t, first.AlreadyInstalled)
+
+	second, err := registry.InstallProcessor(context.Background(), opts)
+	require.NoError(t, err)
+	assert.True(t, second.AlreadyInstalled)
+	assert.Equal(t, first.Digest, second.Digest)
+}
+
+// TestInstallProcessor_DryRun resolves+selects but writes nothing under
+// --processors.path.
+func TestInstallProcessor_DryRun(t *testing.T) {
+	wasm := readTestProcessorWASM(t, "chaos")
+	artifact := tarGzSingle(t, "processor.wasm", wasm)
+	srv, indexURL := newProcessorInstallTestServer(t, "chaos-processor", "1.3.5", artifact, nil)
+	defer srv.Close()
+
+	processorsPath := t.TempDir()
+	res, err := registry.InstallProcessor(context.Background(), registry.InstallOptions{
+		Name: "chaos-processor", ProcessorsPath: processorsPath, IndexURL: indexURL,
+		IndexVerifier: passThroughVerifier{}, ArtifactVerifier: passThroughVerifier{},
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+		DryRun: true,
+	})
+	require.NoError(t, err)
+	assert.True(t, res.DryRun)
+	assert.Equal(t, srv.URL+"/p.tar.gz", res.ArtifactURL)
+
+	entries, err := os.ReadDir(processorsPath)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+// TestInstallProcessor_SpecNameMismatchRefused: a genuine, compilable wasm
+// whose Specification().Name ("chaos-processor") disagrees with the index name
+// ("not-the-real-name") is refused at install time (AC-9) — never installed
+// under a name it does not own.
+func TestInstallProcessor_SpecNameMismatchRefused(t *testing.T) {
+	wasm := readTestProcessorWASM(t, "chaos")
+	artifact := tarGzSingle(t, "processor.wasm", wasm)
+	srv, indexURL := newProcessorInstallTestServer(t, "not-the-real-name", "1.3.5", artifact, nil)
+	defer srv.Close()
+
+	processorsPath := t.TempDir()
+	_, err := registry.InstallProcessor(context.Background(), registry.InstallOptions{
+		Name: "not-the-real-name", ProcessorsPath: processorsPath, IndexURL: indexURL,
+		IndexVerifier: passThroughVerifier{}, ArtifactVerifier: passThroughVerifier{},
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+	})
+	requireCode(t, err, registry.CodeInvalidProcessorArtifact)
+	assertNoInstalledProcessor(t, processorsPath)
+}
+
+// TestInstallProcessor_CompileFailRefused: an artifact whose bytes are not a
+// valid WASM module is refused at install time — the wazero compile step fails
+// before the rename, so nothing lands under --processors.path.
+func TestInstallProcessor_CompileFailRefused(t *testing.T) {
+	artifact := tarGzSingle(t, "processor.wasm", []byte("this is definitely not a wasm module"))
+	srv, indexURL := newProcessorInstallTestServer(t, "broken-processor", "1.0.0", artifact, nil)
+	defer srv.Close()
+
+	processorsPath := t.TempDir()
+	_, err := registry.InstallProcessor(context.Background(), registry.InstallOptions{
+		Name: "broken-processor", ProcessorsPath: processorsPath, IndexURL: indexURL,
+		IndexVerifier: passThroughVerifier{}, ArtifactVerifier: passThroughVerifier{},
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+	})
+	requireCode(t, err, registry.CodeInvalidProcessorArtifact)
+	assertNoInstalledProcessor(t, processorsPath)
+}
+
+// TestInstallProcessor_SpecifyErrorRefused: a module that compiles but whose
+// Specification() returns an error is refused at install time (the spec cannot
+// be read, so its name cannot be trusted).
+func TestInstallProcessor_SpecifyErrorRefused(t *testing.T) {
+	wasm := readTestProcessorWASM(t, "specify_error")
+	artifact := tarGzSingle(t, "processor.wasm", wasm)
+	srv, indexURL := newProcessorInstallTestServer(t, "specify-error-processor", "1.0.0", artifact, nil)
+	defer srv.Close()
+
+	processorsPath := t.TempDir()
+	_, err := registry.InstallProcessor(context.Background(), registry.InstallOptions{
+		Name: "specify-error-processor", ProcessorsPath: processorsPath, IndexURL: indexURL,
+		IndexVerifier: passThroughVerifier{}, ArtifactVerifier: passThroughVerifier{},
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+	})
+	requireCode(t, err, registry.CodeInvalidProcessorArtifact)
+	assertNoInstalledProcessor(t, processorsPath)
+}
+
+// TestInstallProcessor_HostArtifactRefused proves InstallProcessor wires
+// SelectProcessorArtifact (arch-neutral) and NEVER the host-(GOOS,GOARCH)
+// SelectArtifact: a processor entry whose single artifact declares a host
+// os/arch is a hard CodeInvalidProcessorArtifact, not a silent skip (design
+// doc failure mode 3). No download or install happens.
+func TestInstallProcessor_HostArtifactRefused(t *testing.T) {
+	artifact := tarGzSingle(t, "processor.wasm", []byte("irrelevant — never fetched"))
+	srv, indexURL := newProcessorInstallTestServer(t, "chaos-processor", "1.3.5", artifact, func(a *index.Artifact) {
+		a.OS = runtime.GOOS
+		a.Arch = runtime.GOARCH
+	})
+	defer srv.Close()
+
+	processorsPath := t.TempDir()
+	_, err := registry.InstallProcessor(context.Background(), registry.InstallOptions{
+		Name: "chaos-processor", ProcessorsPath: processorsPath, IndexURL: indexURL,
+		IndexVerifier: passThroughVerifier{}, ArtifactVerifier: passThroughVerifier{},
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+	})
+	requireCode(t, err, registry.CodeInvalidProcessorArtifact)
+	assertNoInstalledProcessor(t, processorsPath)
+}
+
+// TestInstallProcessor_FailClosedByConstruction is the processor twin of
+// TestInstall_FailClosedByConstruction: the REAL production wiring
+// (FailClosedVerifier for BOTH verifiers) refuses every processor install with
+// CodeVerificationUnavailable — the trust gate fails BEFORE WASM validation or
+// the rename — and leaves nothing under --processors.path.
+func TestInstallProcessor_FailClosedByConstruction(t *testing.T) {
+	// The artifact need not be a real wasm: the verification gate refuses
+	// before install-time validation is ever reached.
+	artifact := tarGzSingle(t, "processor.wasm", []byte("bytes never validated — refused at the trust gate"))
+	srv, indexURL := newProcessorInstallTestServer(t, "chaos-processor", "1.3.5", artifact, nil)
+	defer srv.Close()
+
+	processorsPath := t.TempDir()
+	_, err := registry.InstallProcessor(context.Background(), registry.InstallOptions{
+		Name: "chaos-processor", ProcessorsPath: processorsPath, IndexURL: indexURL,
+		IndexVerifier:         registry.FailClosedVerifier{},
+		ArtifactVerifier:      registry.FailClosedVerifier{},
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+	})
+	requireCode(t, err, registry.CodeVerificationUnavailable)
+	assertNoInstalledProcessor(t, processorsPath)
+}
+
+// TestInstallProcessor_NotFound returns registry.processor_not_found for a name
+// absent from the index's processors[] collection.
+func TestInstallProcessor_NotFound(t *testing.T) {
+	artifact := tarGzSingle(t, "processor.wasm", []byte("unused"))
+	srv, indexURL := newProcessorInstallTestServer(t, "ai.embed", "1.0.0", artifact, nil)
+	defer srv.Close()
+
+	processorsPath := t.TempDir()
+	_, err := registry.InstallProcessor(context.Background(), registry.InstallOptions{
+		Name: "ai.chunk", ProcessorsPath: processorsPath, IndexURL: indexURL,
+		IndexVerifier: passThroughVerifier{}, ArtifactVerifier: passThroughVerifier{},
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+	})
+	requireCode(t, err, registry.CodeProcessorNotFound)
+	assertNoInstalledProcessor(t, processorsPath)
+}
+
+// TestInstallProcessor_MissingProcessorsPath refuses with an invalid-argument
+// error when --processors.path is not set (validateProcessor).
+func TestInstallProcessor_MissingProcessorsPath(t *testing.T) {
+	_, err := registry.InstallProcessor(context.Background(), registry.InstallOptions{
+		Name: "ai.embed", IndexURL: "https://example.test/index.json",
+		IndexVerifier: passThroughVerifier{}, ArtifactVerifier: passThroughVerifier{},
+	})
+	require.Error(t, err)
+}

--- a/pkg/registry/installtarget.go
+++ b/pkg/registry/installtarget.go
@@ -1,0 +1,96 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/conduitio/conduit/pkg/registry/index"
+	"github.com/conduitio/conduit/pkg/registry/trust"
+)
+
+// resolvedArtifact is the artifact-kind-neutral bundle the shared install core
+// (installArtifact → downloadVerifyAndInstall → runVerificationGate →
+// finalizeArtifactInstall) consumes. Both the connector path (Install) and the
+// processor path (InstallProcessor) populate it from their own resolved index
+// entry, so the trust core — signature/provenance verification, the pinned
+// identity check, and the policy.Decide unsigned gate — is exercised through
+// ONE code path and never forked (ADR 20260727-processors-ride-connector-
+// registry, decision 1).
+type resolvedArtifact struct {
+	// name/version are the resolved index name@version — the authoritative
+	// on-disk/manifest identity (for a processor this is what the file is
+	// named and keyed as, even when the WASM's own Specification().Version is
+	// a "(devel)" dev-build sentinel; see installprocessor.go).
+	name    string
+	version string
+
+	// identity is the publisher identity pin the artifact's signature +
+	// provenance are verified against.
+	identity trust.PinnedIdentity
+
+	// artifact is the single selected artifact: for a connector the host
+	// (os, arch) build chosen by SelectArtifact; for a processor the single
+	// arch-neutral (wasip1/wasm) build chosen by SelectProcessorArtifact.
+	artifact *index.Artifact
+
+	// versionProvenance is the version-level SLSA provenance used as a
+	// fallback when the artifact carries none of its own (fetchArtifactRef
+	// prefers artifact.SLSAProvenance).
+	versionProvenance *index.ProvenanceRef
+
+	// deprecated mirrors the resolved version's Deprecated flag —
+	// informational only, surfaced in the result; never a refusal.
+	deprecated bool
+}
+
+// installTarget parameterizes the artifact-kind-specific tail of the shared
+// install pipeline. connectorTarget reproduces the pre-existing connector
+// behavior exactly (the unchanged connector test suite is the regression
+// guard); wasmProcessorTarget (installprocessor.go) supplies the processor
+// specifics. Nothing outside these two constructors ever builds an
+// installTarget.
+type installTarget struct {
+	// kind is written to ManifestEntry.Kind for a completed install.
+	kind string
+	// finalName builds the on-disk filename (no directory) for the installed
+	// artifact.
+	finalName func(name, version string) string
+	// fileMode is the chmod applied to the installed artifact.
+	fileMode os.FileMode
+	// auditEvent is the AuditEvent.Event label.
+	auditEvent string
+	// validate, if non-nil, runs on the extracted artifact (still inside the
+	// private staging directory) AFTER the corruption + trust gates and BEFORE
+	// the atomic rename. It is the seam for install-time WASM compile+spec
+	// validation; nil for connectors, so their path is unchanged.
+	validate func(ctx context.Context, stagedPath, name, version string) error
+}
+
+// connectorTarget is the default install target: it reproduces today's
+// connector behavior byte-for-byte — the conduit-connector-<name>_<version>
+// filename, 0755 mode, StandaloneArtifactKind manifest Kind, the
+// "connector_install" audit label, and no install-time validation hook.
+func connectorTarget() installTarget {
+	return installTarget{
+		kind:       StandaloneArtifactKind,
+		finalName:  func(name, version string) string { return fmt.Sprintf("conduit-connector-%s_%s", name, version) },
+		fileMode:   0o755,
+		auditEvent: "connector_install",
+		validate:   nil,
+	}
+}

--- a/pkg/registry/resolveprocessor.go
+++ b/pkg/registry/resolveprocessor.go
@@ -1,0 +1,166 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry/index"
+	"github.com/conduitio/conduit/pkg/registry/trust"
+)
+
+// ResolvedProcessorVersion is the processor analogue of ResolvedVersion: the
+// Processor (for its pinned Publisher identity and Name) plus the single
+// ProcessorVersion selected.
+type ResolvedProcessorVersion struct {
+	Processor index.Processor
+	Version   index.ProcessorVersion
+}
+
+// ResolveProcessor is the processor analogue of Resolve, over
+// payload.Processors. It applies IDENTICAL rules — exact-match name
+// (anti-typosquat, no fuzzy suggestion), revoked publisher refused, a pinned
+// yanked version refused, newest-non-yanked-compatible when @version is
+// omitted, and incompatible min-versions refused — differing only in the
+// collection it searches and the (processor-worded, processor-coded) errors it
+// returns. Like Resolve it never mutates payload and performs no I/O.
+//
+// It deliberately does NOT refuse a deprecated version: deprecated is a soft,
+// informational flag surfaced by the caller, not a trust or safety state —
+// exactly as in Resolve (see resolve.go's doc for the rationale).
+func ResolveProcessor(payload index.Payload, opts ResolveOptions) (*ResolvedProcessorVersion, error) {
+	proc, err := findProcessor(payload, opts.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	if proc.Publisher.Revoked != nil {
+		e := conduiterr.New(trust.CodeIdentityRevoked, fmt.Sprintf(
+			"processor %q's publisher identity has been revoked: %s", opts.Name, proc.Publisher.Revoked.Reason))
+		e.Suggestion = "every version of this processor is refused regardless of individual yank status; see the registry security advisory referenced in the revocation reason"
+		return nil, e
+	}
+
+	if opts.Version != "" {
+		return resolveProcessorExact(proc, opts)
+	}
+	return resolveProcessorNewestCompatible(proc, opts)
+}
+
+// findProcessor does the exact-match name lookup over payload.Processors. As
+// in findConnector, no Levenshtein/fuzzy suggestion is computed: a first
+// registration is the one place typosquatting has no cryptographic backstop,
+// so this pipeline must never nudge a typo toward an existing name.
+func findProcessor(payload index.Payload, name string) (*index.Processor, error) {
+	for i := range payload.Processors {
+		if payload.Processors[i].Name == name {
+			return &payload.Processors[i], nil
+		}
+	}
+	e := conduiterr.New(CodeProcessorNotFound, fmt.Sprintf(
+		"processor %q not found in the registry index", name))
+	e.Suggestion = "check the exact spelling — this is an exact-match lookup with no fuzzy suggestion, by design; if the hosted index does not yet carry processors, use the interim offline (--index-file/--bundle) install path"
+	return nil, e
+}
+
+func resolveProcessorExact(proc *index.Processor, opts ResolveOptions) (*ResolvedProcessorVersion, error) {
+	wantV, err := NormalizeVersion(opts.Version)
+	if err != nil {
+		return nil, conduiterr.Wrap(CodeVersionNotFound,
+			fmt.Sprintf("processor %q: %q is not a valid version", proc.Name, opts.Version), err)
+	}
+
+	for i := range proc.Versions {
+		v := proc.Versions[i]
+		gotV, err := NormalizeVersion(v.Version)
+		if err != nil {
+			continue // a malformed index entry; skip defensively rather than fail the whole resolution
+		}
+		if !gotV.Equal(wantV) {
+			continue
+		}
+
+		if v.Yanked != nil {
+			e := conduiterr.New(index.CodeVersionYanked, fmt.Sprintf(
+				"processor %q version %s was yanked: %s", proc.Name, v.Version, v.Yanked.Reason))
+			e.Suggestion = "install a different version, or omit @version to auto-select the newest non-yanked, compatible one"
+			return nil, e
+		}
+		if err := checkProcessorCompatible(proc.Name, v, opts); err != nil {
+			return nil, err
+		}
+		return &ResolvedProcessorVersion{Processor: *proc, Version: v}, nil
+	}
+
+	return nil, conduiterr.New(CodeVersionNotFound, fmt.Sprintf(
+		"processor %q has no version %q in the registry index", proc.Name, opts.Version))
+}
+
+func resolveProcessorNewestCompatible(proc *index.Processor, opts ResolveOptions) (*ResolvedProcessorVersion, error) {
+	versions := append([]index.ProcessorVersion(nil), proc.Versions...)
+	sort.Slice(versions, func(i, j int) bool {
+		vi, ei := NormalizeVersion(versions[i].Version)
+		vj, ej := NormalizeVersion(versions[j].Version)
+		if ei != nil || ej != nil {
+			return false // malformed entries: leave relative order alone rather than guess
+		}
+		return vi.GreaterThan(vj) // descending: newest first
+	})
+
+	for _, v := range versions {
+		if v.Yanked != nil {
+			continue // never auto-select a yanked version
+		}
+		if err := checkProcessorCompatible(proc.Name, v, opts); err != nil {
+			continue // not compatible with the running build; try the next-newest
+		}
+		return &ResolvedProcessorVersion{Processor: *proc, Version: v}, nil
+	}
+
+	e := conduiterr.New(CodeIncompatibleVersion, fmt.Sprintf(
+		"no version of %q is compatible with the running Conduit (conduit %s, protocol %s)",
+		proc.Name, opts.RunningConduitVersion, opts.RunningProtocolVersion))
+	e.Suggestion = "upgrade Conduit, or pin an older @version explicitly if you know one is compatible"
+	return nil, e
+}
+
+// checkProcessorCompatible refuses a candidate version whose MinConduitVersion
+// or MinProtocolVersion exceeds the running build's own versions. It reuses
+// checkMinVersion (resolve.go) verbatim — the compatibility algebra is
+// identical to connectors; only the error wording/type differs.
+func checkProcessorCompatible(name string, v index.ProcessorVersion, opts ResolveOptions) error {
+	if err := checkMinVersion("minConduitVersion", v.MinConduitVersion, opts.RunningConduitVersion); err != nil {
+		return newProcessorIncompatibleError(name, v, opts)
+	}
+	if err := checkMinVersion("minProtocolVersion", v.MinProtocolVersion, opts.RunningProtocolVersion); err != nil {
+		return newProcessorIncompatibleError(name, v, opts)
+	}
+	return nil
+}
+
+// newProcessorIncompatibleError is newIncompatibleError's processor twin:
+// CodeIncompatibleVersion with the required-vs-running facts and a concrete fix
+// suggestion ("errors are API").
+func newProcessorIncompatibleError(name string, v index.ProcessorVersion, opts ResolveOptions) error {
+	e := conduiterr.New(CodeIncompatibleVersion, fmt.Sprintf(
+		"processor %q version %s requires Conduit >= %s and protocol >= %s; running Conduit %s, protocol %s",
+		name, v.Version, v.MinConduitVersion, v.MinProtocolVersion, opts.RunningConduitVersion, opts.RunningProtocolVersion))
+	e.Suggestion = fmt.Sprintf(
+		"upgrade Conduit to >= %s, or install an older %s version compatible with your running Conduit (omit @version to auto-select one)",
+		v.MinConduitVersion, name)
+	return e
+}

--- a/pkg/registry/resolveprocessor_test.go
+++ b/pkg/registry/resolveprocessor_test.go
@@ -1,0 +1,192 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry"
+	"github.com/conduitio/conduit/pkg/registry/index"
+	"github.com/conduitio/conduit/pkg/registry/trust"
+)
+
+// procArtifact builds a well-formed arch-neutral WASM-processor artifact for a
+// resolution fixture (the bytes are never fetched — these are pure Resolve
+// tests).
+func procArtifact() index.Artifact {
+	return index.Artifact{
+		OS: "wasip1", Arch: "wasm", Kind: registry.WASMProcessorArtifactKind,
+		URL: "https://example.test/p.tar.gz", SHA256: "sha256:deadbeef", Size: 1,
+		Signature: index.SignatureRef{BundleURL: "https://example.test/p.sig"},
+	}
+}
+
+// procIndex builds a single-processor index payload with the given versions.
+func procIndex(name string, pub index.Publisher, versions ...index.ProcessorVersion) index.Payload {
+	return index.Payload{
+		SchemaVersion: 1,
+		Index:         index.IndexMeta{Version: 3, Timestamp: time.Now()},
+		Processors: []index.Processor{
+			{Name: name, Publisher: pub, Versions: versions},
+		},
+	}
+}
+
+func okPublisher() index.Publisher {
+	return index.Publisher{
+		ExpectedOIDCIssuer:      "https://token.actions.githubusercontent.com",
+		ExpectedIdentityPattern: `^https://github\.com/conduitio/conduit-processor-ai/.*$`,
+	}
+}
+
+func procVersion(v string) index.ProcessorVersion {
+	return index.ProcessorVersion{
+		Version: v, MinConduitVersion: "0.1.0", MinProtocolVersion: "0.1.0",
+		Artifact: procArtifact(),
+	}
+}
+
+func requireCode(t *testing.T, err error, want conduiterr.Code) {
+	t.Helper()
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.Truef(t, ok, "error is not a ConduitError: %v", err)
+	assert.Equal(t, want, ce.Code)
+}
+
+func TestResolveProcessor_ExactVersion(t *testing.T) {
+	payload := procIndex("ai.embed", okPublisher(), procVersion("1.0.0"), procVersion("1.2.0"))
+
+	res, err := registry.ResolveProcessor(payload, registry.ResolveOptions{
+		Name: "ai.embed", Version: "1.0.0",
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ai.embed", res.Processor.Name)
+	assert.Equal(t, "1.0.0", res.Version.Version)
+}
+
+func TestResolveProcessor_NewestCompatible(t *testing.T) {
+	// Newest (2.0.0) needs a future Conduit; resolution must skip it and land
+	// on the newest COMPATIBLE version (1.2.0), never a yanked one.
+	v20 := procVersion("2.0.0")
+	v20.MinConduitVersion = "9.9.9"
+	yanked := procVersion("1.5.0")
+	yanked.Yanked = &index.YankReason{Reason: "bad release"}
+
+	payload := procIndex("ai.embed", okPublisher(), procVersion("1.0.0"), procVersion("1.2.0"), yanked, v20)
+
+	res, err := registry.ResolveProcessor(payload, registry.ResolveOptions{
+		Name:                  "ai.embed", // no version → newest compatible
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "1.2.0", res.Version.Version)
+}
+
+func TestResolveProcessor_NotFound_ExactMatchNoFuzzy(t *testing.T) {
+	payload := procIndex("ai.embed", okPublisher(), procVersion("1.0.0"))
+
+	// A near-miss name must NOT be nudged toward the real one (anti-typosquat).
+	_, err := registry.ResolveProcessor(payload, registry.ResolveOptions{
+		Name: "ai.embeded", RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+	})
+	requireCode(t, err, registry.CodeProcessorNotFound)
+}
+
+func TestResolveProcessor_VersionNotFound(t *testing.T) {
+	payload := procIndex("ai.embed", okPublisher(), procVersion("1.0.0"))
+
+	_, err := registry.ResolveProcessor(payload, registry.ResolveOptions{
+		Name: "ai.embed", Version: "9.9.9",
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+	})
+	requireCode(t, err, registry.CodeVersionNotFound)
+}
+
+func TestResolveProcessor_PinnedYankedRefused(t *testing.T) {
+	yanked := procVersion("1.0.0")
+	yanked.Yanked = &index.YankReason{Reason: "cve-2026-0001"}
+	payload := procIndex("ai.embed", okPublisher(), yanked)
+
+	_, err := registry.ResolveProcessor(payload, registry.ResolveOptions{
+		Name: "ai.embed", Version: "1.0.0",
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+	})
+	requireCode(t, err, index.CodeVersionYanked)
+}
+
+func TestResolveProcessor_RevokedPublisherRefused(t *testing.T) {
+	pub := okPublisher()
+	pub.Revoked = &index.Revocation{Reason: "key compromise"}
+	payload := procIndex("ai.embed", pub, procVersion("1.0.0"))
+
+	// Even a non-yanked version is refused when the publisher identity is
+	// revoked — the compromise is at the identity level.
+	_, err := registry.ResolveProcessor(payload, registry.ResolveOptions{
+		Name: "ai.embed", Version: "1.0.0",
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+	})
+	requireCode(t, err, trust.CodeIdentityRevoked)
+}
+
+func TestResolveProcessor_IncompatiblePinnedVersion(t *testing.T) {
+	v := procVersion("1.0.0")
+	v.MinConduitVersion = "2.0.0"
+	payload := procIndex("ai.embed", okPublisher(), v)
+
+	_, err := registry.ResolveProcessor(payload, registry.ResolveOptions{
+		Name: "ai.embed", Version: "1.0.0",
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+	})
+	requireCode(t, err, registry.CodeIncompatibleVersion)
+}
+
+func TestResolveProcessor_NoCompatibleVersion(t *testing.T) {
+	v := procVersion("1.0.0")
+	v.MinConduitVersion = "9.9.9"
+	payload := procIndex("ai.embed", okPublisher(), v)
+
+	_, err := registry.ResolveProcessor(payload, registry.ResolveOptions{
+		Name:                  "ai.embed", // newest-compatible, but none is compatible
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+	})
+	requireCode(t, err, registry.CodeIncompatibleVersion)
+}
+
+// TestResolveProcessor_SearchesProcessorsNotConnectors proves the two
+// collections are independent: a name present only in connectors[] is NOT
+// found by ResolveProcessor, and vice versa (design doc failure mode 4).
+func TestResolveProcessor_SearchesProcessorsNotConnectors(t *testing.T) {
+	payload := index.Payload{
+		SchemaVersion: 1,
+		Index:         index.IndexMeta{Version: 1, Timestamp: time.Now()},
+		Connectors: []index.Connector{
+			{Name: "shared-name", Publisher: okPublisher(), Versions: []index.ConnectorVersion{
+				{Version: "1.0.0", MinConduitVersion: "0.1.0", MinProtocolVersion: "0.1.0"},
+			}},
+		},
+	}
+
+	_, err := registry.ResolveProcessor(payload, registry.ResolveOptions{
+		Name: "shared-name", RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+	})
+	requireCode(t, err, registry.CodeProcessorNotFound)
+}


### PR DESCRIPTION
## Risk tier: **1** (supply-chain install pipeline). **Requires DeVaris explicit sign-off before merge.**

WS8 Plan #1, **PR-B** — makes `pkg/registry`'s install pipeline artifact-type-generic so it installs WASM processors through the **same** trust core it uses for connectors. Builds on PR-A (#2710). No CLI (that's PR-C).

## Design: two internal seams, trust core NEVER forked
- **`resolvedArtifact`** — a kind-neutral bundle (name/version, pinned identity, selected `*index.Artifact`, provenance fallback). Both `Install` and `InstallProcessor` populate it, so signature+SLSA-provenance verification and the single `policy.Decide` unsigned gate are **one code path** (ADR decision 1).
- **`installTarget`** — the only kind-specific tail: `kind` / `finalName` / `fileMode` / `auditEvent` / an optional `validate` hook. `connectorTarget()` reproduces today's connector behavior **byte-for-byte** (`conduit-connector-%s_%s`, 0755, `StandaloneArtifactKind`, `connector_install`, no validate); `wasmProcessorTarget()` supplies the processor specifics.

## Connectors are unchanged (the regression guard)
Every existing connector test is an **external** (`package registry_test`) test exercising only the exported surface — all pass with **zero edits**. `Install`/`InstallOptions`/`InstallResult`/`Resolve`/`SelectArtifact` signatures untouched; the connector path routes through `connectorTarget()` (validate `nil` → no WASM compile ever runs for a connector). **I re-ran `go test -race ./pkg/registry/` independently → `ok 259s`.**

## Processor path
- `InstallProcessor` mirrors `Install`: fetch → `VerifyIndex` → `ResolveProcessor` (over `payload.Processors`; revoked→refuse-all, exact vs newest-non-yanked-compatible, incompatible-min refused) → `SelectProcessorArtifact` (arch-neutral `(wasip1,wasm)`, **never** host-platform) → shared `installArtifact` core.
- **Install-time WASM validation** (`validateProcessorWASM`) via `standalone.InspectSpecification` — the **one shared WASM loader** (reuses `loadBlueprint` verbatim; verified no import cycle with `go list -deps`), so install-time validation can never diverge from what runtime discovery registers. Runs on the extracted file **inside staging, after the trust gate, before the atomic rename** — a refusal leaves nothing under `--processors.path`. Refuses compile-failure and a spec-`Name` that disagrees with the resolved index name.
- **`(devel)` handling:** a guest `Specification().Version` of `(devel)` (Go's default for a plain `GOOS=wasip1 go build`) or empty is exempt from the version-equality check (the index version is authoritative); any other concrete disagreement is refused.

## Atomicity / manifest / audit (Invariant 5)
Staging is a private `0700` subdir **of `--processors.path`** (same filesystem → atomic `os.Rename`); `conduit-processor-<name>_<version>.wasm`, chmod **0644**; separate manifest at `<processors.path>/.registry/manifest.json` (`Kind = wasm-processor`), never commingled with the connector manifest; audit label `processor_install`.

## New / reused codes
New `registry.processor_not_found`; reuses `version_not_found` / `incompatible_version` / `version_yanked` / `identity_revoked` / `invalid_processor_artifact` (compile-fail + spec-mismatch) + the shared `download_failed` / `corrupt_download` / `verification_unavailable`. `policy.Decide` stays the single call site (depguard `PolicyBypass` satisfied).

## Tests
`InspectSpecification` (happy/compile-fail/spec-error/missing); `ResolveProcessor` (exact / newest-compatible / not-found / version-not-found / pinned-yanked / revoked / incompatible / collection-isolation); `InstallProcessor` e2e over a signed `httptest` index (full pipeline incl. 0644/Kind/audit/staging-swept/separate-manifest, idempotent, dry-run, spec-name-mismatch refused, compile-fail refused, spec-error refused, **host-arch artifact refused** (proves `SelectProcessorArtifact` wiring), **fail-closed-by-construction** replicated, not-found, missing `--processors.path`).

## Verification
`go build ./...` clean; `go test -race ./pkg/registry/...` GREEN (259s — wazero *compiler* runtime is CPU-heavy); `./pkg/plugin/processor/standalone/` green; `cmd/conduit/root/connectors/...` green; `go vet` + `golangci-lint` v2.12.2 (CI-exact) clean.

## Notes for review
- **Known nit (deliberately not fixed):** `fetchArtifactRef` now carries an unused `opts` param after the refactor. Harmless; `unusedparams` isn't an enabled linter (golangci clean). Left as-is to avoid churning `install.go` and invalidating the 259s connector regression run for a cosmetic change — trivial PR-C-adjacent cleanup.
- **Artifact shape:** a processor artifact is a signed `tar.gz` carrying one `.wasm` (connector convention reused verbatim). The design doc's "provenance subject-digest must match the .wasm digest" is a PR-D publish-Action output-shape concern — flagged so the publish path is confirmed against it.

Next: PR-C (the `processor-plugins install`/`uninstall` CLI + Tranche-A `--bundle`/`--index-file`/gated-unsigned offline install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD