### PR TITLE
feat(cli): conduit processor-plugins install/uninstall + Tranche-A offline install (PR-C)

### DIFF
--- a/cmd/conduit/root/connectors/anchors.go
+++ b/cmd/conduit/root/connectors/anchors.go
@@ -73,6 +73,21 @@ func init() {
 	defaultTrustAnchors = anchors
 }
 
+// DefaultTrustAnchors returns this build's compiled-in registry root/freshness
+// anchors. Exported so the sibling `conduit processor-plugins install` command
+// verifies against the SAME single embedded anchor set (the ceremony writes the
+// PEMs into this package's trustanchors/ directory) rather than embedding a
+// second copy — one trust core, never forked. The processor-plugins package
+// snapshots this at its own package-init time (connectors' init, which
+// populates it, runs first because that package imports this one).
+func DefaultTrustAnchors() index.TrustAnchors { return defaultTrustAnchors }
+
+// AnchorLoadErr reports the embedded-anchor load failure (nil on a normal
+// release build). Exported alongside DefaultTrustAnchors so the sibling
+// processor-plugins install command mirrors guardTrustAnchors' fail-closed
+// refusal on a broken/anchor-stripped build.
+func AnchorLoadErr() error { return errAnchorLoad }
+
 // guardTrustAnchors returns a clear, machine-actionable error when this build's
 // embedded trust anchors could not be loaded. install/audit/bundle call it
 // before constructing the verifier so a broken build reports

--- a/cmd/conduit/root/connectors/install.go
+++ b/cmd/conduit/root/connectors/install.go
@@ -47,6 +47,12 @@ import (
 // alone nor a copy-pasted script line alone can trigger it.
 const unsignedInstallEnvVar = "CONDUIT_ALLOW_UNSIGNED_INSTALL"
 
+// UnsignedInstallEnvVar exports unsignedInstallEnvVar so the sibling
+// `conduit processor-plugins install` command reads the exact same
+// non-interactive escape-hatch env var — the --allow-unsigned gate must be
+// identical across both install surfaces, from one source of truth.
+const UnsignedInstallEnvVar = unsignedInstallEnvVar
+
 var (
 	_ ecdysis.CommandWithFlags   = (*InstallCommand)(nil)
 	_ ecdysis.CommandWithConfig  = (*InstallCommand)(nil)

--- a/cmd/conduit/root/processorplugins/anchors.go
+++ b/cmd/conduit/root/processorplugins/anchors.go
@@ -1,0 +1,54 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processorplugins
+
+import (
+	"github.com/conduitio/conduit/cmd/conduit/root/connectors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry"
+	"github.com/conduitio/conduit/pkg/registry/index"
+)
+
+// defaultTrustAnchors and errAnchorLoad snapshot the connectors package's
+// compiled-in registry root/freshness anchors. There is ONE embedded anchor
+// set for the whole CLI — the ceremony writes its PEMs into the connectors
+// package's trustanchors/ directory, and both `conduit connectors install` and
+// `conduit processor-plugins install` verify against it. This package does NOT
+// embed a second copy (that would fork a security-critical asset); it consumes
+// the same loaded set via connectors' exported accessors. The snapshot is safe:
+// Go runs the connectors package's init (which populates the anchors) before
+// this package's var initializers, because this package imports connectors.
+//
+// Tests override defaultTrustAnchors via SetDefaultTrustAnchorsForTest
+// (export_test.go), exactly as connectors' own install tests override theirs —
+// each test binary overrides its own package's copy.
+var (
+	defaultTrustAnchors index.TrustAnchors = connectors.DefaultTrustAnchors()
+	errAnchorLoad                          = connectors.AnchorLoadErr()
+)
+
+// guardTrustAnchors mirrors connectors.guardTrustAnchors: on a build whose
+// embedded anchors failed to load, refuse up front with the distinct,
+// machine-actionable registry.trust_anchors_unavailable ("reinstall conduit")
+// rather than a generic expired-anchor error. A load failure can only block an
+// install, never let an unverified one through.
+func guardTrustAnchors() error {
+	if errAnchorLoad != nil {
+		return conduiterr.Wrap(registry.CodeTrustAnchorsUnavailable,
+			"this conduit build has no usable registry trust anchors (a build/release defect — reinstall a release build of conduit); processor installation cannot verify indexes without them",
+			errAnchorLoad)
+	}
+	return nil
+}

--- a/cmd/conduit/root/processorplugins/common.go
+++ b/cmd/conduit/root/processorplugins/common.go
@@ -1,0 +1,100 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processorplugins
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/user"
+	"runtime/debug"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// envPrefix is the shared ecdysis.Config.EnvPrefix for every command in this
+// package — the same "CONDUIT" prefix the rest of the CLI uses, so
+// --processors.path resolves from CONDUIT_PROCESSORS_PATH identically to
+// `conduit run`.
+const envPrefix = "CONDUIT"
+
+// runningProtocolVersion reports the conduit-connector-protocol module version
+// this binary was built against, via Go's embedded build info (avoiding a
+// hand-maintained constant that could drift from go.mod). Falls back to
+// "development" (which resolve.go's compatibility check treats as satisfying
+// every minProtocolVersion) when build info isn't available, e.g. `go run`.
+// Duplicated deliberately from the connectors package rather than exported: it
+// is a trivial, self-contained helper, and coupling the two command packages on
+// it would buy nothing.
+func runningProtocolVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "development"
+	}
+	const protocolModule = "github.com/conduitio/conduit-connector-protocol"
+	for _, dep := range info.Deps {
+		if dep.Path == protocolModule {
+			return dep.Version
+		}
+	}
+	return "development"
+}
+
+// installedByUser returns the current OS user's username, best-effort, for the
+// manifest entry's InstalledBy / audit event's Operator field. An empty string
+// (never an error) if it cannot be determined.
+func installedByUser() string {
+	u, err := user.Current()
+	if err != nil {
+		return ""
+	}
+	return u.Username
+}
+
+// isInteractiveTTY reports whether BOTH stdin and stdout are attached to a real
+// terminal — the confirmation prompt needs to both display a message (stdout)
+// and read a typed response (stdin); either being redirected means this is not
+// a context a human can interactively confirm in.
+func isInteractiveTTY() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// confirmUnsignedInstall prints the typed re-confirmation prompt for
+// --allow-unsigned and reads one line from in. Returns true only on an EXACT
+// match of name (never y/N), matching the connector command's convention and
+// the plan's "a typed exact match" requirement.
+func confirmUnsignedInstall(in *os.File, out *os.File, name string) (bool, error) {
+	fmt.Fprintf(out, "Type the processor name (%s) to confirm installing an UNSIGNED artifact — "+
+		"no cryptographic identity was verified: ", name)
+	scanner := bufio.NewScanner(in)
+	if !scanner.Scan() {
+		return false, scanner.Err()
+	}
+	return strings.TrimSpace(scanner.Text()) == name, nil
+}
+
+// confirmStaleBundle is the typed re-confirmation prompt for
+// --allow-stale-bundle, mirroring confirmUnsignedInstall's exact-match (never
+// y/N) convention.
+func confirmStaleBundle(in *os.File, out *os.File, bundlePath string) (bool, error) {
+	fmt.Fprintf(out, "Type the bundle path (%s) to confirm installing a STALE offline bundle — its index "+
+		"snapshot is older than the configured maximum staleness: ", bundlePath)
+	scanner := bufio.NewScanner(in)
+	if !scanner.Scan() {
+		return false, scanner.Err()
+	}
+	return strings.TrimSpace(scanner.Text()) == bundlePath, nil
+}

--- a/cmd/conduit/root/processorplugins/export_test.go
+++ b/cmd/conduit/root/processorplugins/export_test.go
@@ -1,0 +1,45 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processorplugins
+
+import "github.com/conduitio/conduit/pkg/registry/index"
+
+// SetDefaultTrustAnchorsForTest overrides this package's snapshot of the
+// compiled-in registry anchors for install_test.go's happy-path CLI tests,
+// which verify against a locally-generated, test-only signing key rather than
+// the embedded production anchors. Restores the previous value via the returned
+// func. Mirrors connectors.SetDefaultTrustAnchorsForTest — each install test
+// binary overrides its own package's copy. Being a _test.go file, none of this
+// compiles into a production build.
+func SetDefaultTrustAnchorsForTest(anchors index.TrustAnchors) (restore func()) {
+	prev := defaultTrustAnchors
+	defaultTrustAnchors = anchors
+	return func() { defaultTrustAnchors = prev }
+}
+
+// SetAnchorLoadErrForTest forces the "embedded anchors failed to load" state (a
+// broken/anchor-stripped build) so the CLI's trust_anchors_unavailable refusal
+// can be exercised end to end without corrupting the embed. Restores the
+// previous value via the returned func.
+func SetAnchorLoadErrForTest(err error) (restore func()) {
+	prev := errAnchorLoad
+	errAnchorLoad = err
+	return func() { errAnchorLoad = prev }
+}
+
+// UnsignedInstallEnvVarForTest exposes the --allow-unsigned non-interactive
+// escape-hatch env var name to install_test.go so it doesn't hardcode a second
+// copy of the literal that could drift from the real constant.
+const UnsignedInstallEnvVarForTest = "CONDUIT_ALLOW_UNSIGNED_INSTALL"

--- a/cmd/conduit/root/processorplugins/install.go
+++ b/cmd/conduit/root/processorplugins/install.go
@@ -1,0 +1,357 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processorplugins
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/cmd/conduit/root/connectors"
+	"github.com/conduitio/conduit/pkg/conduit"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/registry"
+	"github.com/conduitio/ecdysis"
+)
+
+var (
+	_ ecdysis.CommandWithFlags   = (*InstallCommand)(nil)
+	_ ecdysis.CommandWithConfig  = (*InstallCommand)(nil)
+	_ ecdysis.CommandWithArgs    = (*InstallCommand)(nil)
+	_ ecdysis.CommandWithDocs    = (*InstallCommand)(nil)
+	_ cecdysis.CommandWithResult = (*InstallCommand)(nil)
+)
+
+// InstallFlags embeds conduit.Config so `conduit processor-plugins install`
+// resolves --processors.path the same way (flags, CONDUIT_ env vars, config
+// file) as `conduit run` — install writes into that same directory, so it must
+// agree with the rest of the CLI on where it is. The remaining fields are
+// install-specific and mirror `conduit connectors install` exactly.
+type InstallFlags struct {
+	conduit.Config
+
+	IndexURL    string        `long:"index-url" usage:"registry index URL"`
+	IndexFile   string        `long:"index-file" usage:"read the index from a local file instead of --index-url (offline mode)"`
+	LockTimeout time.Duration `long:"lock-timeout" usage:"max time to wait to acquire the per-processor install lock"`
+	DryRun      bool          `long:"dry-run" usage:"resolve and select the arch-neutral WASM artifact; report what would be installed without downloading or writing anything"`
+
+	// Bundle installs fully offline from a signed processor bundle tarball
+	// (Tranche A, AC-13) — NO network call of any kind is made; everything is
+	// re-verified from the bundle's own contents. When set, the positional
+	// <name>[@version] argument is ignored (the bundle names its own
+	// processor/version).
+	Bundle string `long:"bundle" usage:"install fully offline from a signed processor bundle tarball (ignores the positional <name>[@version] argument)"`
+	// AllowStaleBundle tolerates a bundled index snapshot older than
+	// --install.max-staleness — gated identically to --allow-unsigned:
+	// interactive confirmation or the non-interactive escape-hatch env var, and
+	// hard-disablable by operator policy (install.allow-stale-bundle). Only ever
+	// consulted with --bundle.
+	AllowStaleBundle bool `long:"allow-stale-bundle" usage:"tolerate a --bundle whose snapshot is older than the maximum staleness — requires interactive confirmation or an explicit non-interactive escape hatch; may be disabled entirely by operator policy (install.allow-stale-bundle)"`
+
+	// AllowUnsigned requests skipping signature/provenance verification — the
+	// sha256 corruption check always still runs. It is NOT sufficient on its
+	// own: it is gated by policy.Decide via registry.InstallProcessor (the SAME
+	// single call site the connector path uses, enforced by the PolicyBypass
+	// depguard rule) — interactive typed confirmation, the
+	// CONDUIT_ALLOW_UNSIGNED_INSTALL env var in non-interactive contexts, and
+	// operator policy (install.allow-unsigned).
+	AllowUnsigned bool `long:"allow-unsigned" usage:"install without cryptographic signature/provenance verification — requires interactive confirmation or an explicit non-interactive escape hatch; may be disabled entirely by operator policy (install.allow-unsigned)"`
+}
+
+// InstallArgs holds InstallCommand's parsed positional argument.
+type InstallArgs struct {
+	Name    string
+	Version string // "" = newest compatible
+}
+
+// InstallCommand implements `conduit processor-plugins install <name>[@version]`.
+//
+// # Offline, deliberately (a divergence from its list/describe siblings)
+//
+// Unlike `processor-plugins list`/`describe`, which are ONLINE commands that
+// query a running engine over gRPC, install is OFFLINE: it never dials the
+// engine — it drives pkg/registry.InstallProcessor directly against
+// --processors.path on disk, so it works before any engine is running (the
+// contract is "install, then `conduit run` discovers it at startup"). This is
+// the same offline posture `conduit connectors install` has relative to
+// `connectors list`.
+//
+// # The trust core (reused, never forked)
+//
+// This passes registry.TrustedVerifier for BOTH IndexVerifier and
+// ArtifactVerifier, built from this build's compiled-in ceremony root/freshness
+// keys (the SAME single embedded anchor set the connector install uses — see
+// anchors.go), with RequireProvenance: true. Signature verification, SLSA
+// provenance, identity pinning, and the --allow-unsigned policy.Decide gate all
+// run through the one pkg/registry code path; there is no processor-specific
+// trust logic.
+//
+// # Tranche A vs Tranche B
+//
+// Against the live hosted index (Tranche B), install <name> resolves the
+// processor collection. Until the hosted index carries processors (PR-D), that
+// path returns registry.processor_not_found with a suggestion pointing at the
+// interim offline paths — the Tranche A --index-file / --bundle / gated
+// --allow-unsigned flows, which are fully usable today.
+type InstallCommand struct {
+	flags InstallFlags
+	args  InstallArgs
+	Cfg   conduit.Config
+}
+
+func (c *InstallCommand) Usage() string { return "install <name>[@version]" }
+
+func (c *InstallCommand) Docs() ecdysis.Docs {
+	return ecdysis.Docs{
+		Short: "Install a standalone WASM processor from the registry index",
+		Long: `install resolves <name>[@version] against the registry index's processor collection
+(exact-match name lookup, newest-compatible version selection when @version is omitted),
+downloads the single arch-neutral WASM artifact, verifies its signature + SLSA provenance
+against the processor's pinned publisher identity, compiles it to confirm it is a loadable
+standalone processor whose name matches, and atomically places it under --processors.path so
+the next 'conduit run' discovers it.
+
+This is an OFFLINE command: unlike 'processor-plugins list'/'describe' (which query a running
+engine), install writes to --processors.path on disk with no engine running.
+
+Interim offline paths (until the hosted index serves processors):
+  --index-file <local.json>   install from a locally-provided, still signature-verified index
+  --bundle <path.tgz>         install fully offline from a signed processor bundle
+
+Exit codes (via the ConduitError's registered category):
+  0  success
+  1  Runtime    — internal bug, archive-shape violation, invalid processor artifact
+  2  Validation — processor/version not found, incompatible version, yanked/revoked
+  3  Environment — index unreachable, download failed, corrupt download, install lock contended`,
+		Example: "conduit processor-plugins install ai.embed\n" +
+			"conduit processor-plugins install ai.embed@0.1.0\n" +
+			"conduit processor-plugins install ai.embed --dry-run\n" +
+			"conduit processor-plugins install --index-file ./index.json ai.embed\n" +
+			"conduit processor-plugins install --bundle ./ai-embed.tgz\n" +
+			"conduit processor-plugins install ai.embed --json",
+	}
+}
+
+func (c *InstallCommand) Flags() []ecdysis.Flag {
+	flags := ecdysis.BuildFlags(&c.flags)
+
+	currentPath, err := os.Getwd()
+	if err != nil {
+		panic(cerrors.Errorf("failed to get current working directory: %w", err))
+	}
+	// Assign c.Cfg (not just a local default), mirroring connectors install:
+	// ParseConfig's viper.Unmarshal only overwrites fields it has flag/env/file
+	// data for, so c.Cfg must start non-zero for --processors.path's default to
+	// survive into ExecuteWithResult.
+	c.Cfg = conduit.DefaultConfigWithBasePath(currentPath)
+	flags.SetDefault("config.path", c.Cfg.ConduitCfg.Path)
+	flags.SetDefault("processors.path", c.Cfg.Processors.Path)
+	flags.SetDefault("index-url", registry.DefaultIndexURL)
+	flags.SetDefault("lock-timeout", registry.DefaultLockTimeout)
+
+	return flags
+}
+
+func (c *InstallCommand) Config() ecdysis.Config {
+	path := filepath.Dir(c.flags.ConduitCfg.Path)
+	return ecdysis.Config{
+		EnvPrefix:     envPrefix,
+		Parsed:        &c.Cfg,
+		Path:          c.flags.ConduitCfg.Path,
+		DefaultValues: conduit.DefaultConfigWithBasePath(path),
+	}
+}
+
+// Args parses "<name>[@version]" — split on the FIRST "@" only. With --bundle
+// set, the positional argument is optional and ignored (the bundle names its
+// own processor/version); the "was --bundle set" check happens defensively in
+// ExecuteWithResult, so this method only accepts the zero-or-one-argument shape.
+func (c *InstallCommand) Args(args []string) error {
+	if len(args) > 1 {
+		return cerrors.Errorf("too many arguments")
+	}
+	if len(args) == 0 {
+		return nil // valid for --bundle; ExecuteWithResult rejects it otherwise
+	}
+
+	name, version, _ := strings.Cut(args[0], "@")
+	if name == "" {
+		return cerrors.Errorf("processor name must not be empty")
+	}
+	c.args.Name = name
+	c.args.Version = version
+	return nil
+}
+
+func (c *InstallCommand) ResultCommand() string { return "processor-plugins.install" }
+
+func (c *InstallCommand) ExecuteWithResult(ctx context.Context) (cecdysis.Outcome, error) {
+	if err := guardTrustAnchors(); err != nil {
+		return cecdysis.Outcome{}, err
+	}
+	verifier := &registry.TrustedVerifier{
+		Anchors:      defaultTrustAnchors,
+		StatePath:    registry.IndexStatePath(c.Cfg.Processors.Path),
+		MaxStaleness: c.Cfg.Install.MaxStaleness,
+		// RequireProvenance: true (same Tier-1 posture as connectors) — a
+		// "verified" processor artifact always includes the L3 SLSA
+		// attestation; a validly-signed artifact with no provenance refuses.
+		RequireProvenance: true,
+	}
+
+	if c.flags.Bundle != "" {
+		return c.executeFromBundle(ctx, verifier)
+	}
+	if c.args.Name == "" {
+		return cecdysis.Outcome{}, cerrors.Errorf("requires a processor name, optionally with @version (e.g. ai.embed or ai.embed@0.1.0), or --bundle <path>")
+	}
+
+	tty := isInteractiveTTY()
+	ciEnv := os.Getenv("CI") != ""
+	envVarSet := os.Getenv(connectors.UnsignedInstallEnvVar) == "I_UNDERSTAND"
+
+	// The typed re-confirmation prompt is collected HERE, at the CLI layer,
+	// before anything reaches registry.InstallProcessor — which routes through
+	// the SAME single policy.Decide call site the connector path uses (enforced
+	// by the PolicyBypass depguard rule) and consumes this as an
+	// already-validated bool, never re-implementing the prompt. Only attempted
+	// on a real interactive terminal with --allow-unsigned actually requested.
+	typedConfirmation := false
+	if c.flags.AllowUnsigned && tty && !ciEnv {
+		var err error
+		typedConfirmation, err = confirmUnsignedInstall(os.Stdin, os.Stdout, c.args.Name)
+		if err != nil {
+			return cecdysis.Outcome{}, cerrors.Errorf("could not read confirmation: %w", err)
+		}
+	}
+
+	opts := registry.InstallOptions{
+		Name:           c.args.Name,
+		Version:        c.args.Version,
+		ProcessorsPath: c.Cfg.Processors.Path,
+
+		IndexURL:  c.flags.IndexURL,
+		IndexFile: c.flags.IndexFile,
+
+		IndexVerifier:    verifier,
+		ArtifactVerifier: verifier,
+
+		RunningConduitVersion:  conduit.Version(false),
+		RunningProtocolVersion: runningProtocolVersion(),
+
+		InstalledBy: installedByUser(),
+		LockTimeout: c.flags.LockTimeout,
+		DryRun:      c.flags.DryRun,
+
+		AllowUnsigned:         c.flags.AllowUnsigned,
+		TTY:                   tty,
+		CIEnv:                 ciEnv,
+		IsMCP:                 false, // this is the CLI, never the MCP tool
+		EnvVarSet:             envVarSet,
+		TypedConfirmation:     typedConfirmation,
+		OperatorAllowUnsigned: c.Cfg.Install.AllowUnsigned,
+	}
+
+	result, err := registry.InstallProcessor(ctx, opts)
+	if err != nil {
+		return cecdysis.Outcome{}, err
+	}
+
+	return cecdysis.Outcome{OK: true, Result: result}, nil
+}
+
+// executeFromBundle is `conduit processor-plugins install --bundle <path>`
+// (Tranche A, AC-13): fully offline, no network call — see
+// pkg/registry/bundle.go's InstallProcessorBundle for the verification details.
+// Shares this command's own TrustedVerifier wiring rather than constructing a
+// second, divergent one.
+func (c *InstallCommand) executeFromBundle(ctx context.Context, verifier *registry.TrustedVerifier) (cecdysis.Outcome, error) {
+	tty := isInteractiveTTY()
+	ciEnv := os.Getenv("CI") != ""
+	envVarSet := os.Getenv(registry.StaleBundleEnvVar) == "I_UNDERSTAND"
+
+	typedConfirmation := false
+	if c.flags.AllowStaleBundle && tty && !ciEnv {
+		var err error
+		typedConfirmation, err = confirmStaleBundle(os.Stdin, os.Stdout, c.flags.Bundle)
+		if err != nil {
+			return cecdysis.Outcome{}, cerrors.Errorf("could not read confirmation: %w", err)
+		}
+	}
+
+	result, err := registry.InstallProcessorBundle(ctx, registry.InstallBundleOptions{
+		BundlePath:     c.flags.Bundle,
+		ProcessorsPath: c.Cfg.Processors.Path,
+		Verifier:       verifier,
+		InstalledBy:    installedByUser(),
+		LockTimeout:    c.flags.LockTimeout,
+
+		RunningConduitVersion:  conduit.Version(false),
+		RunningProtocolVersion: runningProtocolVersion(),
+
+		AllowStaleBundle:         c.flags.AllowStaleBundle,
+		TTY:                      tty,
+		CIEnv:                    ciEnv,
+		IsMCP:                    false,
+		EnvVarSet:                envVarSet,
+		TypedConfirmation:        typedConfirmation,
+		OperatorAllowStaleBundle: c.Cfg.Install.AllowStaleBundle,
+	})
+	if err != nil {
+		return cecdysis.Outcome{}, err
+	}
+	return cecdysis.Outcome{OK: true, Result: result}, nil
+}
+
+func (c *InstallCommand) Render(outcome cecdysis.Outcome) string {
+	res, ok := outcome.Result.(*registry.InstallResult)
+	if !ok || res == nil {
+		return ""
+	}
+
+	var b strings.Builder
+	switch {
+	case res.DryRun:
+		fmt.Fprintf(&b, "Would install %s@%s (%s/%s) from %s\n", res.Name, res.Version, res.OS, res.Arch, res.ArtifactURL)
+	case res.AlreadyInstalled:
+		fmt.Fprintf(&b, "%s@%s is already installed (%s)\n", res.Name, res.Version, res.ArtifactFile)
+	default:
+		fmt.Fprintf(&b, "Installed %s@%s (%s/%s) as %s\n", res.Name, res.Version, res.OS, res.Arch, res.ArtifactFile)
+	}
+	if res.Deprecated {
+		fmt.Fprintf(&b, "warning: %s@%s is deprecated\n", res.Name, res.Version)
+	}
+	// Edge case 16 (egress reminder): a processor that reaches out to a provider
+	// (embedding/chunking) will fail closed on the first `conduit run` unless
+	// egress is opened — the engine denies all processor egress by default.
+	// Actionable-error hygiene: remind on a real install (never on dry-run).
+	if !res.DryRun && !res.AlreadyInstalled && looksLikeEgressingProcessor(res.Name) {
+		fmt.Fprintf(&b, "note: %s may make outbound provider calls; set processors.egress.* to allow them, or the first run will fail closed\n", res.Name)
+	}
+	return b.String()
+}
+
+// looksLikeEgressingProcessor is a best-effort heuristic for the egress
+// reminder (edge case 16) — it never gates the install, only whether an
+// informational note is printed. Kept deliberately narrow (embedding-style
+// names) to avoid noise on processors that do no I/O.
+func looksLikeEgressingProcessor(name string) bool {
+	n := strings.ToLower(name)
+	return strings.Contains(n, "embed") || strings.Contains(n, "rerank")
+}

--- a/cmd/conduit/root/processorplugins/install_test.go
+++ b/cmd/conduit/root/processorplugins/install_test.go
@@ -1,0 +1,444 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Full-stack integration tests for `conduit processor-plugins install`: they
+// build the real cobra command (via ecdysis, exactly as cmd/conduit/cli does)
+// and drive it through cmd.ExecuteC(), mirroring
+// cmd/conduit/root/connectors/install_test.go. The command wires the REAL
+// registry.TrustedVerifier for both verifiers; signTestProcessorIndex injects a
+// test-only trust anchor via processorplugins.SetDefaultTrustAnchorsForTest so
+// index-signature verification is exercised end to end.
+//
+// WASM-validation-dependent success paths (which need a real wasip1 artifact)
+// live in pkg/registry/installprocessor_test.go; this file's job is the CLI's
+// wiring, TTY/env/config plumbing, --json error-code surfacing, and the
+// offline (--index-file) / gated --allow-unsigned flows — none of which need a
+// real WASM module to reach the behavior under test.
+package processorplugins_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	json "github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/cmd/conduit/root/processorplugins"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/registry"
+	"github.com/conduitio/conduit/pkg/registry/index"
+	"github.com/conduitio/ecdysis"
+	"github.com/spf13/cobra"
+)
+
+func buildInstallCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	e := ecdysis.New(ecdysis.WithDecorators(cecdysis.CommandWithResultDecorator{}))
+	return e.MustBuildCobraCommand(&processorplugins.InstallCommand{})
+}
+
+func runInstall(t *testing.T, args ...string) (output string, err error) {
+	t.Helper()
+	cmd := buildInstallCmd(t)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+
+	_, err = cmd.ExecuteC()
+	return out.String(), err
+}
+
+func hexEncode(d [32]byte) string {
+	const hextable = "0123456789abcdef"
+	out := make([]byte, 64)
+	for i, b := range d {
+		out[i*2] = hextable[b>>4]
+		out[i*2+1] = hextable[b&0x0f]
+	}
+	return string(out)
+}
+
+// buildProcessorArchive returns a valid tar.gz containing a single root-level
+// regular file. Its bytes are NOT a real WASM module: every test in this file
+// asserts a behavior reached before (fail-closed, not-found, dry-run,
+// trust-anchor) or at (the --allow-unsigned WASM-validation refusal) install-
+// time validation, so a real wasip1 module is never needed here.
+func buildProcessorArchive(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	content := []byte("not-a-real-wasm-module")
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "processor.wasm", Mode: 0o644, Size: int64(len(content))}))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+	return buf.Bytes()
+}
+
+func mustKeyID(t *testing.T, pub ed25519.PublicKey) string {
+	t.Helper()
+	id, err := index.KeyID(pub)
+	require.NoError(t, err)
+	return id
+}
+
+// signTestProcessorIndex JCS-canonicalizes payload, signs it with a freshly
+// generated root ed25519 key, registers that key as this test's ONLY
+// compiled-in trust anchor (via processorplugins.SetDefaultTrustAnchorsForTest,
+// restored via t.Cleanup), and returns the full signed envelope bytes — so a
+// CLI-level test exercises the REAL TrustedVerifier's index-integrity path end
+// to end. Mirrors connectors_test.signTestIndex.
+func signTestProcessorIndex(t *testing.T, payload index.Payload) []byte {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	restore := processorplugins.SetDefaultTrustAnchorsForTest(index.TrustAnchors{
+		Roots: map[string]ed25519.PublicKey{mustKeyID(t, pub): pub},
+	})
+	t.Cleanup(restore)
+
+	payloadRaw, err := json.Marshal(payload)
+	require.NoError(t, err)
+	canonical, err := index.Canonicalize(payloadRaw)
+	require.NoError(t, err)
+	sig := ed25519.Sign(priv, canonical)
+
+	envelope := map[string]any{
+		"payload": payload,
+		"signatures": []map[string]any{
+			{
+				"role": "root", "keyId": mustKeyID(t, pub), "algorithm": "ed25519",
+				"signature": base64.StdEncoding.EncodeToString(sig),
+			},
+		},
+	}
+	data, err := json.Marshal(envelope)
+	require.NoError(t, err)
+	return data
+}
+
+// oneProcessorPayload builds a signed-shape payload carrying exactly one
+// processor at one version. artifactURL/digest/size point at a served artifact;
+// signature bundle URL is included so resolution/selection succeed (the trust
+// gate then refuses because the bundle content is not a real signature).
+func oneProcessorPayload(name, version, artifactURL, sha256hex string, size int64, sigBundleURL string) index.Payload {
+	return index.Payload{
+		SchemaVersion: 1,
+		Index:         index.IndexMeta{Version: 7, Timestamp: time.Now()},
+		Processors: []index.Processor{
+			{
+				Name: name,
+				Publisher: index.Publisher{
+					ExpectedOIDCIssuer:      "https://token.actions.githubusercontent.com",
+					ExpectedIdentityPattern: `^https://github\.com/conduitio/conduit-processor-ai/.*$`,
+				},
+				Versions: []index.ProcessorVersion{
+					{
+						Version: version, MinConduitVersion: "0.1.0", MinProtocolVersion: "0.1.0",
+						Artifact: index.Artifact{
+							OS: "wasip1", Arch: "wasm", Kind: registry.WASMProcessorArtifactKind,
+							URL: artifactURL, SHA256: sha256hex, Size: size,
+							Signature: index.SignatureRef{BundleURL: sigBundleURL},
+						},
+						SLSAProvenance: &index.ProvenanceRef{BundleURL: sigBundleURL, PredicateType: "https://slsa.dev/provenance/v1"},
+					},
+				},
+			},
+		},
+	}
+}
+
+// newProcessorFixtureIndexFile serves a real (non-WASM) artifact over httptest
+// and writes a PROPERLY SIGNED, schema-valid index file to disk referencing it
+// (offline --index-file mode) — so a CLI install runs the FULL pipeline (index
+// verification, resolve, arch-neutral select, download, corruption check) and
+// only then reaches the artifact-verification gate.
+func newProcessorFixtureIndexFile(t *testing.T, name, version string) (indexPath string) {
+	t.Helper()
+	archiveBytes := buildProcessorArchive(t)
+	digest := sha256.Sum256(archiveBytes)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/p.tar.gz":
+			_, _ = w.Write(archiveBytes)
+		default:
+			_, _ = w.Write([]byte(`{"sig":"fake-test-bundle"}`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	payload := oneProcessorPayload(name, version, srv.URL+"/p.tar.gz", hexEncode(digest), int64(len(archiveBytes)), srv.URL+"/sig.json")
+	data := signTestProcessorIndex(t, payload)
+
+	path := filepath.Join(t.TempDir(), "index.json")
+	require.NoError(t, os.WriteFile(path, data, 0o644))
+	return path
+}
+
+func TestInstallArgs_MissingName(t *testing.T) {
+	_, err := runInstall(t, "--json")
+	require.Error(t, err)
+}
+
+func TestInstallArgs_TooManyArgs(t *testing.T) {
+	_, err := runInstall(t, "ai.embed", "extra", "--json")
+	require.Error(t, err)
+}
+
+// TestInstall_DryRun_JSON proves --dry-run resolves the processor collection
+// and reports without reaching the verification gate — no download happens, so
+// the artifact URL is deliberately unreachable.
+func TestInstall_DryRun_JSON(t *testing.T) {
+	payload := oneProcessorPayload("ai.embed", "1.0.0", "https://example.invalid/p.tar.gz",
+		"d34db33fd34db33fd34db33fd34db33fd34db33fd34db33fd34db33fd34db33", 1024, "")
+	data := signTestProcessorIndex(t, payload)
+	indexPath := filepath.Join(t.TempDir(), "index.json")
+	require.NoError(t, os.WriteFile(indexPath, data, 0o644))
+
+	processorsPath := t.TempDir()
+	out, err := runInstall(t,
+		"ai.embed",
+		"--processors.path="+processorsPath,
+		"--index-file="+indexPath,
+		"--dry-run",
+		"--json",
+	)
+	require.NoError(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	assert.True(t, res.OK)
+	assert.Nil(t, res.Error)
+	assert.Equal(t, "processor-plugins.install", res.Command)
+
+	result, ok := res.Result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "ai.embed", result["name"])
+	assert.Equal(t, "1.0.0", result["version"])
+	assert.Equal(t, "wasip1", result["os"])
+	assert.Equal(t, "wasm", result["arch"])
+	assert.Equal(t, true, result["dryRun"])
+
+	// --dry-run never writes a processor artifact.
+	assertNoInstalledArtifact(t, processorsPath)
+}
+
+// TestInstall_FailClosedByConstruction_JSON: the real command with the real
+// TrustedVerifier refuses via --json (no signature bundle content that verifies)
+// after resolving, downloading, and integrity-checking, and installs nothing.
+func TestInstall_FailClosedByConstruction_JSON(t *testing.T) {
+	indexPath := newProcessorFixtureIndexFile(t, "ai.embed", "1.0.0")
+	processorsPath := t.TempDir()
+
+	out, err := runInstall(t,
+		"ai.embed",
+		"--processors.path="+processorsPath,
+		"--index-file="+indexPath,
+		"--json",
+	)
+	require.Error(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	assert.Equal(t, "processor-plugins.install", res.Command)
+	assert.False(t, res.OK)
+	require.NotNil(t, res.Error)
+	// registry.unsigned: got all the way to the artifact-verification gate
+	// (resolution, the arch-neutral select, download, and corruption all
+	// succeeded first), which refuses because the fixture bundle isn't a real
+	// signature.
+	assert.Equal(t, "registry.unsigned", res.Error.Code)
+
+	assertNoInstalledArtifact(t, processorsPath)
+}
+
+// TestInstall_SplitsNameAndVersion proves "ai.embed@1.0.0" is split on the
+// first @ (a wrong split would resolve as processor_not_found instead of
+// reaching the artifact gate with registry.unsigned).
+func TestInstall_SplitsNameAndVersion(t *testing.T) {
+	indexPath := newProcessorFixtureIndexFile(t, "ai.embed", "1.0.0")
+	processorsPath := t.TempDir()
+
+	out, err := runInstall(t,
+		"ai.embed@1.0.0",
+		"--processors.path="+processorsPath,
+		"--index-file="+indexPath,
+		"--json",
+	)
+	require.Error(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	require.NotNil(t, res.Error)
+	assert.Equal(t, "registry.unsigned", res.Error.Code)
+}
+
+// TestInstall_NotFound_WithInterimSuggestion is edge case 1 / item 5: an
+// install for a name absent from the index's processors[] returns
+// registry.processor_not_found, and the suggestion points at the interim
+// offline (--index-file/--bundle) path.
+func TestInstall_NotFound_WithInterimSuggestion(t *testing.T) {
+	indexPath := newProcessorFixtureIndexFile(t, "ai.embed", "1.0.0")
+	processorsPath := t.TempDir()
+
+	out, err := runInstall(t,
+		"ai.chunk",
+		"--processors.path="+processorsPath,
+		"--index-file="+indexPath,
+		"--json",
+	)
+	require.Error(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	require.NotNil(t, res.Error)
+	assert.Equal(t, "registry.processor_not_found", res.Error.Code)
+	assert.Contains(t, res.Error.Suggestion, "--index-file")
+}
+
+// TestInstall_UnsignedIndexFailsClosedAtTrustAnchor: an index not signed by any
+// anchor this build recognizes (no SetDefaultTrustAnchorsForTest override)
+// refuses with registry.trust_anchor_expired BEFORE resolution.
+func TestInstall_UnsignedIndexFailsClosedAtTrustAnchor(t *testing.T) {
+	payload := oneProcessorPayload("ai.embed", "1.0.0", "https://example.invalid/p.tar.gz", "00", 1, "")
+	envelope := map[string]any{"payload": payload, "signatures": []any{}}
+	data, err := json.Marshal(envelope)
+	require.NoError(t, err)
+	indexPath := filepath.Join(t.TempDir(), "index.json")
+	require.NoError(t, os.WriteFile(indexPath, data, 0o644))
+
+	out, err := runInstall(t,
+		"ai.embed",
+		"--processors.path="+t.TempDir(),
+		"--index-file="+indexPath,
+		"--json",
+	)
+	require.Error(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	require.NotNil(t, res.Error)
+	assert.Equal(t, "registry.trust_anchor_expired", res.Error.Code)
+}
+
+// TestInstall_BrokenAnchorEmbed_ReportsTrustAnchorsUnavailable: on a build
+// whose embedded anchors failed to load, install refuses up front with
+// registry.trust_anchors_unavailable ("reinstall conduit").
+func TestInstall_BrokenAnchorEmbed_ReportsTrustAnchorsUnavailable(t *testing.T) {
+	restore := processorplugins.SetAnchorLoadErrForTest(cerrors.New("simulated stripped/corrupt anchor embed"))
+	t.Cleanup(restore)
+
+	out, err := runInstall(t,
+		"ai.embed",
+		"--processors.path="+t.TempDir(),
+		"--json",
+	)
+	require.Error(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	require.NotNil(t, res.Error)
+	assert.Equal(t, "registry.trust_anchors_unavailable", res.Error.Code)
+}
+
+// TestInstall_AllowUnsigned_OperatorDisabledByDefault_Refuses: with a fresh
+// config, install.allow-unsigned is false, so --allow-unsigned refuses with the
+// operator-disabled code even with the non-interactive env var set — the gate
+// fires and refuses before any download/extract.
+func TestInstall_AllowUnsigned_OperatorDisabledByDefault_Refuses(t *testing.T) {
+	indexPath := newProcessorFixtureIndexFile(t, "ai.embed", "1.0.0")
+	processorsPath := t.TempDir()
+
+	t.Setenv(processorplugins.UnsignedInstallEnvVarForTest, "I_UNDERSTAND")
+
+	out, err := runInstall(t,
+		"ai.embed",
+		"--processors.path="+processorsPath,
+		"--index-file="+indexPath,
+		"--allow-unsigned",
+		"--json",
+	)
+	require.Error(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	require.NotNil(t, res.Error)
+	assert.Equal(t, "registry.unsigned_install_disabled_by_policy", res.Error.Code)
+
+	assertNoInstalledArtifact(t, processorsPath)
+}
+
+// TestInstall_AllowUnsigned_GateFiresAndLogsUnderProcessorsPath proves the
+// SAME policy.Decide gate the connector path uses fires for processors (env-var
+// path, operator-enabled, non-interactive → allowed), and — the regression
+// guard for the unsigned-install-log-path fix — that its mandatory durable
+// audit entry lands under --processors.path/.registry, NOT a stray relative
+// path. The install then fails at install-time WASM validation
+// (registry.invalid_processor_artifact) because the fixture artifact is not a
+// real module — which itself proves the gate was PASSED (validation runs after
+// the unsigned gate).
+func TestInstall_AllowUnsigned_GateFiresAndLogsUnderProcessorsPath(t *testing.T) {
+	indexPath := newProcessorFixtureIndexFile(t, "ai.embed", "1.0.0")
+	processorsPath := t.TempDir()
+
+	t.Setenv(processorplugins.UnsignedInstallEnvVarForTest, "I_UNDERSTAND")
+
+	out, err := runInstall(t,
+		"ai.embed",
+		"--processors.path="+processorsPath,
+		"--index-file="+indexPath,
+		"--allow-unsigned",
+		"--install.allow-unsigned", // operator policy: permit the gate at all
+		"--json",
+	)
+	require.Error(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	require.NotNil(t, res.Error)
+	assert.Equal(t, "registry.invalid_processor_artifact", res.Error.Code)
+
+	// The mandatory unsigned-install audit entry must be under --processors.path.
+	logData, readErr := os.ReadFile(filepath.Join(processorsPath, ".registry", "unsigned-installs.log"))
+	require.NoError(t, readErr, "unsigned-install log must be written under --processors.path/.registry")
+	assert.Contains(t, string(logData), "ai.embed")
+
+	// No artifact landed (WASM validation refused before the rename).
+	assertNoInstalledArtifact(t, processorsPath)
+}
+
+func assertNoInstalledArtifact(t *testing.T, processorsPath string) {
+	t.Helper()
+	entries, err := os.ReadDir(processorsPath)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), "conduit-processor-")
+	}
+}

--- a/cmd/conduit/root/processorplugins/processor_plugins.go
+++ b/cmd/conduit/root/processorplugins/processor_plugins.go
@@ -34,6 +34,8 @@ func (c *ProcessorPluginsCommand) SubCommands() []ecdysis.Command {
 	return []ecdysis.Command{
 		&ListCommand{},
 		&DescribeCommand{},
+		&InstallCommand{},
+		&UninstallCommand{},
 	}
 }
 
@@ -42,5 +44,11 @@ func (c *ProcessorPluginsCommand) Usage() string { return "processor-plugins" }
 func (c *ProcessorPluginsCommand) Docs() ecdysis.Docs {
 	return ecdysis.Docs{
 		Short: "Manage Processor Plugins",
+		Long: `Manage standalone WASM processor plugins.
+
+'list' and 'describe' are ONLINE commands: they query a running Conduit engine over gRPC.
+'install' and 'uninstall' are OFFLINE commands: they read and write --processors.path on disk
+with no engine running (the contract is "install, then 'conduit run' discovers it at startup").
+This online/offline split is deliberate and mirrors 'conduit connectors'.`,
 	}
 }

--- a/cmd/conduit/root/processorplugins/uninstall.go
+++ b/cmd/conduit/root/processorplugins/uninstall.go
@@ -1,0 +1,267 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processorplugins
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/pkg/conduit"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/plugin"
+	"github.com/conduitio/conduit/pkg/provisioning/config"
+	"github.com/conduitio/conduit/pkg/provisioning/config/yaml"
+	"github.com/conduitio/conduit/pkg/registry"
+	"github.com/conduitio/ecdysis"
+)
+
+var (
+	_ ecdysis.CommandWithFlags   = (*UninstallCommand)(nil)
+	_ ecdysis.CommandWithConfig  = (*UninstallCommand)(nil)
+	_ ecdysis.CommandWithArgs    = (*UninstallCommand)(nil)
+	_ ecdysis.CommandWithDocs    = (*UninstallCommand)(nil)
+	_ cecdysis.CommandWithResult = (*UninstallCommand)(nil)
+)
+
+// UninstallFlags embeds conduit.Config for the same reason InstallFlags does:
+// --processors.path (and --pipelines.path, for the in-use scan) must resolve
+// identically to every other command that touches these directories.
+type UninstallFlags struct {
+	conduit.Config
+
+	Force bool `long:"force" usage:"remove the artifact even if a pipeline still references it (the affected pipelines are still named in the result/warning)"`
+}
+
+type UninstallArgs struct {
+	Name    string
+	Version string // "" = auto-resolve if exactly one version is installed
+}
+
+// UninstallCommand implements `conduit processor-plugins uninstall
+// <name>[@version]`. Like InstallCommand it is OFFLINE — it drives
+// pkg/registry.UninstallProcessor directly against --processors.path on disk,
+// no running engine required.
+//
+// # In-use check (a distinct code path from the connector uninstall)
+//
+// Before removing anything, uninstall scans the PROCESSORS blocks of every
+// provisioned pipeline config under --pipelines.path — both pipeline-level
+// processors and connector-level processors — for a standalone:<name>[@version]
+// reference (AC-8). This is deliberately NOT the connector uninstall's
+// connectors-block scan, and it is provisioned-config-only: unlike a connector
+// instance, a running processor's API parent may be a connector rather than a
+// pipeline, so it does not cleanly yield the pipeline identity the in-use
+// warning needs; the provisioned config is the complete source of truth for
+// "what a `conduit run` would reference". By default an in-use reference
+// refuses; --force proceeds and the result names the affected pipelines.
+type UninstallCommand struct {
+	flags UninstallFlags
+	args  UninstallArgs
+	Cfg   conduit.Config
+}
+
+func (c *UninstallCommand) Usage() string { return "uninstall <name>[@version]" }
+
+func (c *UninstallCommand) Docs() ecdysis.Docs {
+	return ecdysis.Docs{
+		Short: "Remove an installed standalone WASM processor",
+		Long: `uninstall removes a standalone WASM processor artifact and its install-manifest entry
+from --processors.path. If more than one version of <name> is installed, an explicit @version is
+required — an ambiguous "uninstall <name>" refuses rather than guessing.
+
+Before removing anything, uninstall scans the processors blocks of every provisioned pipeline
+config under --pipelines.path for a standalone:<name> reference. By default this refuses with a
+list of the affected pipelines; --force proceeds anyway and the result carries a warning naming
+them.
+
+Exit codes (via the ConduitError's registered category):
+  0  success
+  1  Runtime    — internal bug
+  2  Validation — not installed, ambiguous uninstall (multiple versions, no @version given)
+  3  Environment — processor is in use by a pipeline and --force was not given`,
+		Example: "conduit processor-plugins uninstall ai.embed\n" +
+			"conduit processor-plugins uninstall ai.embed@0.1.0\n" +
+			"conduit processor-plugins uninstall ai.embed --force\n" +
+			"conduit processor-plugins uninstall ai.embed --json",
+	}
+}
+
+func (c *UninstallCommand) Flags() []ecdysis.Flag {
+	flags := ecdysis.BuildFlags(&c.flags)
+
+	currentPath, err := os.Getwd()
+	if err != nil {
+		panic(cerrors.Errorf("failed to get current working directory: %w", err))
+	}
+	c.Cfg = conduit.DefaultConfigWithBasePath(currentPath)
+	flags.SetDefault("config.path", c.Cfg.ConduitCfg.Path)
+	flags.SetDefault("processors.path", c.Cfg.Processors.Path)
+	flags.SetDefault("pipelines.path", c.Cfg.Pipelines.Path)
+
+	return flags
+}
+
+func (c *UninstallCommand) Config() ecdysis.Config {
+	path := filepath.Dir(c.flags.ConduitCfg.Path)
+	return ecdysis.Config{
+		EnvPrefix:     envPrefix,
+		Parsed:        &c.Cfg,
+		Path:          c.flags.ConduitCfg.Path,
+		DefaultValues: conduit.DefaultConfigWithBasePath(path),
+	}
+}
+
+// Args parses "<name>[@version]" — same convention as InstallCommand.Args, but
+// the name is required (uninstall has no --bundle mode).
+func (c *UninstallCommand) Args(args []string) error {
+	if len(args) == 0 {
+		return cerrors.Errorf("requires a processor name, optionally with @version (e.g. ai.embed or ai.embed@0.1.0)")
+	}
+	if len(args) > 1 {
+		return cerrors.Errorf("too many arguments")
+	}
+
+	name, version, _ := strings.Cut(args[0], "@")
+	if name == "" {
+		return cerrors.Errorf("processor name must not be empty")
+	}
+	c.args.Name = name
+	c.args.Version = version
+	return nil
+}
+
+func (c *UninstallCommand) ResultCommand() string { return "processor-plugins.uninstall" }
+
+func (c *UninstallCommand) ExecuteWithResult(ctx context.Context) (cecdysis.Outcome, error) {
+	refs, err := collectProcessorInUseRefs(ctx, c.Cfg.Pipelines.Path, c.args.Name, c.args.Version)
+	if err != nil {
+		return cecdysis.Outcome{}, err
+	}
+
+	result, err := registry.UninstallProcessor(registry.UninstallProcessorOptions{
+		Name: c.args.Name, Version: c.args.Version, ProcessorsPath: c.Cfg.Processors.Path,
+		Force: c.flags.Force, InUseRefs: refs, InstalledBy: installedByUser(),
+	})
+	if err != nil {
+		return cecdysis.Outcome{}, err
+	}
+
+	return cecdysis.Outcome{OK: true, Result: result}, nil
+}
+
+func (c *UninstallCommand) Render(outcome cecdysis.Outcome) string {
+	res, ok := outcome.Result.(*registry.UninstallResult)
+	if !ok || res == nil {
+		return ""
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Uninstalled %s@%s\n", res.Name, res.Version)
+	for _, w := range res.Warnings {
+		fmt.Fprintf(&b, "warning: %s\n", w)
+	}
+	if res.DriftDetected {
+		fmt.Fprintln(&b, "note: the removed artifact's digest did not match the one recorded at install time")
+	}
+	if res.ArtifactAlreadyMissing {
+		fmt.Fprintln(&b, "note: the artifact file was already missing on disk; only the manifest entry was cleaned up")
+	}
+	return b.String()
+}
+
+// collectProcessorInUseRefs scans the processors blocks of every provisioned
+// pipeline config under pipelinesPath (both pipeline-level and connector-level
+// processors) for a standalone:<name> reference matching the name@version being
+// uninstalled — the distinct in-use code path AC-8 requires. A missing/empty
+// path is not an error (no provisioned pipelines to check == not in use).
+//
+// Version matching is deliberately loose: a standalone reference with no
+// explicit @version defaults to "latest" (plugin.FullName), so a pipeline
+// referencing standalone:ai.embed (unpinned) is treated as in-use for ANY
+// installed version. When an explicit @version is being uninstalled, a
+// reference is in-use if it is unpinned (latest) OR pins that exact version.
+// Over-matching here can only ADD a refusal/warning, never silently miss one.
+func collectProcessorInUseRefs(ctx context.Context, pipelinesPath, name, version string) ([]registry.InUseRef, error) {
+	if pipelinesPath == "" {
+		return nil, nil
+	}
+	if _, err := os.Stat(pipelinesPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, cerrors.Errorf("could not stat pipelines path %q: %w", pipelinesPath, err)
+	}
+
+	files, err := config.ResolveFiles(pipelinesPath)
+	if err != nil {
+		return nil, cerrors.Errorf("could not resolve pipeline config files under %q: %w", pipelinesPath, err)
+	}
+
+	parser := yaml.NewParser(log.Nop())
+	var refs []registry.InUseRef
+	for _, file := range files {
+		f, err := os.Open(file)
+		if err != nil {
+			return nil, cerrors.Errorf("could not open pipeline config %q: %w", file, err)
+		}
+		pipelines, perr := parser.Parse(ctx, f)
+		_ = f.Close()
+		if perr != nil {
+			// A malformed provisioned config is a real problem, but not one
+			// uninstall should silently ignore into a false "not in use" —
+			// surface it so the operator fixes the config.
+			return nil, cerrors.Errorf("could not parse pipeline config %q: %w", file, perr)
+		}
+		for _, p := range pipelines {
+			// Pipeline-level processors.
+			for _, proc := range p.Processors {
+				if procRefMatches(proc.Plugin, name, version) {
+					refs = append(refs, registry.InUseRef{PipelineID: p.ID, ConnectorID: proc.ID})
+				}
+			}
+			// Connector-level processors.
+			for _, conn := range p.Connectors {
+				for _, proc := range conn.Processors {
+					if procRefMatches(proc.Plugin, name, version) {
+						refs = append(refs, registry.InUseRef{PipelineID: p.ID, ConnectorID: proc.ID})
+					}
+				}
+			}
+		}
+	}
+	return refs, nil
+}
+
+// procRefMatches reports whether a processor's plugin reference (e.g.
+// "standalone:ai.embed" or "standalone:ai.embed@0.1.0") targets the standalone
+// processor name (and version, loosely) being uninstalled. A builtin processor
+// reference (no "standalone:" prefix) never matches. See
+// collectProcessorInUseRefs for the version-matching rationale.
+func procRefMatches(pluginRef, name, version string) bool {
+	fn := plugin.FullName(pluginRef)
+	if fn.PluginType() != plugin.PluginTypeStandalone || fn.PluginName() != name {
+		return false
+	}
+	if version == "" {
+		return true
+	}
+	refVersion := fn.PluginVersion()
+	return refVersion == plugin.PluginVersionLatest || refVersion == version
+}

--- a/cmd/conduit/root/processorplugins/uninstall_test.go
+++ b/cmd/conduit/root/processorplugins/uninstall_test.go
@@ -1,0 +1,248 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Full-stack CLI integration tests for `conduit processor-plugins uninstall`.
+// No engine runs in these tests, so the in-use check exercises the offline
+// provisioned-pipeline-config scan — specifically the PROCESSORS-block scan
+// (AC-8), a distinct code path from the connector uninstall's connectors-block
+// scan.
+package processorplugins_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	json "github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/cmd/conduit/root/processorplugins"
+	"github.com/conduitio/ecdysis"
+)
+
+func runUninstall(t *testing.T, args ...string) (output string, err error) {
+	t.Helper()
+	e := ecdysis.New(ecdysis.WithDecorators(cecdysis.CommandWithResultDecorator{}))
+	cmd := e.MustBuildCobraCommand(&processorplugins.UninstallCommand{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	_, err = cmd.ExecuteC()
+	return out.String(), err
+}
+
+// seedProcessorManifest writes an installed-processor manifest entry plus its
+// on-disk .wasm artifact under processorsPath, matching what InstallProcessor
+// would have recorded (Kind "wasm-processor", filename
+// conduit-processor-<name>_<version>.wasm).
+func seedProcessorManifest(t *testing.T, processorsPath string, nameVersions ...[2]string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(processorsPath, ".registry"), 0o755))
+
+	installs := map[string]any{}
+	for _, nv := range nameVersions {
+		name, version := nv[0], nv[1]
+		artifactFile := "conduit-processor-" + name + "_" + version + ".wasm"
+		require.NoError(t, os.WriteFile(filepath.Join(processorsPath, artifactFile), []byte("fixture-wasm-bytes"), 0o644))
+		installs[name+"@"+version] = map[string]any{
+			"name": name, "version": version, "kind": "wasm-processor",
+			"os": "wasip1", "arch": "wasm", "artifactFile": artifactFile,
+			"digest":      "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			"installedAt": time.Now().UTC().Format(time.RFC3339), "source": "index",
+		}
+	}
+	manifest := map[string]any{"schemaVersion": 1, "installs": installs}
+	data, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(processorsPath, ".registry", "manifest.json"), data, 0o644))
+}
+
+func artifactPath(processorsPath, name, version string) string {
+	return filepath.Join(processorsPath, "conduit-processor-"+name+"_"+version+".wasm")
+}
+
+func TestUninstall_NoPipelinesProvisioned_Succeeds(t *testing.T) {
+	processorsPath := t.TempDir()
+	pipelinesPath := t.TempDir() // empty: nothing provisioned, so not in use
+	seedProcessorManifest(t, processorsPath, [2]string{"ai.embed", "1.0.0"})
+
+	out, err := runUninstall(t,
+		"ai.embed@1.0.0",
+		"--processors.path="+processorsPath,
+		"--pipelines.path="+pipelinesPath,
+		"--json",
+	)
+	require.NoError(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	assert.True(t, res.OK)
+	assert.Equal(t, "processor-plugins.uninstall", res.Command)
+
+	_, statErr := os.Stat(artifactPath(processorsPath, "ai.embed", "1.0.0"))
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestUninstall_NotInstalled_HardError(t *testing.T) {
+	processorsPath := t.TempDir()
+	pipelinesPath := t.TempDir()
+
+	out, err := runUninstall(t,
+		"ai.embed",
+		"--processors.path="+processorsPath,
+		"--pipelines.path="+pipelinesPath,
+		"--json",
+	)
+	require.Error(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	require.NotNil(t, res.Error)
+	assert.Equal(t, "registry.processor_not_installed", res.Error.Code)
+}
+
+// TestUninstall_AmbiguousBareName_Refused: two versions installed, a bare-name
+// uninstall refuses rather than guessing (AC-8).
+func TestUninstall_AmbiguousBareName_Refused(t *testing.T) {
+	processorsPath := t.TempDir()
+	pipelinesPath := t.TempDir()
+	seedProcessorManifest(t, processorsPath,
+		[2]string{"ai.embed", "1.0.0"}, [2]string{"ai.embed", "1.1.0"})
+
+	out, err := runUninstall(t,
+		"ai.embed",
+		"--processors.path="+processorsPath,
+		"--pipelines.path="+pipelinesPath,
+		"--json",
+	)
+	require.Error(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	require.NotNil(t, res.Error)
+	assert.Equal(t, "registry.ambiguous_uninstall", res.Error.Code)
+
+	// Nothing removed.
+	_, statErr := os.Stat(artifactPath(processorsPath, "ai.embed", "1.0.0"))
+	assert.NoError(t, statErr)
+}
+
+// TestUninstall_InUseViaProcessorsBlock_RefusesWithoutForce is AC-8's own AC: a
+// pipeline config referencing the processor in a PROCESSORS block (not a
+// connectors block) refuses the uninstall by default and succeeds loudly with
+// --force. This exercises the distinct processors-block in-use scan.
+func TestUninstall_InUseViaProcessorsBlock_RefusesWithoutForce(t *testing.T) {
+	processorsPath := t.TempDir()
+	pipelinesPath := t.TempDir()
+	seedProcessorManifest(t, processorsPath, [2]string{"ai.embed", "1.0.0"})
+
+	// Pipeline-level processors block referencing the standalone processor.
+	pipelineYAML := `
+version: "2.2"
+pipelines:
+  - id: pipe1
+    status: running
+    connectors:
+      - id: conn1
+        type: source
+        plugin: "builtin:generator"
+    processors:
+      - id: proc1
+        plugin: "standalone:ai.embed@1.0.0"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(pipelinesPath, "pipeline1.yaml"), []byte(pipelineYAML), 0o644))
+
+	out, err := runUninstall(t,
+		"ai.embed@1.0.0",
+		"--processors.path="+processorsPath,
+		"--pipelines.path="+pipelinesPath,
+		"--json",
+	)
+	require.Error(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	require.NotNil(t, res.Error)
+	assert.Equal(t, "registry.processor_in_use", res.Error.Code)
+	assert.Contains(t, res.Error.Message, "pipe1")
+	assert.Contains(t, res.Error.Message, "processor proc1")
+
+	// Nothing removed.
+	_, statErr := os.Stat(artifactPath(processorsPath, "ai.embed", "1.0.0"))
+	assert.NoError(t, statErr)
+
+	// --force proceeds, with a warning naming the pipeline.
+	out, err = runUninstall(t,
+		"ai.embed@1.0.0",
+		"--processors.path="+processorsPath,
+		"--pipelines.path="+pipelinesPath,
+		"--force", "--json",
+	)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	assert.True(t, res.OK)
+
+	_, statErr = os.Stat(artifactPath(processorsPath, "ai.embed", "1.0.0"))
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+// TestUninstall_InUseViaConnectorLevelProcessor_Refused proves the in-use scan
+// also reaches processors nested inside a connector's own processors block, not
+// just pipeline-level processors.
+func TestUninstall_InUseViaConnectorLevelProcessor_Refused(t *testing.T) {
+	processorsPath := t.TempDir()
+	pipelinesPath := t.TempDir()
+	seedProcessorManifest(t, processorsPath, [2]string{"ai.embed", "1.0.0"})
+
+	pipelineYAML := `
+version: "2.2"
+pipelines:
+  - id: pipe1
+    status: running
+    connectors:
+      - id: conn1
+        type: source
+        plugin: "builtin:generator"
+        processors:
+          - id: cproc1
+            plugin: "standalone:ai.embed"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(pipelinesPath, "pipeline1.yaml"), []byte(pipelineYAML), 0o644))
+
+	out, err := runUninstall(t,
+		"ai.embed@1.0.0",
+		"--processors.path="+processorsPath,
+		"--pipelines.path="+pipelinesPath,
+		"--json",
+	)
+	require.Error(t, err)
+
+	var res cecdysis.Result
+	require.NoError(t, json.Unmarshal([]byte(out), &res))
+	require.NotNil(t, res.Error)
+	// The reference is unpinned (standalone:ai.embed → latest), so it must match
+	// the specific version being uninstalled (loose version matching, AC-8).
+	assert.Equal(t, "registry.processor_in_use", res.Error.Code)
+	assert.Contains(t, res.Error.Message, "processor cproc1")
+}
+
+func TestUninstall_MissingName_HardError(t *testing.T) {
+	_, err := runUninstall(t, "--json")
+	require.Error(t, err)
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -614,7 +614,7 @@ Author: Meroxa, Inc.
 | `sdk.schema.extract.key.enabled` | bool | true | no | Whether to extract and decode the record key with a schema. |  |
 | `sdk.schema.extract.payload.enabled` | bool | true | no | Whether to extract and decode the record payload with a schema. |  |
 
-## 3. Error codes (85)
+## 3. Error codes (87)
 
 | Reason | gRPC status | Description |
 | --- | --- | --- |
@@ -680,7 +680,9 @@ Author: Meroxa, Inc.
 | `registry.install_locked` | Unavailable | CodeInstallLocked is raised when the per-target install lock is not acquired within --lock-timeout. |
 | `registry.invalid_processor_artifact` | FailedPrecondition | CodeInvalidProcessorArtifact is raised by SelectProcessorArtifact when a processor version's single artifact is not the required arch-neutral WASM shape — Kind != "wasm-processor", or (OS, Arch) != ("wasip1", "wasm"). Unlike the connector path's SelectArtifact, which deliberately SKIPS an unrecognized kind ("no matching artifact"), a malformed processor artifact is a hard validation error, never a silent skip (design doc D2, failure mode 3): a processor has exactly one artifact and it must be the WASM one, so anything else is a malformed or spoofed index entry. FailedPrecondition — the index entry as published does not meet the precondition for install. |
 | `registry.no_platform_artifact` | NotFound | CodeNoPlatformArtifact is raised when no artifact exists for the host (os, arch). |
+| `registry.processor_in_use` | FailedPrecondition | CodeProcessorInUse is raised when an UninstallProcessor is refused because a pipeline still references the exact standalone:<name>[@version] in a processors block. Distinct from CodeConnectorInUse: the in-use scan is a separate code path (the processors blocks of provisioned pipeline YAML, not the connectors blocks). codes.FailedPrecondition, like its connector sibling. |
 | `registry.processor_not_found` | NotFound | CodeProcessorNotFound is raised when an exact-match name lookup in the index's processors[] collection fails. Distinct from CodeConnectorNotFound so an operator/agent can tell which collection was searched (a name may legitimately exist in one and not the other); codes.NotFound, exactly like its connector sibling. Same anti-typosquat stance as findConnector: exact-match only, never a fuzzy suggestion. |
+| `registry.processor_not_installed` | NotFound | CodeProcessorNotInstalled is raised on an UninstallProcessor/manifest lookup miss. Distinct from CodeConnectorNotInstalled so an operator/agent can tell which install directory (--processors.path vs --connectors.path) was searched; codes.NotFound, exactly like its connector sibling. |
 | `registry.provenance_invalid` | PermissionDenied | CodeProvenanceInvalid is raised when the SLSA provenance's subject-digest match or builder.id/configSource.uri binding fails (trust.ErrProvenanceInvalid). |
 | `registry.schema_too_new` | FailedPrecondition | CodeSchemaTooNew is raised when payload.schemaVersion exceeds the highest this build was compiled to understand. |
 | `registry.trust_anchor_expired` | FailedPrecondition | CodeTrustAnchorExpired is raised when no keyId in signatures[] matches any of this build's compiled-in trust anchors at all — the "upgrade Conduit" case, distinct from CodeIndexIntegrity's "recognized key, verification failed". |

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@
 (6 built-in connectors; full parameters in llms-full.txt)
 
 ## Error codes
-- 85 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
+- 87 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
 
 ## MCP tools
 - Read: deploy, doctor, dry_run, inspect, lint, repair, validate

--- a/pkg/registry/bundle.go
+++ b/pkg/registry/bundle.go
@@ -385,8 +385,15 @@ func readCappedTarEntry(tr *tar.Reader, maxBytes int64) ([]byte, error) {
 
 // InstallBundleOptions is InstallFromBundle's configuration.
 type InstallBundleOptions struct {
-	BundlePath     string
+	BundlePath string
+	// ConnectorsPath is the target for InstallFromBundle (a connector bundle).
 	ConnectorsPath string
+	// ProcessorsPath is the target for InstallProcessorBundle (a WASM processor
+	// bundle). Exactly one of ConnectorsPath/ProcessorsPath is set by the
+	// respective entry point; they share this options struct because every
+	// other field (verifier, running versions, and the stale-bundle policy
+	// signals) is identical for both artifact kinds.
+	ProcessorsPath string
 
 	// Verifier MUST be a real *TrustedVerifier — offline install never uses
 	// FailClosedVerifier-style verification-disabled wiring; there is no
@@ -467,7 +474,7 @@ func InstallFromBundle(ctx context.Context, opts InstallBundleOptions) (*Install
 			manifest.BundleFormatVersion, BundleFormatVersion))
 	}
 
-	verified, err := verifyBundleIndex(ctx, opts, snapshotRaw)
+	verified, err := verifyBundleIndex(ctx, opts, snapshotRaw, opts.ConnectorsPath)
 	if err != nil {
 		return nil, err
 	}
@@ -477,10 +484,13 @@ func InstallFromBundle(ctx context.Context, opts InstallBundleOptions) (*Install
 		return nil, err
 	}
 
-	sum, verifyResult, err := verifyBundleArtifact(ctx, opts, bundleArtifactMaterial{
+	sum, verifyResult, err := verifyBundleArtifact(ctx, opts.Verifier, bundleArtifactMaterial{
 		artifactBytes: artifactBytes, manifestSHA256: manifest.SHA256,
 		signatureBundle: signatureBundle, provenanceBundle: provenanceBundle,
-	}, resolved, artifact)
+	}, trust.PinnedIdentity{
+		OIDCIssuer:      resolved.Connector.Publisher.ExpectedOIDCIssuer,
+		IdentityPattern: resolved.Connector.Publisher.ExpectedIdentityPattern,
+	}, artifact)
 	if err != nil {
 		return nil, err
 	}
@@ -559,6 +569,156 @@ func InstallFromBundle(ctx context.Context, opts InstallBundleOptions) (*Install
 	}, nil
 }
 
+// InstallProcessorBundle installs a standalone WASM processor fully offline
+// from a signed bundle tarball — the processor analogue of InstallFromBundle
+// (AC-13). It reuses the SAME offline trust core verbatim: readBundleTar,
+// verifyBundleIndex (including the gated stale-bundle carve-out),
+// verifyBundleArtifact (identity-pinned signature + provenance over bytes
+// already in hand — NO network call of any kind), and finalizeArtifactInstall
+// (which additionally runs the install-time WASM compile+spec validation via
+// wasmProcessorTarget's validate hook, so a bundle whose .wasm won't compile or
+// whose spec name disagrees with the index name is refused before the atomic
+// rename, exactly as the online processor path refuses it). It differs from
+// InstallFromBundle only in resolving over payload.Processors + selecting the
+// single arch-neutral artifact, the processor target/filename/mode/manifest
+// Kind, the "processor_install" audit label, and --processors.path as the
+// install root.
+func InstallProcessorBundle(ctx context.Context, opts InstallBundleOptions) (*InstallResult, error) {
+	if opts.BundlePath == "" {
+		return nil, conduiterr.New(conduiterr.CodeInvalidArgument, "--bundle path is required")
+	}
+	if opts.ProcessorsPath == "" {
+		return nil, conduiterr.New(conduiterr.CodeInvalidArgument, "--processors.path is required")
+	}
+	if opts.Verifier == nil {
+		return nil, conduiterr.New(CodeVerificationUnavailable, "no verifier configured for bundle install")
+	}
+
+	manifest, artifactBytes, signatureBundle, provenanceBundle, snapshotRaw, err := readBundleTar(opts.BundlePath)
+	if err != nil {
+		return nil, err
+	}
+	if manifest.BundleFormatVersion > BundleFormatVersion {
+		return nil, conduiterr.New(conduiterr.CodeInvalidArgument, fmt.Sprintf(
+			"bundle format version %d is newer than this build supports (max %d) — upgrade conduit",
+			manifest.BundleFormatVersion, BundleFormatVersion))
+	}
+
+	verified, err := verifyBundleIndex(ctx, opts, snapshotRaw, opts.ProcessorsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	resolved, artifact, err := resolveProcessorBundleArtifact(verified, manifest, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	sum, verifyResult, err := verifyBundleArtifact(ctx, opts.Verifier, bundleArtifactMaterial{
+		artifactBytes: artifactBytes, manifestSHA256: manifest.SHA256,
+		signatureBundle: signatureBundle, provenanceBundle: provenanceBundle,
+	}, trust.PinnedIdentity{
+		OIDCIssuer:      resolved.Processor.Publisher.ExpectedOIDCIssuer,
+		IdentityPattern: resolved.Processor.Publisher.ExpectedIdentityPattern,
+	}, artifact)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := ManifestKey(resolved.Processor.Name, resolved.Version.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	targetLock, err := AcquireTargetLock(opts.ProcessorsPath, resolved.Processor.Name, opts.lockTimeout())
+	if err != nil {
+		return nil, err
+	}
+	defer targetLock.Unlock() //nolint:errcheck // best-effort; flock also releases at process exit
+
+	entry, alreadyInstalled, err := lookupManifestEntry(opts.ProcessorsPath, key)
+	if err != nil {
+		return nil, err
+	}
+	if alreadyInstalled {
+		return &InstallResult{
+			Name: entry.Name, Version: entry.Version, OS: entry.OS, Arch: entry.Arch,
+			AlreadyInstalled: true, ArtifactFile: entry.ArtifactFile, Digest: entry.Digest,
+			SourceIndexVersion: entry.SourceIndexVersion,
+		}, nil
+	}
+
+	stagingDir, err := createBundleStagingDir(opts.ProcessorsPath)
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(stagingDir)
+
+	archivePath := filepath.Join(stagingDir, "artifact.tar.gz")
+	if err := os.WriteFile(archivePath, artifactBytes, 0o600); err != nil {
+		return nil, conduiterr.Wrap(CodeArchiveInvalid, "could not stage bundled artifact", err)
+	}
+
+	entryToSave, err := finalizeArtifactInstall(ctx, finalizeInstallOptions{
+		targetDir:          opts.ProcessorsPath,
+		target:             wasmProcessorTarget(),
+		stagingDir:         stagingDir,
+		archivePath:        archivePath,
+		name:               resolved.Processor.Name,
+		version:            resolved.Version.Version,
+		os:                 artifact.OS,
+		arch:               artifact.Arch,
+		digest:             sum,
+		size:               int64(len(artifactBytes)),
+		installedBy:        opts.InstalledBy,
+		sourceIndexVersion: verified.Payload.Index.Version,
+		source:             InstallSourceOfflineBundle,
+		bundleIndexVersion: verified.Payload.Index.Version,
+		verifyResult:       verifyResult,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := writeManifestEntry(opts.ProcessorsPath, key, entryToSave, opts.lockTimeout()); err != nil {
+		return nil, err
+	}
+
+	if err := AppendAuditEvent(auditLogPath(opts.ProcessorsPath), AuditEvent{
+		Event: "processor_install", Connector: entryToSave.Name, Version: entryToSave.Version,
+		Digest: entryToSave.Digest, Operator: opts.InstalledBy, Timestamp: entryToSave.InstalledAt,
+		Signed: entryToSave.Signed, VerifiedIdentity: entryToSave.VerifiedIdentity, AllowUnsigned: entryToSave.AllowUnsigned,
+	}); err != nil {
+		return nil, conduiterr.Wrap(conduiterr.CodeInternal, "processor installed but could not append the audit log entry", err)
+	}
+
+	return &InstallResult{
+		Name: entryToSave.Name, Version: entryToSave.Version, OS: entryToSave.OS, Arch: entryToSave.Arch,
+		Deprecated: resolved.Version.Deprecated, ArtifactFile: entryToSave.ArtifactFile,
+		Digest: entryToSave.Digest, SourceIndexVersion: entryToSave.SourceIndexVersion,
+	}, nil
+}
+
+// resolveProcessorBundleArtifact resolves manifest.Name/Version against the
+// verified snapshot's processors[] collection and selects the single
+// arch-neutral WASM artifact — the processor twin of resolveBundleArtifact,
+// factored out purely to keep InstallProcessorBundle's cyclomatic complexity
+// down.
+func resolveProcessorBundleArtifact(verified *index.VerifiedIndex, manifest BundleManifest, opts InstallBundleOptions) (*ResolvedProcessorVersion, *index.Artifact, error) {
+	resolved, err := ResolveProcessor(verified.Payload, ResolveOptions{
+		Name: manifest.Name, Version: manifest.Version,
+		RunningConduitVersion: opts.RunningConduitVersion, RunningProtocolVersion: opts.RunningProtocolVersion,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	artifact, err := SelectProcessorArtifact(resolved.Processor.Name, resolved.Version)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resolved, artifact, nil
+}
+
 // resolveBundleArtifact resolves manifest.Name/Version against the
 // verified snapshot and selects the (os, arch) artifact the bundle claims —
 // factored out of InstallFromBundle purely to keep that function's
@@ -592,8 +752,11 @@ type bundleArtifactMaterial struct {
 // sha256, plan-v2/step5 §7 step 7) and the identity-pinned signature/
 // provenance verification, exactly as install.go's runVerificationGate does
 // for a live artifact — factored out of InstallFromBundle purely to keep
-// that function's cyclomatic complexity down.
-func verifyBundleArtifact(ctx context.Context, opts InstallBundleOptions, m bundleArtifactMaterial, resolved *ResolvedVersion, artifact *index.Artifact) ([32]byte, VerifyResult, error) {
+// that function's cyclomatic complexity down. It takes the pinned identity
+// directly (not a *ResolvedVersion) so the processor bundle path
+// (InstallProcessorBundle) reuses this exact same trust check with its own
+// resolved processor's publisher identity — one trust core, never forked.
+func verifyBundleArtifact(ctx context.Context, verifier *TrustedVerifier, m bundleArtifactMaterial, identity trust.PinnedIdentity, artifact *index.Artifact) ([32]byte, VerifyResult, error) {
 	sum := sha256.Sum256(m.artifactBytes)
 	if err := CheckCorruption(sum, m.manifestSHA256); err != nil {
 		return sum, VerifyResult{}, err
@@ -602,11 +765,7 @@ func verifyBundleArtifact(ctx context.Context, opts InstallBundleOptions, m bund
 		return sum, VerifyResult{}, err
 	}
 
-	identity := trust.PinnedIdentity{
-		OIDCIssuer:      resolved.Connector.Publisher.ExpectedOIDCIssuer,
-		IdentityPattern: resolved.Connector.Publisher.ExpectedIdentityPattern,
-	}
-	verifyResult, err := opts.Verifier.VerifyArtifact(ctx, ArtifactRef{
+	verifyResult, err := verifier.VerifyArtifact(ctx, ArtifactRef{
 		Digest: sum, SignatureBundle: m.signatureBundle, ProvenanceBundle: m.provenanceBundle,
 	}, identity)
 	if err != nil {
@@ -647,7 +806,11 @@ func createBundleStagingDir(connectorsPath string) (string, error) {
 // for this one verification. Every other failure (integrity, rollback,
 // trust-anchor) is refused unconditionally — there is no override for
 // those, ever.
-func verifyBundleIndex(ctx context.Context, opts InstallBundleOptions, snapshotRaw []byte) (*index.VerifiedIndex, error) {
+// auditDir is the install root whose .registry/audit.jsonl a stale-bundle
+// override event is appended to (--connectors.path for InstallFromBundle,
+// --processors.path for InstallProcessorBundle) — the only reason this
+// otherwise artifact-kind-neutral function is parameterized on a directory.
+func verifyBundleIndex(ctx context.Context, opts InstallBundleOptions, snapshotRaw []byte, auditDir string) (*index.VerifiedIndex, error) {
 	verified, err := opts.Verifier.VerifyIndex(ctx, snapshotRaw)
 	if err == nil {
 		if !verified.Verified {
@@ -699,7 +862,7 @@ func verifyBundleIndex(ctx context.Context, opts InstallBundleOptions, snapshotR
 			"the bundled index snapshot could not be cryptographically verified — refusing to install")
 	}
 
-	if logErr := AppendAuditEvent(auditLogPath(opts.ConnectorsPath), AuditEvent{
+	if logErr := AppendAuditEvent(auditLogPath(auditDir), AuditEvent{
 		Event: "stale_bundle_override", Timestamp: time.Now().UTC(), Operator: opts.InstalledBy,
 	}); logErr != nil {
 		return nil, conduiterr.Wrap(conduiterr.CodeInternal, "stale bundle override approved but could not append the audit log entry", logErr)

--- a/pkg/registry/codes.go
+++ b/pkg/registry/codes.go
@@ -110,4 +110,16 @@ var (
 	// so anything else is a malformed or spoofed index entry. FailedPrecondition
 	// — the index entry as published does not meet the precondition for install.
 	CodeInvalidProcessorArtifact = conduiterr.Register("registry.invalid_processor_artifact", codes.FailedPrecondition)
+	// CodeProcessorNotInstalled is raised on an UninstallProcessor/manifest
+	// lookup miss. Distinct from CodeConnectorNotInstalled so an operator/agent
+	// can tell which install directory (--processors.path vs --connectors.path)
+	// was searched; codes.NotFound, exactly like its connector sibling.
+	CodeProcessorNotInstalled = conduiterr.Register("registry.processor_not_installed", codes.NotFound)
+	// CodeProcessorInUse is raised when an UninstallProcessor is refused because
+	// a pipeline still references the exact standalone:<name>[@version] in a
+	// processors block. Distinct from CodeConnectorInUse: the in-use scan is a
+	// separate code path (the processors blocks of provisioned pipeline YAML,
+	// not the connectors blocks). codes.FailedPrecondition, like its connector
+	// sibling.
+	CodeProcessorInUse = conduiterr.Register("registry.processor_in_use", codes.FailedPrecondition)
 )

--- a/pkg/registry/install.go
+++ b/pkg/registry/install.go
@@ -460,7 +460,7 @@ func downloadVerifyAndInstall(ctx context.Context, opts InstallOptions, targetDi
 		}
 	}
 
-	verifyResult, err := runVerificationGate(ctx, opts, dl, ra)
+	verifyResult, err := runVerificationGate(ctx, opts, targetDir, dl, ra)
 	if err != nil {
 		return ManifestEntry{}, err
 	}
@@ -613,14 +613,20 @@ func stageArtifact(ctx context.Context, opts InstallOptions, targetDir string, a
 // (this file) is the ONLY call site of policy.Decide in this codebase,
 // enforced by the PolicyBypass depguard rule in .golangci.yml.
 //
+// targetDir is the install root (--connectors.path or --processors.path); it
+// is threaded through solely so the unsigned-install audit log lands under the
+// SAME directory the artifact is installed into — a processor install
+// (opts.ConnectorsPath == "") would otherwise write its unsigned-install log to
+// a bogus relative path. It never affects the verification decision itself.
+//
 // Invariant (fail-closed by construction, PR-1): with the production
 // FailClosedVerifier and AllowUnsigned unset, VerifyArtifact ALWAYS returns
 // ErrVerificationNotConfigured. With the real TrustedVerifier (PR-2), a
 // non-Signed success without going through the AllowUnsigned+policy.Decide
 // path is a programming error refused below, never silently installed.
-func runVerificationGate(ctx context.Context, opts InstallOptions, dl DownloadResult, ra resolvedArtifact) (VerifyResult, error) {
+func runVerificationGate(ctx context.Context, opts InstallOptions, targetDir string, dl DownloadResult, ra resolvedArtifact) (VerifyResult, error) {
 	if opts.AllowUnsigned {
-		return unsignedInstallGate(opts, dl, ra)
+		return unsignedInstallGate(opts, targetDir, dl, ra)
 	}
 
 	ref, err := fetchArtifactRef(ctx, opts, dl.Digest, ra)
@@ -655,7 +661,7 @@ func runVerificationGate(ctx context.Context, opts InstallOptions, dl DownloadRe
 // unsigned install to be logged, no exceptions — and returns
 // VerifyResult{Signed: false}, which downloadVerifyAndInstall records
 // verbatim into the manifest's Signed/AllowUnsigned fields.
-func unsignedInstallGate(opts InstallOptions, dl DownloadResult, ra resolvedArtifact) (VerifyResult, error) {
+func unsignedInstallGate(opts InstallOptions, targetDir string, dl DownloadResult, ra resolvedArtifact) (VerifyResult, error) {
 	dec, err := policy.Decide(policy.Context{
 		TTY:               opts.TTY,
 		CIEnv:             opts.CIEnv,
@@ -681,7 +687,13 @@ func unsignedInstallGate(opts InstallOptions, dl DownloadResult, ra resolvedArti
 	}
 	logPath := opts.UnsignedInstallsLogPath
 	if logPath == "" {
-		logPath = unsignedInstallsLogPath(opts.ConnectorsPath)
+		// targetDir, not opts.ConnectorsPath: a processor install sets
+		// ProcessorsPath and leaves ConnectorsPath empty, so keying the log off
+		// ConnectorsPath would drop the mandatory unsigned-install audit entry
+		// into a stray relative ".registry" path instead of under
+		// --processors.path. For a connector install targetDir == ConnectorsPath,
+		// so this is behavior-preserving.
+		logPath = unsignedInstallsLogPath(targetDir)
 	}
 	if err := policy.AppendUnsignedInstallEvent(logPath, policy.UnsignedInstallEvent{
 		Connector:      ra.name,

--- a/pkg/registry/installprocessor_unsigned_test.go
+++ b/pkg/registry/installprocessor_unsigned_test.go
@@ -1,0 +1,110 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry"
+	"github.com/conduitio/conduit/pkg/registry/policy"
+)
+
+// TestInstallProcessor_AllowUnsigned_RealInstall_LogsUnderProcessorsPath is the
+// regression guard for the unsigned-install-log-path fix (AC-14): a processor
+// install goes through the SAME single policy.Decide gate connectors use, and
+// its mandatory durable audit entry must land under --processors.path/.registry
+// (NOT the empty --connectors.path, which would drop it into a stray relative
+// path). Uses a REAL wasip1 module so install-time WASM validation passes and
+// the artifact actually lands on disk.
+func TestInstallProcessor_AllowUnsigned_RealInstall_LogsUnderProcessorsPath(t *testing.T) {
+	wasm := readTestProcessorWASM(t, "chaos")
+	artifact := tarGzSingle(t, "processor.wasm", wasm)
+	srv, indexURL := newProcessorInstallTestServer(t, "chaos-processor", "1.3.5", artifact, nil)
+	defer srv.Close()
+
+	processorsPath := t.TempDir()
+	res, err := registry.InstallProcessor(context.Background(), registry.InstallOptions{
+		Name: "chaos-processor", ProcessorsPath: processorsPath, IndexURL: indexURL,
+		IndexVerifier: passThroughVerifier{}, ArtifactVerifier: passThroughVerifier{},
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+		InstalledBy: "test-operator",
+		// Gated unsigned install: operator policy permits it, non-interactive
+		// env-var escape hatch (no TTY) — policy.Decide allows.
+		AllowUnsigned:         true,
+		OperatorAllowUnsigned: true,
+		EnvVarSet:             true,
+		TTY:                   false,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, "chaos-processor", res.Name)
+	assert.Equal(t, "1.3.5", res.Version)
+
+	// Artifact landed on disk (WASM validation passed on the real module).
+	installedPath := filepath.Join(processorsPath, "conduit-processor-chaos-processor_1.3.5.wasm")
+	_, statErr := os.Stat(installedPath)
+	require.NoError(t, statErr)
+
+	// The mandatory unsigned-install audit entry is under --processors.path — the
+	// fix: unsignedInstallGate now keys the log off the install target dir, not
+	// the (empty, for a processor install) ConnectorsPath.
+	logData, readErr := os.ReadFile(filepath.Join(processorsPath, ".registry", "unsigned-installs.log"))
+	require.NoError(t, readErr, "unsigned-install log must be written under --processors.path/.registry")
+	assert.Contains(t, string(logData), "chaos-processor")
+
+	// Manifest records it as an unsigned install.
+	m, err := registry.LoadManifest(filepath.Join(processorsPath, ".registry", "manifest.json"))
+	require.NoError(t, err)
+	entry, ok := m.Installs["chaos-processor@1.3.5"]
+	require.True(t, ok)
+	assert.False(t, entry.Signed)
+	assert.True(t, entry.AllowUnsigned)
+	assert.Equal(t, registry.WASMProcessorArtifactKind, entry.Kind)
+}
+
+// TestInstallProcessor_AllowUnsigned_OperatorDisabled_Refuses proves the same
+// gate refuses when operator policy forbids it (the connector path's identical
+// behavior), leaving nothing on disk and no unsigned-install log.
+func TestInstallProcessor_AllowUnsigned_OperatorDisabled_Refuses(t *testing.T) {
+	artifact := tarGzSingle(t, "processor.wasm", []byte("bytes never validated — refused at the policy gate"))
+	srv, indexURL := newProcessorInstallTestServer(t, "chaos-processor", "1.3.5", artifact, nil)
+	defer srv.Close()
+
+	processorsPath := t.TempDir()
+	_, err := registry.InstallProcessor(context.Background(), registry.InstallOptions{
+		Name: "chaos-processor", ProcessorsPath: processorsPath, IndexURL: indexURL,
+		IndexVerifier: passThroughVerifier{}, ArtifactVerifier: passThroughVerifier{},
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "1.0.0",
+		AllowUnsigned:         true,
+		OperatorAllowUnsigned: false, // operator forbids the whole gate
+		EnvVarSet:             true,
+		TTY:                   false,
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, policy.CodeUnsignedInstallDisabledByPolicy, ce.Code)
+
+	assertNoInstalledProcessor(t, processorsPath)
+	_, statErr := os.Stat(filepath.Join(processorsPath, ".registry", "unsigned-installs.log"))
+	assert.True(t, os.IsNotExist(statErr))
+}

--- a/pkg/registry/installprocessorbundle_test.go
+++ b/pkg/registry/installprocessorbundle_test.go
@@ -1,0 +1,148 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/registry"
+	"github.com/conduitio/conduit/pkg/registry/index"
+	"github.com/conduitio/conduit/pkg/registry/trust"
+)
+
+// oneProcessorSnapshotPayload builds a signed-shape payload carrying one
+// processor version whose single artifact is the arch-neutral WASM shape
+// pointing at the given digest.
+func oneProcessorSnapshotPayload(name, version, sha256hex string, size int64) index.Payload {
+	return index.Payload{
+		SchemaVersion: 1,
+		Index:         index.IndexMeta{Version: 3, Timestamp: time.Now().UTC()},
+		Processors: []index.Processor{{
+			Name: name,
+			Publisher: index.Publisher{
+				ExpectedOIDCIssuer:      "https://token.actions.githubusercontent.com",
+				ExpectedIdentityPattern: `^https://github\.com/conduitio/conduit-processor-ai/.*$`,
+			},
+			Versions: []index.ProcessorVersion{{
+				Version: version, MinConduitVersion: "0.1.0", MinProtocolVersion: "0.1.0",
+				Artifact: index.Artifact{
+					OS: "wasip1", Arch: "wasm", Kind: registry.WASMProcessorArtifactKind,
+					URL: "https://example.test/p.tar.gz", SHA256: sha256hex, Size: size,
+				},
+			}},
+		}},
+	}
+}
+
+// TestInstallProcessorBundle_MissingProcessorsPath refuses with an
+// invalid-argument error when --processors.path is not set.
+func TestInstallProcessorBundle_MissingProcessorsPath(t *testing.T) {
+	manifest := registry.BundleManifest{BundleFormatVersion: 1, Name: "ai.embed", Version: "1.0.0", OS: "wasip1", Arch: "wasm"}
+	path := buildTestBundleTar(t, manifest, []byte("bytes"), nil, nil, []byte("{}"))
+
+	_, err := registry.InstallProcessorBundle(context.Background(), registry.InstallBundleOptions{
+		BundlePath: path, Verifier: &registry.TrustedVerifier{},
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, conduiterr.CodeInvalidArgument, ce.Code)
+}
+
+// TestInstallProcessorBundle_NotFoundInSnapshot proves the bundle path resolves
+// the processors[] collection (distinct from connectors[]): a name absent from
+// processors[] refuses with registry.processor_not_found even before artifact
+// verification.
+func TestInstallProcessorBundle_NotFoundInSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	f := newAuditTrustCoreFixture(t)
+	// Snapshot carries a processor named ai.embed, but the bundle claims ai.chunk.
+	payload := oneProcessorSnapshotPayload("ai.embed", "1.0.0", sha256Hex("bytes"), 5)
+	snapshot := f.sign(t, payload)
+	manifest := registry.BundleManifest{BundleFormatVersion: 1, Name: "ai.chunk", Version: "1.0.0", OS: "wasip1", Arch: "wasm"}
+	path := buildTestBundleTar(t, manifest, []byte("bytes"), nil, nil, snapshot)
+
+	verifier := &registry.TrustedVerifier{Anchors: f.anchors(t), StatePath: filepath.Join(dir, ".registry", "index-state.json")}
+	_, err := registry.InstallProcessorBundle(context.Background(), registry.InstallBundleOptions{
+		BundlePath: path, ProcessorsPath: dir, Verifier: verifier,
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeProcessorNotFound, ce.Code)
+}
+
+// TestInstallProcessorBundle_HostArtifactRefused proves the bundle path uses the
+// arch-neutral SelectProcessorArtifact, never the host-platform SelectArtifact:
+// a processor snapshot whose single artifact declares a host os/arch refuses
+// with registry.invalid_processor_artifact.
+func TestInstallProcessorBundle_HostArtifactRefused(t *testing.T) {
+	dir := t.TempDir()
+	f := newAuditTrustCoreFixture(t)
+	payload := oneProcessorSnapshotPayload("ai.embed", "1.0.0", sha256Hex("bytes"), 5)
+	// Corrupt the arch-neutral artifact into a host-platform shape.
+	payload.Processors[0].Versions[0].Artifact.OS = "linux"
+	payload.Processors[0].Versions[0].Artifact.Arch = "amd64"
+	snapshot := f.sign(t, payload)
+	manifest := registry.BundleManifest{BundleFormatVersion: 1, Name: "ai.embed", Version: "1.0.0", OS: "wasip1", Arch: "wasm"}
+	path := buildTestBundleTar(t, manifest, []byte("bytes"), nil, nil, snapshot)
+
+	verifier := &registry.TrustedVerifier{Anchors: f.anchors(t), StatePath: filepath.Join(dir, ".registry", "index-state.json")}
+	_, err := registry.InstallProcessorBundle(context.Background(), registry.InstallBundleOptions{
+		BundlePath: path, ProcessorsPath: dir, Verifier: verifier,
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeInvalidProcessorArtifact, ce.Code)
+}
+
+// TestInstallProcessorBundle_ReachesArtifactVerification proves the offline
+// processor bundle path drives the FULL trust core (index verification →
+// processor resolution → arch-neutral selection → corruption check) up to the
+// artifact-verification gate, which refuses with trust.CodeUnsigned because
+// this fixture carries no real signature bundle. Nothing lands under
+// --processors.path.
+func TestInstallProcessorBundle_ReachesArtifactVerification(t *testing.T) {
+	dir := t.TempDir()
+	f := newAuditTrustCoreFixture(t)
+	payload := oneProcessorSnapshotPayload("ai.embed", "1.0.0", sha256Hex("processor-bytes"), int64(len("processor-bytes")))
+	snapshot := f.sign(t, payload)
+	manifest := registry.BundleManifest{
+		BundleFormatVersion: 1, Name: "ai.embed", Version: "1.0.0", OS: "wasip1", Arch: "wasm",
+		SHA256: "sha256:" + sha256Hex("processor-bytes"), Size: int64(len("processor-bytes")),
+	}
+	// No signature bundle → the trust gate refuses with CodeUnsigned once
+	// resolution/selection/corruption all succeed.
+	path := buildTestBundleTar(t, manifest, []byte("processor-bytes"), nil, nil, snapshot)
+
+	verifier := &registry.TrustedVerifier{Anchors: f.anchors(t), StatePath: filepath.Join(dir, ".registry", "index-state.json")}
+	_, err := registry.InstallProcessorBundle(context.Background(), registry.InstallBundleOptions{
+		BundlePath: path, ProcessorsPath: dir, Verifier: verifier,
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, trust.CodeUnsigned, ce.Code)
+
+	assertNoInstalledProcessor(t, dir)
+}

--- a/pkg/registry/uninstallprocessor.go
+++ b/pkg/registry/uninstallprocessor.go
@@ -1,0 +1,218 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+)
+
+// UninstallProcessorOptions is UninstallProcessor's full configuration. It is
+// the processor twin of UninstallOptions: identical shape, but rooted at
+// --processors.path and carrying processor-worded/coded errors. InUseRef is
+// reused verbatim (the pipeline/processor-instance pair the caller collected)
+// — see uninstall.go for why the caller, not this function, gathers it.
+type UninstallProcessorOptions struct {
+	// Name is the processor name to uninstall (the registry index name, which
+	// is the name@version key the install manifest recorded — see
+	// installprocessor.go on why that is authoritative even when the WASM's own
+	// Specification().Version is a "(devel)" sentinel).
+	Name string
+	// Version is an optional exact version. Empty auto-resolves ONLY if exactly
+	// one version of Name is installed; more than one refuses with
+	// CodeAmbiguousUninstall rather than guessing (AC-8).
+	Version string
+
+	// ProcessorsPath is the standalone processors directory (--processors.path)
+	// this uninstall operates against — its own .registry/ bookkeeping, never
+	// commingled with the connector manifest.
+	ProcessorsPath string
+
+	// Force proceeds even when InUseRefs is non-empty; the result still names
+	// every affected pipeline via Warnings (a loud warning, never a silent
+	// flag flip).
+	Force bool
+
+	// InUseRefs is every processor instance (across every provisioned/running
+	// pipeline) whose plugin reference is standalone:<name>[@<version>] in a
+	// processors block — the caller (cmd/conduit/root/processorplugins/
+	// uninstall.go) collects this by scanning the PROCESSORS blocks of
+	// provisioned pipeline YAML, a distinct code path from the connector
+	// uninstall's connectors-block scan (AC-8).
+	InUseRefs []InUseRef
+
+	// InstalledBy identifies the operator for the audit event (best-effort).
+	InstalledBy string
+
+	// LockTimeout bounds how long UninstallProcessor waits to acquire the
+	// per-name lock and the manifest lock. Zero uses DefaultLockTimeout.
+	LockTimeout time.Duration
+}
+
+func (o *UninstallProcessorOptions) lockTimeout() time.Duration {
+	if o.LockTimeout > 0 {
+		return o.LockTimeout
+	}
+	return DefaultLockTimeout
+}
+
+// UninstallProcessor removes an installed standalone WASM processor's artifact
+// and manifest entry from --processors.path. It is the processor analogue of
+// Uninstall and reuses every kind-neutral primitive it does — the per-name
+// target lock (AcquireTargetLock), the ambiguous-version resolution
+// (resolveUninstallVersion), the artifact removal + drift/missing detection
+// (removeArtifact), and the atomic manifest-entry deletion (deleteManifestEntry)
+// — differing only in the target directory, the audit-event label
+// ("processor_uninstall"), and the processor-worded/coded not-installed and
+// in-use errors.
+//
+// Invariant 5 (atomic state writes): the manifest is only ever rewritten via
+// SaveManifest's atomic temp+rename (deleteManifestEntry), so a crash
+// mid-uninstall leaves either the pre- or post-uninstall manifest, never a
+// torn one.
+func UninstallProcessor(opts UninstallProcessorOptions) (*UninstallResult, error) {
+	if opts.Name == "" {
+		return nil, conduiterr.New(conduiterr.CodeInvalidArgument, "processor name is required")
+	}
+	if opts.ProcessorsPath == "" {
+		return nil, conduiterr.New(conduiterr.CodeInvalidArgument, "--processors.path is required")
+	}
+
+	// Per-name granularity (only Name, not Name@Version), matching
+	// AcquireTargetLock's install-side use: resolveUninstallVersion below reads
+	// every installed version of Name, so it must not race a concurrent install
+	// adding/removing one.
+	targetLock, err := AcquireTargetLock(opts.ProcessorsPath, opts.Name, opts.lockTimeout())
+	if err != nil {
+		return nil, err
+	}
+	defer targetLock.Unlock() //nolint:errcheck // best-effort; flock also releases at process exit
+
+	m, err := LoadManifest(manifestPath(opts.ProcessorsPath))
+	if err != nil {
+		return nil, conduiterr.Wrap(conduiterr.CodeInternal, "could not read install manifest", err)
+	}
+
+	version, err := resolveProcessorUninstallVersion(m, opts.Name, opts.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := ManifestKey(opts.Name, version)
+	if err != nil {
+		return nil, err
+	}
+	entry, ok := m.Installs[key]
+	if !ok {
+		return nil, processorNotInstalledError(opts.Name, version)
+	}
+
+	var warnings []string
+	forced := false
+	if len(opts.InUseRefs) > 0 {
+		if !opts.Force {
+			return nil, processorInUseError(entry.Name, entry.Version, opts.InUseRefs)
+		}
+		forced = true
+		warnings = append(warnings, processorInUseWarning(entry.Name, entry.Version, opts.InUseRefs))
+	}
+
+	driftDetected, artifactAlreadyMissing, err := removeArtifact(opts.ProcessorsPath, entry)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := deleteManifestEntry(opts.ProcessorsPath, key, opts.lockTimeout()); err != nil {
+		return nil, err
+	}
+
+	if err := AppendAuditEvent(auditLogPath(opts.ProcessorsPath), AuditEvent{
+		Event: "processor_uninstall", Connector: entry.Name, Version: entry.Version,
+		Digest: entry.Digest, Operator: opts.InstalledBy, Timestamp: time.Now().UTC(),
+		Forced: forced,
+	}); err != nil {
+		return nil, conduiterr.Wrap(conduiterr.CodeInternal, "processor uninstalled but could not append the audit log entry", err)
+	}
+
+	return &UninstallResult{
+		Name: entry.Name, Version: entry.Version, Digest: entry.Digest,
+		Forced: forced, Warnings: warnings,
+		DriftDetected: driftDetected, ArtifactAlreadyMissing: artifactAlreadyMissing,
+	}, nil
+}
+
+// resolveProcessorUninstallVersion is resolveUninstallVersion's processor twin
+// (AC-8's ambiguous-uninstall rule): an explicit version is used as-is; an
+// empty version auto-resolves only when exactly one version of name is
+// installed, refusing with CodeAmbiguousUninstall otherwise.
+func resolveProcessorUninstallVersion(m *Manifest, name, version string) (string, error) {
+	if version != "" {
+		return version, nil
+	}
+
+	versions := m.InstalledVersions(name)
+	switch len(versions) {
+	case 0:
+		return "", processorNotInstalledError(name, "")
+	case 1:
+		return versions[0], nil
+	default:
+		err := conduiterr.New(CodeAmbiguousUninstall, fmt.Sprintf(
+			"processor %q has more than one installed version (%s) — specify which one",
+			name, strings.Join(versions, ", ")))
+		err.Suggestion = fmt.Sprintf("re-run as `conduit processor-plugins uninstall %s@<version>`, e.g. %s@%s",
+			name, name, versions[len(versions)-1])
+		return "", err
+	}
+}
+
+func processorNotInstalledError(name, version string) error {
+	target := name
+	if version != "" {
+		target = name + "@" + version
+	}
+	err := conduiterr.New(CodeProcessorNotInstalled, fmt.Sprintf("processor %q is not installed", target))
+	err.Suggestion = "check the exact installed name@version under --processors.path/.registry/manifest.json"
+	return err
+}
+
+func processorInUseError(name, version string, refs []InUseRef) error {
+	err := conduiterr.New(CodeProcessorInUse, fmt.Sprintf(
+		"processor %s@%s is in use by %s", name, version, describeProcessorInUseRefs(refs)))
+	err.Suggestion = "remove the processor from these pipelines first, or re-run with --force to remove the artifact " +
+		"anyway (pipelines referencing it will fail to start/restart until reconfigured)"
+	return err
+}
+
+func processorInUseWarning(name, version string, refs []InUseRef) string {
+	return fmt.Sprintf("removed %s@%s while still in use by %s — pipelines referencing it will fail to "+
+		"start/restart until reconfigured", name, version, describeProcessorInUseRefs(refs))
+}
+
+// describeProcessorInUseRefs is describeInUseRefs' processor-worded twin: the
+// InUseRef.ConnectorID field carries the processor instance ID here, so the
+// human-readable rendering names it "(processor <id>)", not "(connector <id>)".
+func describeProcessorInUseRefs(refs []InUseRef) string {
+	parts := make([]string, 0, len(refs))
+	for _, r := range refs {
+		parts = append(parts, fmt.Sprintf("pipeline %s (processor %s)", r.PipelineID, r.ConnectorID))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ", ")
+}


### PR DESCRIPTION
WS8 Plan #1 PR-C — the operator-visible `processor-plugins install`/`uninstall` commands + Tranche-A offline install (`--index-file`/`--bundle`/gated `--allow-unsigned`), building on PR-B's InstallProcessor. Risk tier 2 (CLI) but touches the shared trust-core install.go (audit-log-path fix) + the unsigned gate, so bringing it for sign-off.

**Trust core one path:** --allow-unsigned routes through the single policy.Decide call site connectors use (CLI never imports policy; PolicyBypass depguard holds). --bundle reuses the offline trust core verbatim (validateProcessorWASM runs before the atomic rename).

**Bug found+fixed (regression-tested):** unsignedInstallGate keyed the audit log off opts.ConnectorsPath — empty for a processor install. Threaded the real targetDir through; behavior-preserving for connectors (connector CLI + registry suites unchanged green).

**Divergences:** offline vs online; uninstall's processors-block in-use scan (pipeline-level + connector-level Processors, distinct from the connector scan); not-found→processor_not_found with interim --index-file/--bundle suggestion.

**Codes/generated:** registry.processor_not_installed + registry.processor_in_use (allcodes auto-collects); make generate run + llms.txt/llms-full.txt committed (85→87).

**Verified:** go build clean; golangci v2.12.2 clean; go test -race processorplugins + connectors CLI green (re-run independently); pkg/registry -race re-run for the install.go change; make generate clean no-op post-commit.

Next: PR-D (publish+index-CI → Tranche-B), PR-E (template+ROADMAP-143). Tranche-A unblocks the RAG template offline the moment this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD