### PR TITLE
docs(pipelines): RAG template preflight → shipped processor-plugins install (PR-E)

### DIFF
--- a/cmd/conduit/root/pipelines/template_gallery.go
+++ b/cmd/conduit/root/pipelines/template_gallery.go
@@ -98,8 +98,8 @@ type GalleryTemplate struct {
 	// one entry can never silently authorize it for another (see
 	// TestValidateGalleryCatalog_RejectsNonBuiltinConnector_ScopedToOneTemplate).
 	AllowedNonBuiltin []string
-	// Prerequisites are preflight steps (registry plugin installs, or —
-	// where no install command exists yet — manual build/placement steps)
+	// Prerequisites are preflight steps (registry plugin installs, offline
+	// `--bundle` installs, or a manual build/placement for a local dev build)
 	// that must be completed before `conduit run` will succeed against this
 	// template's scaffolded YAML. `pipelines init --template <name>`
 	// surfaces these directly in its result (both --json and
@@ -237,13 +237,14 @@ func galleryCatalogSpec() []GalleryTemplate {
 					"error. Architecture v2 is a preview engine — see its status before relying on it in production.",
 				"Install the pgvector destination connector: `conduit connectors install pgvector@<version>` " +
 					"(run `conduit connectors search pgvector` to see available versions).",
-				"conduit-processor-ai's chunking (ai.chunk) and embedding (ai.embed) processors are WASM " +
-					"processor plugins. There is no `conduit processor-plugins install` command in this " +
-					"build — that install path does not exist yet. Until it does: build them yourself from " +
-					"a github.com/conduitio/conduit-processor-ai checkout with " +
-					"`GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-chunk.wasm ./cmd/chunking` and " +
-					"`GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-embed.wasm ./cmd/embedding`, then " +
-					"place both .wasm files in the directory configured as --processors.path.",
+				"conduit-processor-ai's chunking (ai.chunk) and embedding (ai.embed) processors are " +
+					"standalone WASM plugins, installed with `conduit processor-plugins install ai.chunk` " +
+					"and `conduit processor-plugins install ai.embed`. Once conduit-processor-ai publishes " +
+					"signed artifacts to the registry, those commands fetch and verify them directly; until " +
+					"the registry serves processors, install from a signed bundle with `--bundle <path>`, or " +
+					"for local development build them from a github.com/conduitio/conduit-processor-ai " +
+					"checkout (`GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-chunk.wasm ./cmd/chunking`, " +
+					"likewise `./cmd/embedding`) and place the .wasm files under --processors.path.",
 			},
 		},
 	}

--- a/cmd/conduit/root/pipelines/template_gallery_test.go
+++ b/cmd/conduit/root/pipelines/template_gallery_test.go
@@ -380,9 +380,8 @@ func TestGalleryTemplates_ScaffoldParseableYAML(t *testing.T) {
 // present"): scaffolding postgres-pgvector-rag must surface its
 // GalleryTemplate.Prerequisites in BOTH the --json result and the
 // human-readable Render output, naming the exact `conduit connectors
-// install pgvector@<version>` command and stating plainly that no
-// `conduit processor-plugins install` equivalent exists yet for the two
-// WASM processors.
+// install pgvector@<version>` command and the `conduit processor-plugins
+// install ai.chunk`/`ai.embed` commands for the two WASM processors.
 func TestInitCommand_TemplateScaffold_PgvectorRAG_EmitsPrerequisites(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
@@ -405,7 +404,8 @@ func TestInitCommand_TemplateScaffold_PgvectorRAG_EmitsPrerequisites(t *testing.
 
 	joined := strings.Join(result.Prerequisites, "\n")
 	is.True(strings.Contains(joined, "conduit connectors install pgvector@"))
-	is.True(strings.Contains(joined, "no `conduit processor-plugins install` command"))
+	is.True(strings.Contains(joined, "conduit processor-plugins install ai.chunk"))
+	is.True(strings.Contains(joined, "conduit processor-plugins install ai.embed"))
 
 	// The human-readable Render path must surface the same note, not just
 	// the --json payload.

--- a/cmd/conduit/root/pipelines/templates/postgres-pgvector-rag/README.md
+++ b/cmd/conduit/root/pipelines/templates/postgres-pgvector-rag/README.md
@@ -30,12 +30,14 @@ is):
 | Plugin | Kind | Install |
 | --- | --- | --- |
 | `standalone:pgvector` (destination) | Registry-installed Go connector (`conduit-connector-pgvector`) | `conduit connectors install pgvector@<version>` |
-| `standalone:ai.chunk` (processor) | Standalone WASM processor (`conduit-processor-ai`) | **No install command exists yet.** Build `./cmd/chunking` from a `conduit-processor-ai` checkout (`GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-chunk.wasm ./cmd/chunking`) and place the `.wasm` file under your `--processors.path` directory. |
-| `standalone:ai.embed` (processor) | Standalone WASM processor (`conduit-processor-ai`) | Same gap as above: build `./cmd/embedding` (`GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-embed.wasm ./cmd/embedding`) and place it under `--processors.path`. |
+| `standalone:ai.chunk` (processor) | Standalone WASM processor (`conduit-processor-ai`) | `conduit processor-plugins install ai.chunk` once it's published to the signed registry; until then `conduit processor-plugins install --bundle <signed.tgz>`, or build `./cmd/chunking` (`GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-chunk.wasm ./cmd/chunking`) and place the `.wasm` under `--processors.path`. |
+| `standalone:ai.embed` (processor) | Standalone WASM processor (`conduit-processor-ai`) | `conduit processor-plugins install ai.embed` (same options as above; build `./cmd/embedding`). |
 
-This gap — `conduit processor-plugins install` not existing — is stated here plainly rather than
-invented around; `conduit pipelines init --template postgres-pgvector-rag` names it in its
-prerequisite note every time this template is scaffolded.
+The `conduit processor-plugins install` / `uninstall` commands exist, and
+`conduit pipelines init --template postgres-pgvector-rag` names them in its prerequisite note every
+time this template is scaffolded. The hosted `install ai.chunk` / `install ai.embed` fetch goes live
+once `conduit-processor-ai` publishes signed processor artifacts to the registry; until then use the
+offline `--bundle` path or a local build.
 
 ## Requires pipeline architecture v2
 


### PR DESCRIPTION
WS8 Plan #1, **PR-E** (Tier-2, docs) — the capstone. With PR-A/B/C merged (schema, install pipeline, CLI) and PR-D up (registry publish tooling), the `conduit processor-plugins install` command exists — so the postgres-pgvector-rag template's preflight + README are updated from the now-stale "no install command exists yet" to the real commands, **honestly framed**:

- `conduit processor-plugins install ai.chunk` / `ai.embed` are named in the gallery Prerequisites (surfaced by `pipelines init`) and the README install table.
- The **hosted fetch goes live once conduit-processor-ai publishes signed artifacts** to the registry (rides your signing bootstrap); until then the offline `--bundle` path or a local build+place is documented.
- Prerequisites test assertion updated (was asserting the 'no install command' text; now asserts the real commands).

No error-code/CLI-surface change → `make generate` is a clean no-op (verified). Full `./cmd/conduit/root/pipelines/` suite green. README markdownlint clean.

This closes the WS8 processor-install epic's in-repo story; only the live `install ai.embed` end-to-end remains, gated on the registry signing bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD