### PR TITLE
ci: restructure bundle-e2e/rag-e2e → always-report + pinned sibling refs (toward required)

### DIFF
--- a/.github/workflows/bundle-e2e.yml
+++ b/.github/workflows/bundle-e2e.yml
@@ -5,33 +5,37 @@ name: bundle-e2e
 # repo's standalone host module + SSRF egress gate. This is the acceptance bar
 # for the host-egress capability (design docs/design-documents/20260726-wasm-host-egress-capability.md).
 #
-# It is intentionally scoped to the paths that make up the bundle, so it runs on
-# changes to the egress gate, the standalone host module, the processor service,
-# or engine config — the surfaces the e2e actually exercises.
+# REQUIRED-CHECK CONTRACT (mirrors chaos.yml): to be a *required* status check,
+# this job must report a conclusion on EVERY pull request — a path-filtered
+# trigger cannot, because it leaves the check permanently *pending* (and thus
+# unmergeable) on PRs that don't touch its paths. So the trigger is NOT
+# path-filtered; the single `bundle-e2e` job always runs and gates the expensive
+# cross-repo work *inside* the job with a FAIL-CLOSED path detector: any
+# ambiguity (missing base ref, git error) runs the suite; an unrelated PR
+# completes green in seconds (checkout + detector only, no sibling checkout, no
+# wasm build).
+#
+# Sibling ref is PINNED (not `main`): as a required check, tracking a sibling's
+# moving `main` would break this repo's merge gate whenever that sibling's main
+# breaks. The pin is bumped deliberately (edit PROCESSOR_AI_REF below), or
+# overridden per-run via workflow_dispatch for fresh-against-main testing.
 
 on:
   push:
     branches: [ main ]
   pull_request:
-    paths:
-      - 'pkg/plugin/processor/egress/**'
-      - 'pkg/plugin/processor/standalone/**'
-      - 'pkg/processor/**'
-      - 'pkg/conduit/**'
-      - '.github/workflows/bundle-e2e.yml'
-      - 'go.mod'
-      - 'go.sum'
   workflow_dispatch:
     inputs:
       processor_ai_ref:
-        description: 'conduit-processor-ai ref to test against'
+        description: 'conduit-processor-ai ref to test against (default: the pinned SHA)'
         required: false
-        default: 'main'
+        default: ''
 
 env:
-  # The conduit-processor-ai ref whose embedding processor is built into WASM
-  # and exercised. Defaults to main; overridable via workflow_dispatch.
-  PROCESSOR_AI_REF: ${{ github.event.inputs.processor_ai_ref || 'main' }}
+  # Pinned known-good conduit-processor-ai commit. Bump deliberately after
+  # confirming the e2e is green against the new commit; override per-run via
+  # the workflow_dispatch input.
+  PROCESSOR_AI_REF: ${{ github.event.inputs.processor_ai_ref || '24dee9ffd9e8be633a010d427a142d6c2f244793' }}
 
 jobs:
   bundle-e2e:
@@ -39,8 +43,53 @@ jobs:
     steps:
       - name: Check out conduit
         uses: actions/checkout@v4
+        with:
+          # Full history so the path detector can diff against the PR base ref.
+          fetch-depth: 0
+
+      - name: Detect relevant changes
+        id: detect
+        # schedule/workflow_dispatch/push always run. For pull_request, run only
+        # when a surface this e2e exercises changed — FAIL CLOSED: any inability
+        # to compute the diff runs the suite anyway. Keep this list in sync with
+        # the surfaces the bundle e2e actually covers (was the trigger `paths:`).
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "reason=event $EVENT_NAME always runs" >> "$GITHUB_OUTPUT"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          base="$BASE_SHA"
+          if [ -z "$base" ] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+            echo "reason=base ref unavailable - running suite (fail-closed)" >> "$GITHUB_OUTPUT"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! changed=$(git diff --name-only "$base"...HEAD 2>/dev/null); then
+            echo "reason=git diff failed - running suite (fail-closed)" >> "$GITHUB_OUTPUT"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if echo "$changed" | grep -qE '^(pkg/plugin/processor/egress/|pkg/plugin/processor/standalone/|pkg/processor/|pkg/conduit/|\.github/workflows/bundle-e2e\.yml|go\.mod|go\.sum)'; then
+            echo "reason=bundle-surface change detected" >> "$GITHUB_OUTPUT"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "reason=no bundle-surface change - skipping suite, gate passes" >> "$GITHUB_OUTPUT"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Gate decision
+        env:
+          RUN: ${{ steps.detect.outputs.run }}
+          REASON: ${{ steps.detect.outputs.reason }}
+        run: echo "bundle-e2e run=$RUN ($REASON)"
 
       - name: Check out conduit-processor-ai
+        if: steps.detect.outputs.run == 'true'
         uses: actions/checkout@v4
         with:
           repository: ConduitIO/conduit-processor-ai
@@ -48,11 +97,13 @@ jobs:
           path: _bundle/conduit-processor-ai
 
       - name: Set up Go
+        if: steps.detect.outputs.run == 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
 
       - name: Run host-egress bundle e2e (real guest through host gate)
+        if: steps.detect.outputs.run == 'true'
         env:
           CONDUIT_PROCESSOR_AI_DIR: ${{ github.workspace }}/_bundle/conduit-processor-ai
         run: |

--- a/.github/workflows/rag-e2e.yml
+++ b/.github/workflows/rag-e2e.yml
@@ -9,32 +9,35 @@ name: rag-e2e
 # delete-by-source_key). The embedding provider's HTTP endpoint is the only mock;
 # the WASM boundary, egress gate, and pgvector are all real.
 #
-# Scoped to the surfaces the e2e exercises. Not yet a required check (that's a
-# repo-settings change to follow), matching the bundle-e2e precedent.
+# REQUIRED-CHECK CONTRACT (mirrors chaos.yml / bundle-e2e.yml): the trigger is
+# NOT path-filtered so this job reports a conclusion on EVERY PR (a path-filtered
+# required check goes permanently pending and blocks merges); the expensive
+# cross-repo + docker work is gated INSIDE the job by a FAIL-CLOSED path
+# detector. Sibling refs are PINNED (not `main`) so this repo's merge gate can't
+# be broken by a sibling's moving main. NOTE: bundle-e2e (docker-free) is the one
+# made *required* first; this docker+cross-repo job stays advisory-but-always-
+# reporting until a de-flake green-streak soak justifies flipping it too.
 
 on:
   push:
     branches: [ main ]
   pull_request:
-    paths:
-      - 'pkg/plugin/processor/standalone/**'
-      - '.github/workflows/rag-e2e.yml'
-      - 'go.mod'
-      - 'go.sum'
   workflow_dispatch:
     inputs:
       processor_ai_ref:
-        description: 'conduit-processor-ai ref to test against'
+        description: 'conduit-processor-ai ref to test against (default: the pinned SHA)'
         required: false
-        default: 'main'
+        default: ''
       pgvector_ref:
-        description: 'conduit-connector-pgvector ref to test against'
+        description: 'conduit-connector-pgvector ref to test against (default: the pinned SHA)'
         required: false
-        default: 'main'
+        default: ''
 
 env:
-  PROCESSOR_AI_REF: ${{ github.event.inputs.processor_ai_ref || 'main' }}
-  PGVECTOR_REF: ${{ github.event.inputs.pgvector_ref || 'main' }}
+  # Pinned known-good sibling commits. Bump deliberately after confirming the
+  # e2e is green against the new commits; override per-run via the inputs above.
+  PROCESSOR_AI_REF: ${{ github.event.inputs.processor_ai_ref || '24dee9ffd9e8be633a010d427a142d6c2f244793' }}
+  PGVECTOR_REF: ${{ github.event.inputs.pgvector_ref || 'b5361ef72d943a684fcb41b0e33605eef28c41b9' }}
 
 jobs:
   rag-e2e:
@@ -42,8 +45,52 @@ jobs:
     steps:
       - name: Check out conduit
         uses: actions/checkout@v4
+        with:
+          # Full history so the path detector can diff against the PR base ref.
+          fetch-depth: 0
+
+      - name: Detect relevant changes
+        id: detect
+        # push/workflow_dispatch always run. For pull_request, run only when a
+        # surface this e2e exercises changed — FAIL CLOSED: any inability to
+        # compute the diff runs the suite anyway.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "reason=event $EVENT_NAME always runs" >> "$GITHUB_OUTPUT"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          base="$BASE_SHA"
+          if [ -z "$base" ] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+            echo "reason=base ref unavailable - running suite (fail-closed)" >> "$GITHUB_OUTPUT"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! changed=$(git diff --name-only "$base"...HEAD 2>/dev/null); then
+            echo "reason=git diff failed - running suite (fail-closed)" >> "$GITHUB_OUTPUT"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if echo "$changed" | grep -qE '^(pkg/plugin/processor/standalone/|\.github/workflows/rag-e2e\.yml|go\.mod|go\.sum)'; then
+            echo "reason=rag-surface change detected" >> "$GITHUB_OUTPUT"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "reason=no rag-surface change - skipping suite, gate passes" >> "$GITHUB_OUTPUT"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Gate decision
+        env:
+          RUN: ${{ steps.detect.outputs.run }}
+          REASON: ${{ steps.detect.outputs.reason }}
+        run: echo "rag-e2e run=$RUN ($REASON)"
 
       - name: Check out conduit-processor-ai
+        if: steps.detect.outputs.run == 'true'
         uses: actions/checkout@v4
         with:
           repository: ConduitIO/conduit-processor-ai
@@ -51,6 +98,7 @@ jobs:
           path: _rag/conduit-processor-ai
 
       - name: Check out conduit-connector-pgvector
+        if: steps.detect.outputs.run == 'true'
         uses: actions/checkout@v4
         with:
           repository: ConduitIO/conduit-connector-pgvector
@@ -58,14 +106,17 @@ jobs:
           path: _rag/conduit-connector-pgvector
 
       - name: Set up Go
+        if: steps.detect.outputs.run == 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
 
       - name: Start pgvector
+        if: steps.detect.outputs.run == 'true'
         run: docker compose -f pkg/plugin/processor/standalone/testdata/rag_e2e/docker-compose.yml up --wait
 
       - name: Run RAG pipeline e2e (chunk -> embed -> pgvector, incl. delete path)
+        if: steps.detect.outputs.run == 'true'
         env:
           CONDUIT_PROCESSOR_AI_DIR: ${{ github.workspace }}/_rag/conduit-processor-ai
           CONDUIT_CONNECTOR_PGVECTOR_DIR: ${{ github.workspace }}/_rag/conduit-connector-pgvector
@@ -75,5 +126,5 @@ jobs:
             ./pkg/plugin/processor/standalone/...
 
       - name: Stop pgvector
-        if: always()
+        if: always() && steps.detect.outputs.run == 'true'
         run: docker compose -f pkg/plugin/processor/standalone/testdata/rag_e2e/docker-compose.yml down --volumes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,7 +216,7 @@ Do not claim a bar is met when it structurally isn't. Mark PRs against what's re
 | Human (DeVaris) sign-off on Tier 1 | **live now** |
 | Coverage floor enforcement, benchi regression gate | by Phase 1 |
 | Property + fuzz tests on data-path/boundaries | by Phase 1 |
-| Chaos suite (`tests/chaos`) nightly | **live now** (`.github/workflows/chaos.yml`) — nightly + PRs touching `pkg/connector`, `pkg/pipeline`, `pkg/lifecycle`, `pkg/lifecycle-poc`, `tests/chaos`; runs the SIGKILL/FIFO-ack no-infra subset only (everything in `tests/chaos` today); not yet a _required_ (blocking) branch-protection check — that's a repo-settings change |
+| Chaos suite (`tests/chaos`) nightly | **live now + REQUIRED** (`.github/workflows/chaos.yml`) — nightly + every PR via the always-report/fail-closed detector (the job runs on all PRs; the SIGKILL/FIFO-ack no-infra suite executes only when a data-path tree changed, fail-closed on any diff ambiguity). `tests/chaos (race, x3)` **is** in `main`'s required branch-protection contexts (blocking) — the earlier "not yet required" note was stale. `bundle-e2e`/`rag-e2e` are being restructured to the same always-report pattern to become required next (bundle-e2e first; rag-e2e after a de-flake soak) |
 | Upgrade/downgrade tests gating releases | by Phase 2 |
 | 24h soak gating every release | by Phase 2 |
 


### PR DESCRIPTION
WS8 deferred item — make `bundle-e2e`/`rag-e2e` required branch-protection checks. **This PR does the prerequisite restructure; the settings flip is a deliberate follow-up.**

## Why restructure first
A **path-filtered** check can't be *required* — it stays permanently *pending* on PRs that don't touch its paths, blocking every such merge (the exact trap the chaos restructure was built to avoid). So both e2es move to the **chaos.yml pattern**: bare `pull_request:` trigger + an in-job **fail-closed** path detector — an unrelated PR completes green in seconds (checkout + detector only, no sibling checkout / no wasm build / no docker); any diff ambiguity (missing base ref, git error) runs the suite.

## Mandatory: pinned sibling refs
As a *required* check, tracking a sibling's moving `main` would break this repo's merge gate whenever that sibling's main breaks. Both workflows now pin `conduit-processor-ai` (`24dee9f`) and `conduit-connector-pgvector` (`b5361ef`) to known-good SHAs — bumped deliberately, or overridden per-run via `workflow_dispatch`.

## Self-test
This PR touches `.github/workflows/{bundle,rag}-e2e.yml` — both are in their own detector path lists, so **both e2es RUN on this PR**, proving the restructured always-report path works end-to-end (sibling checkout + build + docker).

## Follow-up (NOT in this PR)
The branch-protection settings flip (`PATCH …/required_status_checks` adding the contexts) after a green-streak soak — **bundle-e2e (docker-free) required first**, rag-e2e (docker+cross-repo) after de-flake. Also confirm fork-PR sibling checkout before flipping (a required check fork PRs can't satisfy would hard-block contributors; these need no secrets — mock provider — so it should be fine, but verify).

## CLAUDE.md errata
Fixed the stale process-maturity row: `tests/chaos (race, x3)` **is** in `main`'s required contexts (verified) and chaos.yml is already the always-report/fail-closed pattern — the 'not yet required' + path-filter description was stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD