### PR TITLE
feat(lifecycle): actionable error when a fan-out processor runs on the classic engine (arch-v2 #4)

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -614,7 +614,7 @@ Author: Meroxa, Inc.
 | `sdk.schema.extract.key.enabled` | bool | true | no | Whether to extract and decode the record key with a schema. |  |
 | `sdk.schema.extract.payload.enabled` | bool | true | no | Whether to extract and decode the record payload with a schema. |  |
 
-## 3. Error codes (87)
+## 3. Error codes (88)
 
 | Reason | gRPC status | Description |
 | --- | --- | --- |
@@ -641,6 +641,7 @@ Author: Meroxa, Inc.
 | `orchestrator.invalid_processor_parent_type` | InvalidArgument | CodeInvalidProcessorParentType is raised when a processor's parent is neither a pipeline nor a connector. |
 | `orchestrator.pipeline_has_connectors_attached` | FailedPrecondition | CodePipelineHasConnectorsAttached is raised when a pipeline cannot be deleted because it still has connectors attached. |
 | `orchestrator.pipeline_has_processors_attached` | FailedPrecondition | CodePipelineHasProcessorsAttached is raised when a pipeline cannot be deleted because it still has processors attached. |
+| `pipeline.fanout_requires_arch_v2` | FailedPrecondition | pipeline: fanout requires arch v2 |
 | `pipeline.instance_not_found` | NotFound | CodePipelineNotFound is raised when a referenced pipeline instance cannot be located. |
 | `pipeline.name_already_exists` | AlreadyExists | CodePipelineNameAlreadyExists is raised when a pipeline config's name collides with an existing pipeline's name. |
 | `pipeline.name_missing` | InvalidArgument | CodePipelineNameMissing is raised when a pipeline config is missing the required name field. |

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@
 (6 built-in connectors; full parameters in llms-full.txt)
 
 ## Error codes
-- 87 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
+- 88 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
 
 ## MCP tools
 - Read: deploy, doctor, dry_run, inspect, lint, repair, validate

--- a/pkg/lifecycle/stream/codes.go
+++ b/pkg/lifecycle/stream/codes.go
@@ -1,0 +1,29 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stream
+
+import (
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"google.golang.org/grpc/codes"
+)
+
+// CodeFanOutRequiresArchV2 is raised when a processor returns a fan-out result
+// (sdk.MultiRecord — one input record producing N output records, e.g. ai.chunk,
+// split, clone) on the default (classic) pipeline engine, which is
+// one-record-in-one-record-out and cannot express fan-out. Fan-out is supported
+// only by pipeline architecture v2 (pkg/lifecycle-poc/funnel), enabled via
+// --preview.pipeline-arch-v2. FailedPrecondition: the pipeline as configured
+// cannot run on this engine.
+var CodeFanOutRequiresArchV2 = conduiterr.Register("pipeline.fanout_requires_arch_v2", codes.FailedPrecondition)

--- a/pkg/lifecycle/stream/processor.go
+++ b/pkg/lifecycle/stream/processor.go
@@ -19,12 +19,14 @@ package stream
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/conduitio/conduit-commons/opencdc"
 	sdk "github.com/conduitio/conduit-processor-sdk"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/foundation/metrics"
 )
@@ -153,35 +155,62 @@ func (n *ProcessorNode) Run(ctx context.Context) error {
 			return cerrors.FatalError(err)
 		}
 
-		switch v := recsOut[0].(type) {
-		case sdk.SingleRecord:
-			err := n.handleSingleRecord(ctx, msg, v)
-			// handleSingleRecord already checks the nack error (if any)
-			// so it's enough to just return the error from it
-			if err != nil {
-				return err
-			}
-		case sdk.FilterRecord:
-			msg.filtered = true
-			n.logger.Trace(ctx).
-				Str(log.MessageIDField, msg.ID()).
-				Msg("message marked as filtered, sending directly to next node")
-			err = n.base.Send(ctx, n.logger, msg)
-			if err != nil {
-				return msg.Nack(err, n.ID())
-			}
-		case sdk.ErrorRecord:
-			err = msg.Nack(v.Error, n.ID())
-			if err != nil {
-				return cerrors.FatalError(cerrors.Errorf("error executing processor: %w", err))
-			}
-		default:
-			err := cerrors.Errorf("processor returned unknown record type: %T", v)
-			if nackErr := msg.Nack(err, n.ID()); nackErr != nil {
-				return cerrors.FatalError(nackErr)
-			}
-			return cerrors.FatalError(err)
+		if err := n.handleProcessedRecord(ctx, msg, recsOut[0]); err != nil {
+			return err
 		}
+	}
+}
+
+// handleProcessedRecord routes one ProcessedRecord returned by the processor.
+// It returns nil to continue the run loop (the record was forwarded, filtered,
+// or nacked-and-handled) and a non-nil error to stop the node (a fatal
+// condition, or an unhandled nack). Extracted from Run purely to keep Run's
+// cyclomatic complexity in check; behaviour is identical to the prior inline
+// switch.
+func (n *ProcessorNode) handleProcessedRecord(ctx context.Context, msg *Message, rec sdk.ProcessedRecord) error {
+	switch v := rec.(type) {
+	case sdk.SingleRecord:
+		// handleSingleRecord already checks the nack error (if any), so
+		// returning its error is enough.
+		return n.handleSingleRecord(ctx, msg, v)
+	case sdk.FilterRecord:
+		msg.filtered = true
+		n.logger.Trace(ctx).
+			Str(log.MessageIDField, msg.ID()).
+			Msg("message marked as filtered, sending directly to next node")
+		if err := n.base.Send(ctx, n.logger, msg); err != nil {
+			return msg.Nack(err, n.ID())
+		}
+		return nil
+	case sdk.ErrorRecord:
+		if err := msg.Nack(v.Error, n.ID()); err != nil {
+			return cerrors.FatalError(cerrors.Errorf("error executing processor: %w", err))
+		}
+		return nil
+	case sdk.MultiRecord:
+		// A fan-out result (one input → N output records) is only supported by
+		// pipeline architecture v2 (the funnel lifecycle). The classic engine is
+		// one-record-in-one-record-out, so return an actionable coded error naming
+		// the flag instead of the generic "unknown record type" — a developer
+		// running e.g. ai.chunk/split/clone here otherwise has no way to know the
+		// fix is --preview.pipeline-arch-v2. Fatal (a pipeline misconfiguration for
+		// this engine), not a per-record DLQ.
+		err := conduiterr.New(CodeFanOutRequiresArchV2, fmt.Sprintf(
+			"processor %q emitted a fan-out result (%d records from 1 input), which the default "+
+				"pipeline engine does not support", n.ID(), len(v)))
+		err.Suggestion = "enable pipeline architecture v2: run with --preview.pipeline-arch-v2 " +
+			"(or set preview.pipeline-arch-v2: true in the config); fan-out processors " +
+			"(e.g. ai.chunk, split, clone) require it"
+		if nackErr := msg.Nack(err, n.ID()); nackErr != nil {
+			return cerrors.FatalError(nackErr)
+		}
+		return cerrors.FatalError(err)
+	default:
+		err := cerrors.Errorf("processor returned unknown record type: %T", v)
+		if nackErr := msg.Nack(err, n.ID()); nackErr != nil {
+			return cerrors.FatalError(nackErr)
+		}
+		return cerrors.FatalError(err)
 	}
 }
 

--- a/pkg/lifecycle/stream/processor_test.go
+++ b/pkg/lifecycle/stream/processor_test.go
@@ -16,6 +16,7 @@ package stream
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -25,6 +26,7 @@ import (
 	"github.com/conduitio/conduit-commons/opencdc"
 	sdk "github.com/conduitio/conduit-processor-sdk"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/metrics/noop"
 	"github.com/conduitio/conduit/pkg/lifecycle/stream/mock"
 	"github.com/google/uuid"
@@ -174,6 +176,67 @@ func TestProcessorNode_ErrorWithNackHandler(t *testing.T) {
 	// after the node stops the out channel should be closed
 	_, ok := <-out
 	is.Equal(false, ok)
+}
+
+func TestProcessorNode_FanOutRequiresArchV2_ActionableError(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	processor := mock.NewProcessor(ctrl)
+	processor.EXPECT().Open(gomock.Any())
+	processor.EXPECT().
+		Process(ctx, gomock.Any()).
+		// one input record fanned out to N — only pipeline arch-v2 supports this;
+		// the classic engine must reject it with an ACTIONABLE error.
+		Return([]sdk.ProcessedRecord{sdk.MultiRecord{
+			{Position: []byte("a")}, {Position: []byte("b")},
+		}})
+	processor.EXPECT().Teardown(gomock.Any())
+
+	var nacked error
+	nackHandler := func(_ *Message, nm NackMetadata) error {
+		nacked = nm.Reason
+		return nil // regarded as handled so Run returns nil
+	}
+
+	n := ProcessorNode{
+		Name:           "chunk",
+		Processor:      processor,
+		ProcessorTimer: noop.Timer{},
+	}
+
+	in := make(chan *Message)
+	n.Sub(in)
+	out := n.Pub()
+
+	msg := &Message{Ctx: ctx}
+	msg.RegisterNackHandler(nackHandler)
+	go func() {
+		in <- msg
+		close(in)
+	}()
+
+	// Fan-out on the classic engine is a fatal pipeline misconfiguration (not a
+	// per-record DLQ), so Run stops and returns the coded error — even though the
+	// message was also nacked.
+	err := n.Run(ctx)
+	is.True(err != nil)
+	is.Equal(MessageStatusNacked, msg.Status())
+
+	// Both the returned error and the nacked reason are the coded, actionable
+	// fan-out error naming the flag — NOT the generic "unknown record type".
+	for _, e := range []error{err, nacked} {
+		ce, ok := conduiterr.Get(e)
+		is.True(ok)
+		is.Equal(ce.Code.Reason(), CodeFanOutRequiresArchV2.Reason())
+		is.True(strings.Contains(ce.Suggestion, "--preview.pipeline-arch-v2"))
+		is.True(strings.Contains(e.Error(), "fan-out"))
+		is.True(!strings.Contains(e.Error(), "unknown record type"))
+	}
+
+	_, ok2 := <-out
+	is.Equal(false, ok2)
 }
 
 func TestProcessorNode_BadProcessor_ReturnsMoreRecords(t *testing.T) {


### PR DESCRIPTION
arch-v2 sharp-edge fix (plan archv2/04). A fan-out processor (`sdk.MultiRecord` — ai.chunk/split/clone) on the default engine died with the cryptic `unknown record type: sdk.MultiRecord` — no hint the fix is `--preview.pipeline-arch-v2`. This exact dead-end surfaced the whole arch-v2 requirement in the WS8 RAG e2e.

**Fix:** a coded `pipeline.fanout_requires_arch_v2` (FailedPrecondition) error at the classic `ProcessorNode`, naming the flag + the processor + the fan-out count, with an actionable `Suggestion`. Fatal (a pipeline misconfiguration for this engine, like the existing unknown-type case), not a per-record DLQ. The arch-v2 funnel path (which handles MultiRecord via SplitRecord) is untouched.

Extracted the type switch into `handleProcessedRecord` to keep `Run` under gocyclo (behaviour identical — the existing SingleRecord/Filter/Error/default cases move verbatim).

Tier 2. Ships `TestProcessorNode_FanOutRequiresArchV2_ActionableError` (asserts the coded error + suggestion on both the returned and nacked error, and that it's NOT 'unknown record type'). `make generate` run (new code → llms committed). Stream package `-race` + golangci clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD