### PR TITLE
fix(registry): permit dots in the processor-name schema pattern

### DIFF
--- a/docs/design-documents/registry-index/index-schema.json
+++ b/docs/design-documents/registry-index/index-schema.json
@@ -128,8 +128,8 @@
       "properties": {
         "name": {
           "type": "string",
-          "pattern": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
-          "description": "Unique registry name for the processor, e.g. \"conduit-processor-ai\". Same naming rule as a connector. Resolution by `install` is exact-match only. The runtime registers the processor under the name from its own Specification(), NOT this index name -- install-time validation (PR-B) binds the two."
+          "pattern": "^[a-z0-9]([a-z0-9.-]{0,61}[a-z0-9])?$",
+          "description": "Unique registry name for the processor, e.g. \"ai.chunk\". Like a connector name but also permits dots, because standalone processors are conventionally namespaced (e.g. the \"ai.\" prefix on ai.chunk/ai.embed) and the resolver exact-matches this against the WASM's own Specification().Name. Resolution by `install` is exact-match only. The runtime registers the processor under the name from its own Specification(), NOT this index name -- install-time validation (PR-B) binds the two."
         },
         "displayName": {
           "type": "string",

--- a/pkg/registry/index/schema_validation_test.go
+++ b/pkg/registry/index/schema_validation_test.go
@@ -96,6 +96,38 @@ func TestFrozenSchema_ValidatesConnectorOnlyIndex(t *testing.T) {
 // fixed wasip1/wasm must be a schema violation, not a valid-but-skipped entry.
 // This is what makes "a host os/arch is a malformed/spoofed entry" enforceable
 // by index-CI linting, not only at install time.
+// TestFrozenSchema_AcceptsDottedProcessorName proves the processor name pattern
+// permits dots. Real standalone-processor names are namespaced (ai.chunk,
+// ai.embed) and the resolver exact-matches them against the WASM's own
+// Specification().Name, so the schema MUST accept them. The pattern originally
+// reused the connector rule (no dots), which would have failed every real
+// processor entry at schema-validation time — a latent bug this test locks out.
+func TestFrozenSchema_AcceptsDottedProcessorName(t *testing.T) {
+	is := is.New(t)
+	sch := compileFrozenSchema(t)
+
+	raw, err := os.ReadFile("testdata/sample-index.json")
+	is.NoErr(err)
+
+	var env map[string]any
+	is.NoErr(json.Unmarshal(raw, &env))
+	proc := env["payload"].(map[string]any)["processors"].([]any)[0].(map[string]any)
+
+	// A dotted name must validate.
+	proc["name"] = "ai.chunk"
+	mutated, err := json.Marshal(env)
+	is.NoErr(err)
+	is.NoErr(validateAgainstFrozenSchema(t, sch, mutated))
+
+	// The pattern still enforces the rest of the rule (lowercase only) — an
+	// uppercase name is rejected, so widening to allow dots didn't loosen it into
+	// accepting arbitrary names.
+	proc["name"] = "AI.Chunk"
+	mutatedBad, err := json.Marshal(env)
+	is.NoErr(err)
+	is.True(validateAgainstFrozenSchema(t, sch, mutatedBad) != nil)
+}
+
 func TestFrozenSchema_RejectsHostTargetedProcessorArtifact(t *testing.T) {
 	is := is.New(t)
 	sch := compileFrozenSchema(t)


### PR DESCRIPTION
**Tier 1** (frozen index schema — but a pattern *widening*, additive-safe). Latent bug from WS8 PR-A, surfaced building the processor publish wiring.

The `processors[]` name pattern reused the connector rule and **forbids dots**, but real processor names are namespaced — `ai.chunk`, `ai.embed` — and the resolver exact-matches them against the WASM's `Specification().Name`. So a valid processor entry (`ai.chunk`) fails schema validation. It doesn't break install today (the JSON schema is validation/CI-only; runtime does string `==`), but it blocks any schema gate — including the registry publish PR check — from accepting a real entry.

**Fix:** widen only the *processor* name pattern to `^[a-z0-9]([a-z0-9.-]{0,61}[a-z0-9])?$` (adds `.`); connector pattern unchanged (connectors have no dots). Additive-safe (accepts strictly more; existing entries still validate; runtime unaffected). Ships `TestFrozenSchema_AcceptsDottedProcessorName` (a dotted name validates; an uppercase name still rejected, proving it didn't loosen the rest).

The registry repo's mirror `index-schema.json` carries the identical change (bootstrap Part B branch); they stay byte-identical.

Verified: connector pattern untouched; `pkg/registry/index` tests green (byte-identity + round-trip unaffected — fixtures unchanged); `make generate` no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD