### PR TITLE
feat(lifecycle-poc): port bounded-backoff error recovery to arch-v2

### DIFF
--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -427,11 +427,25 @@ func createServices(r *Runtime) error {
 	}
 	procService := processor.NewService(r.logger, r.DB, procPluginService, processor.WithEgressCeiling(egressCeiling))
 
+	// Error recovery configuration. Shared by both lifecycle implementations
+	// (the v2/funnel service reuses the lifecycle.ErrRecoveryCfg type) so an
+	// operator's pipelines.error-recovery.* settings apply under
+	// Preview.PipelineArchV2 too — without this, v2 silently ignored them and
+	// turned every transient error into a permanently-degraded pipeline.
+	errRecoveryCfg := &lifecycle.ErrRecoveryCfg{
+		MinDelay:         r.Config.Pipelines.ErrorRecovery.MinDelay,
+		MaxDelay:         r.Config.Pipelines.ErrorRecovery.MaxDelay,
+		BackoffFactor:    r.Config.Pipelines.ErrorRecovery.BackoffFactor,
+		MaxRetries:       r.Config.Pipelines.ErrorRecovery.MaxRetries,
+		MaxRetriesWindow: r.Config.Pipelines.ErrorRecovery.MaxRetriesWindow,
+	}
+
 	var lifecycleService lifecycleService
 	if r.Config.Preview.PipelineArchV2 {
 		r.logger.Info(context.Background()).Msg("using lifecycle service v2")
 		lifecycleService = lifecycle_v2.NewService(
 			r.logger,
+			errRecoveryCfg,
 			connService,
 			procService,
 			connPluginService,
@@ -439,15 +453,6 @@ func createServices(r *Runtime) error {
 			r.Config.Preview.PipelineArchV2DisableMetrics,
 		)
 	} else {
-		// Error recovery configuration
-		errRecoveryCfg := &lifecycle.ErrRecoveryCfg{
-			MinDelay:         r.Config.Pipelines.ErrorRecovery.MinDelay,
-			MaxDelay:         r.Config.Pipelines.ErrorRecovery.MaxDelay,
-			BackoffFactor:    r.Config.Pipelines.ErrorRecovery.BackoffFactor,
-			MaxRetries:       r.Config.Pipelines.ErrorRecovery.MaxRetries,
-			MaxRetriesWindow: r.Config.Pipelines.ErrorRecovery.MaxRetriesWindow,
-		}
-
 		lifecycleService = lifecycle.NewService(r.logger, errRecoveryCfg, connService, procService, connPluginService, plService)
 	}
 

--- a/pkg/lifecycle-poc/service.go
+++ b/pkg/lifecycle-poc/service.go
@@ -29,12 +29,22 @@ import (
 	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/foundation/metrics/measure"
+	lifecyclev1 "github.com/conduitio/conduit/pkg/lifecycle"
 	"github.com/conduitio/conduit/pkg/lifecycle-poc/funnel"
 	"github.com/conduitio/conduit/pkg/pipeline"
 	connectorPlugin "github.com/conduitio/conduit/pkg/plugin/connector"
 	"github.com/conduitio/conduit/pkg/processor"
+	"github.com/jpillora/backoff"
 	"gopkg.in/tomb.v2"
 )
+
+// errGracefulShutdownDuringRecovery is an internal sentinel returned by
+// StartWithBackoff when a graceful shutdown (StopAll) began while the pipeline
+// was parked in the recovery backoff wait. It is never surfaced to callers: the
+// cleanup goroutine maps it to a terminal StatusSystemStopped (a graceful stop,
+// not a degraded failure) — see runPipeline's recovery arm. Invariant 7: a
+// shutdown must finalize the pipeline, not race the shutdown with a restart.
+var errGracefulShutdownDuringRecovery = cerrors.New("graceful shutdown during recovery backoff")
 
 type FailureEvent struct {
 	// ID is the ID of the pipeline which failed.
@@ -47,6 +57,13 @@ type FailureHandler func(FailureEvent)
 // Service manages pipelines.
 type Service struct {
 	logger log.CtxLogger
+
+	// errRecoveryCfg configures the bounded-backoff auto-recovery loop that
+	// restarts a pipeline after a transient (non-fatal) error. Shared with the
+	// v1 lifecycle service via the lifecycle.ErrRecoveryCfg type (pure config,
+	// no lifecycle coupling — see the arch-v2 recovery-port design). Must be
+	// non-nil: buildRunnablePipeline reads it to seed each pipeline's backoff.
+	errRecoveryCfg *lifecyclev1.ErrRecoveryCfg
 
 	pipelines  PipelineService
 	connectors ConnectorService
@@ -73,6 +90,7 @@ type Service struct {
 // NewService initializes and returns a lifecycle.Service.
 func NewService(
 	logger log.CtxLogger,
+	errRecoveryCfg *lifecyclev1.ErrRecoveryCfg,
 	connectors ConnectorService,
 	processors ProcessorService,
 	connectorPlugins ConnectorPluginService,
@@ -81,6 +99,7 @@ func NewService(
 ) *Service {
 	return &Service{
 		logger:           logger.WithComponent("lifecycle.Service"),
+		errRecoveryCfg:   errRecoveryCfg,
 		connectors:       connectors,
 		processors:       processors,
 		connectorPlugins: connectorPlugins,
@@ -95,6 +114,14 @@ type runnablePipeline struct {
 	pipeline *pipeline.Instance
 	w        *funnel.Worker
 	t        *tomb.Tomb
+
+	// backoff and recoveryAttempts hold the auto-recovery state. backoff is
+	// seeded per build; recoveryAttempts is carried across restarts by Start so
+	// MaxRetries actually bounds the retry loop (a reset every restart would make
+	// the ceiling unreachable). recoveryAttempts is a pointer so the shared
+	// counter survives the rp swap on restart. Mirrors pkg/lifecycle.
+	backoff          *backoff.Backoff
+	recoveryAttempts *atomic.Int64
 }
 
 // ConnectorService can fetch and create a connector instance.
@@ -170,6 +197,16 @@ func (s *Service) Start(
 	rp, err := s.buildRunnablePipeline(ctx, pl)
 	if err != nil {
 		return cerrors.Errorf("could not build tasks for pipeline %s: %w", pl.ID, err)
+	}
+
+	// If this pipeline was already running (i.e. this Start is a recovery
+	// restart driven by StartWithBackoff), carry its backoff state onto the new
+	// runnablePipeline. Without this, every restart resets the attempt counter
+	// and MaxRetries would never bite — an unbounded restart loop. Mirrors
+	// pkg/lifecycle.Service.Start.
+	if oldRp, ok := s.runningPipelines.Get(pipelineID); ok {
+		rp.backoff = oldRp.backoff
+		rp.recoveryAttempts = oldRp.recoveryAttempts
 	}
 
 	// A new run supersedes any terminal error recorded by a previous run of this
@@ -432,6 +469,17 @@ func (s *Service) buildRunnablePipeline(
 	return &runnablePipeline{
 		pipeline: pl,
 		w:        worker,
+		// Seed a fresh backoff and attempt counter. Start carries these onto the
+		// next runnablePipeline across a recovery restart. Mirrors
+		// pkg/lifecycle.buildRunnablePipeline; the backoff parameters come from
+		// the shared lifecycle.ErrRecoveryCfg (equivalent to its toBackoff()).
+		backoff: &backoff.Backoff{
+			Min:    s.errRecoveryCfg.MinDelay,
+			Max:    s.errRecoveryCfg.MaxDelay,
+			Factor: float64(s.errRecoveryCfg.BackoffFactor),
+			Jitter: true,
+		},
+		recoveryAttempts: &atomic.Int64{},
 	}, nil
 }
 
@@ -740,30 +788,61 @@ func (s *Service) runPipeline(rp *runnablePipeline) error {
 				return err
 			}
 		default:
-			if cerrors.IsFatalError(err) {
-				// we use %+v to get the stack trace too
+			switch {
+			case cerrors.IsFatalError(err):
+				// Invariant 3/7: a fatal terminal error (including a user
+				// force-stop, which stopRunnablePipeline fatal-tags) is never
+				// auto-recovered — it degrades. we use %+v to get the stack trace too.
 				if err := s.pipelines.UpdateStatus(ctx, rp.pipeline.ID, pipeline.StatusDegraded, fmt.Sprintf("%+v", err)); err != nil {
 					return err
 				}
-			} else { //nolint:staticcheck // TODO: implement recovery
-				// // try to recover the pipeline
-				// if recoveryErr := s.recoverPipeline(ctx, rp); recoveryErr != nil {
-				// 	s.logger.
-				// 		Err(ctx, err).
-				// 		Str(log.PipelineIDField, rp.pipeline.ID).
-				// 		Msg("pipeline recovery failed")
-				//
-				// 	if updateErr := s.pipelines.UpdateStatus(ctx, rp.pipeline.ID, pipeline.StatusDegraded, fmt.Sprintf("%+v", recoveryErr)); updateErr != nil {
-				// 		return updateErr
-				// 	}
-				//
-				// 	// we assign it to err so it's returned and notified by the cleanup function
-				// 	err = recoveryErr
-				// } else {
-				// 	// recovery was triggered didn't error, so no cleanup
-				// 	// this is why we return nil to skip the cleanup below.
-				// 	return nil
-				// }
+			case s.isGracefulShutdown.Load():
+				// Transient error that fired while Conduit is already shutting
+				// down: do not start a recovery loop that would race the
+				// shutdown (invariant 7). Finalize as a system stop. This is a
+				// deliberate v2 improvement over v1, which does not gate its
+				// error arm on graceful shutdown — flagged in the PR.
+				err = nil
+				if updateErr := s.pipelines.UpdateStatus(ctx, rp.pipeline.ID, pipeline.StatusSystemStopped, ""); updateErr != nil {
+					return updateErr
+				}
+			default:
+				// Transient (non-fatal) error: attempt bounded-backoff recovery.
+				recoveryErr := s.recoverPipeline(ctx, rp)
+				switch {
+				case recoveryErr == nil:
+					// Recovery restarted the pipeline (or an external Start
+					// already replaced the running entry). The live run now owns
+					// terminal cleanup, so return early WITHOUT running the
+					// cleanup tail below — deleting the runningPipelines entry
+					// here would delete the new run's entry. Mirrors v1's
+					// return nil (pkg/lifecycle/service.go). This early return is
+					// also what lets StartWithBackoff's "am I still the live
+					// pipeline" guard observe a concurrent restart during the
+					// backoff wait: the old entry must stay in runningPipelines
+					// until Start swaps in the new one.
+					return nil
+				case cerrors.Is(recoveryErr, errGracefulShutdownDuringRecovery):
+					// A graceful shutdown began while we were parked in the
+					// backoff wait. Finalize as a system stop, not a degraded
+					// failure, and run the cleanup tail so the entry is removed.
+					err = nil
+					if updateErr := s.pipelines.UpdateStatus(ctx, rp.pipeline.ID, pipeline.StatusSystemStopped, ""); updateErr != nil {
+						return updateErr
+					}
+				default:
+					// Recovery is exhausted (MaxRetries) or itself errored.
+					s.logger.
+						Err(ctx, err).
+						Str(log.PipelineIDField, rp.pipeline.ID).
+						Msg("pipeline recovery failed")
+
+					if updateErr := s.pipelines.UpdateStatus(ctx, rp.pipeline.ID, pipeline.StatusDegraded, fmt.Sprintf("%+v", recoveryErr)); updateErr != nil {
+						return updateErr
+					}
+					// assign so it's the terminal error recorded and notified below.
+					err = recoveryErr
+				}
 			}
 		}
 
@@ -793,6 +872,107 @@ func (s *Service) runPipeline(rp *runnablePipeline) error {
 	err = s.pipelines.UpdateStatus(ctx, rp.pipeline.ID, pipeline.StatusRunning, "")
 	close(startupDone)
 	return err
+}
+
+// recoverPipeline attempts to recover a pipeline that stopped with a transient
+// (non-fatal) error. It marks the pipeline StatusRecovering and hands off to
+// StartWithBackoff, which waits out the backoff and restarts the pipeline.
+//
+// Restart-from-position correctness (invariants 1 & 3) is a connector/persister
+// property, not a lifecycle one: by the time this runs, the cleanup goroutine
+// has already joined the worker goroutine (workersWg.Wait in runPipeline), and
+// that goroutine unconditionally ran Worker.Close → Source.Teardown, which
+// forces a persister flush and waits for pending writes (pkg/connector/source.go
+// Teardown). So every position the old worker durably acked is persisted before
+// this restart builds a fresh worker whose Source.Open resumes from that
+// position: no acked record is re-read as un-acked, and no un-acked record is
+// skipped. The restart re-reads and re-processes anything not yet durably acked
+// (at-least-once).
+func (s *Service) recoverPipeline(ctx context.Context, rp *runnablePipeline) error {
+	s.logger.Trace(ctx).Str(log.PipelineIDField, rp.pipeline.ID).Msg("recovering pipeline")
+	if !s.metricsDisabled {
+		measure.PipelineRecoveringCount.WithValues(rp.pipeline.Config.Name).Inc()
+	}
+
+	err := s.pipelines.UpdateStatus(ctx, rp.pipeline.ID, pipeline.StatusRecovering, "")
+	if err != nil {
+		return err
+	}
+
+	// Exit the goroutine and attempt to restart the pipeline.
+	return s.StartWithBackoff(ctx, rp)
+}
+
+// StartWithBackoff waits out the recovery backoff for rp, then restarts the
+// pipeline. It bounds the number of restarts via ErrRecoveryCfg.MaxRetries
+// (InfiniteRetriesErrRecovery disables the bound), returning a fatal
+// ErrPipelineCannotRecover once the bound is exceeded so the caller degrades the
+// pipeline. Ported from pkg/lifecycle.Service.StartWithBackoff.
+//
+// Return contract (interpreted by runPipeline's recovery arm):
+//   - nil: the pipeline was restarted, or an external Start already replaced the
+//     running entry while we waited — either way the live run owns terminal
+//     cleanup and the caller must NOT run its cleanup tail.
+//   - errGracefulShutdownDuringRecovery: a graceful shutdown began during the
+//     backoff wait; the caller finalizes a system stop instead of restarting.
+//   - any other error: a fatal recovery failure (MaxRetries exhausted) or a
+//     Start error; the caller degrades the pipeline.
+func (s *Service) StartWithBackoff(ctx context.Context, rp *runnablePipeline) error {
+	// Increment number of recovery attempts. recoveryAttempts is shared across
+	// restarts (carried over in Start), so this bounds the whole retry sequence,
+	// not a single restart.
+	attempt := rp.recoveryAttempts.Add(1)
+
+	if s.errRecoveryCfg.MaxRetries != lifecyclev1.InfiniteRetriesErrRecovery && attempt > s.errRecoveryCfg.MaxRetries {
+		return cerrors.FatalError(cerrors.Errorf("failed to recover pipeline %s after %d attempts: %w", rp.pipeline.ID, attempt, pipeline.ErrPipelineCannotRecover))
+	}
+
+	duration := rp.backoff.ForAttempt(float64(attempt))
+	s.logger.Info(ctx).
+		Str(log.PipelineIDField, rp.pipeline.ID).
+		Dur(log.DurationField, duration).
+		Int64(log.AttemptField, attempt).
+		Msg("restarting with backoff")
+
+	// Retry-window reset: decrement the attempt counter after the backoff plus a
+	// stable window, so a pipeline that recovers and stays healthy past the
+	// window effectively resets its backoff, while sustained flapping within the
+	// window accumulates toward MaxRetries. Ported verbatim from v1; note v1
+	// implements only this timer-based reset, not the per-successful-record reset
+	// the design doc also mentions (documented, not shipped).
+	time.AfterFunc(duration+s.errRecoveryCfg.MaxRetriesWindow, func() {
+		s.logger.Debug(ctx).
+			Str(log.PipelineIDField, rp.pipeline.ID).
+			Dur(log.DurationField, duration).
+			Int64(log.AttemptField, attempt).
+			Msg("decreasing recovery attempts")
+		rp.recoveryAttempts.Add(-1) // Decrement the number of attempts after delay.
+	})
+
+	// This results in a default delay progression of 1s, 2s, 4s, 8s, 16s, [...],
+	// 10m, 10m,... balancing recovery time against downtime.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(duration):
+	}
+
+	// The user may have stopped or restarted the pipeline while we were waiting.
+	// If the live entry is no longer this rp, an external Start already replaced
+	// it — that run owns cleanup, so return nil and do not restart.
+	actualRp, ok := s.runningPipelines.Get(rp.pipeline.ID)
+	if !ok || actualRp != rp {
+		return nil
+	}
+
+	// If a graceful shutdown began while we waited, do not restart — finalize a
+	// system stop instead (invariant 7). Checked after the guard so a legitimate
+	// concurrent restart still wins.
+	if s.isGracefulShutdown.Load() {
+		return errGracefulShutdownDuringRecovery
+	}
+
+	return s.Start(ctx, rp.pipeline.ID)
 }
 
 // notify notifies all registered FailureHandlers about an error.

--- a/pkg/lifecycle-poc/service_test.go
+++ b/pkg/lifecycle-poc/service_test.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -29,6 +31,7 @@ import (
 	"github.com/conduitio/conduit/pkg/connector"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/log"
+	lifecyclev1 "github.com/conduitio/conduit/pkg/lifecycle"
 	"github.com/conduitio/conduit/pkg/lifecycle-poc/funnel"
 	"github.com/conduitio/conduit/pkg/pipeline"
 	"github.com/conduitio/conduit/pkg/plugin"
@@ -72,6 +75,7 @@ func TestServiceLifecycle_buildRunnablePipeline(t *testing.T) {
 
 	ls := NewService(
 		logger,
+		testErrRecoveryCfg(),
 		testConnectorService{
 			source.ID:      source,
 			destination.ID: destination,
@@ -135,6 +139,7 @@ func TestService_buildRunnablePipeline_NoSourceNode(t *testing.T) {
 
 	ls := NewService(
 		logger,
+		testErrRecoveryCfg(),
 		testConnectorService{
 			destination.ID: destination,
 			testDLQID:      dlq,
@@ -174,6 +179,7 @@ func TestService_buildRunnablePipeline_NoDestinationNode(t *testing.T) {
 
 	ls := NewService(
 		logger,
+		testErrRecoveryCfg(),
 		testConnectorService{
 			source.ID: source,
 			testDLQID: dlq,
@@ -242,6 +248,7 @@ func TestServiceLifecycle_PipelineSuccess(t *testing.T) {
 
 	ls := NewService(
 		logger,
+		testErrRecoveryCfg(),
 		testConnectorService{
 			source.ID:      source,
 			destination.ID: destination,
@@ -328,6 +335,7 @@ func TestServiceLifecycle_PipelineError(t *testing.T) {
 
 	ls := NewService(
 		logger,
+		testErrRecoveryCfg(),
 		testConnectorService{
 			source.ID:      source,
 			destination.ID: destination,
@@ -418,6 +426,7 @@ func TestServiceLifecycle_PipelineStop(t *testing.T) {
 
 	ls := NewService(
 		logger,
+		testErrRecoveryCfg(),
 		testConnectorService{
 			source.ID:      source,
 			destination.ID: destination,
@@ -511,6 +520,7 @@ func TestServiceLifecycle_PipelineForceStop(t *testing.T) {
 
 	ls := NewService(
 		logger,
+		testErrRecoveryCfg(),
 		testConnectorService{
 			source.ID:      source,
 			destination.ID: destination,
@@ -551,6 +561,470 @@ func TestServiceLifecycle_PipelineForceStop(t *testing.T) {
 	// switch), matching v1. Without the fatal tag, the non-fatal arm writes no
 	// status and the pipeline would remain StatusRunning.
 	is.Equal(pipeline.StatusDegraded, pl.GetStatus())
+}
+
+// TestServiceLifecycle_Recovery_TransientErrorRecovers is the core arch-v2
+// recovery-port acceptance test (design-doc path: running → recovering →
+// running). A running v2 pipeline whose source returns a transient (non-fatal)
+// error must auto-restart with backoff and return to running WITHOUT operator
+// action, then process records on the recovered run.
+//
+// It also pins the status-transition fidelity (AC-7): the recorded UpdateStatus
+// sequence is exactly [Running, Recovering, Running, UserStopped] — the initial
+// run, the recovery entry, the recovered run, and the final graceful stop.
+func TestServiceLifecycle_Recovery_TransientErrorRecovers(t *testing.T) {
+	is := is.New(t)
+	ctx, killAll := context.WithCancel(context.Background())
+	defer killAll()
+	logger := log.New(zerolog.Nop())
+	db := &inmemory.DB{}
+	persister := connector.NewPersister(logger, db, time.Second, 3)
+	defer persister.Wait()
+
+	ps := pipeline.NewService(logger, db)
+	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
+	is.NoErr(err)
+
+	// A non-fatal error drives recovery; the second (recovered) run delivers
+	// these records end-to-end.
+	transientErr := cerrors.New("lost connection to source")
+	healthyRecords := generateRecords(3)
+
+	ctrl := gomock.NewController(t)
+	source, srcDispenser := sourceRecoversAfterTransientError(ctrl, persister, healthyRecords, transientErr)
+	destination, destDispenser := destinationRecovers(ctrl, persister, healthyRecords)
+	dlq, dlqDispenser := dlqDispenserTimes(ctrl, persister, 2)
+	pl.DLQ.Plugin = dlq.Plugin
+
+	pl, err = ps.AddConnector(ctx, pl.ID, source.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, destination.ID)
+	is.NoErr(err)
+
+	rec := newStatusRecorder(ps)
+	ls := NewService(
+		logger,
+		testErrRecoveryCfg(),
+		testConnectorService{
+			source.ID:      source,
+			destination.ID: destination,
+			testDLQID:      dlq,
+		},
+		testProcessorService{},
+		testConnectorPluginService{
+			source.Plugin:      srcDispenser,
+			destination.Plugin: destDispenser,
+			dlq.Plugin:         dlqDispenser,
+		},
+		rec,
+		false,
+	)
+
+	err = ls.Start(ctx, pl.ID)
+	is.NoErr(err)
+
+	// Wait until the pipeline has recovered: it must have passed through
+	// Recovering and be Running again. (The initial run also briefly reports
+	// Running, so "Running after a Recovering" is what distinguishes recovery.)
+	waitForRecovered(t, rec)
+
+	// The recovered run delivers its records end-to-end; wait for the source to
+	// ack them so the graceful stop below has a deterministic last position.
+	waitForRecordsAcked(t, source, healthyRecords)
+	is.Equal(pipeline.StatusRunning, pl.GetStatus())
+
+	err = ls.Stop(ctx, pl.ID, false)
+	is.NoErr(err)
+	is.NoErr(ls.WaitPipeline(pl.ID))
+	is.Equal(pipeline.StatusUserStopped, pl.GetStatus())
+
+	// AC-7: exact status-transition sequence for the recovered-then-stopped path.
+	is.Equal(rec.snapshot(), []pipeline.Status{
+		pipeline.StatusRunning,
+		pipeline.StatusRecovering,
+		pipeline.StatusRunning,
+		pipeline.StatusUserStopped,
+	})
+}
+
+// TestServiceLifecycle_Recovery_MaxRetriesExhausted proves the bounded-retry
+// path (design-doc path: running → recovering → degraded). With a finite
+// MaxRetries and a source that fails on every run, the pipeline attempts exactly
+// MaxRetries restarts and then degrades with a fatal ErrPipelineCannotRecover —
+// it does NOT loop forever. This also guards the §2.2(3) backoff-carry-over: if
+// recoveryAttempts reset on each restart, MaxRetries would never bite and the
+// source would be dispensed indefinitely (the Times(k+1) expectation would fail).
+func TestServiceLifecycle_Recovery_MaxRetriesExhausted(t *testing.T) {
+	is := is.New(t)
+	ctx, killAll := context.WithCancel(context.Background())
+	defer killAll()
+	logger := log.New(zerolog.Nop())
+	db := &inmemory.DB{}
+	persister := connector.NewPersister(logger, db, time.Second, 3)
+	defer persister.Wait()
+
+	ps := pipeline.NewService(logger, db)
+	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
+	is.NoErr(err)
+
+	const maxRetries = 2
+	// Initial run + maxRetries restarts = maxRetries+1 dispenses, then degrade.
+	const wantDispenses = maxRetries + 1
+
+	transientErr := cerrors.New("source keeps flapping")
+	ctrl := gomock.NewController(t)
+	source, srcDispenser := failingSourceTimes(ctrl, persister, transientErr, wantDispenses)
+	destination, destDispenser := destinationTimes(ctrl, persister, wantDispenses)
+	dlq, dlqDispenser := dlqDispenserTimes(ctrl, persister, wantDispenses)
+	pl.DLQ.Plugin = dlq.Plugin
+
+	pl, err = ps.AddConnector(ctx, pl.ID, source.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, destination.ID)
+	is.NoErr(err)
+
+	cfg := testErrRecoveryCfg()
+	cfg.MaxRetries = maxRetries
+
+	rec := newStatusRecorder(ps)
+	ls := NewService(
+		logger,
+		cfg,
+		testConnectorService{
+			source.ID:      source,
+			destination.ID: destination,
+			testDLQID:      dlq,
+		},
+		testProcessorService{},
+		testConnectorPluginService{
+			source.Plugin:      srcDispenser,
+			destination.Plugin: destDispenser,
+			dlq.Plugin:         dlqDispenser,
+		},
+		rec,
+		false,
+	)
+
+	events := make(chan FailureEvent, 1)
+	ls.OnFailure(func(e FailureEvent) { events <- e })
+
+	err = ls.Start(ctx, pl.ID)
+	is.NoErr(err)
+
+	// The terminal fatal error is delivered via the Failurehandler (and recorded
+	// in terminalErrors), not necessarily by WaitPipeline: WaitPipeline can latch
+	// onto an intermediate run's tomb, which carries that run's (non-fatal)
+	// transient error, not the final exhaustion error. The FailureEvent is only
+	// emitted on the terminal degrade, so it carries the fatal cause.
+	event, received, err := cchan.Chan[FailureEvent](events).RecvTimeout(ctx, 10*time.Second)
+	is.NoErr(err)
+	is.True(received)
+	is.Equal(pl.ID, event.ID)
+	is.True(cerrors.IsFatalError(event.Error))                          // exhaustion is terminal
+	is.True(cerrors.Is(event.Error, pipeline.ErrPipelineCannotRecover)) // with the recovery-failed sentinel
+
+	waitForStatus(t, pl, pipeline.StatusDegraded)
+
+	// The recorded transitions: an initial Running, then a Recovering per restart
+	// attempt (with an interleaved Running for each successful re-dispense), and a
+	// terminal Degraded. Assert the shape without over-fitting the interleaving:
+	// Recovering appears, and the terminal status is Degraded.
+	statuses := rec.snapshot()
+	is.True(len(statuses) >= 2)
+	is.Equal(statuses[len(statuses)-1], pipeline.StatusDegraded)
+	var recovering int
+	for _, s := range statuses {
+		if s == pipeline.StatusRecovering {
+			recovering++
+		}
+	}
+	is.Equal(recovering, wantDispenses) // one Recovering per recovery entry (incl. the exhausting one)
+}
+
+// TestServiceLifecycle_Recovery_GracefulShutdownDuringBackoff proves invariant 7
+// under recovery: a graceful shutdown (StopAll) issued while the pipeline is
+// parked in the recovery backoff wait must NOT restart it. The pipeline finalizes
+// as StatusSystemStopped (a clean stop, not a degraded failure) and the source is
+// dispensed exactly once — no recovery restart races the shutdown.
+func TestServiceLifecycle_Recovery_GracefulShutdownDuringBackoff(t *testing.T) {
+	is := is.New(t)
+	ctx, killAll := context.WithCancel(context.Background())
+	defer killAll()
+	logger := log.New(zerolog.Nop())
+	db := &inmemory.DB{}
+	persister := connector.NewPersister(logger, db, time.Second, 3)
+	defer persister.Wait()
+
+	ps := pipeline.NewService(logger, db)
+	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
+	is.NoErr(err)
+
+	transientErr := cerrors.New("lost connection to source")
+	ctrl := gomock.NewController(t)
+	// Exactly one dispense: the initial run. A recovery restart would be a second
+	// dispense and fail the Times(1) expectation — precisely the bug this guards.
+	source, srcDispenser := failingSourceTimes(ctrl, persister, transientErr, 1)
+	destination, destDispenser := destinationTimes(ctrl, persister, 1)
+	dlq, dlqDispenser := dlqDispenserTimes(ctrl, persister, 1)
+	pl.DLQ.Plugin = dlq.Plugin
+
+	pl, err = ps.AddConnector(ctx, pl.ID, source.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, destination.ID)
+	is.NoErr(err)
+
+	// A long MinDelay makes the backoff wait wide enough to reliably observe the
+	// Recovering state and issue StopAll before the wait elapses.
+	cfg := testErrRecoveryCfg()
+	cfg.MinDelay = 500 * time.Millisecond
+	cfg.MaxDelay = 500 * time.Millisecond
+
+	rec := newStatusRecorder(ps)
+	ls := NewService(
+		logger,
+		cfg,
+		testConnectorService{
+			source.ID:      source,
+			destination.ID: destination,
+			testDLQID:      dlq,
+		},
+		testProcessorService{},
+		testConnectorPluginService{
+			source.Plugin:      srcDispenser,
+			destination.Plugin: destDispenser,
+			dlq.Plugin:         dlqDispenser,
+		},
+		rec,
+		false,
+	)
+
+	err = ls.Start(ctx, pl.ID)
+	is.NoErr(err)
+
+	// Wait until the pipeline is parked in the backoff wait (StatusRecovering),
+	// then trigger a graceful shutdown mid-wait.
+	waitForStatus(t, pl, pipeline.StatusRecovering)
+	err = ls.StopAll(ctx, false)
+	is.NoErr(err)
+
+	// It finalizes as a clean system stop and is never restarted. StatusSystemStopped
+	// is written only by the sentinel (graceful-shutdown-during-backoff) path, so
+	// observing it proves the recovery was aborted, not completed. The source is
+	// dispensed exactly once (Times(1)); a restart would be a second dispense and
+	// fail at controller finish.
+	waitForStatus(t, pl, pipeline.StatusSystemStopped)
+	// Drain the pipeline's goroutines before the persister.Wait/ctrl.Finish
+	// deferred cleanups. WaitPipeline's return is intentionally not asserted: it
+	// races the cleanup's runningPipelines delete and surfaces either the run's
+	// transient tomb error or nil — the status assertion above is the invariant.
+	_ = ls.WaitPipeline(pl.ID)
+
+	statuses := rec.snapshot()
+	is.Equal(statuses[len(statuses)-1], pipeline.StatusSystemStopped)
+}
+
+// statusRecorder wraps a PipelineService, recording every UpdateStatus target
+// status in order so a test can assert the transition sequence. UpdateStatus is
+// called from multiple goroutines (the initial run and the cleanup/recovery
+// goroutine), so the slice is mutex-guarded.
+type statusRecorder struct {
+	PipelineService
+	mu       sync.Mutex
+	statuses []pipeline.Status
+}
+
+func newStatusRecorder(inner PipelineService) *statusRecorder {
+	return &statusRecorder{PipelineService: inner}
+}
+
+func (r *statusRecorder) UpdateStatus(ctx context.Context, id string, status pipeline.Status, errMsg string) error {
+	r.mu.Lock()
+	r.statuses = append(r.statuses, status)
+	r.mu.Unlock()
+	return r.PipelineService.UpdateStatus(ctx, id, status, errMsg)
+}
+
+func (r *statusRecorder) snapshot() []pipeline.Status {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]pipeline.Status, len(r.statuses))
+	copy(out, r.statuses)
+	return out
+}
+
+// waitForRecovered blocks until the recorded status sequence shows a recovery:
+// a Recovering entry followed by a later Running. Fails the test on timeout.
+func waitForRecovered(t *testing.T, rec *statusRecorder) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		statuses := rec.snapshot()
+		seenRecovering := false
+		for _, s := range statuses {
+			switch {
+			case s == pipeline.StatusRecovering:
+				seenRecovering = true
+			case s == pipeline.StatusRunning && seenRecovering:
+				return // Running after a Recovering == recovered
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for pipeline to recover (statuses: %v)", statuses)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// waitForStatus blocks until the pipeline instance reports the given status,
+// failing the test on timeout. Used to catch a transient status (Recovering)
+// during the backoff wait.
+func waitForStatus(t *testing.T, pl *pipeline.Instance, want pipeline.Status) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if pl.GetStatus() == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for pipeline status %s (last: %s)", want, pl.GetStatus())
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// sourceRecoversAfterTransientError builds a source whose first dispensed run
+// emits no records and fails with transientErr (driving exactly one recovery),
+// and whose second (recovered) run emits healthyRecords and can be gracefully
+// stopped. Exactly two dispenses are expected: the initial run and the recovery
+// restart.
+func sourceRecoversAfterTransientError(
+	ctrl *gomock.Controller,
+	persister *connector.Persister,
+	healthyRecords []opencdc.Record,
+	transientErr error,
+) (*connector.Instance, *pmock.Dispenser) {
+	source := dummySource(persister)
+	var call atomic.Int64
+	dispenser := pmock.NewDispenser(ctrl)
+	dispenser.EXPECT().DispenseSource().DoAndReturn(func() (connectorPlugin.SourcePlugin, error) {
+		if call.Add(1) == 1 {
+			// First run: fail transiently, no graceful Stop (the error path only
+			// tears the source down via Worker.Close).
+			return pmock.NewConfigurableSourcePlugin(ctrl,
+				pmock.SourcePluginWithConfigure(),
+				pmock.SourcePluginWithOpen(),
+				pmock.SourcePluginWithRun(),
+				pmock.SourcePluginWithRecords(nil, transientErr),
+				pmock.SourcePluginWithAcks(0, false),
+				pmock.SourcePluginWithTeardown(),
+			), nil
+		}
+		// Recovered run: emit records, stay running until stopped. The funnel's
+		// graceful stop tears the source down (Worker.Close → Source.Teardown)
+		// without sending the plugin Stop signal, so no SourcePluginWithStop here.
+		return pmock.NewConfigurableSourcePlugin(ctrl,
+			pmock.SourcePluginWithConfigure(),
+			pmock.SourcePluginWithOpen(),
+			pmock.SourcePluginWithRun(),
+			pmock.SourcePluginWithRecords(healthyRecords, nil),
+			pmock.SourcePluginWithAcks(len(healthyRecords), false),
+			pmock.SourcePluginWithTeardown(),
+		), nil
+	}).Times(2)
+	return source, dispenser
+}
+
+// destinationRecovers mirrors sourceRecoversAfterTransientError on the
+// destination side: the first dispensed run receives no records and is only torn
+// down (error path), the second receives healthyRecords and is gracefully
+// stopped.
+func destinationRecovers(
+	ctrl *gomock.Controller,
+	persister *connector.Persister,
+	healthyRecords []opencdc.Record,
+) (*connector.Instance, *pmock.Dispenser) {
+	dest := dummyDestination(persister)
+	var call atomic.Int64
+	dispenser := pmock.NewDispenser(ctrl)
+	dispenser.EXPECT().DispenseDestination().DoAndReturn(func() (connectorPlugin.DestinationPlugin, error) {
+		if call.Add(1) == 1 {
+			return pmock.NewConfigurableDestinationPlugin(ctrl,
+				pmock.DestinationPluginWithConfigure(),
+				pmock.DestinationPluginWithOpen(),
+				pmock.DestinationPluginWithRun(),
+				pmock.DestinationPluginWithRecords(nil),
+				pmock.DestinationPluginWithTeardown(),
+			), nil
+		}
+		// Recovered run receives the records and is torn down on stop (the funnel
+		// does not send the plugin Stop signal — see sourceRecoversAfterTransientError).
+		return pmock.NewConfigurableDestinationPlugin(ctrl,
+			pmock.DestinationPluginWithConfigure(),
+			pmock.DestinationPluginWithOpen(),
+			pmock.DestinationPluginWithRun(),
+			pmock.DestinationPluginWithRecords(healthyRecords),
+			pmock.DestinationPluginWithTeardown(),
+		), nil
+	}).Times(2)
+	return dest, dispenser
+}
+
+// failingSourceTimes builds a source that emits no records and fails with
+// transientErr on every one of its `times` dispenses (a source that never
+// recovers). Each dispense yields a fresh plugin, mirroring how
+// buildRunnablePipeline re-dispenses on every restart.
+func failingSourceTimes(
+	ctrl *gomock.Controller,
+	persister *connector.Persister,
+	transientErr error,
+	times int,
+) (*connector.Instance, *pmock.Dispenser) {
+	source := dummySource(persister)
+	dispenser := pmock.NewDispenser(ctrl)
+	dispenser.EXPECT().DispenseSource().DoAndReturn(func() (connectorPlugin.SourcePlugin, error) {
+		return pmock.NewConfigurableSourcePlugin(ctrl,
+			pmock.SourcePluginWithConfigure(),
+			pmock.SourcePluginWithOpen(),
+			pmock.SourcePluginWithRun(),
+			pmock.SourcePluginWithRecords(nil, transientErr),
+			pmock.SourcePluginWithAcks(0, false),
+			pmock.SourcePluginWithTeardown(),
+		), nil
+	}).Times(times)
+	return source, dispenser
+}
+
+// destinationTimes builds a destination that receives no records and is only
+// torn down (no graceful Stop) on every one of its `times` dispenses. Suitable
+// for the error/recovery paths where the destination is rebuilt per restart.
+func destinationTimes(
+	ctrl *gomock.Controller,
+	persister *connector.Persister,
+	times int,
+) (*connector.Instance, *pmock.Dispenser) {
+	dest := dummyDestination(persister)
+	dispenser := pmock.NewDispenser(ctrl)
+	dispenser.EXPECT().DispenseDestination().DoAndReturn(func() (connectorPlugin.DestinationPlugin, error) {
+		return pmock.NewConfigurableDestinationPlugin(ctrl,
+			pmock.DestinationPluginWithConfigure(),
+			pmock.DestinationPluginWithOpen(),
+			pmock.DestinationPluginWithRun(),
+			pmock.DestinationPluginWithRecords(nil),
+			pmock.DestinationPluginWithTeardown(),
+		), nil
+	}).Times(times)
+	return dest, dispenser
+}
+
+// dlqDispenserTimes builds a DLQ destination dispensed `times` times (the DLQ is
+// rebuilt on every pipeline (re)start). It receives no records and is only torn
+// down.
+func dlqDispenserTimes(
+	ctrl *gomock.Controller,
+	persister *connector.Persister,
+	times int,
+) (*connector.Instance, *pmock.Dispenser) {
+	return destinationTimes(ctrl, persister, times)
 }
 
 // waitForPipelineRunning blocks until the pipeline instance reports
@@ -603,6 +1077,22 @@ func waitForRecordsAcked(t *testing.T, source *connector.Instance, records []ope
 			t.Fatalf("timed out waiting for source to ack all %d records (last acked state: %+v)", len(records), source.State)
 		}
 		time.Sleep(time.Millisecond)
+	}
+}
+
+// testErrRecoveryCfg returns an error-recovery configuration tuned for fast,
+// deterministic unit tests: a small MinDelay so the backoff wait is short, and a
+// MaxRetriesWindow large enough that the retry-window decrement (a time.AfterFunc
+// in StartWithBackoff) never fires mid-test — so attempt counting stays
+// deterministic. Individual tests override MaxRetries where they need a finite
+// bound. Mirrors pkg/lifecycle's testErrRecoveryCfg, retimed for the funnel.
+func testErrRecoveryCfg() *lifecyclev1.ErrRecoveryCfg {
+	return &lifecyclev1.ErrRecoveryCfg{
+		MinDelay:         time.Millisecond,
+		MaxDelay:         10 * time.Millisecond,
+		BackoffFactor:    2,
+		MaxRetries:       lifecyclev1.InfiniteRetriesErrRecovery,
+		MaxRetriesWindow: time.Minute,
 	}
 }
 

--- a/pkg/lifecycle-poc/stop_and_wait_test.go
+++ b/pkg/lifecycle-poc/stop_and_wait_test.go
@@ -39,7 +39,7 @@ func TestServiceLifecycle_StopAndWait_Unsupported(t *testing.T) {
 	is := is.New(t)
 
 	logger := log.New(zerolog.Nop())
-	ls := NewService(logger, testConnectorService{}, testProcessorService{}, testConnectorPluginService{}, testPipelineService{}, true)
+	ls := NewService(logger, testErrRecoveryCfg(), testConnectorService{}, testProcessorService{}, testConnectorPluginService{}, testPipelineService{}, true)
 
 	err := ls.StopAndWait(context.Background(), uuid.NewString())
 	is.True(err != nil)
@@ -59,7 +59,7 @@ func TestServiceLifecycle_ReconfigureProcessor_Unsupported(t *testing.T) {
 	is := is.New(t)
 
 	logger := log.New(zerolog.Nop())
-	ls := NewService(logger, testConnectorService{}, testProcessorService{}, testConnectorPluginService{}, testPipelineService{}, true)
+	ls := NewService(logger, testErrRecoveryCfg(), testConnectorService{}, testProcessorService{}, testConnectorPluginService{}, testPipelineService{}, true)
 
 	err := ls.ReconfigureProcessor(context.Background(), uuid.NewString(), uuid.NewString())
 	is.True(err != nil)


### PR DESCRIPTION
## What

Ports v1's bounded-backoff error recovery into the **arch-v2 (funnel)** lifecycle
(`pkg/lifecycle-poc`). A **transient** (non-fatal) pipeline error now auto-restarts
with backoff and returns to running; a **fatal** error still degrades. Closes the
arch-v2 recovery gap (plan 01 PR-2) — one of the four "sharp edges" blocking arch-v2
graduation.

Roadmap: v0.20 / Phase 2 arch-v2 graduation epic.

## Risk tier: **Tier 1 (data path)** — recovery/restart logic

### Blast radius is preview-only
`errRecoveryCfg` is now built **once** in `runtime.go` and passed to **both**
lifecycle services with an identical value. The **v1 (default, production) path is
byte-identical** — same struct, same values, just hoisted above the arch branch.
The new recovery loop only activates under `--preview.pipeline-arch-v2`, which is
**off by default**. It cannot regress the shipping engine.

### What changed
- `runtime.go` — hoist `errRecoveryCfg` above the arch branch; pass to `lifecycle_v2.NewService`.
- `service.go` — the port: `recoverPipeline` + `StartWithBackoff`, transcribed from v1
  (MaxRetries fatal conversion, timer-based retry-window decrement, live-pipeline guard).
  The `//nolint:staticcheck // TODO: implement recovery` block became a real `switch`:
  fatal → Degraded; graceful-shutdown-in-progress → SystemStopped (no recovery);
  else → recover. `runnablePipeline` gains `backoff` + `*atomic.Int64 recoveryAttempts`,
  carried across restarts by `Start` so `MaxRetries` actually bounds the loop.

## Failure-mode analysis (Tier 1 required)

| Failure | Behavior | Metric/alert |
| --- | --- | --- |
| Transient connector error | Recovering → backoff → Running | `PipelineRecoveringCount`, status=Recovering |
| MaxRetries exhausted | fatal `ErrPipelineCannotRecover` → Degraded | status=Degraded |
| User force-stop (PR-1 fatal-tag) | routes to fatal arm → Degraded, **never recovered** | verified by `TestServiceLifecycle_PipelineForceStop` (passes with recovery wired) |
| Graceful shutdown mid-backoff | internal sentinel → SystemStopped, source dispensed once (inv 7) | status=SystemStopped |
| Restart-from-position (inv 1 & 3) | see below | at-least-once preserved |

**Invariants 1 & 3 (the crux).** Restart-from-last-durable-position is a
connector/persister property. In `runPipeline` the worker goroutine runs `Worker.Do`
then **unconditionally** `Worker.Close → Source.Teardown`, which forces a persister
flush and waits for pending writes. The worker's `workersWg.Done` fires only **after**
`Close` returns, and the cleanup goroutine blocks on `workersWg.Wait()` **before** the
recovery decision. So every position the old worker durably acked is persisted before
the restart builds a fresh worker whose `Source.Open` resumes from it: no acked record
is skipped (inv 3); no un-acked record is re-acked as handled (inv 1) — the restart
re-reads/re-processes anything not yet durably acked (at-least-once).

**Early-return-without-cleanup.** On successful recovery the arm `return nil` before
the cleanup tail (`terminalErrors.Set`/`runningPipelines.Delete`/`notify`). The tail is
inline in the goroutine — no `defer` — so the return genuinely skips it, leaving the
entry for the new run to own. Mirrors v1's `return nil`.

## Rollback
Revert this PR, or run without `--preview.pipeline-arch-v2` (recovery is inert on v1).

## Tests (regression, all green `-race -count=5` on the recovery set, no flakes)
- `TestServiceLifecycle_Recovery_TransientErrorRecovers` — `[Running, Recovering, Running, UserStopped]`.
- `TestServiceLifecycle_Recovery_MaxRetriesExhausted` — `MaxRetries=2` → 3 dispenses → Degraded + fatal.
- `TestServiceLifecycle_Recovery_GracefulShutdownDuringBackoff` — StopAll mid-backoff → SystemStopped, source dispensed once.
- `TestServiceLifecycle_PipelineForceStop` — force-stop stays Degraded with recovery wired.

## Adversarial self-review findings
- Confirmed the early-`return nil` skips the inline cleanup tail (no `defer`) — reviewed the full goroutine, not just the diff.
- Confirmed v1 path value-identical (no production behavior change).
- Confirmed `StartWithBackoff` handoff is non-blocking-recursive: the parked goroutine spawns a fresh run via `Start` and returns; no stack growth per restart.

## Deliberate deviations (flagged)
- Backoff built inline (v1's `toBackoff()` is unexported) — reuses the config **type** as intended.
- Graceful-shutdown-during-backoff handled via internal sentinel + post-wait re-check — a v2 improvement (v1 doesn't gate its error arm on shutdown).
- Q4 (persisted `StatusRecovering` on boot) left matching v1: a Recovering pipeline is surfaced to the operator, not auto-restarted. No loss.

## Deferred (scoped to PR-3, not this PR)
Full **SIGKILL/crash-during-backoff** chaos proof is PR-3's scenario per the signed-off
plan. This PR's restart-from-position argument rests on the `workersWg.Done`-after-`Close`
happens-before, correct by reading and exercised by the transient-recovery test; the
crash-injection proof lands with the v2 recovery chaos suite.
