### PR TITLE
feat(lifecycle-poc): drain-safe StopAndWait/ReconfigureProcessor for arch-v2

### DIFF
--- a/docs/design-documents/20260731-archv2-drain-reconfigure.md
+++ b/docs/design-documents/20260731-archv2-drain-reconfigure.md
@@ -214,6 +214,15 @@ every connector it manages** — including the DLQ destination, which `lifecycle
 creates through the same `s.connectors.Create` (and thus the same persister) as every other
 connector. There is no DLQ-specific persistence path this misses. **No gap found.**
 
+The same fact has one benign side effect (raised by adversarial review, Finding 3): because
+`WaitPersisted` is a **process-global** barrier over the shared persister — not scoped to a single
+`pipelineID` — a `StopAndWait` can hit its persist-phase O2 timeout because of an _unrelated_
+pipeline's slow/stuck write, not its own. This only ever over-waits (it can never return early
+before this pipeline's writes are durable), and a persist-phase timeout fails safe: `ApplyPlanLive`
+aborts on the error and mutates nothing (invariant 1 preserved). It is a liveness/observability
+wrinkle, not a correctness one; per-pipeline persistence scoping is a possible future refinement,
+not required for this interim.
+
 ### §3.1 — the funnel drain audit
 
 This is the audit the original `CodeStopAndWaitUnsupported` guard was waiting on. It walks the same

--- a/docs/design-documents/20260731-archv2-drain-reconfigure.md
+++ b/docs/design-documents/20260731-archv2-drain-reconfigure.md
@@ -1,0 +1,361 @@
+# Drain-safe live reconfigure for arch-v2 (Preview.PipelineArchV2 / funnel lifecycle)
+
+## Summary
+
+Ports `StopAndWait` and `ReconfigureProcessor` from `pkg/lifecycle` (v1) to the experimental
+`pkg/lifecycle-poc` (arch-v2 / funnel) lifecycle service, removing the `CodeStopAndWaitUnsupported`
+refusal guard those two methods have carried since the `Preview.PipelineArchV2` flag was introduced.
+This closes the "Open parity item" flagged in
+[20260708-live-server-deploy-apply.md](20260708-live-server-deploy-apply.md): `ApplyPlanLive`
+(`provisioning.Service`) can now apply live changes to a running pipeline under arch-v2 exactly as it
+already does under v1, with the same drain/durability guarantee. **Tier 1** — this is a data-path
+change (stop/drain/restart of a running pipeline) plus a fix to the arch-v2 error-recovery loop the
+same PR train landed a few commits ago (`a61d4bc`, #2718).
+
+This PR also fixes a race the recovery port introduced (O3, below): a deliberate, operator-initiated
+`Stop(force=false)` that races a transient (non-fatal) error surfacing from the drain itself was
+being misclassified as a spontaneous failure and auto-restarted — restarting a pipeline the operator
+just told to stop. This is fixed generically, for any caller of `Stop`, not just `StopAndWait`.
+
+## Context
+
+`pkg/lifecycle-poc` is the experimental `funnel`-based pipeline runtime behind
+`Preview.PipelineArchV2` (`runtime.go:444`). Until this PR, its `StopAndWait` and
+`ReconfigureProcessor` unconditionally refused with `CodeStopAndWaitUnsupported`
+(`lifecycle-poc/service.go`, pre-this-PR): the funnel's `Stop`/`WaitPipeline`/`Persister` interaction
+had never been audited the way v1's was for the original live-apply review, so building
+`provisioning.Service.ApplyPlanLive`'s stop-drain-restart on top of it would have skipped the exact
+safety case that review existed to establish.
+
+Since that guard was added, two things changed the ground under it:
+
+1. **The arch-v2 error-recovery loop was ported** (`a61d4bc`, #2718): `pkg/lifecycle-poc/service.go`
+   now has `recoverPipeline`, `StartWithBackoff`, and a live (no longer commented-out) recovery arm
+   in `runPipeline`'s cleanup goroutine. A prerequisite fix for that port (`83e6abf`, #2716) already
+   fatal-tags a user force-stop so it is never auto-recovered — but that fix only covers the
+   **forceful** stop path. The **graceful** path (`Stop(force=false)`, which `StopAndWait` calls) had
+   no equivalent protection: see O3 below.
+2. **The funnel's specific drain mechanics can now be audited** (§3.1) with the recovery port's own
+   worker/source code in front of us, closing the parity gap the original guard was waiting on.
+
+### What "arch-v2" changes about the drain mechanism
+
+v1's `Stop`/`StopAndWait` (`pkg/lifecycle/service.go:278-490`) work over a node graph
+(`stream.Node`), where `Stop` injects a stop-control-message into the source node and
+`stream.SourceNode.Run`'s `openMsgTracker.Wait()` is the quiescence barrier.
+
+Arch-v2's `Stop`/`Worker.Stop` (`pkg/lifecycle-poc/funnel/worker.go:199-228`) work over a single
+`funnel.Worker` processing one batch at a time through a linear task chain (source → processors →
+destination), synchronized by `processingLock` — a different mechanism, which is why the original
+guard insisted on a fresh audit rather than assuming v1's proof transferred.
+
+## Decision
+
+### O1 — `ReconfigureProcessor`: reuse the v1 sentinel, no live-swap capability
+
+Arch-v2 has no equivalent of `stream.ProcessorNode.Reconfigure` — no live in-place processor swap at
+all. `ReconfigureProcessor` therefore **unconditionally** returns
+`lifecyclev1.ErrProcessorNotLiveReconfigurable` (wrapped with the pipeline/processor IDs for
+diagnostics), reusing the v1 sentinel rather than minting a v2-specific one:
+
+```go
+func (s *Service) ReconfigureProcessor(_ context.Context, pipelineID, processorID string) error {
+	return cerrors.Errorf("%w: processor %q in pipeline %q (Preview.PipelineArchV2 has no live in-place reconfigure yet)",
+		lifecyclev1.ErrProcessorNotLiveReconfigurable, processorID, pipelineID)
+}
+```
+
+This keeps `provisioning.applyInPlace`'s existing `cerrors.Is(err, lifecycle.ErrProcessorNotLiveReconfigurable)`
+match (`plan.go:663`) unchanged — no arch-v2-specific branch in `provisioning` at all. The package
+coupling this relies on already exists: `lifecycle-poc/service.go` already imports
+`lifecyclev1 "github.com/conduitio/conduit/pkg/lifecycle"` for `ErrRecoveryCfg`.
+`TestApplyPlanLive_ArchV2_ProcessorUpdate_FallsBackToRestart` (`pkg/provisioning`) wires a **real**
+`lifecycle-poc.Service` (not a mock) into `provisioning.Service` and proves the same
+`processorUpdateFixture` that applies genuinely in place under v1 falls through to the
+`StopAndWait`+`Start` restart path under arch-v2.
+
+### O2 — bounding the drain
+
+The plan called this "the single most important correctness/liveness question" of this port, and the
+answer is: **yes, `WaitPipeline`/`Stop` can hang, and now it is explicitly bounded.**
+
+`funnel.Worker.Stop` acquires `processingLock` before doing anything else
+(`worker.go:205-209`). That lock is held by `doTask` for the **entire duration** of a batch's
+processing — from right after the source read succeeds until the batch has flowed all the way
+through every downstream task (`worker.go:332-337`). If a destination `Write`/`Ack` round-trip never
+returns (a wedged connection, a stuck disk, a hung plugin), the batch holding `processingLock` never
+releases it, and `Worker.Stop`'s `acquireProcessingLock` — and therefore `Stop`, `StopAndWait`, and
+transitively `provisioning.Service.ApplyPlanLive` — blocks forever.
+
+**Resolution:** `StopAndWait` now bounds its entire sequence (`Stop` → drain-wait → persist-wait) by
+a single deadline: `DefaultStopAndWaitTimeout` (30s), or a tighter deadline already set on the
+caller's `ctx`, whichever is sooner.
+
+```go
+deadline := time.Now().Add(DefaultStopAndWaitTimeout)
+if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+	deadline = d
+}
+```
+
+This deadline is threaded into `Stop`'s own `ctx`, which `acquireProcessingLock`'s `select` already
+honors (`worker.go:233-241`) — no new cancellation plumbing was needed inside `funnel.Worker` at all;
+the bound was missing purely at the `StopAndWait` call site. The drain-wait (`WaitPipeline`) and
+persist-wait (`connectors.WaitPersisted`) are each separately bounded by the same remaining budget via
+a small `waitBounded` helper (goroutine + `select`/`time.After`, mirroring the existing `Wait(timeout)`
+method's own idiom and `connector.Persister.WaitPendingWritesContext`'s doc on why the underlying
+wait is not itself abortable).
+
+On timeout, `StopAndWait` returns a coded `CodeStopAndWaitTimeout` error and does **not** force-kill
+anything:
+
+- If `Stop` itself times out (the common case: the wedge holds the lock), `Worker.Stop` never reaches
+  `w.stop.Store(true)` — the worker's internal stop flag is never set, so the pipeline is left exactly
+  as it was: still genuinely `StatusRunning`, still working through the (from the caller's point of
+  view, still wedged) batch. Nothing is torn down, nothing is acked, nothing is lost — safe to retry
+  later, or to leave running while an operator investigates the stuck destination.
+- If `Stop` succeeds but the drain or persist wait times out (a slower, more contained case — the
+  worker did stop, but the tomb join or persister flush itself is slow), the same reasoning applies:
+  the bound only stops **this caller from waiting**, it never cancels the underlying work.
+
+This is deliberately the same "benign, never a silent gap" contract
+`connector.Source.Teardown`'s own bounded-wait fallback already establishes
+(`connector/source.go`, `DefaultTeardownFlushTimeout`): a caller that gives up waiting is not the same
+as an operation that gives up trying. `TestServiceLifecycle_StopAndWait_Timeout`
+(`pkg/lifecycle-poc`) proves the bound fires against a deterministically wedged destination
+(`pmock.DestinationPluginWithControlledError`) and that the pipeline is left `StatusRunning`, not
+torn down or degraded, at the moment the timeout is observed.
+
+**A correctness nuance found while implementing this:** `stopRunnablePipeline` marks a run as
+`intentionalStop` (see O3) **before** calling `Worker.Stop`. If that call then fails outright because
+of this very timeout (rather than because the drain genuinely happened), the worker's stop flag was
+never set — the pipeline is still running unattended. If `intentionalStop` were left `true` in that
+case, a **later, unrelated** transient error on this same (never-actually-stopped) run would be
+misclassified as an already-completed intentional stop and would skip auto-recovery it should still
+be eligible for. `stopRunnablePipeline` therefore rolls `intentionalStop` back to `false` when
+`Worker.Stop` returns a non-nil error, so this only applies to a stop attempt that actually happened.
+
+### O3 — recovery-suppression on intentional stop
+
+The recovery port (`a61d4bc`) added a live `runPipeline` cleanup-goroutine switch that classifies a
+worker's terminal error as fatal (degrade), graceful (`isGracefulShutdown`, `StopAll`-triggered →
+`StatusSystemStopped`), or — the `default` arm — transient, and hands transient errors to
+`recoverPipeline` for bounded-backoff auto-restart. This is correct for a **spontaneous** failure. It
+is wrong for a **deliberate** one: if an operator (or, after this PR, `StopAndWait`) calls
+`Stop(force=false)` and the drain itself then surfaces a non-fatal error — e.g. a batch already
+in-flight when `Stop` was called finishes unwinding because its destination write failed — that error
+falls into the same `default` arm and auto-restarts a pipeline the caller just told to stop.
+
+`83e6abf` (#2716) had already closed the equivalent gap for **forceful** stop, by fatal-tagging
+`ErrForceStop` so it routes to the fatal arm (`StatusDegraded`) instead of `default`. Graceful stop
+has no error to fatal-tag — `Stop(force=false)` doesn't kill the tomb directly at all; the worker's
+own `Do` loop returns whatever error the drain produces, and that return value is not under
+`stopRunnablePipeline`'s control. So this needed a different fix.
+
+**Resolution:** a new field on `runnablePipeline`:
+
+```go
+// intentionalStop is set by stopRunnablePipeline's graceful-stop branch,
+// before it calls rp.w.Stop, to mark this run as one an operator ... deliberately
+// asked to stop...
+intentionalStop atomic.Bool
+```
+
+`stopRunnablePipeline`'s graceful (`force=false`) branch sets it **before** calling `rp.w.Stop`:
+
+```go
+rp.intentionalStop.Store(true)
+err := rp.w.Stop(ctx)
+if err != nil {
+	rp.intentionalStop.Store(false) // see O2's nuance above
+}
+return err
+```
+
+`runPipeline`'s cleanup switch gains a new arm, checked **after** `isGracefulShutdown` (so a
+`StopAll`-triggered system shutdown still reports `StatusSystemStopped`, unchanged) and **before**
+the recovery `default`:
+
+```go
+case rp.intentionalStop.Load():
+	err = nil
+	if updateErr := s.pipelines.UpdateStatus(ctx, rp.pipeline.ID, pipeline.StatusUserStopped, ""); updateErr != nil {
+		return updateErr
+	}
+```
+
+**Design choice: plain field, not pointer-shared like `recoveryAttempts`.** `backoff` and
+`recoveryAttempts` are deliberately carried over to a new `runnablePipeline` across a recovery
+restart (`Start` copies them from the old `rp`), because `MaxRetries` must bound the **whole** retry
+sequence, not reset every attempt. `intentionalStop` must do the **opposite**: an intentional stop
+must never survive a restart, because there is no restart to survive — a stopped pipeline is stopped.
+A fresh `runnablePipeline` (built by a later `Start`, whether operator-initiated or a genuine
+recovery restart from an unrelated, later failure) always begins with `intentionalStop` false, so it
+is not permanently marked "user-stopped" by a previous run's marker.
+
+**Regression test** (`TestServiceLifecycle_Stop_TransientErrorMidDrain_NoRecovery`,
+`pkg/lifecycle-poc/service_test.go`): a single record is read and reaches the destination, in flight
+and holding `processingLock`, deterministically parked there via
+`pmock.DestinationPluginWithControlledError` (a new, small mock helper). The test calls
+`Stop(force=false)` in a goroutine, polls the real `runnablePipeline.intentionalStop` field directly
+(this test is in-package) until it observes `true` — the precise condition `runPipeline`'s cleanup
+goroutine will check — and only then releases the destination to fail with a plain, non-fatal error.
+This reproduces "Stop already recorded this as intentional when the transient error surfaced"
+deterministically, with no timing-based flakiness. Verified to **fail without the fix** (the pipeline
+enters `StatusRecovering` and the source/destination dispensers are invoked a second time, violating
+their `Times(1)` gomock expectations) and **pass with it** (status sequence is exactly
+`[Running, UserStopped]`, dispensers each called exactly once).
+
+### O4 — DLQ / `WaitPersisted` coverage
+
+Checked as part of the §3.1 audit below: `connector.Service.WaitPersisted` (`connector/service.go:106`)
+delegates to `Persister.WaitPendingWrites`, which the shared `connector.Persister` batches **across
+every connector it manages** — including the DLQ destination, which `lifecycle-poc.Service.buildDLQ`
+creates through the same `s.connectors.Create` (and thus the same persister) as every other
+connector. There is no DLQ-specific persistence path this misses. **No gap found.**
+
+### §3.1 — the funnel drain audit
+
+This is the audit the original `CodeStopAndWaitUnsupported` guard was waiting on. It walks the same
+four properties v1's audit established
+([20260708-live-server-deploy-apply.md](20260708-live-server-deploy-apply.md), "Blocker 1"), against
+arch-v2's actual code.
+
+**1. Quiescence: no batch is mid-flight the instant `Stop`'s lock acquisition succeeds.**
+`processingLock` (`worker.go:88-90`) is a buffered channel of size 1, acquired (send) by `doTask` for
+the **first** task in a batch right after that task's own work succeeds (`worker.go:332-337`), and
+released (receive, via `defer`) only once that entire batch — first task through every downstream
+task — has finished (`worker.go:337`, the `defer release()` sits at the frame that wraps the whole
+recursive `doNextTask` chain). `Worker.Stop` acquires the same lock before doing anything else
+(`worker.go:205-209`). So the instant `Stop`'s acquisition succeeds, no batch is between "read from
+source" and "fully processed" — quiescence, by construction of a single mutual-exclusion point every
+batch and every stop both go through.
+
+**2. A batch read but never finished before the stop signal is thrown away without acking — a
+benign duplicate, never a gap.** `doTask`'s handling of the **next** batch after `Stop` has already
+run: if a new batch's first-task read succeeds but, by the time it re-acquires `processingLock`,
+`w.stop.Load()` is already true, the batch is discarded **without ever calling `Ack`**
+(`worker.go:339-347`, "stop signal received just before starting to process next batch, gracefully
+stopping without flushing the batch"). Because it was never acked, `Source.Ack` never advanced the
+persisted position past it — a restart re-reads and redelivers exactly this batch. At-least-once
+(invariant 3) holds; this can never produce a gap, only (at worst) a duplicate, which the record
+pipeline already tolerates end-to-end.
+
+**3. `Source.Teardown` (invoked by `Worker.Stop`'s `tearDownSource`, `worker.go:224`) forces a flush
+and drains the deferred-ack delivery goroutine before returning.** This is the exact machinery
+Approach A2 (issue #2680) built, and the SIGKILL chaos suite already exercises it
+(`connector/source.go:292-346`, `DefaultTeardownFlushTimeout`): every position `Source.Ack` accepted
+before teardown is forced to flush, and the deferred plugin-ack for it is drained (sent) before the
+stream is torn down, bounded so a stalled disk cannot hang shutdown forever. This machinery is
+**identical** whether it is reached from arch-v2's `Worker.Stop` or v1's node-graph teardown path —
+it lives entirely in `pkg/connector`, below both lifecycle implementations. Nothing arch-v2-specific
+had to be re-verified here; it inherits v1's proof by sharing the same `connector.Source`.
+
+**4. `WaitPipeline` (the tomb join) and `connectors.WaitPersisted` (the persister's pending-write
+barrier) are the pipeline-wide barriers a caller needs.** `WaitPipeline` blocks on `rp.t.Wait()` —
+every goroutine `runPipeline` spawned (the worker goroutine and the cleanup goroutine) has exited by
+the time it returns. `connectors.WaitPersisted` blocks on `Persister.WaitPendingWrites`, which the
+persister's own doc establishes is race-free to call **after** learning (via the tomb join) that
+`ConnectorStopped` has already fired for the connector in question (`persister.go:189-226`) — exactly
+the ordering `StopAndWait` uses (`Stop` → `WaitPipeline` → `WaitPersisted`, strictly sequential).
+
+**Conclusion:** the funnel's `Stop`/`WaitPipeline`/`Persister` interaction gives the same
+quiescence-and-durability guarantee v1's audit established for the node graph, via a different but
+equally sound mechanism (`processingLock` instead of `openMsgTracker`). It is therefore safe to build
+`StopAndWait` on top of it, **provided** the drain is explicitly bounded (O2) and a deliberate stop is
+never misread as a failure needing recovery (O3) — both of which this PR also fixes, in the same PR,
+per AC-7.
+
+### AC-7: guard removal in the same PR as the chaos test
+
+`CodeStopAndWaitUnsupported` is removed from `pkg/lifecycle-poc/codes.go` in this same PR, alongside
+the chaos test proving the new `StopAndWait` (`tests/chaos`). All prior references (the two refusal
+call sites, `stop_and_wait_test.go`'s pinning tests, and `llms-full.txt`) are updated or removed in
+this PR; `apply_plan_live_test.go`'s descriptive comment referencing the old code is reworded (it
+never depended on the real symbol — it used a stand-in error). `CodeStopAndWaitTimeout` is the only
+registered code this package needs going forward; it means something different from the removed one
+("this specific attempt did not complete in time," not "this arch cannot do this at all").
+
+## Failure modes
+
+- **Wedged destination during `StopAndWait`.** Covered by O2: bounded, benign, no force-kill, no gap.
+  Chaos-tested (AC-6).
+- **Operator `Stop` racing a transient drain error.** Covered by O3: finalizes `StatusUserStopped`,
+  never auto-restarted. Regression-tested.
+- **`StopAndWait` timeout leaves `intentionalStop` stale on a run that never actually stopped.**
+  Found and fixed during implementation (see O2's "correctness nuance"): rolled back on a failed
+  `Worker.Stop` call, so a later unrelated error on the same run is still recovery-eligible.
+- **Crash (SIGKILL) mid-`StopAndWait`.** Unchanged from the existing, already-proven-safe crash path:
+  `Source.Teardown`'s bounded flush-and-drain and the SIGKILL chaos suite already establish "at worst
+  a benign duplicate, never a gap" independent of which lifecycle service (v1 or arch-v2) initiated
+  the stop. This PR does not weaken that; the new O2 bound only governs how long a **live, running**
+  process waits before giving up, not what happens on an actual crash.
+- **Concurrent `Stop` and `StopAndWait` calls for the same pipeline.** Both funnel through the same
+  `Service.Stop`/`stopRunnablePipeline`, which already serializes via the single `runningPipelines`
+  entry and `Worker`'s own `processingLock`; no new concurrency surface is introduced by this PR.
+- **DLQ writes outstanding at `WaitPersisted` time.** Checked under O4: no gap, the DLQ shares the
+  same `connector.Persister` as every other connector.
+- **`ReconfigureProcessor` silently no-op'ing instead of falling back.** Guarded by the existing
+  `provisioning.applyInPlace` `cerrors.Is` match, which this PR's `ReconfigureProcessor` is
+  specifically designed to satisfy; pinned by
+  `TestApplyPlanLive_ArchV2_ProcessorUpdate_FallsBackToRestart` using the **real** v2 service, not a
+  mock.
+
+## Acceptance criteria
+
+| # | Criterion | Test |
+| --- | --- | --- |
+| AC-1 | A live-apply-under-load drain delivers every pre-apply-acked record durably downstream | `tests/chaos` new drain test |
+| AC-2 | (see plan; folded into AC-1/AC-3 coverage below) | — |
+| AC-3 | The final position is checkpointed (durably persisted) after a successful `StopAndWait` | `TestServiceLifecycle_StopAndWait_DrainsAndPersists`; `tests/chaos` new drain test |
+| AC-4 | (see plan; folded into O1 coverage below) | — |
+| AC-5 | `ReconfigureProcessor` always falls back to restart under arch-v2 | `TestServiceLifecycle_ReconfigureProcessor_FallsBackToRestart`; `TestApplyPlanLive_ArchV2_ProcessorUpdate_FallsBackToRestart` |
+| AC-6 | The O2 bound fires against a stuck destination and still yields no-gap (never force-kill) | `TestServiceLifecycle_StopAndWait_Timeout`; `tests/chaos` stuck-destination variant |
+| AC-7 | The `CodeStopAndWaitUnsupported` guard is removed only alongside a green chaos test, in the same PR | this PR |
+| AC-8 | A deliberate operator `Stop` racing a transient drain error never auto-restarts | `TestServiceLifecycle_Stop_TransientErrorMidDrain_NoRecovery` |
+
+## Consequences
+
+**Positive:**
+
+- `provisioning.Service.ApplyPlanLive` now works uniformly across both lifecycle implementations —
+  no arch-v2-specific branch anywhere in `provisioning`.
+- The recovery port's O3 race is fixed generically (any `Stop(force=false)` caller benefits, not just
+  `StopAndWait`), closing a latent bug the recovery port (`a61d4bc`) introduced before it could reach
+  a release.
+- The drain is now explicitly bounded end-to-end; previously an operator-triggered `Stop` against a
+  wedged destination could hang a CLI/API call forever with no way to know why.
+
+**Costs / follow-ups:**
+
+- `StopAndWait`'s restart-based interim design (stop, drain, restart) is unchanged from v1's own
+  shape — this PR ports the primitive, it does not add a true zero-downtime in-place swap for
+  arch-v2. That remains future work, same as v1.
+- `DefaultStopAndWaitTimeout` (30s) is a single, process-wide constant, not yet configurable per
+  pipeline or per destination class. If a legitimate destination write can validly take longer than
+  30s under load, this will need to become configurable — flagged here rather than guessed at now;
+  no evidence of this in the current benchi reference pipelines.
+- The `intentionalStop` fix is scoped to `pkg/lifecycle-poc`; `pkg/lifecycle` (v1) does not have this
+  bug (its node-graph `Stop` doesn't route through the same recovery classification a batch error
+  does in the funnel model), so no equivalent change was needed there.
+- Multi-connector generalization (Plan 03): `StopAndWait`'s current shape drains a single
+  `funnel.Worker` (one source, per `buildRunnablePipeline`'s `TODO(multi-connector)` markers already
+  in the file). The drain reasoning above (quiescence via `processingLock`, discard-unacked-batch
+  correctness) is per-worker and composes: a future multi-worker pipeline needs `StopAndWait` to wait
+  on **all** of its workers, not assume one. No code change was needed to leave room for this — the
+  existing `WaitPipeline`/tomb-based join already waits on every goroutine `runPipeline` spawns, and
+  `buildRunnablePipeline`'s single-source restriction is enforced (and marked `TODO(multi-connector)`)
+  well upstream of `Stop`/`StopAndWait` themselves — but this is called out explicitly so Plan 03 does
+  not have to retrofit drain correctness onto a change that assumed single-worker.
+
+## Related
+
+- Issue tracked by the arch-v2 recovery-port series: `a61d4bc` (#2718, recovery port),
+  `83e6abf` (#2716, fatal-tag force-stop).
+- [20260708-live-server-deploy-apply.md](20260708-live-server-deploy-apply.md) — v1's `StopAndWait`
+  audit and the "Open parity item" this PR closes.
+- [20260723-source-ack-persist-ordering-fix.md](20260723-source-ack-persist-ordering-fix.md) and
+  [20260728-snapshot-handoff-deferred-ack-deadlock.md](20260728-snapshot-handoff-deferred-ack-deadlock.md) —
+  the `Source.Teardown`/deferred-ack machinery §3.1 point 3 relies on.
+- `pkg/lifecycle-poc/service.go`, `pkg/lifecycle-poc/funnel/worker.go`, `pkg/connector/source.go`,
+  `pkg/provisioning/plan.go`.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -635,7 +635,7 @@ Author: Meroxa, Inc.
 | `connector.running` | FailedPrecondition | CodeConnectorRunning is raised when an operation requires the connector to not be running, but a connector instance for it already exists. |
 | `internal.error` | Internal | CodeInternal is a coded internal failure. |
 | `internal.unknown` | Internal | CodeUnknown is the fallback when an un-coded error reaches a boundary. |
-| `lifecycle_v2.stop_and_wait_unsupported` | Unimplemented | lifecycle v2: stop and wait unsupported |
+| `lifecycle_v2.stop_and_wait_timeout` | DeadlineExceeded | lifecycle v2: stop and wait timeout |
 | `orchestrator.connector_has_processors_attached` | FailedPrecondition | CodeConnectorHasProcessorsAttached is raised when a connector cannot be deleted because it still has processors attached. |
 | `orchestrator.immutable_provisioned_by_config` | FailedPrecondition | CodeImmutableProvisionedByConfig is raised when a pipeline, connector, or processor provisioned by a config file is mutated through the API instead of the config file. |
 | `orchestrator.invalid_processor_parent_type` | InvalidArgument | CodeInvalidProcessorParentType is raised when a processor's parent is neither a pipeline nor a connector. |

--- a/pkg/lifecycle-poc/codes.go
+++ b/pkg/lifecycle-poc/codes.go
@@ -19,14 +19,20 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-// CodeStopAndWaitUnsupported is raised by StopAndWait, which this
-// (Preview.PipelineArchV2 / "funnel") lifecycle implementation does not yet
-// provide. See StopAndWait's doc for why: the sibling pkg/lifecycle package's
-// Stop/WaitPipeline drain semantics were audited for the Tier-1 live-apply
-// review (docs/design-documents/20260708-live-server-deploy-apply.md, "Open
-// parity item") and found safe to build StopAndWait on top of; this
-// experimental worker/funnel architecture has not had the equivalent audit.
-// Rather than guess at its drain semantics, StopAndWait refuses outright so
-// provisioning.Service.ApplyPlanLive can never apply-to-running under an
-// unaudited stop path.
-var CodeStopAndWaitUnsupported = conduiterr.Register("lifecycle_v2.stop_and_wait_unsupported", codes.Unimplemented)
+// CodeStopAndWaitTimeout is returned by StopAndWait when the bounded drain
+// (DefaultStopAndWaitTimeout, or a tighter caller-supplied ctx deadline)
+// elapses before the pipeline finished stopping, draining, or persisting. See
+// StopAndWait's doc ("O2: bounding the drain") for why this is safe to
+// surface rather than silently retrying or force-killing: nothing is torn
+// down on this path, so the pipeline is left exactly as benign-duplicate-safe
+// as it was before the call — never a silent gap.
+//
+// This supersedes the former CodeStopAndWaitUnsupported (removed alongside
+// this package's StopAndWait/ReconfigureProcessor refusal guards — see
+// docs/design-documents/20260731-archv2-drain-reconfigure.md, AC-7): that
+// code meant "this arch cannot do this at all"; this one means "this specific
+// attempt did not complete in time," which is the only refusal shape left
+// once the funnel drain audit (same design doc, §3.1) established the
+// underlying Stop/WaitPipeline/Persister interaction is safe to build
+// StopAndWait on top of.
+var CodeStopAndWaitTimeout = conduiterr.Register("lifecycle_v2.stop_and_wait_timeout", codes.DeadlineExceeded)

--- a/pkg/lifecycle-poc/funnel/worker.go
+++ b/pkg/lifecycle-poc/funnel/worker.go
@@ -227,6 +227,19 @@ func (w *Worker) Stop(ctx context.Context) error {
 	return nil
 }
 
+// Stopping reports whether this worker has armed its stop — i.e. w.stop was set
+// by a Stop call, so the Do loop will exit and no further batch will be read.
+// It becomes true the instant Stop sets the flag, BEFORE source teardown runs,
+// so it stays true even when Stop returns a teardown error. Callers use this to
+// distinguish "Stop returned an error but the worker is genuinely stopping"
+// (teardown failed after the flag was set) from "Stop failed before arming"
+// (lock-acquisition timeout) — the two have opposite implications for whether a
+// deliberate-stop marker should be rolled back. See
+// lifecycle-poc.Service.stopRunnablePipeline.
+func (w *Worker) Stopping() bool {
+	return w.stop.Load()
+}
+
 // acquireProcessingLock tries to acquire the processing lock. It returns a
 // release function that should be called to release the lock. If the context is
 // canceled before the lock is acquired, it returns the context error.

--- a/pkg/lifecycle-poc/service.go
+++ b/pkg/lifecycle-poc/service.go
@@ -122,12 +122,40 @@ type runnablePipeline struct {
 	// counter survives the rp swap on restart. Mirrors pkg/lifecycle.
 	backoff          *backoff.Backoff
 	recoveryAttempts *atomic.Int64
+
+	// intentionalStop is set by stopRunnablePipeline's graceful-stop branch,
+	// before it calls rp.w.Stop, to mark this run as one an operator (or
+	// provisioning.ApplyPlanLive via StopAndWait) deliberately asked to stop —
+	// as opposed to a spontaneous failure. runPipeline's cleanup goroutine
+	// checks it alongside isGracefulShutdown: a transient (non-fatal) error
+	// that surfaces from the drain itself (e.g. a destination write failing
+	// while a batch already in flight when Stop was called finishes unwinding)
+	// must finalize as StatusUserStopped, never auto-restart via
+	// recoverPipeline. Without this, an operator-initiated Stop(force=false)
+	// that happens to race a transient drain error is misclassified as a
+	// spontaneous transient failure and the pipeline is auto-restarted out
+	// from under the operator that just stopped it — the bug this field
+	// fixes.
+	//
+	// Deliberately a plain (non-pointer) atomic.Bool on rp, NOT carried over to
+	// a new runnablePipeline the way backoff/recoveryAttempts are (see Start):
+	// an intentional stop must never survive a restart. A fresh rp always
+	// starts with intentionalStop false, so a pipeline that recovers and later
+	// stops for an unrelated reason gets ordinary recovery semantics again, not
+	// a stale "this was user-stopped" marker from a previous run.
+	intentionalStop atomic.Bool
 }
 
-// ConnectorService can fetch and create a connector instance.
+// ConnectorService can fetch and create a connector instance, and report when
+// every position/state write already queued for persistence has been
+// durably committed — see WaitPersisted's doc (pkg/connector.Service) and
+// StopAndWait, which relies on it to await durability after a pipeline has
+// fully drained. Mirrors the sibling pkg/lifecycle.ConnectorService interface
+// (O1/O2 parity, see StopAndWait's doc).
 type ConnectorService interface {
 	Get(ctx context.Context, id string) (*connector.Instance, error)
 	Create(ctx context.Context, id string, t connector.Type, plugin string, pipelineID string, cfg connector.Config, p connector.ProvisionType) (*connector.Instance, error)
+	WaitPersisted()
 }
 
 // ProcessorService can fetch a processor instance and make a runnable processor from it.
@@ -277,7 +305,29 @@ func (s *Service) stopRunnablePipeline(ctx context.Context, rp *runnablePipeline
 			Str(log.PipelineIDField, rp.pipeline.ID).
 			Any(log.PipelineStatusField, rp.pipeline.GetStatus()).
 			Msg("gracefully stopping pipeline")
-		return rp.w.Stop(ctx)
+
+		// Invariant 3/7: mark this run as an intentional (operator-initiated)
+		// stop BEFORE calling rp.w.Stop, so that if the drain itself surfaces a
+		// transient (non-fatal) error — e.g. a batch already in flight when
+		// Stop was called finishes unwinding with a destination write failure —
+		// runPipeline's cleanup goroutine (see the intentionalStop check there)
+		// finalizes it as StatusUserStopped instead of misreading it as a
+		// spontaneous failure and auto-restarting via recoverPipeline. See the
+		// intentionalStop field doc.
+		rp.intentionalStop.Store(true)
+		err := rp.w.Stop(ctx)
+		if err != nil {
+			// rp.w.Stop failed outright (e.g. it never got past acquiring the
+			// processing lock — see the O2 drain bound in StopAndWait, which
+			// passes a deadline-bound ctx here). w.stop was therefore never
+			// actually set on the worker: the pipeline is still genuinely
+			// running, unattended, exactly as before this call. Clear the
+			// marker so a LATER, unrelated transient error is still eligible
+			// for ordinary auto-recovery instead of being permanently (and
+			// incorrectly) treated as an already-completed user stop.
+			rp.intentionalStop.Store(false)
+		}
+		return err
 	case true:
 		s.logger.Info(ctx).
 			Str(log.PipelineIDField, rp.pipeline.ID).
@@ -368,44 +418,142 @@ func (s *Service) WaitPipeline(id string) error {
 	return nil
 }
 
-// StopAndWait exists to satisfy the LifecycleService interfaces shared with
-// the sibling pkg/lifecycle package (see provisioning.LifecycleService and
-// conduit.Runtime's lifecycleService) but is intentionally unimplemented
-// here: it always refuses with a CodeStopAndWaitUnsupported error.
+// DefaultStopAndWaitTimeout bounds the end-to-end StopAndWait sequence (Stop +
+// drain-wait + persistence-wait) — see StopAndWait's doc, "O2: bounding the
+// drain". A wedged destination (Write that never returns) would otherwise
+// hold the pipeline's processingLock forever, so acquireProcessingLock's own
+// ctx (threaded through Stop -> funnel.Worker.Stop) never gets a deadline
+// unless StopAndWait supplies one — this constant is that deadline. Chosen
+// generously (well above a typical destination write timeout) so a merely
+// slow — not actually wedged — destination isn't spuriously aborted; see
+// docs/design-documents/20260731-archv2-drain-reconfigure.md, "O2".
+const DefaultStopAndWaitTimeout = 30 * time.Second
+
+// StopAndWait gracefully stops the pipeline with the given ID and blocks until
+// it has reached full quiescence (every worker goroutine has exited — see
+// WaitPipeline) AND every connector position/state write that drain triggered
+// has been durably flushed to the store (see connectors.WaitPersisted). It
+// ports pkg/lifecycle.Service.StopAndWait's contract to the funnel/arch-v2
+// lifecycle — see that method's doc for the full invariant-1/3 rationale
+// (never let a caller mutate/restart a pipeline whose drain or flush hasn't
+// actually completed) and
+// docs/design-documents/20260731-archv2-drain-reconfigure.md for the audit
+// (§3.1, "the funnel drain audit") that establishes this package's specific
+// Stop/WaitPipeline/Persister interaction gives the same guarantee:
 //
-// This is a deliberate Tier-1 safety guard, not a TODO. The Stop-and-restart
-// primitive backing provisioning.Service.ApplyPlanLive (stop-drain-restart on
-// the data path) requires a proven quiescence+durability guarantee — see
-// pkg/lifecycle.Service.StopAndWait's doc. That guarantee was established by
-// auditing pkg/lifecycle's specific Stop/WaitPipeline/Persister interaction
-// (docs/design-documents/20260708-live-server-deploy-apply.md, "Review
-// outcome & required rework"). This package's funnel.Worker-based Stop has a
-// different implementation and has not had the equivalent audit. Silently
-// building StopAndWait on top of an unaudited stop path here would let
-// ApplyPlanLive apply-to-running under Preview.PipelineArchV2 without the
-// safety case the design review actually verified — exactly the class of bug
-// blocker 1 found in the original (pre-rework) design. Refusing outright, so
-// ApplyPlanLive's error surfaces immediately instead of silently risking
-// data loss, is intentional until this architecture's drain semantics get
-// the same audit (tracked as the design doc's "Open parity item").
-func (s *Service) StopAndWait(context.Context, string) error {
-	ce := conduiterr.New(CodeStopAndWaitUnsupported,
-		"live apply (stop-drain-restart of a running pipeline) is not supported under the "+
-			"experimental Preview.PipelineArchV2 lifecycle service")
-	ce.Suggestion = "disable Preview.PipelineArchV2, or stop the pipeline manually before applying changes"
+//   - funnel.Worker's processingLock (acquired by Worker.Stop, held by the
+//     first/source task for the lifetime of a batch) guarantees no batch is
+//     mid-flight the instant Stop's lock acquisition succeeds — quiescence.
+//   - A batch that was read but never finished processing before the stop
+//     signal (worker.go's doTask, "stop signal received just before starting
+//     to process next batch") is thrown away WITHOUT acking: the source's
+//     position is never advanced past it, so a restart re-reads it — a benign
+//     duplicate, never a gap (invariants 1/3).
+//   - connector.Source.Teardown (called from Worker.Stop, tearDownSource)
+//     forces the persister to flush and waits (bounded by
+//     connector.DefaultTeardownFlushTimeout) for the deferred ack to drain —
+//     durability for whatever WAS acked.
+//   - WaitPipeline (the tomb join) and connectors.WaitPersisted (the
+//     persister's pending-write barrier) are the pipeline-wide barriers that
+//     let a caller observe both of the above have actually completed, not just
+//     been triggered.
+//
+// O2 (bounding the drain): unlike pkg/lifecycle's StopAndWait, this method
+// bounds the entire sequence — DefaultStopAndWaitTimeout, or a tighter
+// deadline already set on ctx, whichever is sooner — because a wedged
+// destination Write blocks the batch that holds processingLock forever, which
+// would otherwise hang Stop (and thus StopAndWait, and thus
+// provisioning.Service.ApplyPlanLive) indefinitely. On timeout this returns a
+// CodeStopAndWaitTimeout error and does NOT force-kill anything: whichever
+// step timed out (Stop, the drain wait, or the persistence wait) leaves the
+// pipeline in the exact state connector.Source.Teardown's own bounded-wait
+// fallback already established as safe (source.go's Teardown doc) — at worst
+// a benign duplicate on a later restart, never a gap. If Stop itself times
+// out, the worker's internal stop flag was never actually set (see
+// stopRunnablePipeline's rollback of intentionalStop on that path), so the
+// pipeline is simply still running, unattended, exactly as it was before this
+// call — safe to retry.
+//
+// StopAndWait requires the pipeline to already be running (it delegates to
+// Stop, which returns pipeline.ErrPipelineNotRunning-coded errors otherwise)
+// and only ever stops gracefully.
+func (s *Service) StopAndWait(ctx context.Context, pipelineID string) error {
+	deadline := time.Now().Add(DefaultStopAndWaitTimeout)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d // honor a tighter caller-supplied deadline
+	}
+	stopCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
+	if err := s.Stop(stopCtx, pipelineID, false); err != nil {
+		if cerrors.Is(err, context.DeadlineExceeded) {
+			return s.stopAndWaitTimeoutErr(pipelineID, "stop", err)
+		}
+		return cerrors.Errorf("could not stop pipeline %s: %w", pipelineID, err)
+	}
+
+	if err := waitBounded(time.Until(deadline), func() error { return s.WaitPipeline(pipelineID) }); err != nil {
+		if cerrors.Is(err, context.DeadlineExceeded) {
+			return s.stopAndWaitTimeoutErr(pipelineID, "drain", err)
+		}
+		return cerrors.Errorf("pipeline %s did not stop gracefully: %w", pipelineID, err)
+	}
+
+	// Invariant 1/3: do not return — and thus do not let a caller mutate or
+	// tear down this pipeline's connectors — until every position/state write
+	// the drain above already triggered is durably persisted.
+	if err := waitBounded(time.Until(deadline), func() error { s.connectors.WaitPersisted(); return nil }); err != nil {
+		return s.stopAndWaitTimeoutErr(pipelineID, "persist", err)
+	}
+
+	return nil
+}
+
+// stopAndWaitTimeoutErr builds the coded, actionable error StopAndWait returns
+// when the bounded drain (O2) elapses during the named phase ("stop", "drain",
+// or "persist").
+func (s *Service) stopAndWaitTimeoutErr(pipelineID, phase string, cause error) error {
+	ce := conduiterr.Wrap(CodeStopAndWaitTimeout, fmt.Sprintf(
+		"timed out waiting for pipeline %q to %s within %s; the pipeline was not force-stopped and is left exactly as it was — safe to retry",
+		pipelineID, phase, DefaultStopAndWaitTimeout,
+	), cause)
+	ce.Suggestion = "check the destination/DLQ for a stuck write, then retry; this never drops or duplicates a record beyond the normal at-least-once contract"
 	return ce
 }
 
-// ReconfigureProcessor refuses under the experimental Preview.PipelineArchV2
-// lifecycle service, mirroring StopAndWait: live in-place apply is not supported
-// under this arch. Returning the same coded error means a live apply is cleanly
-// refused rather than silently downgraded.
-func (s *Service) ReconfigureProcessor(context.Context, string, string) error {
-	ce := conduiterr.New(CodeStopAndWaitUnsupported,
-		"live in-place apply (processor reconfigure on a running pipeline) is not supported under "+
-			"the experimental Preview.PipelineArchV2 lifecycle service")
-	ce.Suggestion = "disable Preview.PipelineArchV2, or stop the pipeline manually before applying changes"
-	return ce
+// waitBounded runs fn in a goroutine and returns its result, or
+// context.DeadlineExceeded if timeout elapses first. fn's goroutine is not
+// itself canceled on timeout (mirrors Persister.WaitPendingWritesContext's own
+// doc on this point) — if it eventually completes, its result is simply
+// discarded once the caller has already returned.
+func waitBounded(timeout time.Duration, fn func() error) error {
+	done := make(chan error, 1)
+	go func() { done <- fn() }()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(timeout):
+		return context.DeadlineExceeded
+	}
+}
+
+// ReconfigureProcessor always returns lifecyclev1.ErrProcessorNotLiveReconfigurable
+// under the experimental Preview.PipelineArchV2 lifecycle service (O1): unlike
+// pkg/lifecycle, this arch has no live in-place hot-swap capability at all yet
+// (no equivalent of stream.ProcessorNode.Reconfigure), so every reconfigure
+// request is, structurally, "not live-reconfigurable" — the caller must fall
+// back to a restart.
+//
+// Reusing the v1 sentinel (rather than a v2-specific one) is deliberate: the
+// only caller, provisioning.Service.applyInPlace, already matches
+// cerrors.Is(err, lifecycle.ErrProcessorNotLiveReconfigurable) to decide
+// whether to fall back to StopAndWait+Start — reusing it here means
+// applyInPlace needs no arch-v2-specific branch, and the package coupling
+// already exists (this file already imports lifecyclev1 for ErrRecoveryCfg).
+func (s *Service) ReconfigureProcessor(_ context.Context, pipelineID, processorID string) error {
+	return cerrors.Errorf("%w: processor %q in pipeline %q (Preview.PipelineArchV2 has no live in-place reconfigure yet)",
+		lifecyclev1.ErrProcessorNotLiveReconfigurable, processorID, pipelineID)
 }
 
 // buildRunnablePipeline will build and connect all tasks configured in the pipeline.
@@ -804,6 +952,22 @@ func (s *Service) runPipeline(rp *runnablePipeline) error {
 				// error arm on graceful shutdown — flagged in the PR.
 				err = nil
 				if updateErr := s.pipelines.UpdateStatus(ctx, rp.pipeline.ID, pipeline.StatusSystemStopped, ""); updateErr != nil {
+					return updateErr
+				}
+			case rp.intentionalStop.Load():
+				// Invariant 3/7: an operator (or provisioning.ApplyPlanLive via
+				// StopAndWait) deliberately asked THIS pipeline to stop — see
+				// stopRunnablePipeline, which sets intentionalStop before
+				// calling rp.w.Stop. A transient (non-fatal) error surfacing
+				// from that deliberate drain must never be misread as a
+				// spontaneous failure needing recovery: auto-restarting here
+				// would restart a pipeline the operator just stopped, exactly
+				// the race the recovery port introduced (O3). Finalize as
+				// StatusUserStopped, mirroring the tomb.ErrStillAlive branch's
+				// clean-stop status, but via this arm because the drain itself
+				// returned an error instead of returning cleanly.
+				err = nil
+				if updateErr := s.pipelines.UpdateStatus(ctx, rp.pipeline.ID, pipeline.StatusUserStopped, ""); updateErr != nil {
 					return updateErr
 				}
 			default:

--- a/pkg/lifecycle-poc/service.go
+++ b/pkg/lifecycle-poc/service.go
@@ -316,15 +316,23 @@ func (s *Service) stopRunnablePipeline(ctx context.Context, rp *runnablePipeline
 		// intentionalStop field doc.
 		rp.intentionalStop.Store(true)
 		err := rp.w.Stop(ctx)
-		if err != nil {
-			// rp.w.Stop failed outright (e.g. it never got past acquiring the
-			// processing lock — see the O2 drain bound in StopAndWait, which
-			// passes a deadline-bound ctx here). w.stop was therefore never
-			// actually set on the worker: the pipeline is still genuinely
+		if err != nil && !rp.w.Stopping() {
+			// Stop failed BEFORE arming the worker's stop flag — the only such
+			// path is acquireProcessingLock timing out (see funnel.Worker.Stop;
+			// the O2 drain bound in StopAndWait passes a deadline-bound ctx
+			// here). w.stop was never set: the pipeline is still genuinely
 			// running, unattended, exactly as before this call. Clear the
-			// marker so a LATER, unrelated transient error is still eligible
-			// for ordinary auto-recovery instead of being permanently (and
+			// marker so a LATER, unrelated transient error is still eligible for
+			// ordinary auto-recovery instead of being permanently (and
 			// incorrectly) treated as an already-completed user stop.
+			//
+			// Crucially we do NOT roll back when Stop errors but the worker IS
+			// stopping (rp.w.Stopping() == true) — that is the teardown-failed-
+			// after-w.stop-was-set path (a wedged/dead source), where the worker
+			// really is winding down. Rolling back there would let the resulting
+			// non-fatal Close error fall into recoverPipeline and auto-restart a
+			// pipeline the operator just stopped — exactly the O3 bug this field
+			// exists to prevent. Found by adversarial review of the drain PR.
 			rp.intentionalStop.Store(false)
 		}
 		return err
@@ -511,13 +519,28 @@ func (s *Service) StopAndWait(ctx context.Context, pipelineID string) error {
 
 // stopAndWaitTimeoutErr builds the coded, actionable error StopAndWait returns
 // when the bounded drain (O2) elapses during the named phase ("stop", "drain",
-// or "persist").
+// or "persist"). The end-state note is phase-specific because the phases leave
+// the pipeline in genuinely different states — nothing is ever force-stopped or
+// torn down on any of them, so all three stay at-least-once-safe (never a gap),
+// but only the "stop" phase leaves the pipeline still running and cleanly
+// retriable; after "drain"/"persist" the worker is already stopping, so a
+// literal StopAndWait retry would hit ErrPipelineNotRunning (adversarial-review
+// Finding 2).
 func (s *Service) stopAndWaitTimeoutErr(pipelineID, phase string, cause error) error {
+	var state, suggestion string
+	switch phase {
+	case "stop":
+		state = "the pipeline never began stopping (its worker's stop flag was not set) and is still running, exactly as before this call — safe to retry StopAndWait"
+		suggestion = "check the destination/DLQ for a stuck write holding the processing lock, then retry; the pipeline is untouched and at-least-once is intact"
+	default: // "drain" or "persist"
+		state = "the pipeline had already begun stopping and will finish draining on its own; the timeout only means quiescence/durability was not confirmed within the bound"
+		suggestion = "check the destination/DLQ for a stuck write; do not force-restart — let the pipeline reach a stopped state (it is at-least-once-safe, never a gap), then re-apply"
+	}
 	ce := conduiterr.Wrap(CodeStopAndWaitTimeout, fmt.Sprintf(
-		"timed out waiting for pipeline %q to %s within %s; the pipeline was not force-stopped and is left exactly as it was — safe to retry",
-		pipelineID, phase, DefaultStopAndWaitTimeout,
+		"timed out waiting for pipeline %q to %s within %s; %s",
+		pipelineID, phase, DefaultStopAndWaitTimeout, state,
 	), cause)
-	ce.Suggestion = "check the destination/DLQ for a stuck write, then retry; this never drops or duplicates a record beyond the normal at-least-once contract"
+	ce.Suggestion = suggestion
 	return ce
 }
 

--- a/pkg/lifecycle-poc/service_test.go
+++ b/pkg/lifecycle-poc/service_test.go
@@ -823,6 +823,158 @@ func TestServiceLifecycle_Recovery_GracefulShutdownDuringBackoff(t *testing.T) {
 	is.Equal(statuses[len(statuses)-1], pipeline.StatusSystemStopped)
 }
 
+// TestServiceLifecycle_Stop_TransientErrorMidDrain_NoRecovery is the O3
+// regression test (docs/design-documents/20260731-archv2-drain-reconfigure.md):
+// the recovery port (a61d4bc) made a deliberate per-pipeline Stop(force=false)
+// racy against a transient (non-fatal) error surfacing from the drain itself.
+// A single record is read and reaches the destination (in flight, holding
+// funnel.Worker's processingLock); the destination is held there
+// deterministically (via pmock.DestinationPluginWithControlledError) until the
+// test has confirmed — by polling the *runnablePipeline's own intentionalStop
+// field, not a sleep — that Stop has already recorded this as an intentional,
+// operator-initiated stop. Only then is the destination released to fail with
+// a plain (non-fatal) error, exactly reproducing "Stop(force=false) racing a
+// transient drain error".
+//
+// Without the intentionalStop fix, this error falls into runPipeline's
+// recovery default arm and auto-restarts the pipeline — re-dispensing the
+// source and destination a second time, which fails this test's Times(1)
+// dispenser expectations, and finalizing with a Recovering status entry
+// instead of going straight to UserStopped. With the fix, the pipeline
+// finalizes UserStopped, recoverPipeline is never invoked (no Recovering
+// status, source/destination dispensed exactly once), and WaitPipeline
+// returns nil (the transient error is suppressed, mirroring the
+// isGracefulShutdown arm's existing behavior).
+func TestServiceLifecycle_Stop_TransientErrorMidDrain_NoRecovery(t *testing.T) {
+	is := is.New(t)
+	ctx, killAll := context.WithCancel(context.Background())
+	defer killAll()
+	logger := log.New(zerolog.Nop())
+	db := &inmemory.DB{}
+	persister := connector.NewPersister(logger, db, time.Second, 3)
+	defer persister.Wait()
+
+	ps := pipeline.NewService(logger, db)
+	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
+	is.NoErr(err)
+
+	wantRecords := generateRecords(1)
+
+	// Source: delivers the single record, then (since there's only one) its
+	// onRun returns nil without closing the stream — it just goes quiet, as if
+	// still waiting for a record that never comes. It is never acked (the
+	// batch fails downstream before Ack), so no ack-count assertion.
+	ctrl := gomock.NewController(t)
+	sourcePlugin := pmock.NewConfigurableSourcePlugin(ctrl,
+		pmock.SourcePluginWithConfigure(),
+		pmock.SourcePluginWithOpen(),
+		pmock.SourcePluginWithRun(),
+		pmock.SourcePluginWithRecords(wantRecords, nil),
+		pmock.SourcePluginWithAcks(0, false),
+		pmock.SourcePluginWithTeardown(),
+	)
+	source := dummySource(persister)
+	sourceDispenser := pmock.NewDispenser(ctrl)
+	sourceDispenser.EXPECT().DispenseSource().Return(sourcePlugin, nil).Times(1)
+
+	// Destination: receives the one record (signaling `received`), then
+	// blocks on `release` — holding the batch, and thus processingLock, "in
+	// flight" — until the test explicitly releases it with a plain (non-fatal)
+	// transient error.
+	received := make(chan struct{})
+	release := make(chan struct{})
+	transientErr := cerrors.New("transient destination write failure mid-drain")
+	destPlugin := pmock.NewConfigurableDestinationPlugin(ctrl,
+		pmock.DestinationPluginWithConfigure(),
+		pmock.DestinationPluginWithOpen(),
+		pmock.DestinationPluginWithRun(),
+		pmock.DestinationPluginWithControlledError(wantRecords, received, release, transientErr),
+		pmock.DestinationPluginWithTeardown(),
+	)
+	destination := dummyDestination(persister)
+	destDispenser := pmock.NewDispenser(ctrl)
+	destDispenser.EXPECT().DispenseDestination().Return(destPlugin, nil).Times(1)
+
+	dlq, dlqDispenser := asserterDestination(ctrl, persister, nil, false)
+	pl.DLQ.Plugin = dlq.Plugin
+
+	pl, err = ps.AddConnector(ctx, pl.ID, source.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, destination.ID)
+	is.NoErr(err)
+
+	rec := newStatusRecorder(ps)
+	ls := NewService(
+		logger,
+		testErrRecoveryCfg(),
+		testConnectorService{
+			source.ID:      source,
+			destination.ID: destination,
+			testDLQID:      dlq,
+		},
+		testProcessorService{},
+		testConnectorPluginService{
+			source.Plugin:      sourceDispenser,
+			destination.Plugin: destDispenser,
+			dlq.Plugin:         dlqDispenser,
+		},
+		rec,
+		false,
+	)
+
+	err = ls.Start(ctx, pl.ID)
+	is.NoErr(err)
+
+	<-received // the record is in flight at the destination, processingLock held
+
+	stopErr := make(chan error, 1)
+	go func() { stopErr <- ls.Stop(ctx, pl.ID, false) }()
+
+	// Poll the real runnablePipeline's intentionalStop field directly (this
+	// test is in-package) instead of sleeping: this is the exact condition
+	// runPipeline's cleanup goroutine will check, so waiting for it to become
+	// true is the precise, race-free point at which releasing the transient
+	// error reproduces "Stop already recorded this as intentional when the
+	// error surfaced" — not a timing guess.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		rp, ok := ls.runningPipelines.Get(pl.ID)
+		if ok && rp.intentionalStop.Load() {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for intentionalStop to be set")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	close(release) // now let the transient error surface
+
+	is.NoErr(<-stopErr) // Stop itself (rp.w.Stop) completes once the batch unwinds
+
+	// The core O3 assertion: the pipeline finalizes UserStopped, never
+	// Recovering. WaitPipeline's own return is intentionally not asserted
+	// here: it races runPipeline's cleanup deleting the runningPipelines
+	// entry, and can surface either the tomb's raw (pre-reassignment) Kill
+	// error or nil depending on which side of that race the caller lands on
+	// — the same documented caveat TestServiceLifecycle_Recovery_
+	// GracefulShutdownDuringBackoff already establishes for the sibling
+	// isGracefulShutdown arm, which this new arm mirrors. The reliable
+	// signal is the persisted status, not this return value.
+	_ = ls.WaitPipeline(pl.ID)
+	waitForStatus(t, pl, pipeline.StatusUserStopped)
+
+	for _, s := range rec.snapshot() {
+		if s == pipeline.StatusRecovering {
+			t.Fatalf("pipeline entered StatusRecovering - the transient mid-drain error was auto-recovered instead of being treated as an intentional stop (statuses: %v)", rec.snapshot())
+		}
+	}
+
+	// ctrl.Finish() (registered by gomock.NewController(t)) verifies both
+	// dispensers were called exactly once (Times(1)) - i.e. recoverPipeline
+	// never redispensed either connector for a restart.
+}
+
 // statusRecorder wraps a PipelineService, recording every UpdateStatus target
 // status in order so a test can assert the transition sequence. UpdateStatus is
 // called from multiple goroutines (the initial run and the cleanup/recovery
@@ -1252,6 +1404,25 @@ func (s testConnectorService) Get(_ context.Context, id string) (*connector.Inst
 
 func (s testConnectorService) Create(context.Context, string, connector.Type, string, string, connector.Config, connector.ProvisionType) (*connector.Instance, error) {
 	return s[testDLQID], nil
+}
+
+// WaitPersisted is a no-op here: none of the existing tests using
+// testConnectorService directly need a real durability wait — see
+// testConnectorServiceWithPersister below for the tests that do. Mirrors
+// pkg/lifecycle's identical testConnectorService.WaitPersisted no-op.
+func (s testConnectorService) WaitPersisted() {}
+
+// testConnectorServiceWithPersister routes WaitPersisted to the real
+// persister backing its connectors, for tests that need to prove
+// StopAndWait actually blocked until a flush landed (O2/StopAndWait tests).
+// Mirrors pkg/lifecycle's identical helper.
+type testConnectorServiceWithPersister struct {
+	testConnectorService
+	persister *connector.Persister
+}
+
+func (s testConnectorServiceWithPersister) WaitPersisted() {
+	s.persister.WaitPendingWrites()
 }
 
 // testProcessorService fulfills the ProcessorService interface.

--- a/pkg/lifecycle-poc/service_test.go
+++ b/pkg/lifecycle-poc/service_test.go
@@ -975,6 +975,148 @@ func TestServiceLifecycle_Stop_TransientErrorMidDrain_NoRecovery(t *testing.T) {
 	// never redispensed either connector for a restart.
 }
 
+// TestServiceLifecycle_Stop_SourceTeardownFails_NoRecovery is the Path-B O3
+// regression test found by adversarial review of the drain PR
+// (docs/design-documents/20260731-archv2-drain-reconfigure.md). It covers the
+// case the sibling _TransientErrorMidDrain_ test structurally cannot: here
+// funnel.Worker.Stop ARMS its stop flag (w.stop.Store(true)) and THEN
+// tearDownSource FAILS — a wedged/dead source — so Stop returns a non-nil error
+// while the worker is genuinely stopping (Stopping() == true).
+//
+// The original rollback cleared intentionalStop on ANY Stop error, which is
+// correct only for the lock-acquisition-timeout path (flag never armed). On
+// THIS path the flag WAS armed, so the unconditional rollback wrongly cleared
+// it: the subsequent non-fatal Worker.Close teardown error then fell into
+// runPipeline's recovery default arm and auto-restarted a pipeline the operator
+// just stopped — reintroducing the exact O3 bug the field exists to prevent.
+// The fix rolls back only when !rp.w.Stopping(). Without it this test's Times(1)
+// dispenser expectations fail (connectors redispensed for the restart) and a
+// Recovering status appears; with it the pipeline finalizes UserStopped and
+// recoverPipeline is never invoked.
+func TestServiceLifecycle_Stop_SourceTeardownFails_NoRecovery(t *testing.T) {
+	is := is.New(t)
+	ctx, killAll := context.WithCancel(context.Background())
+	defer killAll()
+	logger := log.New(zerolog.Nop())
+	db := &inmemory.DB{}
+	persister := connector.NewPersister(logger, db, time.Second, 3)
+	defer persister.Wait()
+
+	ps := pipeline.NewService(logger, db)
+	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
+	is.NoErr(err)
+
+	wantRecords := generateRecords(1)
+
+	// Source: delivers one record, then goes quiet. Its Teardown FAILS every
+	// time (both Worker.Stop's and Worker.Close's retry), reproducing a
+	// dead/wedged source whose teardown errors AFTER Stop already armed w.stop.
+	teardownErr := cerrors.New("source teardown failure (wedged source)")
+	ctrl := gomock.NewController(t)
+	sourcePlugin := pmock.NewConfigurableSourcePlugin(ctrl,
+		pmock.SourcePluginWithConfigure(),
+		pmock.SourcePluginWithOpen(),
+		pmock.SourcePluginWithRun(),
+		pmock.SourcePluginWithRecords(wantRecords, nil),
+		pmock.SourcePluginWithAcks(1, false),
+		pmock.SourcePluginWithTeardownError(teardownErr),
+	)
+	source := dummySource(persister)
+	sourceDispenser := pmock.NewDispenser(ctrl)
+	sourceDispenser.EXPECT().DispenseSource().Return(sourcePlugin, nil).Times(1)
+
+	// Destination holds the one record in flight (processingLock held), then is
+	// released cleanly once the test has confirmed Stop recorded the intentional
+	// stop — so Stop proceeds into the source teardown that fails. The release
+	// carries no error: the drain-terminating error comes from source teardown,
+	// not the destination, isolating the Path-B path.
+	received := make(chan struct{})
+	release := make(chan struct{})
+	destPlugin := pmock.NewConfigurableDestinationPlugin(ctrl,
+		pmock.DestinationPluginWithConfigure(),
+		pmock.DestinationPluginWithOpen(),
+		pmock.DestinationPluginWithRun(),
+		pmock.DestinationPluginWithControlledBlock(wantRecords, received, release),
+		pmock.DestinationPluginWithTeardown(),
+	)
+	destination := dummyDestination(persister)
+	destDispenser := pmock.NewDispenser(ctrl)
+	destDispenser.EXPECT().DispenseDestination().Return(destPlugin, nil).Times(1)
+
+	dlq, dlqDispenser := asserterDestination(ctrl, persister, nil, false)
+	pl.DLQ.Plugin = dlq.Plugin
+
+	pl, err = ps.AddConnector(ctx, pl.ID, source.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, destination.ID)
+	is.NoErr(err)
+
+	rec := newStatusRecorder(ps)
+	ls := NewService(
+		logger,
+		testErrRecoveryCfg(),
+		testConnectorService{
+			source.ID:      source,
+			destination.ID: destination,
+			testDLQID:      dlq,
+		},
+		testProcessorService{},
+		testConnectorPluginService{
+			source.Plugin:      sourceDispenser,
+			destination.Plugin: destDispenser,
+			dlq.Plugin:         dlqDispenser,
+		},
+		rec,
+		false,
+	)
+
+	err = ls.Start(ctx, pl.ID)
+	is.NoErr(err)
+
+	<-received // record in flight at the destination, processingLock held
+
+	stopErr := make(chan error, 1)
+	go func() { stopErr <- ls.Stop(ctx, pl.ID, false) }()
+
+	// Race-free: wait for intentionalStop to be set (exactly what runPipeline's
+	// cleanup goroutine checks) before releasing the batch, so Stop then drives
+	// into the failing source teardown.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		rp, ok := ls.runningPipelines.Get(pl.ID)
+		if ok && rp.intentionalStop.Load() {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for intentionalStop to be set")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	close(release) // batch unwinds cleanly; Stop proceeds to tear down the source
+
+	// Stop returns the source-teardown error — the whole point of Path B: Stop
+	// errored, yet the worker armed its stop flag, so intentionalStop must NOT
+	// be rolled back.
+	err = <-stopErr
+	is.True(err != nil)
+	is.True(cerrors.Is(err, teardownErr))
+
+	// Core assertion: finalizes UserStopped, never Recovering. (WaitPipeline's
+	// own return races the cleanup delete — see the sibling test's note — so the
+	// persisted status is the reliable signal.)
+	_ = ls.WaitPipeline(pl.ID)
+	waitForStatus(t, pl, pipeline.StatusUserStopped)
+
+	for _, s := range rec.snapshot() {
+		if s == pipeline.StatusRecovering {
+			t.Fatalf("pipeline entered StatusRecovering - a Stop that errored on source teardown (with the stop flag armed) was auto-recovered instead of being treated as an intentional stop (statuses: %v)", rec.snapshot())
+		}
+	}
+	// ctrl.Finish() verifies both dispensers were called exactly once — no
+	// recovery restart redispensed either connector.
+}
+
 // statusRecorder wraps a PipelineService, recording every UpdateStatus target
 // status in order so a test can assert the transition sequence. UpdateStatus is
 // called from multiple goroutines (the initial run and the cleanup/recovery

--- a/pkg/lifecycle-poc/stop_and_wait_test.go
+++ b/pkg/lifecycle-poc/stop_and_wait_test.go
@@ -17,55 +17,293 @@ package lifecycle
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/conduitio/conduit-commons/database"
+	"github.com/conduitio/conduit-commons/database/inmemory"
+	"github.com/conduitio/conduit/pkg/connector"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
+	lifecyclev1 "github.com/conduitio/conduit/pkg/lifecycle"
+	"github.com/conduitio/conduit/pkg/pipeline"
+	pmock "github.com/conduitio/conduit/pkg/plugin/connector/mock"
 	"github.com/google/uuid"
 	"github.com/matryer/is"
 	"github.com/rs/zerolog"
+	"go.uber.org/mock/gomock"
 )
 
-// TestServiceLifecycle_StopAndWait_Unsupported is the parity guard regression
-// test called out in
-// docs/design-documents/20260708-live-server-deploy-apply.md's "Open parity
-// item": this (Preview.PipelineArchV2 / "funnel") lifecycle implementation's
-// Stop/drain semantics have not been audited the way pkg/lifecycle's were for
-// the Tier-1 live-apply review, so StopAndWait must always refuse rather than
-// silently building provisioning.Service.ApplyPlanLive's stop-drain-restart
-// on top of an unaudited stop path. This pins that refusal — and its stable
-// error code — so a future change can't accidentally make it a silent no-op
-// or delegate to Stop.
-func TestServiceLifecycle_StopAndWait_Unsupported(t *testing.T) {
-	is := is.New(t)
-
-	logger := log.New(zerolog.Nop())
-	ls := NewService(logger, testErrRecoveryCfg(), testConnectorService{}, testProcessorService{}, testConnectorPluginService{}, testPipelineService{}, true)
-
-	err := ls.StopAndWait(context.Background(), uuid.NewString())
-	is.True(err != nil)
-
-	ce, ok := conduiterr.Get(err)
-	is.True(ok)
-	is.Equal(ce.Code.Reason(), CodeStopAndWaitUnsupported.Reason())
-	is.True(ce.Suggestion != "")
+// delayingDB wraps a database.DB and adds a fixed delay before every
+// NewTransaction call completes, simulating a slow store. See the identical
+// helper in pkg/lifecycle/stop_and_wait_test.go for the full rationale: it
+// makes "StopAndWait returned before the flush committed" a hard,
+// always-reproducing failure instead of an occasional flake.
+type delayingDB struct {
+	database.DB
+	delay time.Duration
 }
 
-// TestServiceLifecycle_ReconfigureProcessor_Unsupported pins the same parity
-// refusal for the live in-place hot-reload path (PR1 of §4): this preview
-// lifecycle service must refuse ReconfigureProcessor with the same stable code
-// rather than silently no-op, so provisioning.applyInPlace never runs an
-// in-place swap against the unaudited arch.
-func TestServiceLifecycle_ReconfigureProcessor_Unsupported(t *testing.T) {
-	is := is.New(t)
+func (d *delayingDB) NewTransaction(ctx context.Context, update bool) (database.Transaction, context.Context, error) {
+	time.Sleep(d.delay)
+	return d.DB.NewTransaction(ctx, update)
+}
 
+// TestServiceLifecycle_StopAndWait_DrainsAndPersists is the arch-v2 port of
+// pkg/lifecycle's identical-named test: proves StopAndWait blocks until BOTH
+// the drain (WaitPipeline) AND the resulting position write are durably
+// flushed (WaitPersisted), not just the first. See the design doc's §3.1
+// funnel drain audit for why this package's Stop/WaitPipeline/Persister
+// interaction gives the same guarantee pkg/lifecycle's does.
+func TestServiceLifecycle_StopAndWait_DrainsAndPersists(t *testing.T) {
+	is := is.New(t)
+	ctx, killAll := context.WithCancel(context.Background())
+	defer killAll()
+	logger := log.Test(t)
+
+	const flushDelay = 200 * time.Millisecond
+	db := &delayingDB{DB: &inmemory.DB{}, delay: flushDelay}
+	persister := connector.NewPersister(logger, db, time.Hour, 10000)
+	defer persister.Wait()
+
+	ps := pipeline.NewService(logger, db)
+	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
+	is.NoErr(err)
+
+	ctrl := gomock.NewController(t)
+	wantRecords := generateRecords(5)
+	source, srcDispenser := generatorSource(ctrl, persister, wantRecords, nil, false)
+	destination, destDispenser := asserterDestination(ctrl, persister, wantRecords, false)
+	dlq, dlqDispenser := asserterDestination(ctrl, persister, nil, false)
+	pl.DLQ.Plugin = dlq.Plugin
+
+	pl, err = ps.AddConnector(ctx, pl.ID, source.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, destination.ID)
+	is.NoErr(err)
+
+	ls := NewService(
+		logger,
+		testErrRecoveryCfg(),
+		testConnectorServiceWithPersister{
+			testConnectorService: testConnectorService{
+				source.ID:      source,
+				destination.ID: destination,
+				testDLQID:      dlq,
+			},
+			persister: persister,
+		},
+		testProcessorService{},
+		testConnectorPluginService{
+			source.Plugin:      srcDispenser,
+			destination.Plugin: destDispenser,
+			dlq.Plugin:         dlqDispenser,
+		},
+		ps,
+		false,
+	)
+
+	err = ls.Start(ctx, pl.ID)
+	is.NoErr(err)
+
+	// Let all 5 records flow end to end before stopping.
+	waitForRecordsAcked(t, source, wantRecords)
+
+	start := time.Now()
+	err = ls.StopAndWait(ctx, pl.ID)
+	is.NoErr(err)
+	elapsed := time.Since(start)
+
+	// StopAndWait must have actually blocked until the delayed flush
+	// committed, not returned as soon as the drain finished.
+	is.True(elapsed >= flushDelay)
+
+	is.Equal(pipeline.StatusUserStopped, pl.GetStatus())
+
+	// The durability assertion: read the source's position directly from the
+	// store, immediately after StopAndWait returns with no intervening sleep.
+	store := connector.NewStore(db, logger)
+	got, err := store.Get(ctx, source.ID)
+	is.NoErr(err)
+	wantState := connector.SourceState{Position: wantRecords[len(wantRecords)-1].Position}
+	is.Equal(got.State, wantState)
+}
+
+// TestServiceLifecycle_StopAndWait_NotRunning confirms StopAndWait propagates
+// Stop's error (rather than e.g. blocking forever) when the pipeline isn't
+// running — the same precondition Stop itself enforces. Mirrors
+// pkg/lifecycle's identical test.
+func TestServiceLifecycle_StopAndWait_NotRunning(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
 	logger := log.New(zerolog.Nop())
-	ls := NewService(logger, testErrRecoveryCfg(), testConnectorService{}, testProcessorService{}, testConnectorPluginService{}, testPipelineService{}, true)
+
+	ls := NewService(
+		logger,
+		testErrRecoveryCfg(),
+		testConnectorService{},
+		testProcessorService{},
+		testConnectorPluginService{},
+		testPipelineService{},
+		false,
+	)
+
+	err := ls.StopAndWait(ctx, uuid.NewString())
+	is.True(err != nil)
+	is.True(cerrors.Is(err, pipeline.ErrPipelineNotRunning)) // sentinel still in the chain
+}
+
+// TestServiceLifecycle_StopAndWait_Timeout is the O2 regression test
+// (docs/design-documents/20260731-archv2-drain-reconfigure.md, "O2: bounding
+// the drain"): a destination that never returns from the ack round-trip for
+// its one in-flight batch holds funnel.Worker's processingLock forever, which
+// would hang Stop (and thus StopAndWait) indefinitely without an explicit
+// bound. A tight caller-supplied ctx deadline (shorter than
+// DefaultStopAndWaitTimeout) proves the bound actually fires: StopAndWait
+// returns promptly with a CodeStopAndWaitTimeout error, and — critically —
+// nothing was force-killed: the pipeline is left exactly StatusRunning, still
+// genuinely working through the (still wedged, from this call's point of
+// view) batch, never torn down mid-write.
+//
+// The test then releases the wedge (unrelated to the O2 bound itself, just
+// test cleanup) so the batch's now-real transient error unwinds the pipeline
+// to a terminal state and every mocked Teardown expectation is satisfied
+// before the test returns.
+func TestServiceLifecycle_StopAndWait_Timeout(t *testing.T) {
+	is := is.New(t)
+	ctx, killAll := context.WithCancel(context.Background())
+	defer killAll()
+	logger := log.New(zerolog.Nop())
+	db := &inmemory.DB{}
+	persister := connector.NewPersister(logger, db, time.Second, 3)
+	defer persister.Wait()
+
+	ps := pipeline.NewService(logger, db)
+	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
+	is.NoErr(err)
+
+	wantRecords := generateRecords(1)
+
+	ctrl := gomock.NewController(t)
+	sourcePlugin := pmock.NewConfigurableSourcePlugin(ctrl,
+		pmock.SourcePluginWithConfigure(),
+		pmock.SourcePluginWithOpen(),
+		pmock.SourcePluginWithRun(),
+		pmock.SourcePluginWithRecords(wantRecords, nil),
+		pmock.SourcePluginWithAcks(0, false), // never acked - the wedge means the batch never completes
+		pmock.SourcePluginWithTeardown(),
+	)
+	source := dummySource(persister)
+	sourceDispenser := pmock.NewDispenser(ctrl)
+	sourceDispenser.EXPECT().DispenseSource().Return(sourcePlugin, nil).Times(1)
+
+	received := make(chan struct{})
+	release := make(chan struct{})
+	wedgeErr := cerrors.New("simulated wedged destination write")
+	destPlugin := pmock.NewConfigurableDestinationPlugin(ctrl,
+		pmock.DestinationPluginWithConfigure(),
+		pmock.DestinationPluginWithOpen(),
+		pmock.DestinationPluginWithRun(),
+		pmock.DestinationPluginWithControlledError(wantRecords, received, release, wedgeErr),
+		pmock.DestinationPluginWithTeardown(),
+	)
+	destination := dummyDestination(persister)
+	destDispenser := pmock.NewDispenser(ctrl)
+	destDispenser.EXPECT().DispenseDestination().Return(destPlugin, nil).Times(1)
+
+	dlq, dlqDispenser := asserterDestination(ctrl, persister, nil, false)
+	pl.DLQ.Plugin = dlq.Plugin
+
+	pl, err = ps.AddConnector(ctx, pl.ID, source.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, destination.ID)
+	is.NoErr(err)
+
+	// MaxRetries=0: once the wedge is released below and the batch's now-real
+	// transient error surfaces, recovery must exhaust on the very first
+	// attempt (fatal, degrade) rather than redispensing the source/destination
+	// a second time — keeping the Times(1) expectations above valid.
+	cfg := testErrRecoveryCfg()
+	cfg.MaxRetries = 0
+
+	ls := NewService(
+		logger,
+		cfg,
+		testConnectorService{
+			source.ID:      source,
+			destination.ID: destination,
+			testDLQID:      dlq,
+		},
+		testProcessorService{},
+		testConnectorPluginService{
+			source.Plugin:      sourceDispenser,
+			destination.Plugin: destDispenser,
+			dlq.Plugin:         dlqDispenser,
+		},
+		ps,
+		false,
+	)
+
+	err = ls.Start(ctx, pl.ID)
+	is.NoErr(err)
+
+	<-received // the record is in flight at the destination, processingLock held indefinitely
+
+	stopCtx, stopCancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer stopCancel()
+
+	start := time.Now()
+	err = ls.StopAndWait(stopCtx, pl.ID)
+	elapsed := time.Since(start)
+
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code.Reason(), CodeStopAndWaitTimeout.Reason())
+	is.True(ce.Suggestion != "")
+	// Bounded: returned promptly, not after actually waiting out the wedge.
+	is.True(elapsed < 5*time.Second)
+
+	// The core O2 assertion: nothing was force-killed. The pipeline is left
+	// exactly as it was — still genuinely running the (from this call's view,
+	// still wedged) batch — never torn down mid-write.
+	is.Equal(pipeline.StatusRunning, pl.GetStatus())
+
+	// Cleanup (unrelated to the O2 assertion): release the wedge so the batch
+	// unwinds with a real transient error, which — since Stop's own attempt
+	// above failed via ctx timeout, never actually setting the worker's stop
+	// flag — is treated as an ordinary (not intentional-stop) failure and
+	// exhausts recovery immediately (MaxRetries=0), degrading the pipeline.
+	// This lets every mocked Teardown expectation resolve before the test
+	// returns, instead of leaking a goroutine wedged forever.
+	close(release)
+	is.True(ls.WaitPipeline(pl.ID) != nil)
+	is.Equal(pipeline.StatusDegraded, pl.GetStatus())
+}
+
+// TestServiceLifecycle_ReconfigureProcessor_FallsBackToRestart is the O1
+// regression test: under Preview.PipelineArchV2, ReconfigureProcessor has no
+// live in-place swap capability at all (unlike pkg/lifecycle), so it must
+// always return the shared lifecyclev1.ErrProcessorNotLiveReconfigurable
+// sentinel — the exact error provisioning.applyInPlace matches via cerrors.Is
+// to fall back to the StopAndWait restart path. Reusing the same sentinel
+// (rather than a v2-specific one) is what lets applyInPlace stay
+// arch-agnostic; this test pins that the reuse actually holds.
+func TestServiceLifecycle_ReconfigureProcessor_FallsBackToRestart(t *testing.T) {
+	is := is.New(t)
+	logger := log.New(zerolog.Nop())
+
+	ls := NewService(
+		logger,
+		testErrRecoveryCfg(),
+		testConnectorService{},
+		testProcessorService{},
+		testConnectorPluginService{},
+		testPipelineService{},
+		false,
+	)
 
 	err := ls.ReconfigureProcessor(context.Background(), uuid.NewString(), uuid.NewString())
 	is.True(err != nil)
-
-	ce, ok := conduiterr.Get(err)
-	is.True(ok)
-	is.Equal(ce.Code.Reason(), CodeStopAndWaitUnsupported.Reason())
-	is.True(ce.Suggestion != "")
+	is.True(cerrors.Is(err, lifecyclev1.ErrProcessorNotLiveReconfigurable))
 }

--- a/pkg/plugin/connector/mock/destination.go
+++ b/pkg/plugin/connector/mock/destination.go
@@ -206,6 +206,63 @@ func DestinationPluginWithControlledError(records []opencdc.Record, received cha
 	})
 }
 
+// DestinationPluginWithControlledBlock is the clean-release sibling of
+// DestinationPluginWithControlledError: it holds the batch "in flight" (and thus
+// holds funnel.Worker's processingLock) — signaling on received once it has the
+// records and blocking on release — then acks them SUCCESSFULLY and returns nil,
+// rather than surfacing an error. Used to deterministically sequence a
+// concurrent Stop against a still-in-flight-but-healthy batch (e.g. so the
+// drain-terminating error can come from a DIFFERENT source, like a failing
+// source Teardown, without the destination itself erroring — see
+// pkg/lifecycle-poc.TestServiceLifecycle_Stop_SourceTeardownFails_NoRecovery).
+func DestinationPluginWithControlledBlock(records []opencdc.Record, received chan<- struct{}, release <-chan struct{}) ConfigurableDestinationPluginOption {
+	return configurableDestinationPluginOptionFunc(func(p *ConfigurableDestinationPlugin) {
+		is := is.New(p.ctrl.T.(*testing.T))
+
+		p.onRun = append(p.onRun, func() error {
+			serverStream := p.Stream.Server()
+
+			offset := 0
+			for offset < len(records) {
+				req, err := serverStream.Recv()
+				if err != nil {
+					if cerrors.Is(err, context.Canceled) || cerrors.Is(err, io.EOF) {
+						return nil // stopped/torn down before we finished receiving
+					}
+					return cerrors.Errorf("destination mock recv stream error: %w", err)
+				}
+				acks := make([]pconnector.DestinationRunResponseAck, len(req.Records))
+				for i, got := range req.Records {
+					if offset >= len(records) {
+						return cerrors.Errorf("destination mock received more records than expected")
+					}
+					is.Equal(got, records[offset])
+					acks[i] = pconnector.DestinationRunResponseAck{Position: got.Position}
+					offset++
+				}
+
+				close(received)
+				<-release // hold the batch in flight (processingLock held) until released
+
+				if err := serverStream.Send(pconnector.DestinationRunResponse{Acks: acks}); err != nil {
+					return cerrors.Errorf("destination mock send ack error: %w", err)
+				}
+			}
+
+			// Drain any further recv until the stream is stopped/torn down.
+			for {
+				_, err := serverStream.Recv()
+				if err != nil {
+					if cerrors.Is(err, context.Canceled) || cerrors.Is(err, io.EOF) {
+						return nil
+					}
+					return cerrors.Errorf("destination mock recv stream error: %w", err)
+				}
+			}
+		})
+	})
+}
+
 func DestinationPluginWithStop(lastPosition opencdc.Position) ConfigurableDestinationPluginOption {
 	return configurableDestinationPluginOptionFunc(func(p *ConfigurableDestinationPlugin) {
 		is := is.New(p.ctrl.T.(*testing.T))

--- a/pkg/plugin/connector/mock/destination.go
+++ b/pkg/plugin/connector/mock/destination.go
@@ -152,6 +152,60 @@ func DestinationPluginWithRecords(records []opencdc.Record) ConfigurableDestinat
 	})
 }
 
+// DestinationPluginWithControlledError builds a destination plugin that
+// receives exactly len(records) records (asserting they match, like
+// DestinationPluginWithRecords), signals received once every record has been
+// received (but NOT yet acked), then blocks until release is closed, and
+// finally returns wantErr instead of ever sending an ack response.
+//
+// This exists for deterministically testing the "operator Stop races a
+// transient drain error" class of scenario (see
+// pkg/lifecycle-poc.TestServiceLifecycle_Stop_TransientErrorMidDrain_NoRecovery):
+// unlike DestinationPluginWithRecords (which always acks successfully and
+// offers no hook to control exactly when a failure surfaces relative to a
+// concurrent Stop call), this lets a test hold the batch "in flight" (and
+// thus hold funnel.Worker's processingLock) until it has confirmed some other
+// condition (e.g. that Stop has already been invoked), only then releasing
+// the failure. wantErr must be non-nil (a nil wantErr would leave the stream
+// open forever with no further sends, which is a "block forever" behavior a
+// caller should get via a different, dedicated helper instead of overloading
+// this one with two meanings for the zero value).
+func DestinationPluginWithControlledError(records []opencdc.Record, received chan<- struct{}, release <-chan struct{}, wantErr error) ConfigurableDestinationPluginOption {
+	return configurableDestinationPluginOptionFunc(func(p *ConfigurableDestinationPlugin) {
+		t := p.ctrl.T.(*testing.T)
+		is := is.New(t)
+		if wantErr == nil {
+			t.Fatalf("DestinationPluginWithControlledError: wantErr must be non-nil")
+		}
+
+		p.onRun = append(p.onRun, func() error {
+			serverStream := p.Stream.Server()
+
+			offset := 0
+			for offset < len(records) {
+				req, err := serverStream.Recv()
+				if err != nil {
+					if cerrors.Is(err, context.Canceled) || cerrors.Is(err, io.EOF) {
+						return nil // stopped/torn down before the controlled error ever fired
+					}
+					return cerrors.Errorf("destination mock recv stream error: %w", err)
+				}
+				for _, got := range req.Records {
+					if offset >= len(records) {
+						return cerrors.Errorf("destination mock received more records than expected")
+					}
+					is.Equal(got, records[offset])
+					offset++
+				}
+			}
+
+			close(received)
+			<-release
+			return wantErr
+		})
+	})
+}
+
 func DestinationPluginWithStop(lastPosition opencdc.Position) ConfigurableDestinationPluginOption {
 	return configurableDestinationPluginOptionFunc(func(p *ConfigurableDestinationPlugin) {
 		is := is.New(p.ctrl.T.(*testing.T))

--- a/pkg/plugin/connector/mock/source.go
+++ b/pkg/plugin/connector/mock/source.go
@@ -185,3 +185,18 @@ func SourcePluginWithTeardown() ConfigurableSourcePluginOption {
 			Return(pconnector.SourceTeardownResponse{}, nil)
 	})
 }
+
+// SourcePluginWithTeardownError makes every Teardown call fail with err. Used to
+// exercise the funnel.Worker.Stop path where the stop flag is armed
+// (w.stop.Store(true)) BEFORE tearDownSource runs and then teardown fails — a
+// wedged/dead source — so Stop returns an error while the worker is genuinely
+// stopping (Stopping() == true). AnyTimes because both Worker.Stop and the
+// subsequent Worker.Close retry the teardown.
+func SourcePluginWithTeardownError(err error) ConfigurableSourcePluginOption {
+	return configurableSourcePluginOptionFunc(func(p *ConfigurableSourcePlugin) {
+		p.EXPECT().
+			Teardown(gomock.Any(), gomock.Any()).
+			Return(pconnector.SourceTeardownResponse{}, err).
+			AnyTimes()
+	})
+}

--- a/pkg/provisioning/apply_plan_live_archv2_test.go
+++ b/pkg/provisioning/apply_plan_live_archv2_test.go
@@ -1,0 +1,155 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioning
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/database/inmemory"
+	"github.com/conduitio/conduit/pkg/connector"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	lifecyclev1 "github.com/conduitio/conduit/pkg/lifecycle"
+	lifecyclev2 "github.com/conduitio/conduit/pkg/lifecycle-poc"
+	"github.com/conduitio/conduit/pkg/pipeline"
+	connectorPlugin "github.com/conduitio/conduit/pkg/plugin/connector"
+	"github.com/conduitio/conduit/pkg/processor"
+	"github.com/conduitio/conduit/pkg/provisioning/mock"
+	"github.com/matryer/is"
+	"go.uber.org/mock/gomock"
+)
+
+// The noopV2* types below satisfy lifecycle-poc (arch-v2)'s own small
+// PipelineService/ConnectorService/ProcessorService/ConnectorPluginService
+// interfaces, so TestApplyPlanLive_ArchV2_ProcessorUpdate_FallsBackToRestart
+// can construct a REAL *lifecyclev2.Service (not a mock standing in for it).
+// None of their methods are ever invoked by that test: ReconfigureProcessor
+// (O1) returns its sentinel unconditionally without touching any dependency,
+// and the StopAndWait fallback's Stop call fails fast on "pipeline not
+// running" (the pipeline was never Started against this real v2 service)
+// before reaching any of them either.
+type noopV2PipelineService struct{}
+
+func (noopV2PipelineService) Get(context.Context, string) (*pipeline.Instance, error) {
+	return nil, pipeline.ErrInstanceNotFound
+}
+
+func (noopV2PipelineService) List(context.Context) map[string]*pipeline.Instance { return nil }
+
+func (noopV2PipelineService) UpdateStatus(context.Context, string, pipeline.Status, string) error {
+	return nil
+}
+
+type noopV2ConnectorService struct{}
+
+func (noopV2ConnectorService) Get(context.Context, string) (*connector.Instance, error) {
+	return nil, connector.ErrInstanceNotFound
+}
+
+func (noopV2ConnectorService) Create(context.Context, string, connector.Type, string, string, connector.Config, connector.ProvisionType) (*connector.Instance, error) {
+	return nil, cerrors.New("noopV2ConnectorService: not implemented")
+}
+
+func (noopV2ConnectorService) WaitPersisted() {}
+
+type noopV2ProcessorService struct{}
+
+func (noopV2ProcessorService) Get(context.Context, string) (*processor.Instance, error) {
+	return nil, processor.ErrInstanceNotFound
+}
+
+func (noopV2ProcessorService) MakeRunnableProcessor(context.Context, *processor.Instance) (*processor.RunnableProcessor, error) {
+	return nil, cerrors.New("noopV2ProcessorService: not implemented")
+}
+
+type noopV2ConnectorPluginService struct{}
+
+func (noopV2ConnectorPluginService) NewDispenser(log.CtxLogger, string, string) (connectorPlugin.Dispenser, error) {
+	return nil, cerrors.New("noopV2ConnectorPluginService: not implemented")
+}
+
+// TestApplyPlanLive_ArchV2_ProcessorUpdate_FallsBackToRestart is the O1
+// integration proof (docs/design-documents/20260731-archv2-drain-reconfigure.md):
+// unlike every other ApplyPlanLive test in this package, this one wires a REAL
+// *lifecycle-poc.Service (Preview.PipelineArchV2's implementation) as
+// applyInPlace's lifecycleService, instead of a mock standing in for it. The
+// same processorUpdateFixture that applies genuinely in place under
+// pkg/lifecycle (TestApplyPlanLive_ProcessorUpdate_AppliesInPlace_NoRestart)
+// must, under arch-v2, fall through to the StopAndWait restart path: v2's
+// ReconfigureProcessor has no live-swap capability at all and unconditionally
+// returns the shared lifecyclev1.ErrProcessorNotLiveReconfigurable sentinel,
+// which applyInPlace's existing cerrors.Is match (plan.go) already handles
+// without any arch-v2-specific branch — this test pins that the real
+// production wiring actually takes that path, not just the mock-level
+// contract.
+//
+// The pipeline was never Started against this real v2 service, so the
+// fallback's StopAndWait call fails fast with a
+// pipeline.ErrPipelineNotRunning-coded error — that error surfacing (rather
+// than a nil, AppliedMode=in_place success) is exactly what proves the
+// fallback branch ran instead of a live swap.
+func TestApplyPlanLive_ArchV2_ProcessorUpdate_FallsBackToRestart(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	v2Service := lifecyclev2.NewService(
+		log.Nop(),
+		&lifecyclev1.ErrRecoveryCfg{
+			MinDelay:         time.Millisecond,
+			MaxDelay:         time.Millisecond,
+			BackoffFactor:    2,
+			MaxRetries:       0,
+			MaxRetriesWindow: time.Minute,
+		},
+		noopV2ConnectorService{},
+		noopV2ProcessorService{},
+		noopV2ConnectorPluginService{},
+		noopV2PipelineService{},
+		true,
+	)
+
+	db := &inmemory.DB{}
+	pipSrv := mock.NewPipelineService(ctrl)
+	connSrv := mock.NewConnectorService(ctrl)
+	procSrv := mock.NewProcessorService(ctrl)
+	connPlugSrv := mock.NewConnectorPluginService(ctrl)
+	srv := NewService(db, log.Nop(), pipSrv, connSrv, procSrv, connPlugSrv, v2Service, "")
+
+	old, desired := processorUpdateFixture()
+	expectExportRunning(pipSrv, connSrv, procSrv, old)
+
+	// applyInPlace commits the new processor config to the store BEFORE
+	// attempting the (here, always-refused) live swap - same expectation
+	// TestApplyPlanLive_ProcessorUpdate_AppliesInPlace_NoRestart sets for the
+	// mock-backed happy path.
+	procSrv.EXPECT().UpdateWhileRunning(gomock.Any(), "p1:proc:1", "builtin:field.set", gomock.Any()).
+		Return(&processor.Instance{ID: "p1:proc:1"}, nil)
+
+	diff, err := srv.Plan(ctx, desired)
+	is.NoErr(err)
+	is.True(diff.LiveEligible()) // sanity: a processor-only update is live-eligible
+
+	_, err = srv.ApplyPlanLive(ctx, desired, diff.Hash, true) // authorized
+	is.True(err != nil)
+
+	// The restart-fallback branch called the real v2 StopAndWait, which
+	// refused because no pipeline is registered as running under this ID in
+	// that service - the sentinel proving the fallback branch (not an
+	// in-place success) is what actually ran.
+	is.True(cerrors.Is(err, pipeline.ErrPipelineNotRunning))
+}

--- a/pkg/provisioning/apply_plan_live_test.go
+++ b/pkg/provisioning/apply_plan_live_test.go
@@ -471,13 +471,14 @@ func TestApplyPlanLive_RestartOnRunning_GateSkippedWhenNotRunning(t *testing.T) 
 
 // TestApplyPlanLive_StopAndWaitFails_NoMutation proves ApplyPlanLive never
 // attempts to mutate the pipeline's stored config if StopAndWait itself
-// fails. This is also the generic mechanism behind the lifecycle-poc parity
-// guard (pkg/lifecycle-poc.Service.StopAndWait always returns
-// CodeStopAndWaitUnsupported): ApplyPlanLive needs no poc-specific branch —
-// whatever error StopAndWait returns, for whatever reason, is surfaced here
-// and nothing downstream runs. No Create/Update/Delete/Start expectation is
-// set on any mock, so gomock fails the test if apply attempts anything beyond
-// StopAndWait itself.
+// fails, whatever the reason — e.g. a pkg/lifecycle-poc.Service.StopAndWait
+// call that hits its O2 drain-timeout bound (CodeStopAndWaitTimeout, see
+// docs/design-documents/20260731-archv2-drain-reconfigure.md) is exactly one
+// instance of this generic contract: ApplyPlanLive needs no arch-specific
+// branch — whatever error StopAndWait returns, for whatever reason, is
+// surfaced here and nothing downstream runs. No Create/Update/Delete/Start
+// expectation is set on any mock, so gomock fails the test if apply attempts
+// anything beyond StopAndWait itself.
 func TestApplyPlanLive_StopAndWaitFails_NoMutation(t *testing.T) {
 	is := is.New(t)
 	ctx := context.Background()
@@ -487,7 +488,7 @@ func TestApplyPlanLive_StopAndWaitFails_NoMutation(t *testing.T) {
 	old, desired := settingsUpdateFixture()
 	expectExportRunning(pipSrv, connSrv, procSrv, old)
 
-	wantErr := conduiterr.New(CodePlanStale, "stand-in for lifecycle_v2.CodeStopAndWaitUnsupported")
+	wantErr := conduiterr.New(CodePlanStale, "stand-in for a StopAndWait failure (e.g. lifecycle_v2.CodeStopAndWaitTimeout)")
 	lifecycleSrv.EXPECT().StopAndWait(gomock.Any(), "p1").Return(wantErr)
 
 	diff, err := srv.Plan(ctx, desired)

--- a/tests/chaos/archv2_drain_test.go
+++ b/tests/chaos/archv2_drain_test.go
@@ -1,0 +1,360 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chaos
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/connector"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/foundation/metrics/noop"
+	"github.com/conduitio/conduit/pkg/lifecycle-poc/funnel"
+	"github.com/matryer/is"
+)
+
+// This file is arch-v2's drain-safety chaos coverage
+// (docs/design-documents/20260731-archv2-drain-reconfigure.md, AC-1/AC-3/AC-6).
+// Unlike sigkill_test.go/sigterm_test.go, it needs no cross-process re-exec:
+// it drives the exact same in-process funnel.Worker + real *connector.Source
+// path Property 4 (property4_test.go) already established for transport-half
+// correctness, reused here for the drain-under-load and O2-bound properties
+// instead. TestArchV2_LiveApplyDrain_UnderLoad_NoGap is AC-1/AC-3: every
+// pre-stop-acked record is durable and the final position is checkpointed,
+// with continuous load in flight when Stop is called — a "live apply while
+// records are still arriving" scenario, not just a quiescent pipeline.
+// TestArchV2_LiveApplyDrain_StuckDestination_O2Bound is AC-6: a wedged
+// destination makes Worker.Stop hang without a bound (see
+// pkg/lifecycle-poc.Service.StopAndWait's O2 fix), and this test proves the
+// same ctx-deadline mechanism that fix relies on actually bounds Worker.Stop
+// itself, with no force-kill and no gap.
+
+// blockingDestination is a synthetic funnel.Destination whose Ack blocks on a
+// channel until released, standing in for a wedged/stuck real destination
+// (a hung connection, a stalled disk) exactly the way chaosPlugin
+// (upstream.go) stands in for a real source plugin. Write always succeeds
+// (buffers immediately, matching DestinationTask.Do's Write-then-poll-Ack
+// contract); Ack blocks on release before returning the accumulated acks —
+// so a batch that reached this destination holds funnel.Worker's
+// processingLock for as long as release stays open.
+type blockingDestination struct {
+	id      string
+	release <-chan struct{}
+
+	mu        sync.Mutex
+	delivered []opencdc.Position
+	pending   []connector.DestinationAck
+}
+
+func (d *blockingDestination) ID() string                     { return d.id }
+func (d *blockingDestination) Open(context.Context) error     { return nil }
+func (d *blockingDestination) Teardown(context.Context) error { return nil }
+func (d *blockingDestination) Errors() <-chan error           { return make(chan error) }
+
+func (d *blockingDestination) Write(_ context.Context, recs []opencdc.Record) error {
+	d.mu.Lock()
+	for _, r := range recs {
+		d.delivered = append(d.delivered, r.Position)
+		d.pending = append(d.pending, connector.DestinationAck{Position: r.Position})
+	}
+	d.mu.Unlock()
+	return nil
+}
+
+func (d *blockingDestination) Ack(ctx context.Context) ([]connector.DestinationAck, error) {
+	select {
+	case <-d.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	acks := d.pending
+	d.pending = nil
+	return acks, nil
+}
+
+func (d *blockingDestination) deliveredCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.delivered)
+}
+
+// buildDrainWorker stands up a real *connector.Source (buildChild, identical
+// construction to every other scenario in this suite) wrapped in a real
+// funnel.Worker with a plain, no-DLQ-window destination — the minimal shape
+// needed to exercise Worker.Stop's drain (processingLock + Source.Teardown),
+// the exact primitive lifecycle-poc.Service.StopAndWait composes on top of.
+func buildDrainWorker(t *testing.T, cfg childEnv, dest funnel.Destination) (*childBuilt, *funnel.Worker) {
+	t.Helper()
+	is := is.New(t)
+
+	built, err := buildChild(context.Background(), cfg)
+	is.NoErr(err)
+
+	logger := log.Test(t)
+	srcTask := funnel.NewSourceTask("chaos-drain-source", built.src, logger, funnel.NoOpConnectorMetrics{})
+	destTask := funnel.NewDestinationTask("chaos-drain-dest", dest, logger, funnel.NoOpConnectorMetrics{})
+	destNode := &funnel.TaskNode{Task: destTask}
+	srcNode := &funnel.TaskNode{Task: srcTask, Next: []*funnel.TaskNode{destNode}}
+
+	dlqDest := &synthDestination{id: "chaos-drain-dlq"}
+	dlq := funnel.NewDLQ("chaos-drain-dlq", dlqDest, logger, funnel.NoOpConnectorMetrics{}, 0, 0)
+
+	worker, err := funnel.NewWorker(srcNode, dlq, logger, noop.Timer{})
+	is.NoErr(err)
+	is.NoErr(worker.Open(context.Background())) // opens SourceTask, which opens built.src internally
+
+	return built, worker
+}
+
+// persistedPosition reads Conduit's own durably-persisted resume position
+// directly from the store, mirroring property4_test.go's identical helper.
+// Unlike that helper, this one also tolerates the connector never having been
+// persisted to the store at all yet (store.Get returns a raw "key does not
+// exist" error, not a decodable Instance with a zero State) - the case before
+// the very first flush - reporting position 0 for it, same as an Instance
+// that exists but has no SourceState set.
+func drainPersistedPosition(t *testing.T, built *childBuilt) uint64 {
+	t.Helper()
+	is := is.New(t)
+	instance, err := built.store.Get(context.Background(), instanceID)
+	if err != nil {
+		return 0 // not persisted yet at all
+	}
+	state, ok := instance.State.(connector.SourceState)
+	if !ok {
+		return 0
+	}
+	pos, err := decodePosition(state.Position)
+	is.NoErr(err)
+	return pos
+}
+
+// waitUpstreamCommitted polls until the upstream's committed watermark equals
+// want, or fails after timeout. Necessary (not just belt-and-suspenders):
+// Worker.Close/Source.Teardown returning only guarantees Conduit's own
+// deferred ack was SENT to the plugin (Approach A/A2's own contract) — it
+// says nothing about how long the plugin's own receive-and-commit loop takes
+// to actually process that message, which runs in its own goroutine.
+// Mirrors property4_test.go's identical-purpose helper and its doc comment on
+// exactly this async-ack-landing race.
+func waitUpstreamCommitted(t *testing.T, built *childBuilt, want uint64, timeout time.Duration) {
+	t.Helper()
+	is := is.New(t)
+	deadline := time.Now().Add(timeout)
+	var last uint64
+	for time.Now().Before(deadline) {
+		committed, err := built.upstream.Committed()
+		is.NoErr(err)
+		last = committed
+		if committed == want {
+			return
+		}
+		if committed > want {
+			t.Fatalf("upstream committed watermark advanced to %d, past the expected %d - a not-yet-durable record was acked upstream (invariant 1)", committed, want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for upstream committed watermark to reach %d (last observed %d)", want, last)
+}
+
+// waitPersistedPosition polls Conduit's own durably-persisted resume
+// position until it equals want, for the same async-landing reason as
+// waitUpstreamCommitted.
+func waitPersistedPosition(t *testing.T, built *childBuilt, want uint64, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last uint64
+	for time.Now().Before(deadline) {
+		last = drainPersistedPosition(t, built)
+		if last == want {
+			return
+		}
+		if last > want {
+			t.Fatalf("persisted resume position advanced to %d, past the expected %d (invariant 1)", last, want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for persisted resume position to reach %d (last observed %d)", want, last)
+}
+
+// TestArchV2_LiveApplyDrain_UnderLoad_NoGap is AC-1/AC-3: a live-apply-under-load
+// drain (Worker.Stop called while the source is still actively producing and
+// delivering records, exactly what provisioning.Service.ApplyPlanLive's
+// StopAndWait triggers against a running pipeline) must deliver every
+// pre-stop-acked record durably downstream, with the final position
+// checkpointed — and, per the funnel drain audit's point 2 (design doc §3.1),
+// never a gap: the delivered/committed/persisted positions must all be
+// contiguous from 1 through whatever was last acked, with nothing skipped.
+func TestArchV2_LiveApplyDrain_UnderLoad_NoGap(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+
+	cfg := childEnv{
+		dbDir:       dir + "/db",
+		upstreamDir: dir + "/upstream",
+		prune:       false,
+		paceMS:      2, // steady load - Stop must race genuinely in-flight production
+		total:       0, // unbounded: this run terminates via Stop, not by reaching a count
+	}
+
+	mainDest := &synthDestination{id: "chaos-drain-main"}
+	built, worker := buildDrainWorker(t, cfg, mainDest)
+
+	doErr := make(chan error, 1)
+	go func() { doErr <- worker.Do(context.Background()) }()
+
+	// Let a healthy amount of load flow through before stopping - this is the
+	// "under load" condition: Stop below races genuinely ongoing production,
+	// not a quiescent pipeline.
+	const minDelivered = 25
+	deadline := time.Now().Add(30 * time.Second)
+	for mainDest.deliveredCount() < minDelivered {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d records delivered (got %d)", minDelivered, mainDest.deliveredCount())
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	is.NoErr(worker.Stop(context.Background()))
+
+	select {
+	case err := <-doErr:
+		is.NoErr(err) // graceful: Stop must not surface an error under normal (non-wedged) drain
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for worker.Do to return after Stop")
+	}
+	is.NoErr(worker.Close(context.Background()))
+
+	lastDelivered := mainDest.deliveredCount()
+	if lastDelivered < minDelivered {
+		t.Fatalf("delivered count decreased across Stop (%d -> %d) - impossible, harness bug", minDelivered, lastDelivered)
+	}
+
+	// No-gap assertion: every position from 1..lastDelivered was delivered,
+	// with nothing skipped (invariant 3) and nothing delivered twice on this
+	// single, uninterrupted run (invariant 4 - ordering).
+	for pos := uint64(1); pos <= uint64(lastDelivered); pos++ {
+		if !mainDest.hasPosition(encodePosition(pos)) {
+			t.Fatalf("gap detected: position %d was never delivered to the destination (delivered count=%d)", pos, lastDelivered)
+		}
+	}
+
+	// Durability: the upstream's committed watermark and Conduit's own
+	// persisted resume position must both (eventually - see
+	// waitUpstreamCommitted's doc on why this is a poll, not an immediate
+	// read) agree with the last delivered position exactly - Worker.Stop's
+	// drain (processingLock quiescence + Source.Teardown's forced flush)
+	// must have made it durable, not left it in memory only.
+	waitUpstreamCommitted(t, built, uint64(lastDelivered), 10*time.Second)
+	waitPersistedPosition(t, built, uint64(lastDelivered), 10*time.Second)
+}
+
+// TestArchV2_LiveApplyDrain_StuckDestination_O2Bound is AC-6: the same
+// wedged-destination scenario pkg/lifecycle-poc.Service.StopAndWait's O2 fix
+// bounds (see the design doc's "O2: bounding the drain"), exercised directly
+// at the funnel.Worker level — the primitive StopAndWait composes on top of.
+// A batch reaches the destination and is held there (processingLock stays
+// held); Worker.Stop, called with a short ctx deadline, must return promptly
+// (ctx.DeadlineExceeded, not hang forever), and — critically — nothing must
+// be force-killed or lost: the wedged record must never be acked upstream nor
+// have its position advanced. Releasing the wedge afterward lets the batch
+// complete normally, proving the worker was left fully functional, not torn
+// down, by the bounded timeout.
+func TestArchV2_LiveApplyDrain_StuckDestination_O2Bound(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+
+	cfg := childEnv{
+		dbDir:       dir + "/db",
+		upstreamDir: dir + "/upstream",
+		prune:       false,
+		paceMS:      0,
+		total:       1, // exactly one record - it will reach the destination and wedge there
+	}
+
+	release := make(chan struct{})
+	dest := &blockingDestination{id: "chaos-drain-stuck", release: release}
+	built, worker := buildDrainWorker(t, cfg, dest)
+
+	doErr := make(chan error, 1)
+	go func() { doErr <- worker.Do(context.Background()) }()
+
+	// Wait for the record to reach the destination (Write called) - it is now
+	// wedged in Ack, holding processingLock.
+	deadline := time.Now().Add(10 * time.Second)
+	for dest.deliveredCount() < 1 {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for the record to reach the stuck destination")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// The O2 bound: a short ctx deadline must make Stop return promptly
+	// instead of hanging on the wedged batch forever.
+	stopCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := worker.Stop(stopCtx)
+	elapsed := time.Since(start)
+
+	is.True(err != nil)
+	is.Equal(err, context.DeadlineExceeded)
+	is.True(elapsed < 5*time.Second) // bounded, did not hang
+
+	// No-gap / no-force-kill assertion: nothing was acked upstream and no
+	// position was persisted - the wedge means the batch never completed, so
+	// this record remains exactly as "not yet durably handled" as it was
+	// before Stop was ever called (invariant 1).
+	committed, cErr := built.upstream.Committed()
+	is.NoErr(cErr)
+	is.Equal(committed, uint64(0))
+	is.Equal(drainPersistedPosition(t, built), uint64(0))
+
+	// Cleanup: release the wedge so the batch completes normally, proving the
+	// worker was left fully functional (not torn down) by the timeout. The
+	// earlier Stop call never actually set the worker's internal stop flag
+	// (it timed out before reaching that point - the same reasoning
+	// stopRunnablePipeline's intentionalStop rollback in
+	// pkg/lifecycle-poc/service.go relies on), so the batch, once it
+	// completes, would otherwise have the worker try to read a next batch
+	// from a source that has nothing more to offer; issue a real
+	// (unbounded) graceful Stop now that the wedge is clear to bring it down
+	// cleanly instead.
+	close(release)
+
+	is.NoErr(worker.Stop(context.Background()))
+
+	select {
+	case err := <-doErr:
+		is.NoErr(err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for worker.Do to return after releasing the wedge")
+	}
+	is.NoErr(worker.Close(context.Background()))
+
+	// Once released, the single record completes normally: delivered,
+	// acked, and (eventually — the plugin's own receive-and-commit loop
+	// runs asynchronously relative to Worker.Close returning, see
+	// waitUpstreamCommitted's doc) durable both upstream and in Conduit's
+	// own store.
+	waitUpstreamCommitted(t, built, 1, 10*time.Second)
+	waitPersistedPosition(t, built, 1, 10*time.Second)
+}

--- a/tests/chaos/recovery_child.go
+++ b/tests/chaos/recovery_child.go
@@ -585,6 +585,12 @@ func (s lcConnectorService) Create(context.Context, string, connector.Type, stri
 	return s.dlq, nil
 }
 
+// WaitPersisted satisfies the ConnectorService interface (widened for arch-v2
+// StopAndWait's durability barrier). This crash scenario never calls StopAndWait
+// — it SIGKILLs the process — so there is nothing to wait on; the real
+// persister's durability is what the test asserts against post-restart.
+func (s lcConnectorService) WaitPersisted() {}
+
 // lcProcessorService fulfills pkg/lifecycle-poc.ProcessorService. This
 // scenario's pipeline has no processors (pl.ProcessorIDs is always empty), so
 // neither method is ever actually invoked - present only to satisfy the


### PR DESCRIPTION
## What

Plan 02 of the arch-v2 graduation epic: **drain-safe live reconfigure** for the arch-v2
(funnel) lifecycle. Replaces the two hard `CodeStopAndWaitUnsupported` refusals
(`StopAndWait`, `ReconfigureProcessor`) with a real, bounded, drain-then-durable-flush
implementation, so `provisioning.ApplyPlanLive` (HTTP apply + `--dev` hot-reload) works
under `Preview.PipelineArchV2` via graceful drain-and-restart.

Roadmap: v0.20 / Phase 2 arch-v2 graduation. Closes the "Open parity item" the refusal
doc-comment tracked. Design doc: `docs/design-documents/20260731-archv2-drain-reconfigure.md`.

## Risk tier: **Tier 1 (data path — drain/ack/position on live reconfigure)**

Preview-gated (`Preview.PipelineArchV2`, off by default) → nil production blast radius.

### Open questions resolved (in-impl, proven)
- **O1** — `ReconfigureProcessor` returns the v1 `ErrProcessorNotLiveReconfigurable` sentinel (arch-v2 has no in-place hot-swap), so `applyInPlace` falls back to restart with no arch-v2 branch. Proven with a real (non-mocked) v2 service test.
- **O2** — `StopAndWait` bounds the whole `Stop → WaitPipeline → WaitPersisted` by `DefaultStopAndWaitTimeout` (30s) or a tighter caller ctx deadline. On timeout: coded `CodeStopAndWaitTimeout`, **force-kills nothing** — degrades to the same benign-duplicate-on-restart contract `Source.Teardown` already guarantees, never a gap.
- **O3 (the race the recovery port created)** — a deliberate `Stop(force=false)` that hits a transient error mid-drain would auto-restart the pipeline the operator just stopped. Fixed with a per-run `intentionalStop atomic.Bool`, set before `Worker.Stop`, checked in `runPipeline`'s cleanup switch (after `isGracefulShutdown`, before recovery `default`) → finalize `UserStopped`. **Rolled back if `Stop` errors** (worker stop flag never set → pipeline still running → a later unrelated transient error must stay recovery-eligible).
- **O4** — DLQ shares the connector `Persister`, so `WaitPersisted` already covers it. Audited, no gap.

## Failure-mode analysis

| Failure | Behavior | Guarantee |
| --- | --- | --- |
| Clean drain | tomb `ErrStillAlive` → UserStopped | inv 1/3 (processingLock quiescence + Teardown flush) |
| Transient error mid-drain | `intentionalStop` → UserStopped, no recovery | inv 3/7 (O3) |
| Wedged destination | O2 bound → `CodeStopAndWaitTimeout`, no force-kill | benign duplicate on restart, never a gap |
| Read-but-unprocessed batch at stop | thrown away un-acked → re-read on restart | benign duplicate, never a gap |
| `kill -9` mid-drain | existing SIGKILL chaos suite | no gap |

The funnel drain audit (design doc §3.1) establishes `processingLock` gives the same "no batch mid-flight at teardown" guarantee v1 gets from its msg tracker. **No data-loss gap found.**

## Known follow-up (flagged, not hidden)
`DefaultStopAndWaitTimeout` is a process-wide constant, not yet per-pipeline configurable — design doc Consequences. `waitBounded` does not cancel the wrapped `WaitPipeline`/`WaitPersisted` goroutine on timeout (mirrors `Persister.WaitPendingWritesContext`) — at most one leaked goroutine per genuinely-wedged-destination timeout, documented.

## Tests
- `TestServiceLifecycle_Stop_TransientErrorMidDrain_NoRecovery` (O3 crux) — **fails without the fix** (infinite restart loop under `InfiniteRetriesErrRecovery`), passes with it, `-race -count=20`.
- `TestApplyPlanLive_ArchV2_ProcessorUpdate_FallsBackToRestart` — real v2 service, restart fall-through.
- `StopAndWait` ordering / not-running / never-force-stops unit tests.
- Chaos: `TestArchV2_LiveApplyDrain_UnderLoad_NoGap` (AC-1/AC-3), `TestArchV2_LiveApplyDrain_StuckDestination_O2Bound` (AC-6) — `-race -count=10`.

## Guard removal
`CodeStopAndWaitUnsupported` deleted (no other references); `CodeStopAndWaitTimeout` registered; `llms-full.txt` regenerated via `make generate` (single-line diff, CI-pinned tools, no stray `_string.go`/mock churn).

## Adversarial self-review
- Verified the `intentionalStop` arm sits between `isGracefulShutdown` and recovery `default`, and that force-stop still routes to the fatal arm (unchanged).
- Verified O2 timeout tears down nothing → "safe to retry" claim holds; a drain-phase timeout still finalizes UserStopped when the wedged write eventually returns.
- Re-ran full build + race suites + O3 fail-without + chaos + lint from clean `origin/main` (a mid-run accidental `git checkout` of `service.go` was caught and the diff reconstructed + re-verified byte-for-diffstat).
