### PR TITLE
feat(lifecycle-poc): M-destination fan-out with per-record ack accounting (3a)

### DIFF
--- a/cmd/conduit/root/run/run_test.go
+++ b/cmd/conduit/root/run/run_test.go
@@ -55,7 +55,7 @@ func TestRunCommandFlags(t *testing.T) {
 		{longName: "pipelines.error-recovery.max-retries-window", usage: "amount of time running without any errors after which a pipeline is considered healthy"},
 		{longName: "schema-registry.type", usage: "schema registry type; accepts builtin,confluent"},
 		{longName: "schema-registry.confluent.connection-string", usage: "confluent schema registry connection string"},
-		{longName: "preview.pipeline-arch-v2", usage: "enables experimental pipeline architecture v2 (note that the new architecture currently supports only 1 source and 1 destination per pipeline)"},
+		{longName: "preview.pipeline-arch-v2", usage: "enables experimental pipeline architecture v2 (note that the new architecture currently supports only 1 source, but multiple destinations, per pipeline)"},
 		{longName: "preview.pipeline-arch-v2-disable-metrics", usage: "disables metrics about amount of data (in bytes) moved in pipeline architecture v2 (increases performance)"},
 		{longName: "dev.cpuprofile", usage: "write CPU profile to file"},
 		{longName: "dev.memprofile", usage: "write memory profile to file"},

--- a/docs/architecture-decision-records/20260731-archv2-fanout-ack-model.md
+++ b/docs/architecture-decision-records/20260731-archv2-fanout-ack-model.md
@@ -1,0 +1,126 @@
+# arch-v2 destination fan-out: per-record ack tally, not per-batch
+
+## Summary
+
+For `funnel.Worker`'s M-destination fan-out (slice 3a of the arch-v2 multi-connector epic),
+`multiAckNacker` tracks ack/nack votes **per original source position**, acks the source only once
+**every** destination branch has acked a position (unanimity), routes a position to the DLQ exactly
+once the instant **any** branch nacks it (nack wins), and releases resolved positions to the source
+strictly in ascending source order. A per-batch counter — the shape the pre-existing (disabled) sketch
+code implied — is rejected as a data-loss bug: destinations diverge per record, not per batch, and a
+batch-level counter cannot represent that divergence at all.
+
+## Context
+
+`pkg/lifecycle-poc/funnel/worker.go` had a `multiAckNacker` type since the funnel architecture's
+introduction (#1913), but it was never completed: `Ack`/`Nack` both `panic("not implemented")`, and it
+was constructed as `newMultiAckNacker(parent, count)` — a single `*atomic.Int32` counter, decremented
+once per branch's call, intended to fire the parent action once it reached zero. The `doNextTask`
+caller that would have used it was itself disabled (`"multiple next tasks not supported yet"`).
+
+Bringing this online for slice 3a required deciding how to represent "M destinations, each
+independently voting ack or nack, for a batch of N records" — the counter's granularity (per batch,
+per record, or something else) determines whether the implementation can even express the scenarios
+a real fan-out produces.
+
+## Decision
+
+Track ack/nack state **per original source position**, not per batch. `multiAckNacker` holds parallel
+slices (indexed by position, captured once at fan-out time from `b.originalBatch()`): an ack-vote
+count, a terminal flag, and — for a nack — which branch's record/error/task-ID to use. `Ack`/`Nack`
+each update every position in the batch they're handed (after collapsing splits back to root positions
+via `originalBatch()`), then attempt to release a leading, contiguous run of now-terminal positions to
+the parent, in source order.
+
+Unanimity (ack) and nack-wins are enforced directly by this per-position structure: a position is
+`acked[i]` only when its vote count reaches the branch count; it is `nacked` immediately on the first
+nack vote, and a later vote (of either kind) for an already-terminal position is a no-op.
+
+## Alternatives considered
+
+### A per-batch counter (the pre-existing sketch's implied shape)
+
+A single counter per batch, decremented once per branch's `Ack`/`Nack` call, firing the parent action
+once it reaches zero (mirroring `stream.FanoutNode`'s v1 per-**message** counter, but applied at
+batch — not record — granularity, since arch-v2 batches many records per call).
+
+**Rejected — this is a data-loss bug, not a simplification.** Destination 1 might ack records 0-4 of a
+5-record batch while destination 2 nacks record 3. There is no single moment where "the batch" is
+uniformly ack'd or nack'd. A per-batch counter has no way to represent record 3 being nacked while
+records 0, 1, 2, and 4 are acked: it either drops the divergence (silently acking a record that a
+destination never durably wrote — violating invariant 1) or blocks forever (waiting for a nack vote on
+a record every branch actually acked, since the count never reaches the value a uniform outcome would
+need). This is not a hypothetical edge case — any batch containing more than one record and more than
+one destination can diverge this way, and arch-v2's whole point is large batches (its committed
+benchmark, `20260704-pipeline-architecture-v2.md`, uses 1000-record batches).
+
+### Port v1's channel/async-handler model (`stream.FanoutNode` + `stream.SourceAckerNode`)
+
+v1 (`pkg/lifecycle/stream`) already solves this correctly, at **per-message** granularity:
+`FanoutNode.Run` tracks `remainingAcks` per message (an `atomic.Int32` per in-flight message, not per
+batch), and each cloned message's ack/nack handler decrements it, propagating the original message's
+ack only once every fan-out branch has acked its clone (or propagating a nack the instant one branch
+nacks). Ordering to the source is separately enforced by `SourceAckerNode`'s semaphore
+(`pkg/lifecycle/stream/source_acker.go`), which serializes forwarding to `Source.Ack` in strict
+enqueue order regardless of which message's ack handler fires first.
+
+**Rejected for arch-v2 specifically** (not rejected as a design in general — it is the correct
+reference model, and this ADR's per-position tally is a batch-shaped adaptation of the same idea, not
+a departure from it): v1's model is built around one goroutine-and-channel per in-flight **message**,
+which is exactly the per-record overhead arch-v2 exists to eliminate — the committed benchmark
+(~6.3× fewer allocations, ~3.3× less memory per record, `20260704-pipeline-architecture-v2.md`)
+depends on batches moving through the pipeline as single objects with shared bookkeeping, not as N
+independently-scheduled messages each carrying their own ack-handler closures. Porting v1's model
+verbatim — a semaphore-and-channel entry per record — would reintroduce the per-record overhead
+arch-v2's adoption ADR was written to move away from. `multiAckNacker`'s per-position **tally within
+one batch-shaped struct**, updated under one mutex per fan-out call rather than one goroutine/channel
+per record, gets the identical unanimity/nack-wins/ordering guarantees while keeping the batch as the
+unit of work.
+
+### Lock-free / atomic per-position tally
+
+Considered and rejected on simplicity grounds, not correctness grounds: a mutex-guarded tally is easy
+to state, easy to review, and easy to prove correct by inspection (the entire critical section — tally
+update plus release attempt — is one function, `releaseLocked`, called under one lock). This is
+Tier-1, highest-data-loss-risk code; CLAUDE.md's own review criterion applies directly ("if a reviewer
+can't explain the approach back in two sentences, it's too clever"). Given the contention window is
+one mutex acquisition per branch-vote (not per record within a large batch — each branch calls
+`Ack`/`Nack` once per contiguous sub-batch, not once per record), the throughput cost of the lock is
+expected to be negligible relative to the underlying destination I/O it's coordinating; revisit only
+if profiling ever shows otherwise.
+
+## Consequences
+
+- **Correctness first, coalescing where it's free.** Acks are coalesced into contiguous runs before
+  reaching the parent (preserving the parent's own batch-call semantics and keeping `Source.Ack` call
+  volume low); nacks are released one position at a time, because a run of nacked positions can
+  legitimately span different branches/task-IDs and `parent.Nack` takes one task ID per call (used for
+  DLQ metadata) — coalescing would misattribute the failure reason. This asymmetry is deliberate: nacks
+  are the rare/exceptional path, so the extra parent calls there are an acceptable tradeoff for
+  attribution correctness.
+- **No new durable state.** `multiAckNacker` is entirely in-memory, rebuilt fresh from the replayed
+  batch on every restart — see the companion design doc's crash-safety argument
+  (`20260731-archv2-multiconnector.md`). This ADR's decision has no serialization format of its own and
+  therefore no migration/upgrade-test obligation beyond what the source's existing position-persistence
+  already covers.
+- **Composition with record-splitting is load-bearing.** Because the tally is keyed by
+  `originalBatch()`-collapsed positions, not raw batch indices, a per-destination processor that splits
+  records differently on different branches still converges on one shared key. This only holds because
+  `Batch.clone()` was fixed (in the same PR) to copy `splitRecords` rather than drop it — an ADR-level
+  dependency worth naming explicitly: if `clone()` regresses to dropping that map, `multiAckNacker`'s
+  correctness claim above no longer holds for pipelines with pre-fan-out splitting.
+- **Extending to N sources is out of scope for this decision.** This ADR only covers 1 source, M
+  destinations. A future N-source slice would need its own decision about how (or whether) acks
+  compose across multiple `funnel.Worker` instances — not addressed here.
+
+## Related
+
+- Design doc: [20260731-archv2-multiconnector.md](../design-documents/20260731-archv2-multiconnector.md)
+  — the full implementation, composition with record-splitting (OQ-1), failure modes, and crash-safety
+  argument.
+- ADR: [20260704-pipeline-architecture-v2.md](20260704-pipeline-architecture-v2.md) — adopts arch-v2 as
+  the target architecture on the strength of its batching model, the same model this ADR's rejected
+  v1-port alternative would have undermined.
+- `pkg/lifecycle/stream/fanout.go`, `pkg/lifecycle/stream/source_acker.go` — v1's per-message reference
+  model this decision adapts to arch-v2's batch shape.
+- `pkg/lifecycle-poc/funnel/worker.go` — `multiAckNacker`.

--- a/docs/architecture-decision-records/20260731-archv2-fanout-ack-model.md
+++ b/docs/architecture-decision-records/20260731-archv2-fanout-ack-model.md
@@ -103,12 +103,21 @@ if profiling ever shows otherwise.
   (`20260731-archv2-multiconnector.md`). This ADR's decision has no serialization format of its own and
   therefore no migration/upgrade-test obligation beyond what the source's existing position-persistence
   already covers.
-- **Composition with record-splitting is load-bearing.** Because the tally is keyed by
-  `originalBatch()`-collapsed positions, not raw batch indices, a per-destination processor that splits
-  records differently on different branches still converges on one shared key. This only holds because
-  `Batch.clone()` was fixed (in the same PR) to copy `splitRecords` rather than drop it — an ADR-level
-  dependency worth naming explicitly: if `clone()` regresses to dropping that map, `multiAckNacker`'s
-  correctness claim above no longer holds for pipelines with pre-fan-out splitting.
+- **Composition with record-splitting is load-bearing, and holds only for uniform-flag split runs.**
+  Because the tally is keyed by `originalBatch()`-collapsed positions, not raw batch indices, a
+  per-destination processor that splits records differently on different branches still converges on
+  one shared key. This only holds because `Batch.clone()` was fixed (in the same PR) to copy
+  `splitRecords` rather than drop it — an ADR-level dependency worth naming explicitly: if `clone()`
+  regresses to dropping that map, `multiAckNacker`'s correctness claim above no longer holds for
+  pipelines with pre-fan-out splitting.
+
+  **Known gap (narrowing this claim):** convergence assumes a split run carries a _uniform_ status
+  flag. `Batch.Nack` propagates across a run, but `Retry` and `Filter` do not — so a sub-batch can
+  cover only the _head_ of a split run and vote ack for the original position before the tail has
+  been delivered. Tracked as issue #2723; the nil-tail half of that shape is already contained by
+  `validateAckPositions` (an empty position is refused rather than acked, which would otherwise
+  overwrite the durable source position), but the head case remains open. Do not read the
+  convergence claim as covering `Retry`/`Filter`-partitioned split runs.
 - **Extending to N sources is out of scope for this decision.** This ADR only covers 1 source, M
   destinations. A future N-source slice would need its own decision about how (or whether) acks
   compose across multiple `funnel.Worker` instances — not addressed here.

--- a/docs/design-documents/20260731-archv2-multiconnector.md
+++ b/docs/design-documents/20260731-archv2-multiconnector.md
@@ -1,0 +1,314 @@
+# M-destination fan-out for arch-v2 (slice 3a of the multi-connector epic)
+
+## Summary
+
+Lights up `funnel.Worker`'s destination fan-out: one source, M destinations, wired through
+`doNextTask`'s previously-disabled `default` branch and a fully-implemented `multiAckNacker`. This is
+**slice 3a** of the arch-v2 multi-connector epic — 1 source, multiple destinations. Multiple
+**sources** (N workers per pipeline) are explicitly out of scope and stay guarded off
+(`buildSourceTasks`'s existing check in `pkg/lifecycle-poc/service.go`). **Tier 1** — this is the
+highest-data-loss-risk code the multi-connector epic adds: a wrong ack here silently drops customer
+data.
+
+`multiAckNacker` replaces a per-batch ack counter (which cannot represent per-record divergence
+across destinations and is a data-loss bug — see the companion ADR,
+[20260731-archv2-fanout-ack-model.md](../architecture-decision-records/20260731-archv2-fanout-ack-model.md))
+with a per-position tally: a source record is acked to the source only once **every** destination
+branch has acked it (unanimity), and is routed to the DLQ exactly once the instant **any** branch
+nacks it (nack wins), released to the source in strict source order regardless of which branch
+finishes first.
+
+Two latent bugs in `Batch.clone()` were found and fixed while building this (they were unreachable
+before this slice, since `clone()` had no caller): a positions-slice-aliasing hazard that could
+corrupt a sibling branch's positions on concurrent splits, and a silently-dropped `splitRecords` map
+that would have broken DLQ record-content fidelity for records a shared upstream processor already
+split before the fan-out point. Neither shipped in production — this PR is what makes `clone()`
+correct for its first real caller.
+
+## Context
+
+`pkg/lifecycle-poc/funnel.Worker` processes a pipeline as a `TaskNode` linked list/tree: a source
+task, zero or more shared processor tasks, then — at a branch point — one task chain per destination.
+`TaskNode.Next` has always supported multiple children (`[]*TaskNode`), but `doNextTask`'s `default`
+case (more than one `Next`) has, since the funnel architecture's introduction (#1913), unconditionally
+returned `"multiple next tasks not supported yet"`, with a dead sketch underneath showing the intended
+shape: clone the batch per branch, run branches concurrently via a worker pool, and track acks with a
+`multiAckNacker` whose `Ack`/`Nack` both `panic("not implemented")`. `pkg/lifecycle-poc/service.go`
+mirrors this with an explicit guard: `buildDestinationTasks` refuses a pipeline with more than one
+destination connector ("pipelines with multiple destination connectors currently not supported").
+
+Two prior slices in this epic landed the surrounding machinery this slice builds on:
+
+- **Slice 01 (recovery)**: `pkg/lifecycle-poc.Service`'s error-recovery loop
+  (`recoverPipeline`/`StartWithBackoff`), so a fan-out worker that fatally errors (e.g. a DLQ
+  threshold exceeded on one branch) recovers the same way a single-destination one does.
+- **Slice 02 (drain)**: `StopAndWait`/`ReconfigureProcessor` drain semantics
+  (`20260731-archv2-drain-reconfigure.md`), establishing that `Worker.Stop`'s
+  `processingLock`-plus-source-teardown discipline gives the same quiescence guarantee this slice's
+  fan-out inherits unchanged — `doNextTask`'s pool of branch goroutines all complete (or the batch is
+  thrown away, unacked) before `Stop` returns, exactly like the single-destination path.
+
+This slice's job is narrowly: replace the `panic`/`not supported` stubs with a correct
+implementation, for exactly the M-destination (not M-source) axis.
+
+## Decision
+
+### The two fan-out axes and their composition
+
+Two independent things can multiply a single source record into several pieces, and this slice has
+to compose them correctly:
+
+1. **Destination fan-out** (this slice): one batch, cloned once per destination branch
+   (`Batch.clone()`), each branch processing its own copy concurrently.
+2. **Record splitting** (pre-existing, `Batch.SplitRecord`): a processor can split one record into
+   several (e.g. a decompression/expansion processor), tracked via `Batch.splitRecords` (a
+   position-string-keyed map back to the pre-split original) and collapsed back via
+   `Batch.originalBatch()`.
+
+These compose at the fan-out boundary: a **shared** processor (running before the branch point, e.g.
+a pipeline-level processor) can already have split a record by the time `doNextTask`'s `default` case
+runs; each **branch**'s own processors can then split (or not split, or split differently)
+independently on top of that. `multiAckNacker` must therefore be keyed by the same **root** original
+position on every branch, regardless of how each branch split further — this is `OQ-1` below.
+
+`doNextTask`'s fan-out:
+
+```go
+orig := b.originalBatch()                                    // capture root positions BEFORE cloning
+multiAcker := newMultiAckNacker(acker, len(taskNode.Next), orig.positions)
+for _, nextTask := range taskNode.Next {
+    branchBatch := b.clone()                                  // independent copy per branch
+    p.Go(func() error { return w.doTask(ctx, nextTask, branchBatch, multiAcker) })
+}
+```
+
+`multiAckNacker.Ack`/`Nack` each call `batch.originalBatch()` on the batch they're handed — exactly
+mirroring how the single-destination `Worker.Ack`/`Worker.Nack` already do it — so a branch's own
+splits are collapsed to the root position before the tally ever sees them. Since `Batch.clone()`
+(fixed by this PR — see "Batch.clone() bugs" below) carries over the pre-existing `splitRecords` map
+as an independent copy per branch, every branch's `originalBatch()` resolves the **same** root
+position, even though each branch's own subsequent splitting is independent.
+
+### `multiAckNacker` semantics
+
+`multiAckNacker` (`pkg/lifecycle-poc/funnel/worker.go`) is a mutex-guarded per-position tally —
+deliberately not lock-free or channel-based; this is Tier-1, highest-data-loss-risk code, and
+boring-and-obviously-correct beats clever. It is constructed once per fan-out invocation
+(`newMultiAckNacker(parent, branches, positions)`), where `positions` is the **original** (pre-split)
+position set captured from `b.originalBatch()` right before cloning.
+
+Per position, it tracks: how many branches have voted ack so far, whether it has reached a terminal
+decision (ack — all branches voted ack — or nack — any branch voted nack), and (for a nack) which
+branch's record/error/task-ID to use when finally routing to the DLQ.
+
+1. **Ack-only-when-unanimous** (invariant 1 enforcement site): a position is only forwarded to the
+   parent's `Ack` once every branch has voted ack for it.
+2. **Nack-wins** (invariant 3 enforcement site): the first nack vote for a position is terminal —
+   routed to the parent's `Nack` (DLQ) exactly once. A record durably written by some but not all
+   branches is a **failure of the whole record**, never a partial success; it is never acked to the
+   source as if every branch had succeeded. The DLQ write is itself the "durable handling" that earns
+   the eventual source ack (via the parent `Worker.Nack`'s own existing DLQ-then-ack logic, unchanged
+   by this slice).
+3. **Idempotent, race-free**: once a position is terminal, any further vote for it (a slow branch's
+   ack arriving after a sibling already nacked the same position) is a no-op. This relies on the
+   existing invariant that each branch votes exactly once per position (ack xor nack, never both,
+   never skipped) — the same assumption `doTask`'s tainted-batch splitting already makes for the
+   single-destination path.
+4. **In-source-order release** (invariant 4 enforcement site): positions are released to the parent
+   strictly in ascending source order — never out of branch-completion order. A branch that finishes
+   position 10 before a sibling finishes position 3 must not let position 10's ack reach the parent
+   first, or `Source.Ack`'s monotonically-advancing `State.Position` (`pkg/connector/source.go`) would
+   skip ahead of a record not actually resolved yet. Contiguous **ack** runs are coalesced into a
+   single `parent.Ack` call (preserving the parent's batch semantics and Source.Ack call volume);
+   **nacks** are released one position at a time, since `parent.Nack` takes one task ID for the whole
+   batch it's given (used for DLQ metadata) and a run of nacked positions can legitimately come from
+   different branches/tasks — coalescing them would misattribute the DLQ failure reason. Nacks are
+   the rare/exceptional path, so the extra parent calls are an acceptable tradeoff for that
+   correctness.
+5. **Fatal DLQ error propagation**: if the parent's `Nack` returns a fatal error (DLQ nack-threshold
+   exceeded, `funnel.DLQ.Nack`), `multiAckNacker` returns it unchanged, so the branch pool
+   (`pool.New().WithErrors()`) errors out and the worker tombs — identical to the single-destination
+   path's behavior.
+
+### `Batch.clone()` bugs found and fixed
+
+`clone()` had no caller before this slice (the only production call site was the dead sketch code in
+`doNextTask`). Making it a real caller surfaced two bugs:
+
+**(a) Positions-slice aliasing.** `clone()` shared `b.positions` by reference across every branch —
+same slice header, same length **and capacity** as the original. `Batch.SplitRecord` grows
+`b.positions` via `append(b.positions[:i+1], newElems...)`, and Go's `append` reuses spare backing-
+array capacity whenever it exists (slicing to a shorter length does not reduce capacity). A batch
+fresh out of `NewBatch` always has `cap == len` (no headroom), so a single split on it always
+reallocates regardless of this bug — but confirmed empirically, splitting once already gives the
+result spare capacity (`cap=10, len=7` from a 5-record batch split into one 3-piece group). So the
+reachable failure mode is: a **shared** processor splits a record before the fan-out point (giving the
+shared batch spare capacity), the batch is then cloned into M branches (still sharing that same
+backing array, uncapped), and two branches independently call `SplitRecord` concurrently — one
+branch's `append` can silently overwrite the other's still-live positions in the shared array, a data
+race whose blast radius is a corrupted position reaching `Source.Ack` (invariant 2). Fixed via
+`slices.Clip(b.positions)` in `clone()`: zero-cost (no reallocation at clone time, since it's a
+3-index reslice), but forces the _first_ subsequent `SplitRecord` call on either branch to allocate a
+fresh backing array, leaving every sibling's slice header untouched. See
+`TestBatch_Clone_PositionsAliasing` (verified to fail without the fix, both a serial reproduction and
+a concurrent one run under `-race`).
+
+**(b) Dropped `splitRecords`.** `clone()` returned a `nil` `splitRecords` map unconditionally, silently
+losing the ability to restore a record's true pre-split content via `originalBatch()` once cloned —
+relevant whenever a shared processor split a record before the fan-out point. This wasn't a
+position/ack-accounting bug (Source.Ack only cares about positions, which stayed intact even with
+`splitRecords` dropped), but it would have corrupted DLQ record **content** fidelity (a nacked record
+whose DLQ entry contains a post-split fragment instead of the true original). Fixed by having `clone()`
+copy the map (not share the reference — two branches calling `SplitRecord` concurrently on a _shared_
+map is a fatal, unrecoverable `concurrent map write` crash, not just a benign race; the stored
+`opencdc.Record` values themselves are read-only after being stored, so a shallow copy — reusing the
+same `Record` values across branches — is safe). See `TestBatch_Clone_PreservesSplitRecords`.
+
+Both bugs were latent in a feature that was fully disabled until this PR (the sketch code always hit
+the `panic`/error stub first), so nothing shipped was ever exposed to them — but they would have been
+the first thing a multi-destination pipeline with a splitting processor hit had this slice shipped
+`clone()` unchanged.
+
+### `doNextTask` wiring
+
+```go
+default:
+    orig := b.originalBatch()
+    multiAcker := newMultiAckNacker(acker, len(taskNode.Next), orig.positions)
+    p := pool.New().WithErrors()
+    for _, nextTask := range taskNode.Next {
+        branchBatch := b.clone()
+        p.Go(func() error { return w.doTask(ctx, nextTask, branchBatch, multiAcker) })
+    }
+    return p.Wait()
+```
+
+Each branch runs `doTask` exactly as the single-destination path does, with `multiAcker` standing in
+for the `Worker` itself as the `ackNacker` the branch's tasks (ultimately `Worker.Ack`/`Worker.Nack`
+via `multiAcker`'s own `Ack`/`Nack`) call into.
+
+### Service wiring (`pkg/lifecycle-poc/service.go`)
+
+- `buildDestinationTasks`'s "more than one destination" guard is removed; it now builds one task
+  branch per destination connector, same as it always built one per source (still capped at one
+  source — see below).
+- `buildTaskNodes` now attaches all M destination branches to the shared prefix's tail in a single
+  `AppendToEnd(destBranches...)` call, instead of assuming exactly one. For M=1 this is byte-for-byte
+  the previous behavior.
+- The multi-**source** guard in `buildSourceTasks` ("pipelines with multiple source connectors
+  currently not supported") is untouched and stays enforced — `runnablePipeline` remains single-worker
+  in this slice.
+- `Preview.PipelineArchV2`'s flag usage text (`pkg/conduit/config.go`) is updated from "supports only
+  1 source and 1 destination" to "supports only 1 source, but multiple destinations" — an interim
+  description, since multi-source is a later slice. `docs/architecture-decision-records/
+  20260704-pipeline-architecture-v2.md` quotes the **old** text verbatim as historical context; per
+  this repo's ADR-immutability convention that file is not edited — the flag's live behavior is
+  documented by `config.go`'s own usage string and this doc, not retroactively in that ADR.
+
+## Consequences
+
+- Pipelines can now fan out to multiple destinations under `Preview.PipelineArchV2`, with the same
+  at-least-once, no-silent-partial-ack guarantee the single-destination path has always had.
+- The nack path is intentionally less throughput-optimized than the ack path (one `parent.Nack` call
+  per nacked position, vs. coalesced runs for acks) — acceptable because nacks are the rare/exceptional
+  case; revisit only if profiling ever shows DLQ-heavy workloads bottlenecked here.
+- `Batch.clone()` is now used in production for the first time; the two bugs fixed here mean any
+  _future_ caller of `clone()` (e.g. a later fan-out-like feature) inherits a correct implementation
+  rather than rediscovering the same aliasing/dropped-map hazards.
+- No serialized-state format changes: `multiAckNacker` is entirely in-memory, rebuilt fresh on every
+  restart from the source's own replayed batch — see "Crash-safety argument" below. No migration, no
+  upgrade test needed for this slice specifically (beyond the existing single-destination coverage,
+  which is unaffected).
+- Metrics: `ConnectorMetrics.Observe` is called once per destination branch (each `DestinationTask`
+  independently), so per-destination byte/record counters are already correct without change; no new
+  aggregate "fan-out" metric is added in this slice.
+
+## Failure modes
+
+- **One destination slow, others fast**: unanimity means the source position does not advance past
+  a record any branch hasn't yet acked, regardless of how far ahead a faster sibling gets. Covered by
+  `TestDoNextTask_FanOut_SlowDestination_SourceDoesNotAdvancePastWithheld` (AC-3).
+- **One destination nacks, others ack**: nack wins — the record is DLQ'd once (using the nacking
+  branch's own error/task-ID), and the source is still acked for it once the DLQ write succeeds
+  (existing single-destination `Worker.Nack` behavior, unchanged). The other branch's already-written
+  copy is a harmless partial write, not a leak. Covered by
+  `TestDoNextTask_FanOut_PartialNack_RoutesToDLQ_NotSourceLoss` and the `multiAckNacker` unit suite.
+- **DLQ nack-threshold exceeded on one branch**: the fatal error propagates out of the branch pool
+  exactly like the single-destination path — the worker tombs, `pkg/lifecycle-poc.Service`'s existing
+  recovery loop (slice 01) takes over. Covered by `TestMultiAckNacker_FatalDLQError_Propagates`.
+- **Differential per-destination splitting** (OQ-1): a processor on branch A splits a record into
+  pieces that branch B never splits at all. Both branches must still collapse to the _same_ root
+  position via `originalBatch`, or `multiAckNacker`'s tally would silently diverge per-branch and
+  either double-count or lose a vote. Resolved — see "OQ-1" below.
+- **Crash mid-fan-out** (SIGKILL, a subset of destinations durably wrote a record before it was
+  unanimously acked): see "Crash-safety argument" below and `tests/chaos/fanout_child.go`'s SIGKILL
+  scenario.
+- **Positions-slice aliasing under concurrent splits** (found during this slice, not a live bug — see
+  "`Batch.clone()` bugs" above): fixed and regression-tested
+  (`TestBatch_Clone_PositionsAliasing`, run under `-race`).
+- **Malformed task graph** (a branch somehow produces a record whose position doesn't trace back to
+  one of the positions captured at fan-out time — an internal bug, not a runtime condition):
+  `multiAckNacker.Ack`/`Nack` return a `(bug)`-prefixed error rather than panicking or silently
+  dropping the vote. Covered by `TestMultiAckNacker_UnknownPosition_ReturnsBugError`.
+
+## Crash-safety argument (edge (e))
+
+`multiAckNacker` holds no durable state of its own — no serialized format, no on-disk representation,
+nothing written to the connector store. It exists only as an in-memory struct for the lifetime of one
+`doNextTask` fan-out call (one batch). If the process is killed at any point during a fan-out:
+
+- Any position `multiAckNacker` had already released to the parent (`Worker.Ack`/`Worker.Nack`) is
+  handled exactly as the single-destination path already handles a crash after ack — durable per
+  `pkg/connector.Source.Ack`'s own invariant-1 persist-before-plugin-ack ordering (unchanged by this
+  slice).
+- Any position `multiAckNacker` had NOT yet released (still tallying votes, or waiting for a slower
+  branch) is, from the source's perspective, simply never acked — its position never advanced past it.
+  On restart, the source re-reads and re-delivers that record (and everything after it) from its own
+  last durably persisted position, exactly as it would for any other in-flight, unacked batch.
+- A record that was durably written to a **subset** of the M destinations before the crash (the
+  precise scenario `multiAckNacker` exists to get right) may be **re-delivered and re-written** to
+  that same destination on restart — a duplicate, which every destination in this architecture is
+  already expected to tolerate under at-least-once (the same tolerance the single-destination path has
+  always required). It is never silently skipped on the destinations that hadn't gotten it yet, because
+  the source never advanced past it in the first place.
+
+There is therefore no migration path to design and no upgrade test to add for this slice specifically:
+`multiAckNacker`'s entire state is rebuilt from scratch, from the replayed batch, on every restart.
+`tests/chaos/fanout_child.go`'s `TestSIGKILL_MidFanout_GaplessResume` proves this directly: SIGKILL a
+child process mid-fan-out (one destination deliberately slower than the other, so a kill reliably lands
+with a record durably in destination A's ledger but not yet in B's), then restart against the same
+on-disk state and assert every position `1..total` reaches **both** destinations' durable ledgers —
+duplicates allowed, gaps forbidden (run `-race -count=10`, non-flaky).
+
+## Open questions resolved
+
+**OQ-1 (highest composition risk): does differential per-destination splitting collapse to the same
+original position on both sides?** Yes — resolved by construction (see "Composition" above:
+`multiAckNacker`'s positions are captured from `b.originalBatch()` before cloning, and each branch's
+own `Ack`/`Nack` calls `batch.originalBatch()` again on its own, independently-split batch, which
+resolves back to the same root position via the per-branch-copied `splitRecords` map). Verified by
+`TestFanOut_OQ1_DifferentialSplitCollapsesToSameOriginalPosition`: 200 random iterations (deterministic
+seed, logged on failure — see the test's own doc comment on why this repo uses a seeded pseudo-random
+driver rather than a new `pgregory.net/rapid`/`gopter` dependency, matching the precedent already set by
+`builder_roundtrip_test.go`) over 2-3 branches, 3-8 records, random per-branch splits and at most one
+nack per branch, asserting every original position is acked exactly once — never twice, never zero
+times — regardless of how differently each branch split it.
+
+**OQ-5: does anything external depend on the destination-branch structure?** N/A for slice 3a — the
+DLQ remains singular and unchanged (one `funnel.DLQ` shared across all branches, exactly as it was for
+the single-destination path); no external format or API exposes per-branch structure in this slice.
+
+## Related
+
+- ADR: [20260731-archv2-fanout-ack-model.md](../architecture-decision-records/20260731-archv2-fanout-ack-model.md)
+  — the decision to use per-record ack counting with unanimity/nack-wins/in-order-release, and the
+  rejected alternatives.
+- ADR: [20260704-pipeline-architecture-v2.md](../architecture-decision-records/20260704-pipeline-architecture-v2.md)
+  — adopts arch-v2 as the target architecture; this slice closes part of the "incomplete" gap it named.
+- Design doc: [20260731-archv2-drain-reconfigure.md](20260731-archv2-drain-reconfigure.md) — slice 02
+  (drain), whose `Stop`/quiescence guarantee this slice's fan-out pool inherits unchanged.
+- `pkg/lifecycle-poc/funnel/worker.go` — `multiAckNacker`, `doNextTask`.
+- `pkg/lifecycle-poc/funnel/batch.go` — `Batch.clone()`, `Batch.originalBatch()`.
+- `pkg/lifecycle-poc/service.go` — `buildTaskNodes`, `buildDestinationTasks`.
+- `tests/chaos/fanout_child.go`, `tests/chaos/fanout_sigkill_test.go` — the SIGKILL-mid-fan-out chaos
+  scenario.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -614,7 +614,7 @@ Author: Meroxa, Inc.
 | `sdk.schema.extract.key.enabled` | bool | true | no | Whether to extract and decode the record key with a schema. |  |
 | `sdk.schema.extract.payload.enabled` | bool | true | no | Whether to extract and decode the record payload with a schema. |  |
 
-## 3. Error codes (88)
+## 3. Error codes (89)
 
 | Reason | gRPC status | Description |
 | --- | --- | --- |
@@ -641,6 +641,7 @@ Author: Meroxa, Inc.
 | `orchestrator.invalid_processor_parent_type` | InvalidArgument | CodeInvalidProcessorParentType is raised when a processor's parent is neither a pipeline nor a connector. |
 | `orchestrator.pipeline_has_connectors_attached` | FailedPrecondition | CodePipelineHasConnectorsAttached is raised when a pipeline cannot be deleted because it still has connectors attached. |
 | `orchestrator.pipeline_has_processors_attached` | FailedPrecondition | CodePipelineHasProcessorsAttached is raised when a pipeline cannot be deleted because it still has processors attached. |
+| `pipeline.duplicate_source_position` | FailedPrecondition | pipeline: duplicate source position |
 | `pipeline.fanout_requires_arch_v2` | FailedPrecondition | pipeline: fanout requires arch v2 |
 | `pipeline.instance_not_found` | NotFound | CodePipelineNotFound is raised when a referenced pipeline instance cannot be located. |
 | `pipeline.name_already_exists` | AlreadyExists | CodePipelineNameAlreadyExists is raised when a pipeline config's name collides with an existing pipeline's name. |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -614,7 +614,7 @@ Author: Meroxa, Inc.
 | `sdk.schema.extract.key.enabled` | bool | true | no | Whether to extract and decode the record key with a schema. |  |
 | `sdk.schema.extract.payload.enabled` | bool | true | no | Whether to extract and decode the record payload with a schema. |  |
 
-## 3. Error codes (89)
+## 3. Error codes (90)
 
 | Reason | gRPC status | Description |
 | --- | --- | --- |
@@ -642,6 +642,7 @@ Author: Meroxa, Inc.
 | `orchestrator.pipeline_has_connectors_attached` | FailedPrecondition | CodePipelineHasConnectorsAttached is raised when a pipeline cannot be deleted because it still has connectors attached. |
 | `orchestrator.pipeline_has_processors_attached` | FailedPrecondition | CodePipelineHasProcessorsAttached is raised when a pipeline cannot be deleted because it still has processors attached. |
 | `pipeline.duplicate_source_position` | FailedPrecondition | pipeline: duplicate source position |
+| `pipeline.empty_source_position` | FailedPrecondition | pipeline: empty source position |
 | `pipeline.fanout_requires_arch_v2` | FailedPrecondition | pipeline: fanout requires arch v2 |
 | `pipeline.instance_not_found` | NotFound | CodePipelineNotFound is raised when a referenced pipeline instance cannot be located. |
 | `pipeline.name_already_exists` | AlreadyExists | CodePipelineNameAlreadyExists is raised when a pipeline config's name collides with an existing pipeline's name. |

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@
 (6 built-in connectors; full parameters in llms-full.txt)
 
 ## Error codes
-- 89 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
+- 90 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
 
 ## MCP tools
 - Read: deploy, doctor, dry_run, inspect, lint, repair, validate

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@
 (6 built-in connectors; full parameters in llms-full.txt)
 
 ## Error codes
-- 88 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
+- 89 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
 
 ## MCP tools
 - Read: deploy, doctor, dry_run, inspect, lint, repair, validate

--- a/pkg/conduit/config.go
+++ b/pkg/conduit/config.go
@@ -263,7 +263,7 @@ type Config struct {
 
 	Preview struct {
 		// PipelineArchV2 enables the new pipeline architecture.
-		PipelineArchV2               bool `long:"preview.pipeline-arch-v2" mapstructure:"pipeline-arch-v2" usage:"enables experimental pipeline architecture v2 (note that the new architecture currently supports only 1 source and 1 destination per pipeline)"`
+		PipelineArchV2               bool `long:"preview.pipeline-arch-v2" mapstructure:"pipeline-arch-v2" usage:"enables experimental pipeline architecture v2 (note that the new architecture currently supports only 1 source, but multiple destinations, per pipeline)"`
 		PipelineArchV2DisableMetrics bool `long:"preview.pipeline-arch-v2-disable-metrics" mapstructure:"pipeline-arch-v2-disable-metrics" usage:"disables metrics about amount of data (in bytes) moved in pipeline architecture v2 (increases performance)"`
 	}
 

--- a/pkg/lifecycle-poc/funnel/batch.go
+++ b/pkg/lifecycle-poc/funnel/batch.go
@@ -309,18 +309,70 @@ func (b *Batch) findSplitRecord(i int) (int, int) {
 	return from, to
 }
 
+// clone returns an independent copy of the batch, suitable for handing to a
+// concurrently-running destination branch in a fan-out (see
+// Worker.doNextTask's multi-destination case).
+//
+// records, recordStatuses and splitRecords are fully copied so a branch can
+// mutate them (Ack/Nack/Filter/Retry/SplitRecord) without affecting its
+// siblings or the original batch.
+//
+// positions is intentionally NOT deep-copied: the underlying opencdc.Position
+// values are shared by reference with the original batch across all branches
+// (cheap, and multiAckNacker's per-position tally relies on the exact same
+// position bytes to match votes across branches — see
+// docs/design-documents/20260731-archv2-multiconnector.md). What IS required
+// is that the shared backing ARRAY can never be mutated through one branch's
+// slice header and observed by another's.
+//
+// Before this fix, clone() shared b.positions verbatim (same len AND cap).
+// Batch.SplitRecord grows b.positions via
+// `append(b.positions[:i+1], newElems...)`, and Go's append reuses the
+// backing array whenever spare capacity exists past the slice's length —
+// which it always did here, because slicing to a shorter length does not
+// reduce capacity. Two branches created from the same clone() call therefore
+// shared one growable backing array: if branch A called SplitRecord first, it
+// could silently overwrite index i+1 (and beyond) of the SAME array that
+// branch B's still-unmodified `positions` slice header pointed to, corrupting
+// B's view of its own positions out from under it while B's goroutine was
+// concurrently reading them — a data race with a data-loss blast radius
+// (wrong positions reaching Source.Ack violates invariant 2). This was only
+// reachable once destination fan-out went live (clone() had no caller before
+// slice 3a), so nothing shipped was ever exposed to it, but it would have
+// been the first thing a multi-destination pipeline with a splitting
+// processor hit. slices.Clip caps the capacity to the length (no reallocation
+// happens here — it's a zero-cost 3-index reslice), so the FIRST subsequent
+// SplitRecord call on either branch is forced to allocate a fresh backing
+// array via append, leaving every sibling's slice header (and the original
+// batch) untouched. See TestBatch_Clone_PositionsAliasing.
 func (b *Batch) clone() *Batch {
 	records := make([]opencdc.Record, len(b.records))
 	for i, r := range b.records {
 		records[i] = r.Clone()
 	}
 
+	var splitRecords map[string]opencdc.Record
+	if len(b.splitRecords) > 0 {
+		// Copy the map (not just the reference): SplitRecord writes new
+		// entries into it, and two branches calling SplitRecord concurrently
+		// on a shared map is a concurrent map write - a fatal, unrecoverable
+		// runtime crash, not just a benign race. The stored opencdc.Record
+		// values themselves are never mutated after being stored (only read
+		// back by originalBatch), so a shallow copy - reusing the same
+		// Record values across branches - is safe.
+		splitRecords = make(map[string]opencdc.Record, len(b.splitRecords))
+		for k, v := range b.splitRecords {
+			splitRecords[k] = v
+		}
+	}
+
 	return &Batch{
 		records:        records,
 		recordStatuses: slices.Clone(b.recordStatuses),
-		positions:      b.positions,
+		positions:      slices.Clip(b.positions),
 		tainted:        b.tainted,
 		filterCount:    b.filterCount,
+		splitRecords:   splitRecords,
 	}
 }
 

--- a/pkg/lifecycle-poc/funnel/batch_test.go
+++ b/pkg/lifecycle-poc/funnel/batch_test.go
@@ -266,3 +266,128 @@ func TestBatch_Clone(t *testing.T) {
 	})
 	is.Equal(batch.splitRecords, nil)
 }
+
+// TestBatch_Clone_PositionsAliasing is the regression test for edge (j) named
+// in the arch-v2 multi-connector slice 3a plan: clone() must never let a
+// SplitRecord call on one fan-out branch corrupt a sibling branch's
+// (or the original batch's) view of its own positions.
+//
+// Before the fix, clone() shared b.positions verbatim - same length AND same
+// capacity as the original. Go's append reuses spare backing-array capacity
+// whenever it's available, and slicing to a shorter length does not reduce
+// capacity, so `append(b.positions[:i+1], newElems...)` (SplitRecord's own
+// implementation) could silently overwrite index i+1 (and beyond) of the
+// SAME backing array every branch's clone still pointed to - a data race
+// with a data-loss blast radius, since a corrupted position could reach
+// Source.Ack (invariant 2).
+//
+// The corruption needs the shared array to have SPARE capacity (cap > len)
+// to reproduce: a batch fresh out of NewBatch always has cap == len (no
+// headroom), so a single split on it always reallocates regardless of the
+// bug - it can never trigger the very first time. Go's append growth
+// strategy over-allocates once a slice DOES grow, though (confirmed
+// empirically: splitting a freshly-built 5-position batch once yields
+// cap=10, len=7), so the reachable scenario - and the one this test
+// reproduces - is a SHARED upstream processor splitting a record before the
+// destination fan-out point (giving the shared batch spare capacity), which
+// is then cloned into M branches that split further, independently, on top
+// of that same spare-capacity array.
+func TestBatch_Clone_PositionsAliasing(t *testing.T) {
+	is := is.New(t)
+
+	newPreSplitBatch := func() *Batch {
+		b := NewBatch(randomRecords(5))
+		b.SplitRecord(1, randomRecords(3)) // gives b.positions spare capacity (cap > len) - see doc comment
+		if cap(b.positions) == len(b.positions) {
+			t.Fatalf("test precondition failed: expected spare capacity after a split, got cap==len==%d", len(b.positions))
+		}
+		return b
+	}
+
+	original := newPreSplitBatch()
+	branchA := original.clone()
+	branchB := original.clone()
+
+	wantBPositions := slices.Clone(branchB.positions)
+	wantOriginalPositions := slices.Clone(original.positions)
+
+	// Split a record on branch A only, indexed into the shared array's spare
+	// capacity. If clone() shared the backing array without capping
+	// capacity, this append reuses (and corrupts) it - branchB's and
+	// original's positions would silently change despite neither being
+	// touched directly.
+	branchA.SplitRecord(3, randomRecords(2))
+
+	is.Equal(branchB.positions, wantBPositions)
+	is.Equal(original.positions, wantOriginalPositions)
+
+	// The concurrent version of the same scenario, run under -race: M
+	// branches split records from the same pre-split source AT THE SAME
+	// TIME, as doNextTask's real fan-out pool does. Without slices.Clip in
+	// clone(), this is a genuine data race on the shared backing array (not
+	// just a logical corruption a serial test might miss), so this loop
+	// gives the race detector many chances to catch it directly.
+	for i := 0; i < 50; i++ {
+		base := newPreSplitBatch()
+		a := base.clone()
+		b := base.clone()
+
+		done := make(chan struct{}, 2)
+		go func() {
+			defer func() { done <- struct{}{} }()
+			a.SplitRecord(3, randomRecords(2))
+		}()
+		go func() {
+			defer func() { done <- struct{}{} }()
+			b.SplitRecord(4, randomRecords(2))
+		}()
+		<-done
+		<-done
+	}
+}
+
+// TestBatch_Clone_PreservesSplitRecords guards the second bug clone() had
+// before this fix: it silently dropped splitRecords entirely (returned nil),
+// losing the ability to restore a record's true original (pre-split)
+// content via originalBatch() once cloned - relevant whenever a SHARED
+// processor (running before a destination fan-out point) already split a
+// record before the batch is cloned per branch. clone() must carry over a
+// COPY of the map (not the same map reference: two branches calling
+// SplitRecord concurrently on a shared map is a fatal concurrent-map-write
+// crash, not just a benign race).
+func TestBatch_Clone_PreservesSplitRecords(t *testing.T) {
+	is := is.New(t)
+	records := randomRecords(3)
+	batch := NewBatch(slices.Clone(records))
+	originalPositions := slices.Clone(batch.positions) // pre-split, for comparison below
+
+	// Simulate a shared upstream processor splitting record 1 BEFORE the
+	// fan-out point clones the batch.
+	batch.SplitRecord(1, randomRecords(2))
+	is.Equal(len(batch.splitRecords), 1)
+
+	branchA := batch.clone()
+	branchB := batch.clone()
+
+	// Both branches see the split, and it collapses back to the true
+	// original record via originalBatch() on EITHER branch independently.
+	is.Equal(len(branchA.splitRecords), 1)
+	is.Equal(len(branchB.splitRecords), 1)
+
+	origFromA := branchA.originalBatch()
+	origFromB := branchB.originalBatch()
+	// Collapsing removes the split fragment (position nil), so the 4
+	// records/positions the split introduced collapse back down to the
+	// original 3.
+	is.Equal(origFromA.positions, originalPositions)
+	is.Equal(origFromA.records[1], records[1]) // the true pre-split original, not a split fragment
+	is.Equal(origFromB.records[1], records[1])
+
+	// The two branches' maps are independent objects: further splitting on
+	// branch A must not appear in branch B's map (this is what makes the
+	// "copy, don't share" fix concurrency-safe - see
+	// TestBatch_Clone_PositionsAliasing for the analogous positions check).
+	branchA.SplitRecord(0, randomRecords(2))
+	is.Equal(len(branchA.splitRecords), 2)
+	is.Equal(len(branchB.splitRecords), 1)
+}

--- a/pkg/lifecycle-poc/funnel/codes.go
+++ b/pkg/lifecycle-poc/funnel/codes.go
@@ -40,3 +40,20 @@ import (
 // Emitting duplicate positions within one batch is a connector contract
 // violation, so this is a user-actionable error, not an internal assertion.
 var CodeDuplicateSourcePosition = conduiterr.Register("pipeline.duplicate_source_position", codes.FailedPrecondition)
+
+// CodeEmptySourcePosition is returned when a batch about to be acked to the
+// source contains a record with an empty/nil position.
+//
+// connector.Source.Ack persists State.Position = p[len(p)-1] unconditionally,
+// so acking an empty position OVERWRITES the durable source position with
+// nothing: on restart the source resumes from an empty position — a full
+// re-snapshot for Postgres, offset 0 for file/Kafka. That is an invariant-2
+// (monotonic, crash-safe positions) violation.
+//
+// Unlike CodeDuplicateSourcePosition, this is usually NOT the source
+// connector's fault. Batch.SplitRecord gives every piece after the first a nil
+// position, so a sub-batch that covers only the tail of a split run collapses
+// to nils — which happens when a later processor returns only part of a split
+// run (a Retry/Filter that does not propagate across the run). The suggestion
+// therefore points at the processor chain, not the source.
+var CodeEmptySourcePosition = conduiterr.Register("pipeline.empty_source_position", codes.FailedPrecondition)

--- a/pkg/lifecycle-poc/funnel/codes.go
+++ b/pkg/lifecycle-poc/funnel/codes.go
@@ -1,0 +1,42 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funnel
+
+import (
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"google.golang.org/grpc/codes"
+)
+
+// CodeDuplicateSourcePosition is returned when a single batch read from a
+// source contains two or more records carrying identical position bytes, and
+// that batch is fanned out to multiple destinations.
+//
+// A position is a record's identity: multiAckNacker keys its per-position
+// unanimity tally on it, and connector.Source.Ack advances the persisted
+// position from it. Two records sharing one position make those two things
+// ambiguous — the tally cannot tell the records apart, so one of them could
+// never reach unanimity, and because positions are released to the source
+// strictly in order (invariant 4), a single unresolvable slot silently stops
+// the WHOLE batch from ever being acked. The pipeline would keep running,
+// reading and writing records, while its source position never advanced and
+// no error was ever surfaced.
+//
+// Failing loudly here is deliberate. At-least-once is not violated by the
+// stall (nothing is acked, so nothing is lost — the records replay on
+// restart), but a silent, unbounded liveness failure is far worse for an
+// operator than a clear error naming the offending connector behaviour.
+// Emitting duplicate positions within one batch is a connector contract
+// violation, so this is a user-actionable error, not an internal assertion.
+var CodeDuplicateSourcePosition = conduiterr.Register("pipeline.duplicate_source_position", codes.FailedPrecondition)

--- a/pkg/lifecycle-poc/funnel/multi_ack_nacker_test.go
+++ b/pkg/lifecycle-poc/funnel/multi_ack_nacker_test.go
@@ -1,0 +1,365 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funnel
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/matryer/is"
+)
+
+// recordedAck/recordedNack capture exactly what a fakeParentAckNacker
+// observed, in call order, so tests can assert both WHAT was released to the
+// parent and in WHAT ORDER (invariant 4 - in-source-order release).
+type recordedAck struct {
+	positions []opencdc.Position
+}
+
+type recordedNack struct {
+	positions []opencdc.Position
+	taskID    string
+}
+
+// fakeParentAckNacker stands in for the Worker (or an outer multiAckNacker)
+// that multiAckNacker.releaseLocked calls into. It's a plain recorder by
+// default; ackErr/nackErr (or the *Func overrides, for per-call control) let
+// a test simulate the parent failing - in particular a fatal DLQ-threshold
+// error, which multiAckNacker must propagate rather than swallow
+// (requirement 5 in worker.go's multiAckNacker doc comment).
+type fakeParentAckNacker struct {
+	mu    sync.Mutex
+	acks  []recordedAck
+	nacks []recordedNack
+
+	ackErr  error
+	nackErr error
+}
+
+func (p *fakeParentAckNacker) Ack(_ context.Context, b *Batch) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.acks = append(p.acks, recordedAck{positions: append([]opencdc.Position(nil), b.positions...)})
+	return p.ackErr
+}
+
+func (p *fakeParentAckNacker) Nack(_ context.Context, b *Batch, taskID string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.nacks = append(p.nacks, recordedNack{positions: append([]opencdc.Position(nil), b.positions...), taskID: taskID})
+	return p.nackErr
+}
+
+func (p *fakeParentAckNacker) ackCalls() []recordedAck {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]recordedAck(nil), p.acks...)
+}
+
+func (p *fakeParentAckNacker) nackCalls() []recordedNack {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]recordedNack(nil), p.nacks...)
+}
+
+// ackBatchFor builds a *Batch of RecordFlagAck records for positions,
+// suitable for passing directly to multiAckNacker.Ack - mirrors what a
+// branch's doTask would hand its acker at the "clean batch" shortcut
+// (worker.go's doTask, !b.tainted case).
+func ackBatchFor(records []opencdc.Record, positions ...opencdc.Position) *Batch {
+	recs := make([]opencdc.Record, len(positions))
+	for i, p := range positions {
+		recs[i] = findRecordByPosition(records, p)
+	}
+	return &Batch{
+		records:        recs,
+		recordStatuses: make([]RecordStatus, len(positions)), // zero value is RecordFlagAck
+		positions:      append([]opencdc.Position(nil), positions...),
+	}
+}
+
+// nackBatchFor builds a single-record *Batch flagged RecordFlagNack, as a
+// branch's doTask would hand its acker for a nacked sub-batch.
+func nackBatchFor(records []opencdc.Record, pos opencdc.Position, nackErr error) *Batch {
+	return &Batch{
+		records:        []opencdc.Record{findRecordByPosition(records, pos)},
+		recordStatuses: []RecordStatus{{Flag: RecordFlagNack, Error: nackErr}},
+		positions:      []opencdc.Position{pos},
+		tainted:        true,
+	}
+}
+
+func findRecordByPosition(records []opencdc.Record, pos opencdc.Position) opencdc.Record {
+	for _, r := range records {
+		if string(r.Position) == string(pos) {
+			return r
+		}
+	}
+	panic("findRecordByPosition: no record with position " + string(pos))
+}
+
+// TestMultiAckNacker_UnanimousAck_ReleasesOnce is the core happy-path
+// invariant-1 check: with M=2 branches, a position is released to the
+// parent's Ack exactly once ack votes from BOTH branches have arrived, in
+// one coalesced call covering the whole contiguous run.
+func TestMultiAckNacker_UnanimousAck_ReleasesOnce(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	records := randomRecords(3)
+	positions := []opencdc.Position{records[0].Position, records[1].Position, records[2].Position}
+
+	parent := &fakeParentAckNacker{}
+	m := newMultiAckNacker(parent, 2, positions)
+
+	// Branch 1 acks all three - not yet unanimous, nothing released.
+	is.NoErr(m.Ack(ctx, ackBatchFor(records, positions...)))
+	is.Equal(len(parent.ackCalls()), 0)
+	is.Equal(len(parent.nackCalls()), 0)
+
+	// Branch 2 acks all three too - now unanimous for every position, and
+	// they're released as ONE coalesced call (invariant 4's batching).
+	is.NoErr(m.Ack(ctx, ackBatchFor(records, positions...)))
+
+	acks := parent.ackCalls()
+	is.Equal(len(acks), 1)
+	is.Equal(acks[0].positions, positions)
+	is.Equal(len(parent.nackCalls()), 0)
+}
+
+// TestMultiAckNacker_AnyNack_DLQsOnceRegardlessOfOrder is the nack-wins
+// check (invariant 3): for a single position with M=2 branches, however the
+// ack and nack votes are interleaved, the position is routed to the parent's
+// DLQ (Nack) exactly once, and NEVER also acked.
+func TestMultiAckNacker_AnyNack_DLQsOnceRegardlessOfOrder(t *testing.T) {
+	nackErr := cerrors.New("dest B failed to write")
+
+	t.Run("ack then nack", func(t *testing.T) {
+		is := is.New(t)
+		ctx := context.Background()
+		records := randomRecords(1)
+		positions := []opencdc.Position{records[0].Position}
+
+		parent := &fakeParentAckNacker{}
+		m := newMultiAckNacker(parent, 2, positions)
+
+		is.NoErr(m.Ack(ctx, ackBatchFor(records, positions...)))                          // branch A acks
+		is.NoErr(m.Nack(ctx, nackBatchFor(records, positions[0], nackErr), "destB-task")) // branch B nacks
+
+		is.Equal(len(parent.ackCalls()), 0) // never acked - nack won
+		nacks := parent.nackCalls()
+		is.Equal(len(nacks), 1)
+		is.Equal(nacks[0].positions, positions)
+		is.Equal(nacks[0].taskID, "destB-task")
+	})
+
+	t.Run("nack then ack (late ack vote is a no-op)", func(t *testing.T) {
+		is := is.New(t)
+		ctx := context.Background()
+		records := randomRecords(1)
+		positions := []opencdc.Position{records[0].Position}
+
+		parent := &fakeParentAckNacker{}
+		m := newMultiAckNacker(parent, 2, positions)
+
+		is.NoErr(m.Nack(ctx, nackBatchFor(records, positions[0], nackErr), "destB-task")) // branch B nacks first
+		is.NoErr(m.Ack(ctx, ackBatchFor(records, positions...)))                          // branch A's ack arrives late
+
+		is.Equal(len(parent.ackCalls()), 0) // still never acked
+		nacks := parent.nackCalls()
+		is.Equal(len(nacks), 1) // still exactly once, not twice
+		is.Equal(nacks[0].positions, positions)
+	})
+}
+
+// TestMultiAckNacker_PartialPerRecordDivergence is the central multi-record
+// scenario the whole type exists for: destination A acks everything, but
+// destination B nacks ONE record in the middle of the batch. The nacked
+// record must be DLQ'd (and, since the DLQ write is itself the durable
+// handling, acked to the source by the parent's own Nack implementation -
+// tested separately at the Worker level), while its neighbors are acked
+// normally in their own coalesced runs. A per-BATCH counter could not
+// represent this at all (see worker.go's multiAckNacker doc comment) - this
+// test is the direct proof a per-position tally can.
+func TestMultiAckNacker_PartialPerRecordDivergence(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	records := randomRecords(5)
+	positions := make([]opencdc.Position, 5)
+	for i, r := range records {
+		positions[i] = r.Position
+	}
+
+	parent := &fakeParentAckNacker{}
+	m := newMultiAckNacker(parent, 2, positions)
+
+	// Destination A: clean batch, acks all 5 in one call (worker.go's
+	// !b.tainted shortcut path).
+	is.NoErr(m.Ack(ctx, ackBatchFor(records, positions...)))
+
+	// Destination B: records[2] failed, so its batch is tainted and split
+	// into three sub-batches by doTask's subBatchByFlag - ack(0,1), nack(2),
+	// ack(3,4).
+	nackErr := cerrors.New("dest B: write failed for record 2")
+	is.NoErr(m.Ack(ctx, ackBatchFor(records, positions[0], positions[1])))
+	is.NoErr(m.Nack(ctx, nackBatchFor(records, positions[2], nackErr), "destB-task"))
+	is.NoErr(m.Ack(ctx, ackBatchFor(records, positions[3], positions[4])))
+
+	acks := parent.ackCalls()
+	is.Equal(len(acks), 2)
+	is.Equal(acks[0].positions, positions[0:2])
+	is.Equal(acks[1].positions, positions[3:5])
+
+	nacks := parent.nackCalls()
+	is.Equal(len(nacks), 1)
+	is.Equal(nacks[0].positions, positions[2:3])
+	is.Equal(nacks[0].taskID, "destB-task")
+}
+
+// TestMultiAckNacker_OutOfOrderCompletion_ReleasesInSourceOrder is
+// invariant 4's direct test: destB votes for a LATER position before an
+// EARLIER position has even received its first vote. The later position must
+// never be released to the parent until every position before it (in source
+// order) has also reached a terminal decision - otherwise Source.Ack's
+// monotonically-advancing position would skip over a record still in
+// flight.
+func TestMultiAckNacker_OutOfOrderCompletion_ReleasesInSourceOrder(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	records := randomRecords(3)
+	p0, p1, p2 := records[0].Position, records[1].Position, records[2].Position
+
+	parent := &fakeParentAckNacker{}
+	m := newMultiAckNacker(parent, 2, []opencdc.Position{p0, p1, p2})
+
+	// Branch B races ahead and votes for p2 FIRST - only 1 of 2 votes, so it
+	// cannot go terminal yet regardless.
+	is.NoErr(m.Ack(ctx, ackBatchFor(records, p2)))
+	is.Equal(len(parent.ackCalls()), 0)
+
+	// Branch A votes for p0 - still only 1 of 2 votes for p0.
+	is.NoErr(m.Ack(ctx, ackBatchFor(records, p0)))
+	is.Equal(len(parent.ackCalls()), 0)
+
+	// Branch B now votes for p0 too - p0 is unanimous and releases...
+	is.NoErr(m.Ack(ctx, ackBatchFor(records, p0)))
+	acks := parent.ackCalls()
+	is.Equal(len(acks), 1)
+	is.Equal(acks[0].positions, []opencdc.Position{p0})
+
+	// ...but p1 has zero votes and p2 (despite already being fully voted on
+	// branch B's side) still needs branch A's vote, and even once it gets
+	// it, p2 must NOT release until p1 does too.
+	is.NoErr(m.Ack(ctx, ackBatchFor(records, p1, p2))) // branch A votes p1 and p2
+	// p1 only just got its first (of two) votes here - still not terminal -
+	// so nothing new can release yet even though p2's tally is now 2/2.
+	is.Equal(len(parent.ackCalls()), 1) // unchanged
+
+	// Branch B finally votes p1 - NOW both p1 and p2 are terminal, and they
+	// release together as one contiguous run (never p2 without p1 first).
+	is.NoErr(m.Ack(ctx, ackBatchFor(records, p1)))
+	acks = parent.ackCalls()
+	is.Equal(len(acks), 2)
+	is.Equal(acks[1].positions, []opencdc.Position{p1, p2})
+}
+
+// TestMultiAckNacker_FatalDLQError_Propagates is requirement 5's direct
+// test: a fatal error from the parent's Nack (e.g. DLQ nack-threshold
+// exceeded, see funnel.DLQ.Nack) must be returned from multiAckNacker's own
+// Nack call, so the branch pool (doNextTask's pool.New().WithErrors()) fails
+// and the worker tombs with it - identical to the single-destination path.
+func TestMultiAckNacker_FatalDLQError_Propagates(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	records := randomRecords(1)
+	pos := records[0].Position
+
+	fatalErr := cerrors.FatalError(cerrors.New("DLQ nack threshold exceeded"))
+	parent := &fakeParentAckNacker{nackErr: fatalErr}
+	m := newMultiAckNacker(parent, 2, []opencdc.Position{pos})
+
+	err := m.Nack(ctx, nackBatchFor(records, pos, cerrors.New("write failed")), "destA-task")
+	is.True(err != nil)
+	is.True(cerrors.Is(err, fatalErr))
+	is.True(cerrors.IsFatalError(err))
+
+	// Exactly one Nack call was attempted (no retry loop inside
+	// multiAckNacker - the caller/pool is responsible for propagating this
+	// up, just like Worker.Nack's own fatal-error path).
+	is.Equal(len(parent.nackCalls()), 1)
+}
+
+// TestMultiAckNacker_UnknownPosition_ReturnsBugError guards against a task
+// graph bug (a branch producing a record whose position doesn't trace back,
+// via originalBatch, to one of the positions captured when the fan-out
+// started) being silently swallowed - it must surface as a reportable error,
+// not a panic or a silent drop.
+func TestMultiAckNacker_UnknownPosition_ReturnsBugError(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	records := randomRecords(2)
+	known := records[0].Position
+
+	parent := &fakeParentAckNacker{}
+	m := newMultiAckNacker(parent, 2, []opencdc.Position{known})
+
+	err := m.Ack(ctx, ackBatchFor(records, records[1].Position)) // records[1].Position was never registered
+	is.True(err != nil)
+}
+
+// TestMultiAckNacker_ThreeBranches_UnanimousRequiresAllThree confirms the
+// unanimity gate scales past M=2: with 3 branches, 2 acks are not enough to
+// release, and a 3rd branch's nack (even after 2 acks already arrived) still
+// wins per invariant 3.
+func TestMultiAckNacker_ThreeBranches_UnanimousRequiresAllThree(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	records := randomRecords(2)
+	pAcked, pNacked := records[0].Position, records[1].Position
+
+	parent := &fakeParentAckNacker{}
+	m := newMultiAckNacker(parent, 3, []opencdc.Position{pAcked, pNacked})
+
+	// pAcked: all 3 branches ack it.
+	is.NoErr(m.Ack(ctx, ackBatchFor(records, pAcked)))
+	is.NoErr(m.Ack(ctx, ackBatchFor(records, pAcked)))
+	is.Equal(len(parent.ackCalls()), 0) // only 2/3 so far
+
+	// pNacked: 2 branches ack, but the 3rd nacks - nack wins even though it
+	// arrives last.
+	is.NoErr(m.Ack(ctx, ackBatchFor(records, pNacked)))
+	is.NoErr(m.Ack(ctx, ackBatchFor(records, pNacked)))
+	is.NoErr(m.Nack(ctx, nackBatchFor(records, pNacked, cerrors.New("branch 3 failed")), "destC-task"))
+
+	// pAcked's 3rd (final) vote arrives after pNacked was already resolved -
+	// order across DIFFERENT positions doesn't matter, only per-position
+	// unanimity does.
+	is.NoErr(m.Ack(ctx, ackBatchFor(records, pAcked)))
+
+	// Release order still respects source order: pAcked (index 0) before
+	// pNacked (index 1).
+	acks := parent.ackCalls()
+	is.Equal(len(acks), 1)
+	is.Equal(acks[0].positions, []opencdc.Position{pAcked})
+
+	nacks := parent.nackCalls()
+	is.Equal(len(nacks), 1)
+	is.Equal(nacks[0].positions, []opencdc.Position{pNacked})
+	is.Equal(nacks[0].taskID, "destC-task")
+}

--- a/pkg/lifecycle-poc/funnel/multi_ack_nacker_test.go
+++ b/pkg/lifecycle-poc/funnel/multi_ack_nacker_test.go
@@ -409,9 +409,8 @@ func TestMultiAckNacker_DuplicatePositions_FailsLoud(t *testing.T) {
 	is.True(strings.Contains(ce.Suggestion, "distinct, non-empty position"))
 }
 
-// TestMultiAckNacker_EmptyPositions_FailsLoud covers the most plausible real
-// trigger of the same bug: a source emitting several records with empty/nil
-// positions, which all collapse to the same "" map key.
+// TestMultiAckNacker_EmptyPositions_FailsLoud: nil positions are rejected, and
+// attributed to the processor chain (SplitRecord makes them), NOT to the source.
 func TestMultiAckNacker_EmptyPositions_FailsLoud(t *testing.T) {
 	is := is.New(t)
 	positions := []opencdc.Position{nil, nil}
@@ -422,5 +421,56 @@ func TestMultiAckNacker_EmptyPositions_FailsLoud(t *testing.T) {
 
 	ce, ok := conduiterr.Get(err)
 	is.True(ok)
-	is.Equal(ce.Code.Reason(), CodeDuplicateSourcePosition.Reason())
+	is.Equal(ce.Code.Reason(), CodeEmptySourcePosition.Reason())
+}
+
+// TestMultiAckNacker_SingleEmptyPosition_Rejected is the regression test for a
+// position-WIPE bug found by adversarial review of this PR.
+//
+// The duplicate guard keys on string(p), so TWO nils collide and were caught —
+// but a SINGLE nil sailed straight through. That is reachable: SplitRecord
+// gives every piece after the first a nil position, so a sub-batch covering
+// only the tail of a split run collapses to exactly [nil]. It then reached
+// connector.Source.Ack, which persists State.Position = p[len(p)-1]
+// unconditionally — overwriting the durable source position with NOTHING. On
+// restart the source resumes from an empty position: a full re-snapshot for
+// Postgres, offset 0 for file/Kafka. Invariant 2 (monotonic, crash-safe
+// positions) violated, with a far worse blast radius than the stall the
+// duplicate guard was written to close.
+func TestMultiAckNacker_SingleEmptyPosition_Rejected(t *testing.T) {
+	is := is.New(t)
+
+	m, err := newMultiAckNacker(&fakeParentAckNacker{}, 2, []opencdc.Position{nil})
+	is.True(m == nil)
+	is.True(err != nil)
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code.Reason(), CodeEmptySourcePosition.Reason())
+}
+
+// TestValidateAckPositions_RejectsEmpty guards the actual corruption site.
+// Worker.Ack calls this before connector.Source.Ack, so the protection covers
+// the single-destination (M=1) path too — where the same [nil] sub-batch would
+// otherwise wipe the position with no fan-out involved at all.
+func TestValidateAckPositions_RejectsEmpty(t *testing.T) {
+	is := is.New(t)
+
+	is.NoErr(validateAckPositions([]opencdc.Position{
+		opencdc.Position("p0"), opencdc.Position("p1"),
+	}))
+
+	for _, tc := range [][]opencdc.Position{
+		{nil},
+		{opencdc.Position("p0"), nil},
+		{opencdc.Position{}},
+	} {
+		err := validateAckPositions(tc)
+		is.True(err != nil)
+		ce, ok := conduiterr.Get(err)
+		is.True(ok)
+		is.Equal(ce.Code.Reason(), CodeEmptySourcePosition.Reason())
+		// The blame must point at the processor chain, not the source.
+		is.True(strings.Contains(ce.Suggestion, "processor"))
+	}
 }

--- a/pkg/lifecycle-poc/funnel/multi_ack_nacker_test.go
+++ b/pkg/lifecycle-poc/funnel/multi_ack_nacker_test.go
@@ -16,11 +16,13 @@ package funnel
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/conduitio/conduit-commons/opencdc"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/matryer/is"
 )
 
@@ -124,7 +126,7 @@ func TestMultiAckNacker_UnanimousAck_ReleasesOnce(t *testing.T) {
 	positions := []opencdc.Position{records[0].Position, records[1].Position, records[2].Position}
 
 	parent := &fakeParentAckNacker{}
-	m := newMultiAckNacker(parent, 2, positions)
+	m := mustNewMultiAckNacker(t, parent, 2, positions)
 
 	// Branch 1 acks all three - not yet unanimous, nothing released.
 	is.NoErr(m.Ack(ctx, ackBatchFor(records, positions...)))
@@ -155,7 +157,7 @@ func TestMultiAckNacker_AnyNack_DLQsOnceRegardlessOfOrder(t *testing.T) {
 		positions := []opencdc.Position{records[0].Position}
 
 		parent := &fakeParentAckNacker{}
-		m := newMultiAckNacker(parent, 2, positions)
+		m := mustNewMultiAckNacker(t, parent, 2, positions)
 
 		is.NoErr(m.Ack(ctx, ackBatchFor(records, positions...)))                          // branch A acks
 		is.NoErr(m.Nack(ctx, nackBatchFor(records, positions[0], nackErr), "destB-task")) // branch B nacks
@@ -174,7 +176,7 @@ func TestMultiAckNacker_AnyNack_DLQsOnceRegardlessOfOrder(t *testing.T) {
 		positions := []opencdc.Position{records[0].Position}
 
 		parent := &fakeParentAckNacker{}
-		m := newMultiAckNacker(parent, 2, positions)
+		m := mustNewMultiAckNacker(t, parent, 2, positions)
 
 		is.NoErr(m.Nack(ctx, nackBatchFor(records, positions[0], nackErr), "destB-task")) // branch B nacks first
 		is.NoErr(m.Ack(ctx, ackBatchFor(records, positions...)))                          // branch A's ack arrives late
@@ -206,7 +208,7 @@ func TestMultiAckNacker_PartialPerRecordDivergence(t *testing.T) {
 	}
 
 	parent := &fakeParentAckNacker{}
-	m := newMultiAckNacker(parent, 2, positions)
+	m := mustNewMultiAckNacker(t, parent, 2, positions)
 
 	// Destination A: clean batch, acks all 5 in one call (worker.go's
 	// !b.tainted shortcut path).
@@ -246,7 +248,7 @@ func TestMultiAckNacker_OutOfOrderCompletion_ReleasesInSourceOrder(t *testing.T)
 	p0, p1, p2 := records[0].Position, records[1].Position, records[2].Position
 
 	parent := &fakeParentAckNacker{}
-	m := newMultiAckNacker(parent, 2, []opencdc.Position{p0, p1, p2})
+	m := mustNewMultiAckNacker(t, parent, 2, []opencdc.Position{p0, p1, p2})
 
 	// Branch B races ahead and votes for p2 FIRST - only 1 of 2 votes, so it
 	// cannot go terminal yet regardless.
@@ -292,7 +294,7 @@ func TestMultiAckNacker_FatalDLQError_Propagates(t *testing.T) {
 
 	fatalErr := cerrors.FatalError(cerrors.New("DLQ nack threshold exceeded"))
 	parent := &fakeParentAckNacker{nackErr: fatalErr}
-	m := newMultiAckNacker(parent, 2, []opencdc.Position{pos})
+	m := mustNewMultiAckNacker(t, parent, 2, []opencdc.Position{pos})
 
 	err := m.Nack(ctx, nackBatchFor(records, pos, cerrors.New("write failed")), "destA-task")
 	is.True(err != nil)
@@ -317,7 +319,7 @@ func TestMultiAckNacker_UnknownPosition_ReturnsBugError(t *testing.T) {
 	known := records[0].Position
 
 	parent := &fakeParentAckNacker{}
-	m := newMultiAckNacker(parent, 2, []opencdc.Position{known})
+	m := mustNewMultiAckNacker(t, parent, 2, []opencdc.Position{known})
 
 	err := m.Ack(ctx, ackBatchFor(records, records[1].Position)) // records[1].Position was never registered
 	is.True(err != nil)
@@ -334,7 +336,7 @@ func TestMultiAckNacker_ThreeBranches_UnanimousRequiresAllThree(t *testing.T) {
 	pAcked, pNacked := records[0].Position, records[1].Position
 
 	parent := &fakeParentAckNacker{}
-	m := newMultiAckNacker(parent, 3, []opencdc.Position{pAcked, pNacked})
+	m := mustNewMultiAckNacker(t, parent, 3, []opencdc.Position{pAcked, pNacked})
 
 	// pAcked: all 3 branches ack it.
 	is.NoErr(m.Ack(ctx, ackBatchFor(records, pAcked)))
@@ -362,4 +364,63 @@ func TestMultiAckNacker_ThreeBranches_UnanimousRequiresAllThree(t *testing.T) {
 	is.Equal(len(nacks), 1)
 	is.Equal(nacks[0].positions, []opencdc.Position{pNacked})
 	is.Equal(nacks[0].taskID, "destC-task")
+}
+
+// mustNewMultiAckNacker builds a multiAckNacker for tests whose positions are
+// known-unique, failing the test if construction rejects them (see
+// CodeDuplicateSourcePosition).
+func mustNewMultiAckNacker(t *testing.T, parent ackNacker, branches int, positions []opencdc.Position) *multiAckNacker {
+	t.Helper()
+	m, err := newMultiAckNacker(parent, branches, positions)
+	is.New(t).NoErr(err)
+	return m
+}
+
+// TestMultiAckNacker_DuplicatePositions_FailsLoud is the regression test for a
+// silent-stall bug found while reviewing this slice.
+//
+// posIndex maps position bytes to a slot index. Two records in one batch
+// carrying identical positions (including two empty/nil positions) made the
+// map's later entry shadow the earlier one: the shadowed slot could never
+// accumulate ack votes, never became terminal, and because positions are
+// released to the source strictly in order (invariant 4), releaseLocked stopped
+// at that slot forever. Verified before the fix: with 3 positions where #0 and
+// #2 collide, parent.Ack was called ZERO times — the entire batch was never
+// acked to the source, silently and unboundedly, while the pipeline kept
+// running. At-least-once still held (nothing acked, so nothing lost — records
+// replay on restart), but a silent liveness failure with no error is worse for
+// an operator than a clear one.
+//
+// Construction now rejects duplicates with a coded, actionable error instead.
+func TestMultiAckNacker_DuplicatePositions_FailsLoud(t *testing.T) {
+	is := is.New(t)
+	records := randomRecords(3)
+	records[0].Position = opencdc.Position("dup")
+	records[2].Position = opencdc.Position("dup")
+	positions := []opencdc.Position{records[0].Position, records[1].Position, records[2].Position}
+
+	m, err := newMultiAckNacker(&fakeParentAckNacker{}, 2, positions)
+	is.True(m == nil)
+	is.True(err != nil)
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // must be a coded error, not a bare one
+	is.Equal(ce.Code.Reason(), CodeDuplicateSourcePosition.Reason())
+	is.True(strings.Contains(ce.Suggestion, "distinct, non-empty position"))
+}
+
+// TestMultiAckNacker_EmptyPositions_FailsLoud covers the most plausible real
+// trigger of the same bug: a source emitting several records with empty/nil
+// positions, which all collapse to the same "" map key.
+func TestMultiAckNacker_EmptyPositions_FailsLoud(t *testing.T) {
+	is := is.New(t)
+	positions := []opencdc.Position{nil, nil}
+
+	m, err := newMultiAckNacker(&fakeParentAckNacker{}, 2, positions)
+	is.True(m == nil)
+	is.True(err != nil)
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code.Reason(), CodeDuplicateSourcePosition.Reason())
 }

--- a/pkg/lifecycle-poc/funnel/worker.go
+++ b/pkg/lifecycle-poc/funnel/worker.go
@@ -468,6 +468,16 @@ OUTER:
 	return b.sub(firstIndex, lastIndex)
 }
 
+// doNextTask advances the batch b to whatever comes after taskNode. A single
+// next task is the common case (linear pipeline). Multiple next tasks means
+// taskNode is the fan-out point into M destination branches (see slice 3a of
+// the arch-v2 multi-connector epic): the batch is cloned once per branch and
+// the branches run concurrently, each writing to a different destination.
+//
+// Only the destination-fan-out axis is supported here (single source, M
+// destinations) — spawning multiple *workers* for multiple *sources* is a
+// separate, later slice; see the multi-source guard in
+// pkg/lifecycle-poc/service.go's buildSourceTasks.
 func (w *Worker) doNextTask(ctx context.Context, taskNode *TaskNode, b *Batch, acker ackNacker) error {
 	switch len(taskNode.Next) {
 	case 0:
@@ -477,26 +487,34 @@ func (w *Worker) doNextTask(ctx context.Context, taskNode *TaskNode, b *Batch, a
 		// single next task, let's pass the batch to it
 		return w.doTask(ctx, taskNode.Next[0], b, acker)
 	default:
-		// TODO(multi-connector): remove error
-		return cerrors.Errorf("multiple next tasks not supported yet")
+		// Multiple next tasks: fan the batch out to each destination branch
+		// concurrently and track per-record ack/nack outcomes across all of
+		// them with multiAckNacker.
+		//
+		// Invariant 1/3 (enforcement site): capture the batch's ORIGINAL
+		// (pre-split) positions up front, before any branch runs. Branches
+		// diverge independently from this point on — a per-branch processor
+		// may split a record into pieces that a sibling branch does not — so
+		// multiAckNacker must key its per-position tally on a position that
+		// is stable across all M branches. b.originalBatch() is exactly the
+		// batch-wide "no splits yet" view; any splitting an upstream SHARED
+		// processor already did (before this fan-out point) is collapsed
+		// here so the tally is keyed by the true root position, not an
+		// intermediate one.
+		orig := b.originalBatch()
+		multiAcker := newMultiAckNacker(acker, len(taskNode.Next), orig.positions)
 
-		// multiple next tasks, let's clone the batch and pass it to them
-		// concurrently
-		//nolint:govet // TODO implement multi ack nacker
-		multiAcker := newMultiAckNacker(acker, len(taskNode.Next))
-		p := pool.New().WithErrors() // TODO WithContext?
+		p := pool.New().WithErrors()
 		for _, nextTask := range taskNode.Next {
-			b := b.clone()
+			branchBatch := b.clone()
 			p.Go(func() error {
-				return w.doTask(ctx, nextTask, b, multiAcker)
+				return w.doTask(ctx, nextTask, branchBatch, multiAcker)
 			})
 		}
-		err := p.Wait()
-		if err != nil {
+		if err := p.Wait(); err != nil {
 			return err // no need to wrap, it already contains the task ID
 		}
 
-		// TODO merge batch statuses?
 		return nil
 	}
 }
@@ -644,27 +662,297 @@ type ackNacker interface {
 	Nack(context.Context, *Batch, string) error
 }
 
-// multiAckNacker is an ackNacker that expects multiple acks/nacks for the same
-// batch. It keeps track of the number of acks/nacks and only acks/nacks the
-// batch when all expected acks/nacks are received.
+// multiAckNacker is the ackNacker used at a destination fan-out point (see
+// Worker.doNextTask): it sits between M concurrently-running destination
+// branches and the single parent ackNacker (the Worker itself, or an outer
+// multiAckNacker), and is responsible for turning M independent per-branch
+// votes for each source record into exactly one Ack or Nack call on the
+// parent.
+//
+// # Why per-batch counting is wrong
+//
+// A naive implementation would count acks/nacks per BATCH (one counter,
+// decremented once per branch, act once it hits zero). That is a data-loss
+// bug: destinations diverge per RECORD, not per batch. Destination 1 might
+// ack records 0-4 of a 5-record batch while destination 2 nacks record 3 —
+// there is no single moment where "the batch" is uniformly ack'd or nack'd.
+// A per-batch counter has no way to represent record 3 being nacked while
+// records 0, 1, 2 and 4 are acked, and either drops the divergence (silently
+// acking a record that a destination never durably wrote — invariant 1) or
+// blocks forever (waiting for a nack vote on a record every branch actually
+// acked).
+//
+// # Required semantics (per original source position)
+//
+//  1. Ack-only-when-unanimous (invariant 1): a position is acked to the
+//     parent only once ALL M branches have voted ack for it.
+//  2. Nack-wins (invariant 3): if ANY branch nacks a position, it is routed
+//     to the parent's DLQ exactly once, regardless of how the other
+//     branches voted. A record written durably to destination 1 but failed
+//     on destination 2 is NOT a partial success — the whole record goes to
+//     the DLQ, then is acked to the source (the DLQ write is itself the
+//     durable handling that earns the source ack). A partially-written
+//     record is never acked to the source as if it were a full success.
+//  3. Idempotent, race-free: branches run concurrently and call Ack/Nack
+//     from separate goroutines; once a position reaches a terminal decision
+//     (acked-by-all or nacked-by-one), any further vote for it (a slow
+//     branch's ack arriving after a sibling already nacked the same
+//     position) is a no-op. This assumes each branch votes exactly once per
+//     position (ack xor nack) — the same assumption the rest of the batch
+//     pipeline already makes (see Batch's tainted-splitting in doTask).
+//  4. In-source-order release (invariant 4): positions are released to the
+//     parent in ascending source order, never in branch-completion order —
+//     a branch that finishes record 10 before another branch finishes
+//     record 3 must not let record 10 reach the parent first, or
+//     Source.Ack's monotonically-advancing position would skip ahead of a
+//     record that has not actually reached a terminal decision yet.
+//     Contiguous runs of ack decisions are batched into a single parent.Ack
+//     call to preserve the parent's batch semantics; nacks are released one
+//     position at a time (see the comment on releaseLocked for why).
+//  5. Fatal-error propagation: if the parent's Nack returns a fatal error
+//     (e.g. the DLQ nack-threshold was exceeded), that error is returned to
+//     the caller so the branch pool errors out and the worker tombs with it
+//     — identical to what happens on the single-destination path.
+//
+// This is intentionally a mutex-guarded per-position tally rather than a
+// lock-free or channel-based design: it is Tier-1, highest-data-loss-risk
+// code, and boring-and-obviously-correct beats clever here. See
+// docs/design-documents/20260731-archv2-multiconnector.md and
+// docs/architecture-decision-records/20260731-archv2-fanout-ack-model.md.
 type multiAckNacker struct {
-	parent ackNacker
-	count  *atomic.Int32
+	parent   ackNacker
+	branches int
+
+	// positions holds the ORIGINAL (pre-split) source positions the fan-out
+	// batch contained, captured once at construction time (see
+	// Worker.doNextTask). Index i in every other slice below corresponds to
+	// positions[i].
+	positions []opencdc.Position
+	// posIndex maps a position's byte content to its index in positions, so
+	// Ack/Nack can look up which slot an incoming (already-collapsed-to-
+	// original) record belongs to.
+	posIndex map[string]int
+
+	mu sync.Mutex
+	// ackVotes[i] counts how many of the M branches have voted ack for
+	// positions[i] so far. Only meaningful while !terminal[i].
+	ackVotes []int
+	// terminal[i] is true once positions[i] has reached a final decision
+	// (ack'd by all branches, or nack'd by any one of them) — further votes
+	// for it are no-ops (requirement 3 above).
+	terminal []bool
+	// acked[i] is only meaningful once terminal[i] is true: true means the
+	// terminal decision was "ack", false means "nack".
+	acked []bool
+	// record[i] holds a record to represent positions[i] in the eventual
+	// parent Ack/Nack call. For an ack it can come from any branch (only the
+	// position matters for Source.Ack; content is used only for metrics/DLQ-
+	// window bookkeeping). For a nack it MUST be the record and error from
+	// the branch that actually nacked it, so the DLQ entry reflects the real
+	// failure.
+	record []opencdc.Record
+	// nackErr[i] and nackTaskID[i] are set alongside acked[i]=false: the
+	// error and originating task ID of the branch that nacked positions[i],
+	// needed to reconstruct the single-record batch passed to parent.Nack.
+	nackErr    []error
+	nackTaskID []string
+
+	// released is the count of leading positions (a prefix of positions)
+	// that have already been handed to the parent. Positions are only ever
+	// released in order, released..len(positions), never out of order
+	// (invariant 4).
+	released int
 }
 
-func newMultiAckNacker(parent ackNacker, count int) *multiAckNacker {
-	c := atomic.Int32{}
-	c.Add(int32(count)) //nolint:gosec // no risk of overflow
+// newMultiAckNacker creates a multiAckNacker for a fan-out of a batch whose
+// original (pre-split) source positions are given by positions, split across
+// branches concurrently-running destination branches. positions must be
+// captured from the fan-out batch's originalBatch() before cloning it for
+// the branches — see Worker.doNextTask.
+func newMultiAckNacker(parent ackNacker, branches int, positions []opencdc.Position) *multiAckNacker {
+	posIndex := make(map[string]int, len(positions))
+	for i, p := range positions {
+		posIndex[string(p)] = i
+	}
+
+	n := len(positions)
 	return &multiAckNacker{
-		parent: parent,
-		count:  &c,
+		parent:     parent,
+		branches:   branches,
+		positions:  positions,
+		posIndex:   posIndex,
+		ackVotes:   make([]int, n),
+		terminal:   make([]bool, n),
+		acked:      make([]bool, n),
+		record:     make([]opencdc.Record, n),
+		nackErr:    make([]error, n),
+		nackTaskID: make([]string, n),
 	}
 }
 
-func (m *multiAckNacker) Ack(ctx context.Context, batch *Batch) error {
-	panic("not implemented")
+// indexOf returns the tally slot for pos, or an error if pos is not part of
+// the original fan-out batch. That would mean a branch produced a record
+// whose position doesn't trace back (via originalBatch) to one of the
+// positions captured when the fan-out started — an internal bug in the task
+// graph, not a runtime/data condition, so it's reported as such rather than
+// silently dropped.
+func (m *multiAckNacker) indexOf(pos opencdc.Position) (int, error) {
+	idx, ok := m.posIndex[string(pos)]
+	if !ok {
+		return 0, cerrors.Errorf("(bug) multiAckNacker: position %q is not part of the original fan-out batch", pos)
+	}
+	return idx, nil
 }
 
+// Ack records an ack vote from one branch for every position in batch.
+// batch.originalBatch() is applied first, so a branch that split records
+// internally still votes using the same original positions every other
+// branch votes on — see the doc comment on the type for why this matters.
+//
+// Invariant 1 (enforcement site): a position is only ever forwarded to
+// parent.Ack once ALL m.branches have voted ack for it.
+func (m *multiAckNacker) Ack(ctx context.Context, batch *Batch) error {
+	ob := batch.originalBatch()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for i, pos := range ob.positions {
+		idx, err := m.indexOf(pos)
+		if err != nil {
+			return err
+		}
+
+		if m.terminal[idx] {
+			// Requirement 3: this position already reached a terminal
+			// decision. The only way to get here is a sibling branch having
+			// nacked it already (an ack can only ever be the LAST vote to
+			// arrive, since it takes exactly m.branches acks to go
+			// terminal) — nack wins, this vote is a no-op.
+			continue
+		}
+
+		m.record[idx] = ob.records[i]
+		m.ackVotes[idx]++
+		if m.ackVotes[idx] == m.branches {
+			m.terminal[idx] = true
+			m.acked[idx] = true
+		}
+	}
+
+	return m.releaseLocked(ctx)
+}
+
+// Nack records a nack vote from one branch (identified by taskID) for every
+// position in batch. Like Ack, batch.originalBatch() is applied first.
+//
+// Invariant 3 (enforcement site): nack wins. The first nack vote for a
+// position is terminal — it is routed to the parent's DLQ exactly once, and
+// any later vote (ack or nack) for the same position from another branch is
+// a no-op. A record durably written by some but not all branches is treated
+// as a failure of the whole record, never partially acked.
 func (m *multiAckNacker) Nack(ctx context.Context, batch *Batch, taskID string) error {
-	panic("not implemented")
+	ob := batch.originalBatch()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for i, pos := range ob.positions {
+		idx, err := m.indexOf(pos)
+		if err != nil {
+			return err
+		}
+
+		if m.terminal[idx] {
+			// Already resolved (either a sibling nack got here first, which
+			// is idempotent, or - should never happen given the one-vote-
+			// per-branch-per-position invariant - an ack already went
+			// terminal). Either way, nothing to do.
+			continue
+		}
+
+		m.terminal[idx] = true
+		m.acked[idx] = false
+		m.record[idx] = ob.records[i]
+		m.nackErr[idx] = ob.recordStatuses[i].Error
+		m.nackTaskID[idx] = taskID
+	}
+
+	return m.releaseLocked(ctx)
+}
+
+// releaseLocked walks the positions starting at m.released and forwards
+// every leading run of terminal positions to the parent, stopping at the
+// first position that hasn't reached a terminal decision yet. Must be called
+// with m.mu held.
+//
+// Invariant 4 (enforcement site): positions are only ever released as a
+// prefix, in ascending source order — m.released only ever moves forward,
+// and never past a position that is not yet terminal - so the parent (and
+// transitively Source.Ack's monotonically-advancing State.Position) never
+// observes a position out of order or skips over one still in flight.
+//
+// Contiguous ack runs are coalesced into a single parent.Ack call to
+// preserve the parent's batch semantics (fewer, larger Source.Ack calls).
+// Nacks are released one position at a time: parent.Nack takes a single
+// taskID for the whole batch it's given (used for DLQ metadata on every
+// record in that call), and a run of nacked positions can legitimately come
+// from different branches/tasks. Coalescing them under one taskID would
+// misattribute the DLQ failure reason for some records. Nacks are the
+// exceptional, rare path, so the extra parent calls are an acceptable
+// tradeoff for that correctness.
+func (m *multiAckNacker) releaseLocked(ctx context.Context) error {
+	for m.released < len(m.positions) {
+		if !m.terminal[m.released] {
+			return nil
+		}
+
+		if m.acked[m.released] {
+			from := m.released
+			to := from
+			for to < len(m.positions) && m.terminal[to] && m.acked[to] {
+				to++
+			}
+
+			if err := m.parent.Ack(ctx, m.ackBatch(from, to)); err != nil {
+				return err
+			}
+			m.released = to
+			continue
+		}
+
+		idx := m.released
+		if err := m.parent.Nack(ctx, m.nackBatch(idx), m.nackTaskID[idx]); err != nil {
+			// Requirement 5: a fatal DLQ error (nack threshold exceeded)
+			// must surface exactly like it does on the single-destination
+			// path, so the branch pool errors out and the worker tombs.
+			return err
+		}
+		m.released = idx + 1
+	}
+	return nil
+}
+
+// ackBatch builds a Batch representing the already-resolved, all-branches-
+// acked positions [from, to) for a parent.Ack call. The result carries no
+// split records (they were already collapsed by Ack/Nack via
+// batch.originalBatch()), so the parent's own originalBatch() call is a
+// no-op on it.
+func (m *multiAckNacker) ackBatch(from, to int) *Batch {
+	return &Batch{
+		records:        m.record[from:to],
+		recordStatuses: make([]RecordStatus, to-from), // zero value is RecordFlagAck
+		positions:      m.positions[from:to],
+	}
+}
+
+// nackBatch builds a single-record Batch for positions[idx], which some
+// branch nacked, for a parent.Nack call.
+func (m *multiAckNacker) nackBatch(idx int) *Batch {
+	return &Batch{
+		records:        []opencdc.Record{m.record[idx]},
+		recordStatuses: []RecordStatus{{Flag: RecordFlagNack, Error: m.nackErr[idx]}},
+		positions:      []opencdc.Position{m.positions[idx]},
+		tainted:        true,
+	}
 }

--- a/pkg/lifecycle-poc/funnel/worker.go
+++ b/pkg/lifecycle-poc/funnel/worker.go
@@ -529,6 +529,24 @@ func (w *Worker) doNextTask(ctx context.Context, taskNode *TaskNode, b *Batch, a
 
 func (w *Worker) Ack(ctx context.Context, batch *Batch) error {
 	originalBatch := batch.originalBatch()
+
+	// Invariant 2: positions are monotonic and crash-safe. connector.Source.Ack
+	// persists State.Position = p[len(p)-1] unconditionally, so handing it an
+	// empty/nil position OVERWRITES the durable source position with nothing —
+	// on restart the source resumes from an empty position, which for Postgres
+	// means a full re-snapshot and for file/Kafka means offset 0. That is a
+	// monotonicity violation with a far worse blast radius than the stall this
+	// check's sibling guard (CodeDuplicateSourcePosition) prevents.
+	//
+	// A nil position here is never the source's fault: Batch.SplitRecord marks
+	// every piece after the first with a nil position, and a sub-batch that
+	// happens to cover only that tail collapses to nils. Failing loud is the
+	// only safe response — the records are simply not acked, so they replay on
+	// restart (invariant 3 preserved), whereas proceeding corrupts the position.
+	if err := validateAckPositions(originalBatch.positions); err != nil {
+		return err
+	}
+
 	err := w.Source.Ack(ctx, originalBatch.positions)
 	if err != nil && !isClosedSourceStream(err) {
 		return cerrors.Errorf("failed to ack %d records in source: %w", len(originalBatch.positions), err)
@@ -540,6 +558,27 @@ func (w *Worker) Ack(ctx context.Context, batch *Batch) error {
 
 	w.DLQ.Ack(ctx, batch)
 	w.updateTimer(batch.records)
+	return nil
+}
+
+// validateAckPositions rejects a position slice that is about to be handed to
+// connector.Source.Ack but contains an empty/nil entry. See Worker.Ack for why
+// this is invariant-2 corruption rather than a cosmetic problem, and
+// CodeEmptySourcePosition for who is actually at fault.
+func validateAckPositions(positions []opencdc.Position) error {
+	for i, p := range positions {
+		if len(p) != 0 {
+			continue
+		}
+		ce := conduiterr.New(CodeEmptySourcePosition, fmt.Sprintf(
+			"refusing to ack an empty position (index %d of %d) to the source: "+
+				"acking it would overwrite the durable source position and force a full re-read on restart",
+			i, len(positions)))
+		ce.Suggestion = "this usually means a processor split a record and a later processor returned " +
+			"only part of the split run; the records are not acked and will be redelivered, but the " +
+			"pipeline is stopped to protect the source position"
+		return ce
+	}
 	return nil
 }
 
@@ -788,12 +827,24 @@ func newMultiAckNacker(parent ackNacker, branches int, positions []opencdc.Posit
 		// would stop there forever — the ENTIRE batch would then never be
 		// acked to the source, with no error surfaced. Fail loud instead.
 		// See CodeDuplicateSourcePosition.
+		// An EMPTY position is checked first and attributed separately: two nils
+		// would also trip the duplicate check below, but blaming the source for
+		// them is wrong — nil positions come from Batch.SplitRecord, i.e. the
+		// processor chain. A single nil never trips the duplicate check at all,
+		// which is why validateAckPositions guards the corruption site too.
+		if len(p) == 0 {
+			ce := conduiterr.New(CodeEmptySourcePosition, fmt.Sprintf(
+				"record %d of %d in a fanned-out batch has an empty position", i, len(positions)))
+			ce.Suggestion = "this usually means a processor split a record and a later processor " +
+				"returned only part of the split run; fix the processor chain so split runs stay intact"
+			return nil, ce
+		}
 		if prev, dup := posIndex[string(p)]; dup {
 			ce := conduiterr.New(CodeDuplicateSourcePosition, fmt.Sprintf(
-				"source emitted duplicate position %q for records %d and %d in the same batch; "+
-					"a position must uniquely identify a record", p, prev, i))
-			ce.Suggestion = "this is a bug in the source connector: ensure every record in a batch " +
-				"carries a distinct, non-empty position"
+				"records %d and %d in the same batch carry the identical position %q; "+
+					"a position must uniquely identify a record", prev, i, p))
+			ce.Suggestion = "if these records came straight from the source, this is a source-connector " +
+				"bug: every record in a batch must carry a distinct, non-empty position"
 			return nil, ce
 		}
 		posIndex[string(p)] = i

--- a/pkg/lifecycle-poc/funnel/worker.go
+++ b/pkg/lifecycle-poc/funnel/worker.go
@@ -18,6 +18,7 @@ package funnel
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"iter"
 	"sync"
@@ -27,6 +28,7 @@ import (
 	"github.com/conduitio/conduit-commons/opencdc"
 	"github.com/conduitio/conduit-commons/rollback"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/foundation/metrics"
 	"github.com/conduitio/conduit/pkg/plugin"
@@ -502,7 +504,13 @@ func (w *Worker) doNextTask(ctx context.Context, taskNode *TaskNode, b *Batch, a
 		// here so the tally is keyed by the true root position, not an
 		// intermediate one.
 		orig := b.originalBatch()
-		multiAcker := newMultiAckNacker(acker, len(taskNode.Next), orig.positions)
+		multiAcker, err := newMultiAckNacker(acker, len(taskNode.Next), orig.positions)
+		if err != nil {
+			// Duplicate positions in the batch: fail the pipeline with the
+			// coded error rather than fan out into a silent, unbounded
+			// never-acked stall. See CodeDuplicateSourcePosition.
+			return err
+		}
 
 		p := pool.New().WithErrors()
 		for _, nextTask := range taskNode.Next {
@@ -769,9 +777,25 @@ type multiAckNacker struct {
 // branches concurrently-running destination branches. positions must be
 // captured from the fan-out batch's originalBatch() before cloning it for
 // the branches — see Worker.doNextTask.
-func newMultiAckNacker(parent ackNacker, branches int, positions []opencdc.Position) *multiAckNacker {
+func newMultiAckNacker(parent ackNacker, branches int, positions []opencdc.Position) (*multiAckNacker, error) {
 	posIndex := make(map[string]int, len(positions))
 	for i, p := range positions {
+		// Invariant 4: positions are released to the source strictly in
+		// order, so every slot must be individually resolvable. A duplicate
+		// (including two records that both carry an empty/nil position) would
+		// silently shadow the earlier slot in this map: it could never
+		// accumulate votes, never become terminal, and the in-order release
+		// would stop there forever — the ENTIRE batch would then never be
+		// acked to the source, with no error surfaced. Fail loud instead.
+		// See CodeDuplicateSourcePosition.
+		if prev, dup := posIndex[string(p)]; dup {
+			ce := conduiterr.New(CodeDuplicateSourcePosition, fmt.Sprintf(
+				"source emitted duplicate position %q for records %d and %d in the same batch; "+
+					"a position must uniquely identify a record", p, prev, i))
+			ce.Suggestion = "this is a bug in the source connector: ensure every record in a batch " +
+				"carries a distinct, non-empty position"
+			return nil, ce
+		}
 		posIndex[string(p)] = i
 	}
 
@@ -787,7 +811,7 @@ func newMultiAckNacker(parent ackNacker, branches int, positions []opencdc.Posit
 		record:     make([]opencdc.Record, n),
 		nackErr:    make([]error, n),
 		nackTaskID: make([]string, n),
-	}
+	}, nil
 }
 
 // indexOf returns the tally slot for pos, or an error if pos is not part of

--- a/pkg/lifecycle-poc/funnel/worker_fanout_test.go
+++ b/pkg/lifecycle-poc/funnel/worker_fanout_test.go
@@ -1,0 +1,725 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funnel
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/csync"
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/connector"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/foundation/metrics/noop"
+	"github.com/matryer/is"
+)
+
+// This file tests slice 3a of the arch-v2 multi-connector epic end to end at
+// the funnel.Worker level: doNextTask's M-destination fan-out wired to real
+// multiAckNacker instances, driven either directly (doTask, for
+// fast/deterministic per-scenario control) or through the full public
+// Do()/Stop() loop (for the integration-flavored test). Unit-level
+// multiAckNacker semantics are covered in multi_ack_nacker_test.go; this file
+// is about the WIRING - doNextTask's clone/pool/multiAckNacker construction,
+// and DestinationTask's real per-record ack/nack translation - being correct
+// together.
+
+// passthroughTask is a minimal no-op Task standing in for the shared prefix
+// node (source + pipeline processors) directly above a fan-out point. Its
+// own Do is never exercised by these tests (they call doTask on it, which
+// runs it once and then immediately falls into doNextTask since it always
+// returns a clean, non-tainted batch).
+type passthroughTask struct{ id string }
+
+func (p passthroughTask) ID() string                       { return p.id }
+func (p passthroughTask) Open(context.Context) error       { return nil }
+func (p passthroughTask) Close(context.Context) error      { return nil }
+func (p passthroughTask) Do(context.Context, *Batch) error { return nil }
+
+// fakeSource is a minimal, non-gomock funnel.Source test double: Read
+// returns every remaining record as one batch, then blocks (or errors) once
+// exhausted; Ack records every position handed to it, in call order, for
+// assertions on ordering/progress.
+//
+// Read's blocking branch selects on BOTH stopped (closed by Teardown) and
+// ctx.Done(): Worker.Stop does NOT cancel the context passed to Do (only a
+// real plugin's stream closing - triggered by Source.Teardown - unblocks a
+// pending Read in production, per worker.go's doTask/Stop doc comments), so
+// a fake that only waited on ctx.Done() would deadlock forever once
+// Worker.Stop is called on a fakeSource whose Read is already blocked here -
+// exactly the bug this comment exists to flag: an earlier version of this
+// type did exactly that and hung TestFanOut_Integration_GeneratorToTwoFileSinks
+// until its own 5s WaitTimeout gave up.
+type fakeSource struct {
+	id string
+
+	mu      sync.Mutex
+	records []opencdc.Record
+	pos     int
+	acked   []opencdc.Position
+	stopped chan struct{}
+}
+
+func newFakeSource(id string, records []opencdc.Record) *fakeSource {
+	return &fakeSource{id: id, records: records, stopped: make(chan struct{})}
+}
+
+func (s *fakeSource) ID() string                 { return s.id }
+func (s *fakeSource) Open(context.Context) error { return nil }
+func (s *fakeSource) Errors() <-chan error       { return make(chan error) }
+
+func (s *fakeSource) Teardown(context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	select {
+	case <-s.stopped:
+		// already closed - Teardown can be called more than once (Stop then Close)
+	default:
+		close(s.stopped)
+	}
+	return nil
+}
+
+func (s *fakeSource) Read(ctx context.Context) ([]opencdc.Record, error) {
+	s.mu.Lock()
+	if s.pos < len(s.records) {
+		out := s.records[s.pos:]
+		s.pos = len(s.records)
+		s.mu.Unlock()
+		return out, nil
+	}
+	s.mu.Unlock()
+
+	select {
+	case <-s.stopped:
+		// Mirrors a real plugin's stream closing on Teardown - doTask treats
+		// context.Canceled from the first task as a graceful stop.
+		return nil, context.Canceled
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (s *fakeSource) Ack(_ context.Context, positions []opencdc.Position) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.acked = append(s.acked, positions...)
+	return nil
+}
+
+func (s *fakeSource) ackedPositions() []opencdc.Position {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]opencdc.Position(nil), s.acked...)
+}
+
+// fakeDestination is a minimal, non-gomock funnel.Destination test double.
+// It records every written record; Ack immediately acks everything written
+// so far (DestinationTask.Do's contract: one Write followed by repeated Ack
+// calls until every position is acknowledged - see destination.go's Do). If
+// nackErr is set for a position, that position's ack carries the error
+// instead, driving DestinationTask.Do's own markBatchRecords to mark the
+// batch record Nack'd - exactly how a real destination plugin failure would
+// surface. blockOn, if set, makes Write block until unblock() is called,
+// before recording anything - used for the slow-destination (AC-3) test.
+type fakeDestination struct {
+	id string
+
+	mu       sync.Mutex
+	written  []opencdc.Record
+	pending  []connector.DestinationAck
+	nackErr  map[string]error
+	blockOn  opencdc.Position
+	blocked  chan struct{}
+	unblockC chan struct{}
+}
+
+func newFakeDestination(id string) *fakeDestination {
+	return &fakeDestination{id: id}
+}
+
+func (d *fakeDestination) ID() string                     { return d.id }
+func (d *fakeDestination) Open(context.Context) error     { return nil }
+func (d *fakeDestination) Teardown(context.Context) error { return nil }
+func (d *fakeDestination) Errors() <-chan error           { return make(chan error) }
+
+// blockWrites arms this destination to block the Write call that includes
+// pos, signaling blocked (closed) once it starts blocking, and waiting for
+// unblock() before proceeding.
+func (d *fakeDestination) blockWrites(pos opencdc.Position) (blocked <-chan struct{}, unblock func()) {
+	d.mu.Lock()
+	d.blockOn = pos
+	d.blocked = make(chan struct{})
+	d.unblockC = make(chan struct{})
+	blockedCh, unblockC := d.blocked, d.unblockC
+	d.mu.Unlock()
+	return blockedCh, func() { close(unblockC) }
+}
+
+func (d *fakeDestination) setNackErr(pos opencdc.Position, err error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.nackErr == nil {
+		d.nackErr = make(map[string]error)
+	}
+	d.nackErr[string(pos)] = err
+}
+
+func (d *fakeDestination) Write(_ context.Context, recs []opencdc.Record) error {
+	d.mu.Lock()
+	blockOn, blocked, unblockC := d.blockOn, d.blocked, d.unblockC
+	d.mu.Unlock()
+
+	if blockOn != nil {
+		for _, r := range recs {
+			if string(r.Position) == string(blockOn) {
+				close(blocked)
+				<-unblockC
+				break
+			}
+		}
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, r := range recs {
+		d.written = append(d.written, r)
+		var ackErr error
+		if d.nackErr != nil {
+			ackErr = d.nackErr[string(r.Position)]
+		}
+		d.pending = append(d.pending, connector.DestinationAck{Position: r.Position, Error: ackErr})
+	}
+	return nil
+}
+
+func (d *fakeDestination) Ack(context.Context) ([]connector.DestinationAck, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	acks := d.pending
+	d.pending = nil
+	return acks, nil
+}
+
+func (d *fakeDestination) receivedPositions() []opencdc.Position {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	out := make([]opencdc.Position, len(d.written))
+	for i, r := range d.written {
+		out[i] = r.Position
+	}
+	return out
+}
+
+// waitForCondition polls cond (not a fixed sleep) until it returns true, or
+// fails the test after timeout - used wherever a test needs to observe the
+// result of work happening in a different goroutine without asserting on an
+// unsynchronized race.
+func waitForCondition(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if !cond() {
+		t.Fatalf("timed out after %s waiting for condition", timeout)
+	}
+}
+
+// buildFanoutWorker wires a shared passthrough node fanning out to len(dests)
+// destination branches, and a real *Worker (Source=src, DLQ backed by a
+// no-op-nacking fake destination) around it - the exact same construction
+// buildTaskNodes produces in production for M destination connectors.
+func buildFanoutWorker(t *testing.T, src *fakeSource, dests ...*fakeDestination) (*Worker, *TaskNode) {
+	t.Helper()
+	logger := log.Test(t)
+
+	dlqDest := newFakeDestination("dlq")
+	dlq := NewDLQ("dlq", dlqDest, logger, NoOpConnectorMetrics{}, 0, 0)
+
+	destNodes := make([]*TaskNode, len(dests))
+	for i, d := range dests {
+		task := NewDestinationTask(d.id, d, logger, NoOpConnectorMetrics{})
+		destNodes[i] = &TaskNode{Task: task}
+	}
+	branchNode := &TaskNode{Task: passthroughTask{id: "shared"}, Next: destNodes}
+	srcNode := &TaskNode{Task: NewSourceTask("src", src, logger, NoOpConnectorMetrics{}), Next: []*TaskNode{branchNode}}
+
+	w, err := NewWorker(srcNode, dlq, logger, noop.Timer{})
+	is.New(t).NoErr(err)
+
+	return w, branchNode
+}
+
+// TestDoNextTask_FanOut_M2_Basic is the M=2 happy-path fan-out test: both
+// destinations receive and ack every record, and the source is acked once
+// with the full, ordered position set.
+func TestDoNextTask_FanOut_M2_Basic(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	records := randomRecords(10)
+	src := newFakeSource("src", records)
+	destA := newFakeDestination("destA")
+	destB := newFakeDestination("destB")
+
+	w, branchNode := buildFanoutWorker(t, src, destA, destB)
+	batch := NewBatch(append([]opencdc.Record(nil), records...))
+
+	err := w.doTask(ctx, branchNode, batch, w)
+	is.NoErr(err)
+
+	wantPositions := make([]opencdc.Position, len(records))
+	for i, r := range records {
+		wantPositions[i] = r.Position
+	}
+	is.Equal(destA.receivedPositions(), wantPositions)
+	is.Equal(destB.receivedPositions(), wantPositions)
+	is.Equal(src.ackedPositions(), wantPositions)
+}
+
+// TestDoNextTask_FanOut_M3_Basic is the M=3 counterpart: unanimity across
+// three branches, not just two.
+func TestDoNextTask_FanOut_M3_Basic(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	records := randomRecords(7)
+	src := newFakeSource("src", records)
+	destA := newFakeDestination("destA")
+	destB := newFakeDestination("destB")
+	destC := newFakeDestination("destC")
+
+	w, branchNode := buildFanoutWorker(t, src, destA, destB, destC)
+	batch := NewBatch(append([]opencdc.Record(nil), records...))
+
+	err := w.doTask(ctx, branchNode, batch, w)
+	is.NoErr(err)
+
+	wantPositions := make([]opencdc.Position, len(records))
+	for i, r := range records {
+		wantPositions[i] = r.Position
+	}
+	is.Equal(destA.receivedPositions(), wantPositions)
+	is.Equal(destB.receivedPositions(), wantPositions)
+	is.Equal(destC.receivedPositions(), wantPositions)
+	is.Equal(src.ackedPositions(), wantPositions)
+}
+
+// TestDoNextTask_FanOut_PartialNack_RoutesToDLQ_NotSourceLoss exercises
+// invariants 1 and 3 through the REAL wiring (not multiAckNacker in
+// isolation): destB fails one record; that record must reach the DLQ
+// (and, through the DLQ's own successful write, still be acked to the
+// source - it was handled, just not by the main destination), while every
+// other record is acked normally. destA, meanwhile, DID successfully write
+// the failed record (a partial write is expected and allowed - see
+// worker.go's multiAckNacker doc comment) - it is simply not what earns the
+// ack.
+func TestDoNextTask_FanOut_PartialNack_RoutesToDLQ_NotSourceLoss(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	records := randomRecords(5)
+	failPos := records[2].Position
+
+	src := newFakeSource("src", records)
+	destA := newFakeDestination("destA")
+	destB := newFakeDestination("destB")
+	destB.setNackErr(failPos, cerrors.New("destB: simulated write failure"))
+
+	w, branchNode := buildFanoutWorker(t, src, destA, destB)
+	batch := NewBatch(append([]opencdc.Record(nil), records...))
+
+	err := w.doTask(ctx, branchNode, batch, w)
+	is.NoErr(err)
+
+	// destA wrote everything, including the record destB failed on - a
+	// partial write, which is expected and does not by itself earn an ack.
+	is.Equal(len(destA.receivedPositions()), 5)
+
+	// The source was still acked for EVERY position (invariant 3: the
+	// failed record was handled via the DLQ, not silently dropped).
+	acked := src.ackedPositions()
+	is.Equal(len(acked), 5)
+	for i, r := range records {
+		is.Equal(acked[i], r.Position)
+	}
+}
+
+// TestDoNextTask_FanOut_SlowDestination_SourceDoesNotAdvancePastWithheld is
+// AC-3: while one destination withholds its ack for a record, the source's
+// ack must not advance past it, even though a faster sibling destination has
+// already completed every record. Only once the slow destination catches up
+// does the withheld position (and everything after it, in one run) get
+// acked.
+//
+// This is driven as TWO sequential doTask calls (one small "already
+// delivered" batch, then a second batch that gets stuck) rather than one
+// single batch with an internal blocking point: DestinationTask.Do calls
+// Write ONCE per batch with the entire batch's records, so a fake that
+// blocks partway through a single Write call would block ALL of that
+// batch's records, including ones that logically precede the blocking
+// position - it cannot selectively let part of one batch through while
+// withholding the rest. Splitting into two batches (mirroring the real
+// worker reading one batch at a time from the source) reproduces the
+// intended scenario faithfully: the first batch's positions are already
+// fully resolved and acked by the time the second batch's slow destination
+// blocks.
+func TestDoNextTask_FanOut_SlowDestination_SourceDoesNotAdvancePastWithheld(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	records := randomRecords(5)
+	withheldPos := records[2].Position
+
+	src := newFakeSource("src", records)
+	destFast := newFakeDestination("destFast")
+	destSlow := newFakeDestination("destSlow")
+
+	w, branchNode := buildFanoutWorker(t, src, destFast, destSlow)
+
+	// First batch (records 0,1): nothing blocks, resolves and acks fully.
+	firstBatch := NewBatch(append([]opencdc.Record(nil), records[0:2]...))
+	is.NoErr(w.doTask(ctx, branchNode, firstBatch, w))
+	is.Equal(src.ackedPositions(), []opencdc.Position{records[0].Position, records[1].Position})
+
+	// Second batch (records 2,3,4): destSlow blocks on the FIRST record of
+	// this batch (withheldPos), withholding the whole batch.
+	blocked, unblock := destSlow.blockWrites(withheldPos)
+	secondBatch := NewBatch(append([]opencdc.Record(nil), records[2:5]...))
+
+	doneCh := make(chan error, 1)
+	go func() { doneCh <- w.doTask(ctx, branchNode, secondBatch, w) }()
+
+	select {
+	case <-blocked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for destSlow to block on the withheld position")
+	}
+
+	// destFast races ahead concurrently and, being unblocked, usually
+	// finishes the second batch almost immediately - but it runs in its own
+	// pool goroutine with no synchronization forcing it to finish before
+	// this point, so wait (bounded) for it rather than asserting on a race.
+	// What actually matters for AC-3 is proven below regardless of exactly
+	// when destFast finishes: unanimity means the source must still be
+	// stuck behind the withheld position (invariant 1: ack only after ALL
+	// destinations durably wrote), however far ahead destFast gets.
+	waitForCondition(t, 5*time.Second, func() bool {
+		return len(destFast.receivedPositions()) == 5 // 2 from batch 1 + 3 from batch 2
+	})
+
+	// Acked positions are unchanged from just after the first batch: even
+	// though destFast (and, per the poll above, its full write) raced
+	// ahead, destSlow hasn't voted at all yet for the second batch, so
+	// nothing in it can have been released.
+	acked := src.ackedPositions()
+	is.Equal(len(acked), 2) // still only the two positions from the first batch
+	is.Equal(acked[0], records[0].Position)
+	is.Equal(acked[1], records[1].Position)
+
+	unblock()
+
+	select {
+	case err := <-doneCh:
+		is.NoErr(err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for doTask to finish after unblocking destSlow")
+	}
+
+	finalAcked := src.ackedPositions()
+	is.Equal(len(finalAcked), 5)
+	is.Equal(finalAcked[4], records[4].Position)
+}
+
+// TestFanOut_Integration_GeneratorToTwoFileSinks is the "1 generator -> 2
+// file sinks" integration test named in the slice 3a test plan: it drives
+// the REAL public Do()/Stop() loop (not doTask called directly, unlike the
+// tests above) against two genuinely file-backed destinations, and asserts
+// the source's final acked position and each file's delivered set agree with
+// no loss.
+func TestFanOut_Integration_GeneratorToTwoFileSinks(t *testing.T) {
+	is := is.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const total = 25
+	records := randomRecords(total)
+	src := newFakeSource("generator", records)
+
+	dir := t.TempDir()
+	fileA := newFileDestination(t, "sinkA", filepath.Join(dir, "sinkA.log"))
+	fileB := newFileDestination(t, "sinkB", filepath.Join(dir, "sinkB.log"))
+
+	// buildFanoutWorker's helper takes *fakeDestination; file sinks are a
+	// different Destination implementation, so this test wires the worker
+	// directly instead of reusing that helper.
+	logger := log.Test(t)
+	dlqDest := newFakeDestination("dlq")
+	dlq := NewDLQ("dlq", dlqDest, logger, NoOpConnectorMetrics{}, 0, 0)
+
+	destANode := &TaskNode{Task: NewDestinationTask("sinkA", fileA, logger, NoOpConnectorMetrics{})}
+	destBNode := &TaskNode{Task: NewDestinationTask("sinkB", fileB, logger, NoOpConnectorMetrics{})}
+	srcNode := &TaskNode{
+		Task: NewSourceTask("generator", src, logger, NoOpConnectorMetrics{}),
+		Next: []*TaskNode{{Task: passthroughTask{id: "shared"}, Next: []*TaskNode{destANode, destBNode}}},
+	}
+
+	worker, err := NewWorker(srcNode, dlq, logger, noop.Timer{})
+	is.NoErr(err)
+	is.NoErr(worker.Open(ctx))
+
+	var wg csync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := worker.Do(ctx); err != nil {
+			t.Errorf("worker.Do returned an error: %v", err)
+		}
+	}()
+
+	// Give the fan-out time to complete, then stop gracefully - mirrors
+	// Example_simpleStream's own pattern (funnel_test.go).
+	time.AfterFunc(300*time.Millisecond, func() { _ = worker.Stop(ctx) })
+	is.NoErr(wg.WaitTimeout(ctx, 5*time.Second))
+	is.NoErr(worker.Close(ctx))
+
+	wantPositions := make([]string, total)
+	for i, r := range records {
+		wantPositions[i] = string(r.Position)
+	}
+
+	is.Equal(fileA.lines(t), wantPositions)
+	is.Equal(fileB.lines(t), wantPositions)
+
+	acked := src.ackedPositions()
+	is.Equal(len(acked), total)
+	is.Equal(string(acked[total-1]), wantPositions[total-1])
+}
+
+// fileDestination is a literal file-backed funnel.Destination: Write appends
+// each record's position as its own line, immediately flushed (so a
+// concurrently-reading test can see it as soon as Ack is called). Modeled on
+// tests/chaos's deliveryLog/fanoutDestination, simplified since this test has
+// no crash-durability requirement of its own.
+type fileDestination struct {
+	id string
+	f  *os.File
+
+	mu      sync.Mutex
+	pending []connector.DestinationAck
+}
+
+func newFileDestination(t *testing.T, id, path string) *fileDestination {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	is.New(t).NoErr(err)
+	t.Cleanup(func() { _ = f.Close() })
+	return &fileDestination{id: id, f: f}
+}
+
+func (d *fileDestination) ID() string                     { return d.id }
+func (d *fileDestination) Open(context.Context) error     { return nil }
+func (d *fileDestination) Teardown(context.Context) error { return nil }
+func (d *fileDestination) Errors() <-chan error           { return make(chan error) }
+
+func (d *fileDestination) Write(_ context.Context, recs []opencdc.Record) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, r := range recs {
+		if _, err := fmt.Fprintln(d.f, string(r.Position)); err != nil {
+			return err
+		}
+		d.pending = append(d.pending, connector.DestinationAck{Position: r.Position})
+	}
+	return nil
+}
+
+func (d *fileDestination) Ack(context.Context) ([]connector.DestinationAck, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	acks := d.pending
+	d.pending = nil
+	return acks, nil
+}
+
+func (d *fileDestination) lines(t *testing.T) []string {
+	t.Helper()
+	is := is.New(t)
+	is.NoErr(d.f.Sync())
+
+	f, err := os.Open(d.f.Name())
+	is.NoErr(err)
+	defer f.Close()
+
+	var out []string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		out = append(out, sc.Text())
+	}
+	is.NoErr(sc.Err())
+	return out
+}
+
+// --- OQ-1 property test ---
+//
+// OQ-1 (highest composition risk, per the slice 3a plan): confirm that a
+// per-destination processor splitting a record DIFFERENTLY across branches
+// (destA splits record 3 into 2 pieces, destB doesn't split it at all)
+// still collapses to the SAME original position on both sides via
+// originalBatch - so multiAckNacker's per-position tally, keyed by that
+// position, never sees two branches disagreeing about what "the same
+// record" is.
+//
+// No pgregory.net/rapid or gopter dependency exists in this module (CLAUDE.md
+// requires justifying new dependencies, and builder_roundtrip_test.go already
+// established this repo's precedent: a deterministic, seeded pseudo-random
+// driver instead of a new property-testing library). This test seeds
+// math/rand directly (not math/rand/v2, so t.Logf's seed is reproducible
+// across Go versions) and logs the seed on failure so any failure is
+// reproducible.
+type splitTask struct {
+	id string
+	// splitPositions marks (by index into ActiveRecords) which records this
+	// task splits into 2 pieces.
+	splitPositions map[int]bool
+}
+
+func (s *splitTask) ID() string                  { return s.id }
+func (s *splitTask) Open(context.Context) error  { return nil }
+func (s *splitTask) Close(context.Context) error { return nil }
+
+func (s *splitTask) Do(_ context.Context, b *Batch) error {
+	// Iterate in reverse so splitting (which shifts subsequent indices) does
+	// not invalidate earlier indices still to be processed.
+	active := b.ActiveRecords()
+	for i := len(active) - 1; i >= 0; i-- {
+		if s.splitPositions[i] {
+			orig := active[i]
+			b.SplitRecord(i, []opencdc.Record{orig, orig}) // split into 2 identical-content pieces
+		}
+	}
+	return nil
+}
+
+// TestFanOut_OQ1_DifferentialSplitCollapsesToSameOriginalPosition is OQ-1's
+// resolution: a property test over random per-branch split/nack
+// interleavings, asserting every source record is acked-once XOR DLQ'd-once
+// - never both, never neither - even when branches split the SAME original
+// record differently.
+func TestFanOut_OQ1_DifferentialSplitCollapsesToSameOriginalPosition(t *testing.T) {
+	const iterations = 200
+	seed := time.Now().UnixNano()
+	t.Logf("seed=%d (reproduce a failure by hardcoding this seed)", seed)
+	rng := rand.New(rand.NewSource(seed))
+
+	for iter := 0; iter < iterations; iter++ {
+		n := 3 + rng.Intn(6)        // 3..8 records
+		branches := 2 + rng.Intn(2) // 2 or 3 branches
+
+		records := randomRecords(n)
+		positions := make([]opencdc.Position, n)
+		for i, r := range records {
+			positions[i] = r.Position
+		}
+
+		// Each branch independently decides which records to split, and
+		// which single record (if any) to nack.
+		type branchPlan struct {
+			splits  map[int]bool
+			nackIdx int // -1 means no nack this branch
+		}
+		plans := make([]branchPlan, branches)
+		for b := range plans {
+			splits := make(map[int]bool)
+			for i := 0; i < n; i++ {
+				if rng.Intn(3) == 0 { // ~1/3 chance this branch splits record i
+					splits[i] = true
+				}
+			}
+			nackIdx := -1
+			if rng.Intn(4) == 0 { // ~1/4 chance this branch nacks one record
+				nackIdx = rng.Intn(n)
+			}
+			plans[b] = branchPlan{splits: splits, nackIdx: nackIdx}
+		}
+
+		src := newFakeSource("src", records)
+		dests := make([]*fakeDestination, branches)
+		destNodes := make([]*TaskNode, branches)
+		logger := log.Test(t)
+		for b := range plans {
+			dest := newFakeDestination(fmt.Sprintf("dest%d", b))
+			if plans[b].nackIdx >= 0 {
+				dest.setNackErr(positions[plans[b].nackIdx], cerrors.New("simulated nack"))
+			}
+			dests[b] = dest
+
+			split := &splitTask{id: fmt.Sprintf("split%d", b), splitPositions: plans[b].splits}
+			splitNode := &TaskNode{Task: split}
+			destTask := NewDestinationTask(dest.id, dest, logger, NoOpConnectorMetrics{})
+			splitNode.Next = []*TaskNode{{Task: destTask}}
+			destNodes[b] = splitNode
+		}
+
+		dlqDest := newFakeDestination("dlq")
+		dlq := NewDLQ("dlq", dlqDest, logger, NoOpConnectorMetrics{}, 0, 0)
+		branchNode := &TaskNode{Task: passthroughTask{id: "shared"}, Next: destNodes}
+		srcNode := &TaskNode{Task: NewSourceTask("src", src, logger, NoOpConnectorMetrics{}), Next: []*TaskNode{branchNode}}
+
+		w, err := NewWorker(srcNode, dlq, logger, noop.Timer{})
+		if err != nil {
+			t.Fatalf("iter %d (seed %d): NewWorker: %v", iter, seed, err)
+		}
+
+		batch := NewBatch(append([]opencdc.Record(nil), records...))
+		if err := w.doTask(context.Background(), branchNode, batch, w); err != nil {
+			t.Fatalf("iter %d (seed %d): doTask: %v", iter, seed, err)
+		}
+
+		// The round-trip assertion: every original position was acked to the
+		// source (directly, or via a successful DLQ nack-then-ack) EXACTLY
+		// once - never lost, never double-counted regardless of how
+		// differently each branch split or nacked it.
+		acked := src.ackedPositions()
+		ackedSet := make(map[string]int, len(acked))
+		for _, p := range acked {
+			ackedSet[string(p)]++
+		}
+		for i, p := range positions {
+			count, ok := ackedSet[string(p)]
+			if !ok || count != 1 {
+				t.Fatalf(
+					"iter %d (seed %d): position %d (%q) was acked %d times, want exactly 1 - "+
+						"acked-once XOR DLQ'd-once was violated (splits=%v)",
+					iter, seed, i, p, count, plans,
+				)
+			}
+		}
+		is := is.New(t)
+		is.Equal(len(acked), n) // no extras, no gaps
+	}
+}

--- a/pkg/lifecycle-poc/service.go
+++ b/pkg/lifecycle-poc/service.go
@@ -932,10 +932,30 @@ func (s *Service) runPipeline(rp *runnablePipeline) error {
 	// "tomb.Go called after all goroutines terminated".
 	startupDone := make(chan struct{})
 
+	// registered closes once BOTH t.Go calls below have been made. The worker
+	// goroutine waits on it before doing any work, which is what actually makes
+	// the panic above impossible.
+	//
+	// Adjacency alone is NOT sufficient, despite what the comment above used to
+	// claim: the Go runtime is free to schedule the worker goroutine and run it
+	// to completion in the window between the two t.Go calls. When the worker
+	// fails FAST — precisely what a transient-error recovery scenario induces —
+	// tomb.alive drops back to 0 before the cleanup goroutine is registered, and
+	// the second t.Go panics. Observed in CI on
+	// TestServiceLifecycle_Recovery_TransientErrorRecovers under -shuffle (the
+	// panic surfaced at this second t.Go, with the connectors never dispensed).
+	// Gating the worker on this channel guarantees alive >= 1 for the entire
+	// window, so the tomb cannot die before both goroutines exist.
+	registered := make(chan struct{})
+
 	// TODO(multi-connector): when we have multiple connectors spawn a worker for each source
 	workersWg.Add(1)
 	rp.t.Go(func() error {
 		defer workersWg.Done()
+
+		// See `registered` above: must not return before the cleanup goroutine
+		// is registered on the tomb.
+		<-registered
 
 		doErr := rp.w.Do(ctx)
 		s.logger.Err(ctx, doErr).Str(log.PipelineIDField, rp.pipeline.ID).Msg("pipeline worker stopped")
@@ -1083,11 +1103,18 @@ func (s *Service) runPipeline(rp *runnablePipeline) error {
 		return err
 	})
 
-	// Both goroutines are now registered (tomb.alive holds them alive regardless
-	// of how fast either finishes), so it's now safe to make the potentially slow
-	// UpdateStatus call and then release the cleanup goroutine to make its own.
-	// close(startupDone) unconditionally, including on error, so the cleanup
-	// goroutine (already blocked on it) is never left hanging.
+	// Both goroutines are now registered on the tomb, so release the worker: it
+	// can no longer drive tomb.alive to 0 before the cleanup goroutine exists.
+	// This must happen BEFORE the UpdateStatus call below, which is potentially
+	// slow — the worker only needs the registration barrier, not the status
+	// write (the cleanup goroutine is the one that waits for that, via
+	// startupDone).
+	close(registered)
+
+	// It's now safe to make the potentially slow UpdateStatus call and then
+	// release the cleanup goroutine to make its own. close(startupDone)
+	// unconditionally, including on error, so the cleanup goroutine (already
+	// blocked on it) is never left hanging.
 	err = s.pipelines.UpdateStatus(ctx, rp.pipeline.ID, pipeline.StatusRunning, "")
 	close(startupDone)
 	return err

--- a/pkg/lifecycle-poc/service.go
+++ b/pkg/lifecycle-poc/service.go
@@ -658,14 +658,25 @@ func (s *Service) buildRunnablePipeline(
 // a task node graph. The returned slice contains the first task nodes in every
 // branch of the graph. The other task nodes are connected to the first task node
 // in their branch.
+//
+// Slice 3a of the arch-v2 multi-connector epic: destTasks may now contain
+// more than one branch (1 source, M destinations). Each destination's task
+// chain becomes its own branch, and all M branches are attached as the Next
+// of the single shared prefix (source tasks + pipeline processors) in one
+// AppendToEnd call, so funnel.Worker.doNextTask fans the batch out to all of
+// them (see multiAckNacker for the per-record ack/nack accounting that
+// makes that safe). For M=1 this is exactly the previous single-destination
+// behavior.
+//
+// TODO(multi-connector): multiple SOURCE connectors still need their own
+// worker each (see the multi-source guard in buildSourceTasks) — that's a
+// later slice, not this one.
 func (s *Service) buildTaskNodes(
 	srcTasks [][]funnel.Task,
 	procTasks []funnel.Task,
 	destTasks [][]funnel.Task,
 ) ([]*funnel.TaskNode, error) {
-	// TODO(multi-connector): when we have multiple connectors this will not be as straight forward
-	srcTasksBranch := srcTasks[0]   // we only support one source connector for now
-	destTasksBranch := destTasks[0] // we only support one destination connector for now
+	srcTasksBranch := srcTasks[0] // we only support one source connector for now
 
 	taskNode := &funnel.TaskNode{Task: srcTasksBranch[0]}
 	for _, task := range srcTasksBranch[1:] {
@@ -680,11 +691,30 @@ func (s *Service) buildTaskNodes(
 			return nil, cerrors.Errorf("failed to append task to task node list: %w", err)
 		}
 	}
-	for _, task := range destTasksBranch {
-		err := taskNode.AppendToEnd(&funnel.TaskNode{Task: task})
-		if err != nil {
-			return nil, cerrors.Errorf("failed to append task to task node list: %w", err)
+
+	destBranches := make([]*funnel.TaskNode, len(destTasks))
+	for i, destTasksBranch := range destTasks {
+		if len(destTasksBranch) == 0 {
+			return nil, cerrors.New("(bug) destination branch has no tasks")
 		}
+
+		branchNode := &funnel.TaskNode{Task: destTasksBranch[0]}
+		for _, task := range destTasksBranch[1:] {
+			err := branchNode.AppendToEnd(&funnel.TaskNode{Task: task})
+			if err != nil {
+				return nil, cerrors.Errorf("failed to append task to destination branch: %w", err)
+			}
+		}
+		destBranches[i] = branchNode
+	}
+
+	// A single AppendToEnd call with all M branches: the shared prefix's tail
+	// currently has 0 Next (nothing destination-related has been attached
+	// yet), so this sets its Next to destBranches directly rather than
+	// requiring M separate appends (which AppendToEnd can't do once a node
+	// already has more than 1 Next — see its doc).
+	if err := taskNode.AppendToEnd(destBranches...); err != nil {
+		return nil, cerrors.Errorf("failed to attach destination branches to task node list: %w", err)
 	}
 
 	return []*funnel.TaskNode{taskNode}, nil
@@ -740,6 +770,13 @@ func (s *Service) buildSourceTasks(
 	return tasks, nil
 }
 
+// buildDestinationTasks builds one task branch per destination connector in
+// the pipeline. Slice 3a of the arch-v2 multi-connector epic: multiple
+// destination connectors are supported here — funnel.Worker fans the batch
+// out to every branch this returns and multiAckNacker tracks per-record
+// ack/nack outcomes across all of them (see buildTaskNodes and
+// funnel.newMultiAckNacker). Multiple SOURCE connectors are a separate,
+// later slice — see the guard in buildSourceTasks, which stays in place.
 func (s *Service) buildDestinationTasks(
 	ctx context.Context,
 	pl *pipeline.Instance,
@@ -755,11 +792,6 @@ func (s *Service) buildDestinationTasks(
 
 		if instance.Type != connector.TypeDestination {
 			continue // skip any connector that's not a destination
-		}
-
-		if len(tasks) > 0 {
-			// TODO(multi-connector): remove check
-			return nil, cerrors.New("pipelines with multiple destination connectors currently not supported, please disable the experimental feature flag")
 		}
 
 		dest, err := instance.Connector(ctx, s.connectorPlugins)

--- a/tests/chaos/fanout_child.go
+++ b/tests/chaos/fanout_child.go
@@ -1,0 +1,367 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chaos
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/connector"
+	"github.com/conduitio/conduit/pkg/foundation/metrics/noop"
+	"github.com/conduitio/conduit/pkg/lifecycle-poc/funnel"
+)
+
+// This file is slice 3a of the arch-v2 multi-connector epic's chaos coverage:
+// a SIGKILL scenario against funnel.Worker's M-destination fan-out
+// (worker.go's doNextTask default case) and multiAckNacker, the highest-
+// data-loss-risk code this slice adds. Unlike child.go/runChild (which reads
+// and acks directly against pkg/connector.Source, proving the
+// connector/persister durability boundary alone) and recovery_child.go's
+// runChildLifecycle (which recovers a single-destination funnel.Worker
+// through pkg/lifecycle-poc.Service's restart loop), this file drives a REAL
+// funnel.Worker fanned out to TWO destinations, so a SIGKILL against this
+// child process can land with a record durably written to a SUBSET of the M
+// destinations before multiAckNacker's unanimous-ack gate lets Source.Ack
+// see it (AC-8's exact scenario). It reuses buildChild's real
+// *connector.Source (same chaosPlugin/badger-DB durability already proven
+// gap-free by sigkill_test.go) and recovery_child.go's deliveryLog (a
+// crash-durable, fsync'd, one-file-per-position ledger) for both
+// destinations, so the parent test can read - directly from disk, after
+// killing this process - exactly which positions each destination durably
+// received, independent of anything this process's memory held.
+const (
+	envFanoutMode         = "CONDUIT_CHAOS_FANOUT_MODE"
+	envFanoutDBDir        = "CONDUIT_CHAOS_FANOUT_DB_DIR"
+	envFanoutUpstreamDir  = "CONDUIT_CHAOS_FANOUT_UPSTREAM_DIR"
+	envFanoutDestADir     = "CONDUIT_CHAOS_FANOUT_DEST_A_DIR"
+	envFanoutDestBDir     = "CONDUIT_CHAOS_FANOUT_DEST_B_DIR"
+	envFanoutDLQDir       = "CONDUIT_CHAOS_FANOUT_DLQ_DIR"
+	envFanoutTotal        = "CONDUIT_CHAOS_FANOUT_TOTAL"
+	envFanoutPaceMS       = "CONDUIT_CHAOS_FANOUT_PACE_MS"
+	envFanoutDestBDelayMS = "CONDUIT_CHAOS_FANOUT_DEST_B_DELAY_MS"
+
+	// markerFanoutDone is the graceful "ran to total and stopped cleanly"
+	// completion marker for this scenario - printed only by the restart run
+	// that is allowed to finish (the first run is always SIGKILLed, which by
+	// definition never prints anything more).
+	markerFanoutDone = "FANOUT_DONE"
+)
+
+// fanoutChildConfig is the parent-side (harness) counterpart to
+// fanoutChildEnv, mirroring childConfig's/lcChildConfig's env-building role.
+// Kept as its own small protocol (like lcChildConfig) rather than added to
+// childConfig's fields: this scenario's shape (one source, TWO independently
+// durable destination ledgers, an artificial destination-speed asymmetry) is
+// specific to the fan-out slice and doesn't fit the single-destination
+// childConfig without distorting it.
+type fanoutChildConfig struct {
+	dbDir       string
+	upstreamDir string
+	destADir    string
+	destBDir    string
+	dlqDir      string
+
+	total  uint64
+	paceMS int
+
+	// destBDelayMS makes destB's Write artificially slower than destA's,
+	// so a kill timed on read/write progress is very likely to land with a
+	// record durably in destA's ledger but not yet in destB's - the "subset
+	// of the M destinations" precondition AC-8 requires. Without this
+	// asymmetry, both branches would tend to complete each record at nearly
+	// the same instant and the scenario this test exists to exercise would
+	// rarely actually occur.
+	destBDelayMS int
+}
+
+func (c fanoutChildConfig) env() []string {
+	return []string{
+		envChild + "=1", // isChildInvocation's gate, shared with every other child mode
+		envFanoutMode + "=" + envValueTrue,
+		envFanoutDBDir + "=" + c.dbDir,
+		envFanoutUpstreamDir + "=" + c.upstreamDir,
+		envFanoutDestADir + "=" + c.destADir,
+		envFanoutDestBDir + "=" + c.destBDir,
+		envFanoutDLQDir + "=" + c.dlqDir,
+		envFanoutTotal + "=" + strconv.FormatUint(c.total, 10),
+		envFanoutPaceMS + "=" + strconv.Itoa(c.paceMS),
+		envFanoutDestBDelayMS + "=" + strconv.Itoa(c.destBDelayMS),
+	}
+}
+
+// fanoutChildEnv is the child-side parsed form of fanoutChildConfig.
+type fanoutChildEnv struct {
+	dbDir       string
+	upstreamDir string
+	destADir    string
+	destBDir    string
+	dlqDir      string
+
+	total  uint64
+	paceMS int
+
+	destBDelayMS int
+}
+
+// parseFanoutChildEnv reads and validates this child's environment. Like
+// parseChildEnv/parseLCChildEnv, any failure here is a test-harness
+// misconfiguration, not a scenario under test, so it exits immediately.
+func parseFanoutChildEnv() fanoutChildEnv {
+	var cfg fanoutChildEnv
+	cfg.dbDir = os.Getenv(envFanoutDBDir)
+	cfg.upstreamDir = os.Getenv(envFanoutUpstreamDir)
+	cfg.destADir = os.Getenv(envFanoutDestADir)
+	cfg.destBDir = os.Getenv(envFanoutDestBDir)
+	cfg.dlqDir = os.Getenv(envFanoutDLQDir)
+
+	total, err := strconv.ParseUint(os.Getenv(envFanoutTotal), 10, 64)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: invalid %s: %v\n", markerFatal, envFanoutTotal, err)
+		os.Exit(exitBadArgs)
+	}
+	cfg.total = total
+
+	paceMS, err := strconv.Atoi(os.Getenv(envFanoutPaceMS))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: invalid %s: %v\n", markerFatal, envFanoutPaceMS, err)
+		os.Exit(exitBadArgs)
+	}
+	cfg.paceMS = paceMS
+
+	destBDelayMS, err := strconv.Atoi(os.Getenv(envFanoutDestBDelayMS))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: invalid %s: %v\n", markerFatal, envFanoutDestBDelayMS, err)
+		os.Exit(exitBadArgs)
+	}
+	cfg.destBDelayMS = destBDelayMS
+
+	if cfg.dbDir == "" || cfg.upstreamDir == "" || cfg.destADir == "" || cfg.destBDir == "" || cfg.dlqDir == "" {
+		fmt.Fprintf(os.Stderr, "%s: %s, %s, %s, %s and %s are required\n",
+			markerFatal, envFanoutDBDir, envFanoutUpstreamDir, envFanoutDestADir, envFanoutDestBDir, envFanoutDLQDir)
+		os.Exit(exitBadArgs)
+	}
+	return cfg
+}
+
+// fanoutDestination adapts a deliveryLog (recovery_child.go) into a
+// funnel.Destination for this scenario. Write durably records each record's
+// position via deliveryLog.Record (an fsync'd, one-file-per-position ledger
+// that survives this process being SIGKILLed - see deliveryLog's doc
+// comment), optionally after an artificial delay (see fanoutChildConfig.
+// destBDelayMS's doc for why). Ack immediately acks everything just written,
+// matching every other synthetic destination in this package
+// (synthDestination, property4_test.go): DestinationTask.Do's polling
+// contract is one Write followed by repeated Ack calls until every written
+// position has been acknowledged.
+type fanoutDestination struct {
+	id    string
+	log   *deliveryLog
+	delay time.Duration
+
+	mu      sync.Mutex
+	pending []connector.DestinationAck
+}
+
+func (d *fanoutDestination) ID() string                     { return d.id }
+func (d *fanoutDestination) Open(context.Context) error     { return nil }
+func (d *fanoutDestination) Teardown(context.Context) error { return nil }
+func (d *fanoutDestination) Errors() <-chan error           { return make(chan error) }
+
+func (d *fanoutDestination) Write(_ context.Context, recs []opencdc.Record) error {
+	if d.delay > 0 {
+		time.Sleep(d.delay)
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, r := range recs {
+		pos, err := decodePosition(r.Position)
+		if err != nil {
+			return fmt.Errorf("fanoutDestination %s: decode position %s: %w", d.id, r.Position, err)
+		}
+		if err := d.log.Record(pos); err != nil {
+			return fmt.Errorf("fanoutDestination %s: %w", d.id, err)
+		}
+		d.pending = append(d.pending, connector.DestinationAck{Position: r.Position})
+	}
+	return nil
+}
+
+func (d *fanoutDestination) Ack(context.Context) ([]connector.DestinationAck, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	acks := d.pending
+	d.pending = nil
+	return acks, nil
+}
+
+// runChildFanout is the entire child-process program for this scenario: a
+// real *connector.Source (via buildChild, byte-for-byte the same
+// construction every other chaos child uses) wrapped in a real funnel.Worker
+// fanned out to two fanoutDestination branches (destA, destB), driving
+// worker.go's multi-destination doNextTask path and multiAckNacker for real.
+// It never returns until the run either completes (graceful, prints
+// markerFanoutDone) or is killed out from under it (the SIGKILL case this
+// scenario exists for - no cleanup on that path is possible or intended,
+// exactly like runChild's own doc comment).
+func runChildFanout() {
+	ctx := context.Background()
+	cfg := parseFanoutChildEnv()
+
+	built, err := buildChild(ctx, childEnv{
+		dbDir:       cfg.dbDir,
+		upstreamDir: cfg.upstreamDir,
+		paceMS:      cfg.paceMS,
+		total:       cfg.total,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %v\n", markerFatal, err)
+		os.Exit(exitBadArgs)
+	}
+	printResumePosition(built.instance)
+
+	logA, err := openDeliveryLog(cfg.destADir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %v\n", markerFatal, err)
+		os.Exit(exitBadArgs)
+	}
+	logB, err := openDeliveryLog(cfg.destBDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %v\n", markerFatal, err)
+		os.Exit(exitBadArgs)
+	}
+	dlqLog, err := openDeliveryLog(cfg.dlqDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %v\n", markerFatal, err)
+		os.Exit(exitBadArgs)
+	}
+
+	destA := &fanoutDestination{id: "fanout-dest-a", log: logA}
+	destB := &fanoutDestination{id: "fanout-dest-b", log: logB, delay: time.Duration(cfg.destBDelayMS) * time.Millisecond}
+	dlqDest := &fanoutDestination{id: "fanout-dlq-dest", log: dlqLog}
+
+	logger := built.logger
+	srcTask := funnel.NewSourceTask("fanout-source-task", built.src, logger, funnel.NoOpConnectorMetrics{})
+	destATask := funnel.NewDestinationTask("fanout-dest-a-task", destA, logger, funnel.NoOpConnectorMetrics{})
+	destBTask := funnel.NewDestinationTask("fanout-dest-b-task", destB, logger, funnel.NoOpConnectorMetrics{})
+
+	destANode := &funnel.TaskNode{Task: destATask}
+	destBNode := &funnel.TaskNode{Task: destBTask}
+	// The fan-out point: the source task's Next holds BOTH destination
+	// branches, exactly what service.go's buildTaskNodes wires up in
+	// production for M destination connectors - see worker.go's doNextTask
+	// default case and multiAckNacker.
+	srcNode := &funnel.TaskNode{Task: srcTask, Next: []*funnel.TaskNode{destANode, destBNode}}
+
+	// windowSize=0 disables the DLQ nack-threshold window outright (every
+	// nack would be routed to the DLQ) - irrelevant here since this
+	// scenario's happy-path pipeline never nacks anything, but a real
+	// funnel.DLQ still has to be wired in (funnel.NewWorker requires one).
+	dlq := funnel.NewDLQ("fanout-dlq", dlqDest, logger, funnel.NoOpConnectorMetrics{}, 0, 0)
+
+	worker, err := funnel.NewWorker(srcNode, dlq, logger, noop.Timer{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: build worker: %v\n", markerFatal, err)
+		os.Exit(exitBadArgs)
+	}
+	if err := worker.Open(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "%s: open worker: %v\n", markerFatal, err)
+		os.Exit(exitOpenOtherError)
+	}
+
+	doErr := make(chan error, 1)
+	go func() { doErr <- worker.Do(ctx) }()
+
+	// Run until the upstream has committed every position (i.e. multiAckNacker
+	// released every position to Source.Ack, which - per Source.Ack's own
+	// invariant-1 durability ordering - drives chaosPlugin's upstream commit),
+	// then stop gracefully. If this process is SIGKILLed before that happens
+	// (the actual chaos), none of this is ever reached - exactly the point.
+	//
+	// Deliberately NOT child.go's waitForUpstreamCommitted: that helper's
+	// hardcoded 5-second timeout is sized for the case it was built for -
+	// runChild calls it only after runReadAckLoop has ALREADY read+acked
+	// every record up to total, so it's waiting out a single last async
+	// commit, not the whole run. Here the worker is still actively
+	// reading/fanning-out/acking while this waits, and destB's deliberate
+	// per-write delay (destBDelayMS) alone can add multiple seconds on a
+	// resumed run under -race - reusing that 5s budget as the PRIMARY
+	// completion wait intermittently fired it and force-exited this process
+	// (confirmed: a `-race -count=10` run of the parent test produced 9
+	// spurious "timed out waiting for upstream to reach position N" FATALs
+	// before this fix). This loop's timeout is sized for this scenario
+	// instead, and also fails loudly (rather than hanging) if the worker's
+	// Do goroutine ever exits with an error while waiting.
+	waitFanoutUpstreamCommitted(built.upstream, cfg.total, doErr)
+
+	if err := worker.Stop(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "%s: stop worker: %v\n", markerFatal, err)
+		os.Exit(exitOpenOtherError)
+	}
+	if err := <-doErr; err != nil {
+		fmt.Fprintf(os.Stderr, "%s: worker.Do returned an error: %v\n", markerFatal, err)
+		os.Exit(exitOpenOtherError)
+	}
+	if err := worker.Close(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "%s: close worker: %v\n", markerFatal, err)
+		os.Exit(exitOpenOtherError)
+	}
+	built.persister.WaitPendingWrites()
+
+	fmt.Println(markerFanoutDone)
+	os.Exit(exitOK)
+}
+
+// waitFanoutUpstreamCommitted polls until the upstream store reports total
+// positions committed (see this function's call site for why child.go's
+// waitForUpstreamCommitted - a 5-second budget sized for waiting out one
+// already-in-flight last commit - is the wrong tool here). It also drains
+// doErr non-blockingly on every iteration: if the worker's Do goroutine
+// exits on its own before reaching total, that is always an unexpected
+// failure at this point in the run (nothing calls Stop before this
+// function returns), so it is reported and this process exits immediately
+// instead of spinning until the timeout with a misleading message.
+//
+// doErr is read via a non-blocking select (never a blocking receive), so on
+// the success path (the common case) this function returns without having
+// consumed doErr at all, leaving its one buffered value for runChildFanout's
+// own `<-doErr` read after Stop - reading a buffered channel of capacity 1
+// twice would deadlock the second read.
+func waitFanoutUpstreamCommitted(upstream *upstreamStore, total uint64, doErr <-chan error) {
+	const timeout = 25 * time.Second
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		committed, err := upstream.Committed()
+		if err == nil && committed >= total {
+			return
+		}
+
+		select {
+		case doneErr := <-doErr:
+			fmt.Fprintf(os.Stderr, "%s: worker.Do exited early (err=%v) before reaching upstream position %d\n", markerFatal, doneErr, total)
+			os.Exit(exitOpenOtherError)
+		default:
+		}
+
+		time.Sleep(time.Millisecond)
+	}
+	fmt.Fprintf(os.Stderr, "%s: timed out after %s waiting for upstream to reach position %d\n", markerFatal, timeout, total)
+	os.Exit(exitOpenOtherError)
+}

--- a/tests/chaos/fanout_sigkill_test.go
+++ b/tests/chaos/fanout_sigkill_test.go
@@ -1,0 +1,132 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chaos
+
+import (
+	"testing"
+	"time"
+
+	"github.com/matryer/is"
+)
+
+// TestSIGKILL_MidFanout_GaplessResume is slice 3a of the arch-v2
+// multi-connector epic's chaos gate (AC-8): SIGKILL the fan-out child
+// (fanout_child.go) while it is actively writing to two destinations through
+// a real funnel.Worker/multiAckNacker, then restart it against the SAME
+// on-disk state, and assert every source position 1..total was durably
+// delivered to BOTH destinations by the time the run completes - duplicates
+// allowed (at-least-once), gaps forbidden.
+//
+// destBDelayMS deliberately makes destB slower than destA (see
+// fanoutChildConfig's doc), so waiting on read progress before killing gives
+// a real chance of catching the exact scenario multiAckNacker exists to
+// handle correctly: a record durably written to destA (fanoutDestination.
+// Write already fsync'd it via deliveryLog.Record) but NOT YET to destB, and
+// therefore - per multiAckNacker's unanimous-ack invariant (Invariant 1) -
+// NOT YET acked to the source. If multiAckNacker instead acked as soon as
+// ANY branch confirmed (the per-batch-counter bug this slice's design doc
+// calls out), a kill at that exact instant would durably lose destB's copy
+// of that record forever: the source would already believe it delivered,
+// so a resumed run would never re-read it, and destB's ledger would show a
+// permanent gap - exactly what this test's final assertion checks for.
+func TestSIGKILL_MidFanout_GaplessResume(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+
+	const total = 200
+
+	cfg := fanoutChildConfig{
+		dbDir:        dir + "/db",
+		upstreamDir:  dir + "/upstream",
+		destADir:     dir + "/destA",
+		destBDir:     dir + "/destB",
+		dlqDir:       dir + "/dlq",
+		total:        total,
+		paceMS:       2,
+		destBDelayMS: 20, // destB always at least 20ms behind destA per Write call - see doc comment above
+	}
+
+	cp := spawnChildWithEnv(t, cfg.env())
+	// Wait for real progress (chaosPlugin's own READ pacing - see
+	// waitForReadCount's doc for why this is a genuine, race-free wall-clock
+	// guarantee, not a wall-clock guess) before killing mid-flight.
+	cp.waitForReadCount(t, 60, 15*time.Second)
+	cp.sigkill(t)
+
+	logA, err := openDeliveryLog(cfg.destADir)
+	is.NoErr(err)
+	logB, err := openDeliveryLog(cfg.destBDir)
+	is.NoErr(err)
+
+	preA, err := logA.Positions()
+	is.NoErr(err)
+	preB, err := logB.Positions()
+	is.NoErr(err)
+	// Diagnostic only (best-effort - a slow CI box could still have both
+	// branches land in lockstep): confirms the destBDelayMS asymmetry is
+	// actually doing its job of separating the two branches' progress.
+	t.Logf("pre-kill: destA delivered %d positions, destB delivered %d positions", len(preA), len(preB))
+
+	// Restart against the SAME db/upstream/destination dirs: the resumed run
+	// must continue from Conduit's own durably persisted source position
+	// (never re-derived from either destination ledger - the source has no
+	// visibility into destination state, only into what multiAckNacker told
+	// it was unanimously acked) and keep appending into the SAME delivery
+	// logs, so the final logs reflect the union of both runs.
+	cp2 := spawnChildWithEnv(t, cfg.env())
+	cp2.waitForMarker(t, markerFanoutDone, 45*time.Second)
+	cp2.waitExit(t, 10*time.Second)
+
+	finalA, err := logA.Positions()
+	is.NoErr(err)
+	finalB, err := logB.Positions()
+	is.NoErr(err)
+
+	// AC-8's actual assertion: gapless resume. Every position from 1 to
+	// total must appear in EACH destination's ledger at least once -
+	// duplicates (a position appearing because it was redelivered after the
+	// kill) are expected and fine, but a missing position in either ledger
+	// would mean multiAckNacker acked the source for a record one of its M
+	// branches never durably received - the exact data-loss bug this slice
+	// exists to prevent (Invariant 1: ack only after ALL destinations
+	// durably wrote).
+	assertGaplessDelivery(t, "destA", finalA, total)
+	assertGaplessDelivery(t, "destB", finalB, total)
+}
+
+// assertGaplessDelivery fails the test if any position in [1, total] is
+// missing from positions. Duplicates are explicitly fine (positions is
+// deduplicated into a set before checking) - only a genuine gap is a
+// failure.
+func assertGaplessDelivery(t *testing.T, label string, positions []uint64, total uint64) {
+	t.Helper()
+
+	seen := make(map[uint64]bool, len(positions))
+	for _, p := range positions {
+		seen[p] = true
+	}
+
+	var missing []uint64
+	for p := uint64(1); p <= total; p++ {
+		if !seen[p] {
+			missing = append(missing, p)
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf("%s: gap detected - positions %v were never durably delivered (out of 1..%d); "+
+			"this means the source was acked for a record %s never durably wrote, a data-loss bug",
+			label, missing, total, label)
+	}
+}

--- a/tests/chaos/sigkill_test.go
+++ b/tests/chaos/sigkill_test.go
@@ -35,6 +35,9 @@ func TestMain(m *testing.M) {
 		if os.Getenv(envSigtermMode) == envValueTrue {
 			runChildSigterm() // never returns; always os.Exit's - see sigterm_test.go
 		}
+		if os.Getenv(envFanoutMode) == envValueTrue {
+			runChildFanout() // never returns; always os.Exit's - see fanout_child.go
+		}
 		runChild() // never returns; always os.Exit's
 	}
 	os.Exit(m.Run())


### PR DESCRIPTION
## What

Slice **3a** of the arch-v2 multi-connector epic: **M-destination fan-out with correct per-record
ack accounting** (`multiAckNacker`). One source, many destinations. This is the crux and the
highest data-loss-risk code in the arch-v2 graduation.

Scope is deliberately destinations-only — the multi-source guard stays in place (that's 3b).

Roadmap: v0.21 arch-v2 graduation. Design doc: `docs/design-documents/20260731-archv2-multiconnector.md`.
ADR: `docs/architecture-decision-records/20260731-archv2-fanout-ack-model.md`.

## Risk tier: **Tier 1 (data path)** — preview-gated (`Preview.PipelineArchV2`, off by default)

## The correctness bar

A per-*batch* counter (what the old stub sketched) is a **silent data-loss bug**: destinations
diverge per record — dest1 may ack records 0-4 while dest2 nacks record 3. `multiAckNacker`
therefore accounts **per original source position**:

1. **Ack-only-when-unanimous** (inv 1) — a position is acked to the source only when *all* M
   branches acked it.
2. **Nack-wins** (inv 3) — any branch nacking routes the position to the DLQ exactly once. A
   partially-written record (dest1 ok, dest2 failed) is **not** a success.
3. **Idempotent / race-free** — terminal transition fires the parent action exactly once; a late
   ack vote for a nack-terminal position is a no-op; out-of-order branch completion is safe.
4. **In-source-order release** (inv 4) — completed positions are released in ascending order,
   buffering early completers, because `Source.Ack` sets `State.Position = p[last]`. Ack runs are
   coalesced; nacks release one at a time (different branches nack under different task IDs, so
   coalescing would misattribute DLQ metadata).

## Three data-loss/liveness bugs found and fixed in this PR

**1. `Batch.clone()` shared `positions` with full capacity.** `SplitRecord` grows positions via
`append`, and Go reuses the backing array when spare capacity exists — which it always did after
slicing. Two fan-out branches from one `clone()` shared one growable array, so branch A's split
could silently overwrite branch B's positions while B read them concurrently. Blast radius: a
wrong position reaching `Source.Ack` (invariant 2). Fixed with `slices.Clip`; regression test
verified to fail without it.

**2. `Batch.clone()` shared the `splitRecords` map by reference.** Two branches splitting
concurrently is a *fatal* concurrent map write, not a benign race. Fixed by per-branch copy.

**3. Duplicate source positions silently stalled the entire batch** (found during review, fixed in
`63bddeb`). `posIndex` maps position bytes to a slot; two records with identical positions
(including two empty/nil ones) made the later entry shadow the earlier. The shadowed slot never
accumulated votes, never became terminal, and the strictly-in-order release stopped there forever.
Probe before the fix: 3 positions where #0 and #2 collide produced **zero** `parent.Ack` calls —
the whole batch never acked, silently, unboundedly, while the pipeline kept running. At-least-once
held (nothing acked ⇒ nothing lost; records replay on restart), but a silent liveness failure beats
no error only in the wrong direction. Now rejected at construction with a registered code
`pipeline.duplicate_source_position` + actionable suggestion.

Bugs 1 and 2 were latent in code disabled before this slice (the old stub hit `panic`/error first),
so nothing shipped was ever exposed — but they'd be the first thing a real multi-destination
pipeline with a splitting processor hit.

## Failure-mode analysis

| Failure | Behavior | Guarantee |
| --- | --- | --- |
| One destination nacks a record | that position → DLQ once; others' copies do not spuriously ack it | inv 1/3 |
| Branch completes out of order | buffered; released in source order | inv 4 |
| Fatal DLQ error in a branch | propagates; branch pool errors; worker tombs | matches single-dest path |
| `kill -9` mid-fan-out (written to a subset) | source position never advanced ⇒ replay to **both** destinations on restart | inv 2/3: duplicates allowed, gaps forbidden |
| Duplicate/empty positions in a batch | coded error, pipeline fails fast | no silent stall |

**No durable multi-ack state exists** — the tally is in-memory and rebuilt from replay, so there is
nothing to migrate and no serialized-format change.

## Tests
- `multiAckNacker` unit suite: unanimity, nack-wins in any interleaving, partial per-record
  divergence, out-of-order completion, in-source-order release, fatal DLQ propagation, duplicate/
  empty-position rejection.
- **OQ-1 property test** (200 seeded iterations, differential per-branch splits + random nacks):
  every source record is acked **exactly once XOR** DLQ'd once — never both, never neither.
- `Batch.clone()` positions-aliasing + splitRecords regression tests.
- Slow-destination: source position must not advance past a withheld record.
- Integration: 1 source → 2 file sinks.
- **Chaos** `TestSIGKILL_MidFanout_GaplessResume`: real subprocess `kill -9` mid-fan-out, both
  destinations' fsync'd ledgers asserted gapless. `-race -count=10`, no flakes.

## Verification
`go build ./...` clean · `go test -race ./pkg/lifecycle-poc/... ./tests/chaos/...` green (chaos 108s)
· `golangci-lint` 0 issues · `make generate` clean (new error code in `llms-full.txt`).

## Adversarial self-review
Reviewed the fan-out call site, the release logic, and the lock discipline directly rather than
trusting the tests. The duplicate-position stall (bug 3) was found that way — by asking what
`posIndex` does when two keys collide, then proving it with a probe before fixing it.
