### PR TITLE
fix(funnel): advance the tainted-batch cursor by the span actually covered

### DIFF
--- a/pkg/lifecycle-poc/funnel/worker.go
+++ b/pkg/lifecycle-poc/funnel/worker.go
@@ -391,6 +391,22 @@ func (w *Worker) doTask(
 			break
 		}
 
+		// Invariant 2/3: capture the span this sub-batch covers in the PARENT
+		// batch BEFORE handing it to a task, and advance idx by that — never by
+		// the sub-batch's length afterwards.
+		//
+		// A task may GROW the sub-batch: Batch.SplitRecord appends, and both the
+		// RecordFlagRetry branch (which re-enters doTask) and doNextTask can
+		// trigger it. Because subBatchByFlag three-index-clips, that growth
+		// reallocates and leaves the parent untouched — so after the call
+		// len(subBatch.positions) is larger than the span it actually covered.
+		// Advancing by the grown length made idx overshoot, and the records in
+		// between were never handed to any downstream task, never acked — while
+		// a later sub-batch's ack still advanced the persisted source position
+		// PAST them. Silent, permanent record loss with no error and no gap in
+		// the position sequence. See issue #2722.
+		span := len(subBatch.positions)
+
 		w.logger.Trace(ctx).
 			Str("task_id", t.ID()).
 			Int("batch_size", len(b.records)).
@@ -430,7 +446,7 @@ func (w *Worker) doTask(
 			}
 		}
 
-		idx += len(subBatch.positions)
+		idx += span
 	}
 
 	return nil

--- a/pkg/lifecycle-poc/funnel/worker_retry_span_test.go
+++ b/pkg/lifecycle-poc/funnel/worker_retry_span_test.go
@@ -1,0 +1,117 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funnel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/matryer/is"
+)
+
+// retryThenSplitTask marks one record Retry on its first pass, then on the
+// retry pass splits that record into several. The split GROWS the sub-batch
+// that doTask handed it — which is exactly the shape that made the parent
+// loop's index overshoot.
+type retryThenSplitTask struct {
+	id         string
+	retryIndex int
+	splitInto  int
+	seen       bool
+}
+
+func (t *retryThenSplitTask) ID() string                  { return t.id }
+func (t *retryThenSplitTask) Open(context.Context) error  { return nil }
+func (t *retryThenSplitTask) Close(context.Context) error { return nil }
+
+func (t *retryThenSplitTask) Do(_ context.Context, b *Batch) error {
+	if !t.seen {
+		t.seen = true
+		// First pass over the whole batch: mark exactly one record for retry,
+		// which splits the batch into [ack..][retry][ack..] sub-batches.
+		b.Retry(t.retryIndex, t.retryIndex+1)
+		return nil
+	}
+	// Retry pass: this sub-batch holds just the retried record. Split it,
+	// growing the sub-batch beyond the span it covered in the parent.
+	active := b.ActiveRecords()
+	if len(active) == 1 {
+		pieces := make([]opencdc.Record, t.splitInto)
+		for i := range pieces {
+			pieces[i] = active[0]
+		}
+		b.SplitRecord(0, pieces)
+	}
+	return nil
+}
+
+// TestDoTask_RetryThatSplits_DoesNotSkipRecords is the regression test for
+// issue #2722.
+//
+// doTask's tainted loop advanced its cursor with `idx += len(subBatch.positions)`
+// AFTER handing the sub-batch to a task. A task may GROW that sub-batch
+// (SplitRecord appends), and because subBatchByFlag three-index-clips, the
+// growth reallocates and leaves the parent batch untouched — so the post-call
+// length exceeded the span actually covered. The cursor overshot, and the
+// records in between were never handed to any downstream task and never acked,
+// while a later sub-batch's ack still advanced the persisted source position
+// PAST them. Silent, permanent record loss: no error, and no gap in the
+// position sequence to notice afterwards.
+//
+// Without the fix (advancing by the span captured BEFORE the call) this test
+// fails: positions p2 and p3 never reach the acker, yet p4/p5 do — proving the
+// source position would have moved past undelivered records.
+func TestDoTask_RetryThatSplits_DoesNotSkipRecords(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	const total = 6
+	records := make([]opencdc.Record, total)
+	positions := make([]opencdc.Position, total)
+	for i := range records {
+		records[i] = opencdc.Record{Position: opencdc.Position{byte('p'), byte('0' + i)}}
+		positions[i] = records[i].Position
+	}
+
+	parent := &fakeParentAckNacker{}
+	task := &retryThenSplitTask{id: "retry-split", retryIndex: 1, splitInto: 3}
+	node := &TaskNode{Task: task}
+
+	w := &Worker{
+		logger:         log.Nop(),
+		processingLock: make(chan struct{}, 1),
+	}
+
+	b := NewBatch(records)
+	is.NoErr(w.doTask(ctx, node, b, parent))
+
+	// Every original position must have reached the acker exactly once. The
+	// bug's signature is p2/p3 missing while p4/p5 are present.
+	got := map[string]int{}
+	for _, call := range parent.ackCalls() {
+		for _, p := range call.positions {
+			got[string(p)]++
+		}
+	}
+	for i, p := range positions {
+		if got[string(p)] != 1 {
+			t.Fatalf("position %d (%q) was acked %d times, want exactly 1 — "+
+				"a record was skipped by the retry-span overshoot (acked: %v)",
+				i, p, got[string(p)], got)
+		}
+	}
+}


### PR DESCRIPTION
## What

Fixes **#2722** — silent, permanent record loss in `funnel`'s tainted-batch loop.

## The bug

`doTask` advanced its cursor with `idx += len(subBatch.positions)` **after** handing the sub-batch to a task. A task may **grow** that sub-batch (`Batch.SplitRecord` appends), and both the `RecordFlagRetry` branch (which re-enters `doTask`) and `doNextTask` can trigger it. Because `subBatchByFlag` three-index-clips, the growth reallocates and leaves the parent batch untouched — so the post-call length exceeds the span the sub-batch actually covered.

The cursor overshot. Records in between were **never handed to any downstream task and never acked**, while a later sub-batch's ack still advanced the persisted source position **past** them.

No error. No gap in the position sequence. Monotonic and wrong — the hardest failure shape to detect after the fact. **Invariants 2 and 3.**

## Fix

Capture the span **before** the task call; advance by that.

## Risk tier: **Tier 1 (data path)** — preview-gated (`Preview.PipelineArchV2`, off by default)

## Failure-mode analysis

| | |
| --- | --- |
| **What it broke** | Any pipeline where a processor returns fewer records than it received (emitting `Retry`) and a retry pass then splits — records silently dropped, source position advanced past them |
| **Blast radius** | `Preview.PipelineArchV2` only, off by default today — but this engine is scheduled to become the default, so it is a graduation blocker |
| **Which signal would show it** | None existed. That is the point: no error, no position gap. Detection would have required comparing source-read vs destination-write counts — the divergence metric the arch-v2 flip work is adding |
| **Rollback** | Revert this PR, or run without the preview flag |

The M-destination fan-out path added in 3a was already **immune**: skipped positions never go terminal, so `multiAckNacker`'s strictly-in-order release stalls at the gap rather than releasing past it. It is the single-destination path that lost data — an accidental argument for the in-order release design.

## Regression test

`TestDoTask_RetryThatSplits_DoesNotSkipRecords` reproduces the issue's exact shape: 6 records, one retried, the retry pass splits it 3 ways.

**Verified fail-without/pass-with.** Reverting to the old cursor:

```text
position 2 ("p2") was acked 0 times, want exactly 1 —
a record was skipped by the retry-span overshoot
(acked: map[p0:1 p1:1 p4:1 p5:1])
```

`p2`/`p3` undelivered while `p4`/`p5` acked — i.e. the source position would have moved past undelivered records. With the fix, all six positions are acked exactly once.

## Verification
`go build ./...` clean · `go test -race ./pkg/lifecycle-poc/...` green · full chaos suite green (109s) · `golangci-lint` 0 issues.

## Adversarial self-review
Traced whether any *other* caller advances a cursor by a post-call length (none do). Confirmed the sub-batch really is clipped, so growth cannot write through to the parent — meaning the parent's own indices stay valid and only the cursor arithmetic was wrong. Confirmed the fan-out path's immunity rather than assuming the bug was universal.
