### PR TITLE
fix(funnel): propagate Retry/Filter across split runs (split-run head acked before its tail)

### DIFF
--- a/docs/architecture-decision-records/20260731-archv2-fanout-ack-model.md
+++ b/docs/architecture-decision-records/20260731-archv2-fanout-ack-model.md
@@ -111,13 +111,21 @@ if profiling ever shows otherwise.
   regresses to dropping that map, `multiAckNacker`'s correctness claim above no longer holds for
   pipelines with pre-fan-out splitting.
 
-  **Known gap (narrowing this claim):** convergence assumes a split run carries a _uniform_ status
-  flag. `Batch.Nack` propagates across a run, but `Retry` and `Filter` do not — so a sub-batch can
-  cover only the _head_ of a split run and vote ack for the original position before the tail has
-  been delivered. Tracked as issue #2723; the nil-tail half of that shape is already contained by
-  `validateAckPositions` (an empty position is refused rather than acked, which would otherwise
-  overwrite the durable source position), but the head case remains open. Do not read the
-  convergence claim as covering `Retry`/`Filter`-partitioned split runs.
+  **Known gap, closed:** convergence assumes a split run carries a _uniform_ status flag.
+  `Batch.Nack` propagated across a run from the start, but `Retry` and `Filter` did not — so a
+  sub-batch could cover only the _head_ of a split run and vote ack for the original position
+  before the tail had been delivered. Filed as issue #2723; the nil-tail half of that shape was
+  already contained by `validateAckPositions` (an empty position is refused rather than acked,
+  which would otherwise overwrite the durable source position), but the head case remained open.
+  Fixed by giving every flag that can leave a record "not yet done" (`Retry`, `Filter`, alongside
+  the pre-existing `Nack`) the same whole-run propagation, ranked so a stronger flag can never be
+  downgraded by a weaker one touching a different piece of the same run (`splitRunFlagTier` in
+  `pkg/lifecycle-poc/funnel/batch.go`) — a split run now always carries one uniform flag, so
+  `Worker.subBatchByFlag`'s same-flag grouping can no longer land on a partial run. A defensive,
+  coded backstop (`CodeSplitRunPartitioned`, `validateSplitRunBoundary` in worker.go) rejects a
+  partitioned boundary outright if this guarantee ever regresses, rather than silently allowing a
+  premature ack. The convergence claim above now covers `Retry`/`Filter`-partitioned split runs
+  too, not just `Nack`-partitioned ones.
 - **Extending to N sources is out of scope for this decision.** This ADR only covers 1 source, M
   destinations. A future N-source slice would need its own decision about how (or whether) acks
   compose across multiple `funnel.Worker` instances — not addressed here.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -614,7 +614,7 @@ Author: Meroxa, Inc.
 | `sdk.schema.extract.key.enabled` | bool | true | no | Whether to extract and decode the record key with a schema. |  |
 | `sdk.schema.extract.payload.enabled` | bool | true | no | Whether to extract and decode the record payload with a schema. |  |
 
-## 3. Error codes (90)
+## 3. Error codes (91)
 
 | Reason | gRPC status | Description |
 | --- | --- | --- |
@@ -649,6 +649,7 @@ Author: Meroxa, Inc.
 | `pipeline.name_missing` | InvalidArgument | CodePipelineNameMissing is raised when a pipeline config is missing the required name field. |
 | `pipeline.not_running` | FailedPrecondition | CodePipelineNotRunning is raised when an operation requires the pipeline to be running, but it is currently stopped. |
 | `pipeline.running` | FailedPrecondition | CodePipelineRunning is raised when an operation requires the pipeline to be stopped, but it is currently running. |
+| `pipeline.split_run_partitioned` | Internal | pipeline: split run partitioned |
 | `pipelines.init_destination_exists` | AlreadyExists | pipelines: init destination exists |
 | `pipelines.init_template_flags_exclusive` | InvalidArgument | pipelines: init template flags exclusive |
 | `pipelines.init_template_version_mismatch` | FailedPrecondition | pipelines: init template version mismatch |

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@
 (6 built-in connectors; full parameters in llms-full.txt)
 
 ## Error codes
-- 90 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
+- 91 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
 
 ## MCP tools
 - Read: deploy, doctor, dry_run, inspect, lint, repair, validate

--- a/pkg/lifecycle-poc/funnel/batch.go
+++ b/pkg/lifecycle-poc/funnel/batch.go
@@ -105,8 +105,12 @@ func (b *Batch) Nack(i int, errs ...error) {
 // Note that the indices i and j point to the slice returned by ActiveRecords.
 // If the slice contains filtered records, the filtered records are skipped and
 // not marked to be retried.
+//
+// If any of the marked records belongs to a split run (see SplitRecord), the
+// Retry flag propagates to every other record in that run - see
+// setFlagEscalating and splitRunFlagTier for why.
 func (b *Batch) Retry(i int, j ...int) {
-	b.setFlagNoErr(RecordFlagRetry, i, j...)
+	b.setFlagEscalating(RecordFlagRetry, i, j...)
 	b.tainted = true
 }
 
@@ -120,13 +124,15 @@ func (b *Batch) Retry(i int, j ...int) {
 // Note that the indices i and j point to the slice returned by ActiveRecords.
 // If the slice contains filtered records, the filtered records are skipped and
 // not marked to be retried.
+//
+// Filtering never overrides a stronger flag (Retry/Nack) already present
+// elsewhere in the same split run - see setFlagEscalating and
+// splitRunFlagTier. filterCount is maintained by setFlagEscalating as part of
+// applying the flag, not here, so that a filter that gets refused (because a
+// sibling split-run record already escalated this one past RecordFlagFilter)
+// never gets double-counted.
 func (b *Batch) Filter(i int, j ...int) {
-	b.setFlagNoErr(RecordFlagFilter, i, j...)
-	end := i + 1
-	if len(j) == 1 {
-		end = j[0]
-	}
-	b.filterCount += end - i
+	b.setFlagEscalating(RecordFlagFilter, i, j...)
 }
 
 // SetRecords replaces the records in the batch starting at index i with the
@@ -262,6 +268,13 @@ func (b *Batch) setFlagNoErr(f RecordFlag, i int, j ...int) {
 // assigned to the records starting at index i. If an error is assigned to a
 // split record, all records in the split record are marked with the same flag
 // and error.
+//
+// Only Nack calls this today. The primary record (idx) is always set
+// unconditionally, matching Nack's existing (pre-#2723) behaviour: Nack is
+// the highest tier in splitRunFlagTier, so it can never legitimately be
+// downgraded by a later touch within the same task, and unconditional
+// overwrite has always been how it wins over a sibling split-run record that
+// was previously Filtered or marked for Retry.
 func (b *Batch) setFlagWithErr(f RecordFlag, i int, errs []error) {
 	// TODO: we should not have to recalculate the active record indices every time.
 	activeIndices := b.activeRecordIndices()
@@ -273,8 +286,7 @@ func (b *Batch) setFlagWithErr(f RecordFlag, i int, errs []error) {
 		}
 
 		// Set the flag and error for this record.
-		b.recordStatuses[idx].Flag = f
-		b.recordStatuses[idx].Error = err
+		b.setRecordFlag(idx, f, err)
 
 		// Handle split records when nacking.
 		if len(b.splitRecords) > 0 && f == RecordFlagNack {
@@ -285,10 +297,145 @@ func (b *Batch) setFlagWithErr(f RecordFlag, i int, errs []error) {
 				// records in the split record.
 				from, to := b.findSplitRecord(idx)
 				for j := from; j <= to; j++ {
-					b.recordStatuses[j].Flag = f
-					b.recordStatuses[j].Error = err
+					b.setRecordFlag(j, f, err)
 				}
 			}
+		}
+	}
+}
+
+// splitRunFlagTier ranks a flag by how strongly it must propagate across a
+// split run (the pieces SplitRecord produces from one original record, see
+// the splitRecords field). RecordFlagAck and RecordFlagFilter share the
+// lowest tier because Worker.subBatchByFlag already groups them into a
+// single sub-batch (its "Collect Filters and Acks together" case), so a
+// split run made only of Ack/Filter pieces can never be partitioned by it and
+// needs no further protection here. RecordFlagRetry outranks both: a run
+// that isn't fully done with the current task must be held back and
+// resubmitted as a whole rather than letting some pieces move on ahead of
+// it. RecordFlagNack outranks everything: any single failed piece condemns
+// the entire run (see setFlagWithErr, which predates this ranking but is
+// equivalent to it since Nack already sits at the top).
+//
+// setFlagEscalating and setRecordFlag use this ranking to decide whether a
+// flag write is allowed: a record's flag may only escalate (move to a
+// strictly higher tier) or hold, never downgrade. That asymmetry is what
+// guarantees a split run always ends up carrying one uniform flag - and
+// therefore can never be torn apart by Worker.subBatchByFlag into a
+// sub-batch that covers only part of the run, regardless of the order in
+// which ProcessorTask.Do happens to mark its output ranges (it marks them
+// from the end of the batch towards the start; see the comment there).
+//
+// Invariant 1/3 (design rationale): before this ranking existed, a split
+// run's head could be acked while its tail (marked for Retry or Filter by a
+// later processor that returned fewer records than it received) had gone
+// nowhere - #2723.
+func splitRunFlagTier(f RecordFlag) int {
+	switch f { //nolint:exhaustive // Ack and Filter are intentionally the same tier, handled by default.
+	case RecordFlagNack:
+		return 2
+	case RecordFlagRetry:
+		return 1
+	default: // RecordFlagAck, RecordFlagFilter
+		return 0
+	}
+}
+
+// setRecordFlag writes flag f (and, for a Nack, error err) to the record at
+// idx unless idx already carries a strictly stronger flag per
+// splitRunFlagTier, in which case the write is silently ignored (never
+// downgrade). It keeps filterCount in sync with any Filter <-> non-Filter
+// transition, so HasActiveRecords/ActiveRecords stay accurate even when a
+// record is escalated away from Filter by a sibling split-run record's
+// Retry or Nack (see setFlagEscalating).
+func (b *Batch) setRecordFlag(idx int, f RecordFlag, err error) {
+	if splitRunFlagTier(f) < splitRunFlagTier(b.recordStatuses[idx].Flag) {
+		return
+	}
+	switch {
+	case b.recordStatuses[idx].Flag == RecordFlagFilter && f != RecordFlagFilter:
+		b.filterCount--
+	case f == RecordFlagFilter && b.recordStatuses[idx].Flag != RecordFlagFilter:
+		b.filterCount++
+	}
+	b.recordStatuses[idx].Flag = f
+	if f == RecordFlagNack {
+		b.recordStatuses[idx].Error = err
+	}
+}
+
+// setFlagEscalating sets the flag for the record at index i (or, with a
+// second index j, every record in [i, j)) to f, tier-guarded per
+// splitRunFlagTier: it is used for RecordFlagRetry and RecordFlagFilter,
+// neither of which may downgrade a record a prior touch within the same task
+// already escalated to a stronger flag.
+//
+// If a marked record belongs to a split run, the same tier-guarded write is
+// propagated to every other record in that run (see escalateFlag). This is
+// the mechanism that makes Retry and Filter behave like Nack already did
+// (setFlagWithErr): a split run can never end up carrying a mix of "done
+// with this task" (Ack/Filter) and "not yet" (Retry) that
+// Worker.subBatchByFlag would partition into separate sub-batches - the
+// exact shape that let a split run's head be acked before the rest of the
+// run was ever delivered anywhere (#2723).
+func (b *Batch) setFlagEscalating(f RecordFlag, i int, j ...int) {
+	// TODO: we should not have to recalculate the active record indices every time.
+	activeIndices := b.activeRecordIndices()
+	end := i + 1
+	switch len(j) {
+	case 0:
+	case 1:
+		if i >= j[0] {
+			panic(fmt.Sprintf("invalid range (%d >= %d)", i, j[0]))
+		}
+		end = j[0]
+	default:
+		panic(fmt.Sprintf("too many arguments (%d)", len(j)))
+	}
+
+	for k := i; k < end; k++ {
+		idx := k
+		if activeIndices != nil {
+			// We have filtered records, so we need to use the active index.
+			idx = activeIndices[k]
+		}
+		b.escalateFlag(idx, f)
+	}
+}
+
+// escalateFlag sets the flag of the record at idx to f via setRecordFlag
+// (which refuses to downgrade a strictly stronger existing flag). If idx is
+// part of a split run (its position is nil, or it is the run's head - i.e.
+// its position is a key in splitRecords), the escalation also propagates to
+// every OTHER record in that run, but only where it is a strict upgrade for
+// that specific sibling (splitRunFlagTier(f) > the sibling's current tier).
+//
+// The strict (not "or equal") comparison for siblings is deliberate: it is
+// what stops Filter (tier 0) from ever being pushed onto an Ack sibling
+// (also tier 0) it did not itself choose. Doing that would silently drop the
+// sibling's real output from ActiveRecords - a data-loss bug of its own, not
+// the one this function exists to close. Retry and Nack (tiers 1 and 2)
+// still escalate tier-0 siblings (both Ack and Filter) without any special
+// case, because they are strictly higher.
+func (b *Batch) escalateFlag(idx int, f RecordFlag) {
+	b.setRecordFlag(idx, f, nil)
+
+	if len(b.splitRecords) == 0 {
+		return
+	}
+	pos := b.positions[idx]
+	_, isHead := b.splitRecords[pos.String()]
+	if pos != nil && !isHead {
+		return // idx is not part of a split run.
+	}
+
+	from, to := b.findSplitRecord(idx)
+	for k := from; k <= to; k++ {
+		if k == idx {
+			continue
+		}
+		if splitRunFlagTier(f) > splitRunFlagTier(b.recordStatuses[k].Flag) {
+			b.setRecordFlag(k, f, nil)
 		}
 	}
 }

--- a/pkg/lifecycle-poc/funnel/batch_test.go
+++ b/pkg/lifecycle-poc/funnel/batch_test.go
@@ -234,10 +234,18 @@ func TestBatch_Clone(t *testing.T) {
 		{},
 		{},
 	})
+	// Indices 2 and 3 are the two pieces of the SplitRecord(1, ...) call
+	// above (raw indices 2,3 - pos3 split into 2). clonedBatch.Retry(2)
+	// (active index 2, raw index 3) marks only the SECOND piece, but Retry
+	// propagates across a split run (setFlagEscalating/splitRunFlagTier), so
+	// index 2 (the run's other piece, otherwise left at the default Ack) is
+	// escalated to Retry too - this is the #2723 fix: a split run must never
+	// carry a mix of Ack and Retry, or Worker.subBatchByFlag could later
+	// partition it and ack the run's head before its tail is delivered.
 	is.Equal(clonedBatch.recordStatuses, []RecordStatus{
 		{Flag: RecordFlagFilter},
 		{Flag: RecordFlagNack, Error: nackErr},
-		{Flag: RecordFlagAck},
+		{Flag: RecordFlagRetry},
 		{Flag: RecordFlagRetry},
 	})
 	is.Equal(clonedBatch.positions, []opencdc.Position{

--- a/pkg/lifecycle-poc/funnel/codes.go
+++ b/pkg/lifecycle-poc/funnel/codes.go
@@ -57,3 +57,27 @@ var CodeDuplicateSourcePosition = conduiterr.Register("pipeline.duplicate_source
 // run (a Retry/Filter that does not propagate across the run). The suggestion
 // therefore points at the processor chain, not the source.
 var CodeEmptySourcePosition = conduiterr.Register("pipeline.empty_source_position", codes.FailedPrecondition)
+
+// CodeSplitRunPartitioned is returned when Worker.subBatchByFlag is about to
+// build a sub-batch whose boundary cuts through the middle of a split run
+// (see Batch.SplitRecord) — some of the run's pieces inside the proposed
+// sub-batch, the rest outside it.
+//
+// This should never happen: Batch.Retry, Batch.Filter and Batch.Nack all
+// propagate their flag across a whole split run (splitRunFlagTier in
+// batch.go), specifically so a run always carries one uniform flag and
+// subBatchByFlag's same-flag grouping can never cut through the middle of
+// it. If this error fires anyway, that guarantee has regressed — most likely
+// a new flag-setting code path was added without routing it through the
+// tiered propagation.
+//
+// This is a second line of defense behind that propagation, not a substitute
+// for it: it exists because the alternative is the exact bug this whole
+// mechanism was added to close (#2723) — a sub-batch covering only the head
+// of a split run collapses (via Batch.originalBatch) to the original
+// position and gets acked while the rest of the run has gone nowhere,
+// violating invariants 1 and 3. Failing loud here, before that ack/nack call
+// is ever made, converts a silent data-loss bug into a stopped pipeline with
+// a coded, actionable error — the same trade CodeEmptySourcePosition makes
+// for the nil-tail half of this shape.
+var CodeSplitRunPartitioned = conduiterr.Register("pipeline.split_run_partitioned", codes.Internal)

--- a/pkg/lifecycle-poc/funnel/worker.go
+++ b/pkg/lifecycle-poc/funnel/worker.go
@@ -385,7 +385,10 @@ func (w *Worker) doTask(
 	// status before further processing.
 	idx := 0
 	for {
-		subBatch := w.subBatchByFlag(b, idx)
+		subBatch, err := w.subBatchByFlag(b, idx)
+		if err != nil {
+			return err
+		}
 		if subBatch == nil {
 			w.logger.Trace(ctx).Msg("processed last batch")
 			break
@@ -454,9 +457,17 @@ func (w *Worker) doTask(
 
 // subBatchByFlag collects a sub-batch of records with the same status starting
 // from the given index. It returns nil if firstIndex is out of bounds.
-func (w *Worker) subBatchByFlag(b *Batch, firstIndex int) *Batch {
+//
+// It returns an error if the resulting boundary would partition a split run
+// (see validateSplitRunBoundary) — a defensive backstop, not the primary
+// safeguard: Batch.Retry, Batch.Filter and Batch.Nack are what actually
+// guarantee a split run always carries one uniform flag (splitRunFlagTier in
+// batch.go), so in practice this check should never trip. It exists so that
+// if that guarantee ever regresses, the failure is a loud coded error
+// instead of the silent premature ack #2723 was filed for.
+func (w *Worker) subBatchByFlag(b *Batch, firstIndex int) (*Batch, error) {
 	if firstIndex >= len(b.recordStatuses) {
-		return nil
+		return nil, nil
 	}
 
 	flags := make([]RecordFlag, 0, 2)
@@ -483,7 +494,54 @@ OUTER:
 		break
 	}
 
-	return b.sub(firstIndex, lastIndex)
+	if err := validateSplitRunBoundary(b, firstIndex, lastIndex); err != nil {
+		return nil, err
+	}
+
+	return b.sub(firstIndex, lastIndex), nil
+}
+
+// validateSplitRunBoundary reports an error if the proposed sub-batch bounds
+// [firstIndex, lastIndex) cut through the middle of a split run instead of
+// containing it entirely or excluding it entirely. Split runs are always
+// physically contiguous in a batch (see the splitRecords field), so a single
+// interval boundary can only ever partition a run at one of its two edges —
+// checking both edges (the first and last record the proposed sub-batch
+// would contain) is therefore sufficient to catch every possible partition,
+// including the case where the boundary lands mid-run on both sides at once.
+//
+// See CodeSplitRunPartitioned for why this fires loud rather than letting
+// the partition through.
+func validateSplitRunBoundary(b *Batch, firstIndex, lastIndex int) error {
+	if len(b.splitRecords) == 0 {
+		return nil
+	}
+
+	checkEdge := func(idx int) error {
+		pos := b.positions[idx]
+		_, isHead := b.splitRecords[pos.String()]
+		if pos != nil && !isHead {
+			return nil // idx is not part of a split run.
+		}
+
+		from, to := b.findSplitRecord(idx)
+		if from < firstIndex || to >= lastIndex {
+			ce := conduiterr.New(CodeSplitRunPartitioned, fmt.Sprintf(
+				"split run spanning batch indices [%d,%d] was about to be partitioned by a sub-batch "+
+					"boundary [%d,%d): this would ack or nack part of a split record before the rest of it "+
+					"was durably handled",
+				from, to, firstIndex, lastIndex))
+			ce.Suggestion = "this is an internal invariant violation (see #2723), not a connector or " +
+				"processor bug; please report it"
+			return ce
+		}
+		return nil
+	}
+
+	if err := checkEdge(firstIndex); err != nil {
+		return err
+	}
+	return checkEdge(lastIndex - 1)
 }
 
 // doNextTask advances the batch b to whatever comes after taskNode. A single

--- a/pkg/lifecycle-poc/funnel/worker_split_run_test.go
+++ b/pkg/lifecycle-poc/funnel/worker_split_run_test.go
@@ -1,0 +1,414 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funnel
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	sdk "github.com/conduitio/conduit-processor-sdk"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/foundation/metrics/noop"
+	"github.com/matryer/is"
+	"go.uber.org/mock/gomock"
+)
+
+// This file is the regression coverage for #2723: a split run's head could be
+// acked before its tail (marked for Retry or Filter by a later processor that
+// returned fewer records than it received) was ever delivered anywhere,
+// violating invariants 1 and 3. See splitRunFlagTier and setFlagEscalating in
+// batch.go for the fix, and validateSplitRunBoundary in worker.go for the
+// defensive backstop.
+
+// buildSplitRunRecords returns 3 distinct source records, positions "p0",
+// "p1", "p2".
+func buildSplitRunRecords() (p0, p1, p2 opencdc.Record) {
+	recs := randomRecords(3)
+	recs[0].Position = opencdc.Position("p0")
+	recs[1].Position = opencdc.Position("p1")
+	recs[2].Position = opencdc.Position("p2")
+	return recs[0], recs[1], recs[2]
+}
+
+// TestSplitRun_RetryHead_NotAckedBeforeTailResolved is the exact repro from
+// #2723: processor A splits p0 into 3 pieces; a later processor B (task
+// "procB") returns success for the split run's head but nil (unprocessed,
+// ProcessorTask.Do's documented Retry trigger, see processor.go) for the
+// other two pieces - the same [p0, nil, nil, p1, p2] / [ack, retry, retry,
+// ack, ack] shape the issue's own reproduction used.
+//
+// Before the fix, Worker.subBatchByFlag would partition this into a 1-record
+// Ack sub-batch (just the head) and a 2-record Retry sub-batch (the
+// orphaned tail, which had already lost its splitRecords association - see
+// Batch.sub). The head's sub-batch collapses via Batch.originalBatch to
+// position p0 alone and is acked immediately - before the tail is ever
+// resubmitted to procB. This test wires a REAL two-processor pipeline (not
+// just Batch-level calls) and fails on that premature ack via a strict,
+// ordered gomock expectation: the mocked Source.Ack is only ever set up to
+// accept the position set that is correct AFTER the retry resolves, so any
+// earlier or different call is an unexpected call and fails the test.
+func TestSplitRun_RetryHead_NotAckedBeforeTailResolved(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	logger := log.Test(t)
+	ctrl := gomock.NewController(t)
+
+	p0, p1, p2 := buildSplitRunRecords()
+
+	sourceMock := NewMockSource(ctrl)
+	sourceMock.EXPECT().ID().Return("src").AnyTimes()
+	dlqMock, _ := NewMockDLQ(ctrl, logger)
+
+	processorA := NewMockProcessor(ctrl)
+	processorB := NewMockProcessor(ctrl)
+	destinationMock := NewMockDestination(ctrl)
+
+	srcTask := NewSourceTask("src", sourceMock, logger, NoOpConnectorMetrics{})
+	taskA := NewProcessorTask("procA", processorA, logger, NoOpProcessorMetrics{})
+	taskB := NewProcessorTask("procB", processorB, logger, NoOpProcessorMetrics{})
+	destTask := NewDestinationTask("dest", destinationMock, logger, NoOpConnectorMetrics{})
+
+	destNode := &TaskNode{Task: destTask}
+	bNode := &TaskNode{Task: taskB, Next: []*TaskNode{destNode}}
+	aNode := &TaskNode{Task: taskA, Next: []*TaskNode{bNode}}
+	srcNode := &TaskNode{Task: srcTask, Next: []*TaskNode{aNode}}
+
+	w, err := NewWorker(srcNode, dlqMock, logger, noop.Timer{})
+	is.NoErr(err)
+
+	splitPieces := randomRecords(3) // the 3 pieces processor A splits p0 into
+
+	// Processor A: splits p0 into 3, passes p1/p2 through unchanged.
+	processorA.EXPECT().Process(ctx, []opencdc.Record{p0, p1, p2}).Return(
+		toProcessedRecords([]opencdc.Record{p0, p1, p2}, markMultiRecord(0, splitPieces)),
+	)
+
+	// Processor B, first pass: succeeds for the split run's HEAD (piece 0)
+	// and for p1/p2, but returns nil - "not processed" - for pieces 1 and 2
+	// of the run. This is the exact shape from the issue: only the run's
+	// head looks done.
+	firstPassIn := []opencdc.Record{splitPieces[0], splitPieces[1], splitPieces[2], p1, p2}
+	processorB.EXPECT().Process(ctx, firstPassIn).Return([]sdk.ProcessedRecord{
+		sdk.SingleRecord(splitPieces[0]),
+		nil,
+		nil,
+		sdk.SingleRecord(p1),
+		sdk.SingleRecord(p2),
+	})
+
+	// Processor B, retry pass: called again with ONLY the split run once it
+	// is escalated to Retry as a whole (see setFlagEscalating) - never with
+	// just the head, and never with an orphaned tail missing the head.
+	processorB.EXPECT().Process(ctx, splitPieces).Return(toProcessedRecords(splitPieces))
+
+	// The destination must receive the split run's 3 pieces together
+	// (after the retry resolves), and separately p1/p2 - never a lone head.
+	gomock.InOrder(
+		destinationMock.EXPECT().Write(ctx, splitPieces).Return(nil),
+		destinationMock.EXPECT().Ack(ctx).Return(toDestinationAcks(splitPieces, nil), nil),
+		// Invariant 1/3 enforcement: the source may only be acked for p0
+		// once every piece of its split run has been durably written above -
+		// never for p0 alone while pieces 1/2 are still outstanding.
+		sourceMock.EXPECT().Ack(ctx, []opencdc.Position{p0.Position}).Return(nil),
+		destinationMock.EXPECT().Write(ctx, []opencdc.Record{p1, p2}).Return(nil),
+		destinationMock.EXPECT().Ack(ctx).Return(toDestinationAcks([]opencdc.Record{p1, p2}, nil), nil),
+		sourceMock.EXPECT().Ack(ctx, []opencdc.Position{p1.Position, p2.Position}).Return(nil),
+	)
+
+	batch := NewBatch([]opencdc.Record{p0, p1, p2})
+	err = w.doTask(ctx, aNode, batch, w)
+	is.NoErr(err)
+}
+
+// TestSplitRun_FilterHead_NotAckedBeforeTailResolved is the Filter variant:
+// a split run where one piece is explicitly Filtered while a SIBLING piece
+// of the SAME run is marked Retry (this is what taints the batch - Filter
+// alone never does, see Batch.Filter's doc comment - and is what makes the
+// scenario reachable: Worker.subBatchByFlag only partitions a tainted
+// batch). Before the fix, Batch.Filter never propagated, so
+// Worker.subBatchByFlag's "collect Filter and Ack together" rule would group
+// the filtered piece with the run's (default-Ack) head into a sub-batch that
+// excludes the still-Retry-flagged sibling - the run's head, again, acked
+// before the rest of its own run resolved.
+func TestSplitRun_FilterHead_NotAckedBeforeTailResolved(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	logger := log.Test(t)
+	ctrl := gomock.NewController(t)
+
+	p0, p1, p2 := buildSplitRunRecords()
+
+	sourceMock := NewMockSource(ctrl)
+	sourceMock.EXPECT().ID().Return("src").AnyTimes()
+	dlqMock, _ := NewMockDLQ(ctrl, logger)
+
+	processorA := NewMockProcessor(ctrl)
+	processorB := NewMockProcessor(ctrl)
+	destinationMock := NewMockDestination(ctrl)
+
+	srcTask := NewSourceTask("src", sourceMock, logger, NoOpConnectorMetrics{})
+	taskA := NewProcessorTask("procA", processorA, logger, NoOpProcessorMetrics{})
+	taskB := NewProcessorTask("procB", processorB, logger, NoOpProcessorMetrics{})
+	destTask := NewDestinationTask("dest", destinationMock, logger, NoOpConnectorMetrics{})
+
+	destNode := &TaskNode{Task: destTask}
+	bNode := &TaskNode{Task: taskB, Next: []*TaskNode{destNode}}
+	aNode := &TaskNode{Task: taskA, Next: []*TaskNode{bNode}}
+	srcNode := &TaskNode{Task: srcTask, Next: []*TaskNode{aNode}}
+
+	w, err := NewWorker(srcNode, dlqMock, logger, noop.Timer{})
+	is.NoErr(err)
+
+	splitPieces := randomRecords(3)
+
+	processorA.EXPECT().Process(ctx, []opencdc.Record{p0, p1, p2}).Return(
+		toProcessedRecords([]opencdc.Record{p0, p1, p2}, markMultiRecord(0, splitPieces)),
+	)
+
+	// Processor B, first pass: pieces 0 and 1 of the run are explicitly
+	// Filtered (dropped for good), but piece 2 comes back nil (Retry) - the
+	// run as a whole is NOT done, even though none of its pieces are still
+	// waiting to be acked in the ordinary sense.
+	firstPassIn := []opencdc.Record{splitPieces[0], splitPieces[1], splitPieces[2], p1, p2}
+	processorB.EXPECT().Process(ctx, firstPassIn).Return([]sdk.ProcessedRecord{
+		sdk.FilterRecord{},
+		sdk.FilterRecord{},
+		nil,
+		sdk.SingleRecord(p1),
+		sdk.SingleRecord(p2),
+	})
+
+	// Retry pass: the WHOLE run is resubmitted (all 3 pieces), not just
+	// piece 2 - Filter must not have been able to carve pieces 0/1 out of
+	// the run ahead of piece 2's Retry.
+	processorB.EXPECT().Process(ctx, splitPieces).Return([]sdk.ProcessedRecord{
+		sdk.FilterRecord{},
+		sdk.FilterRecord{},
+		sdk.SingleRecord(splitPieces[2]),
+	})
+
+	// Only piece 2 is actually active (0 and 1 are filtered, but retained in
+	// the batch - see Batch.Filter), so only it reaches the destination.
+	gomock.InOrder(
+		destinationMock.EXPECT().Write(ctx, []opencdc.Record{splitPieces[2]}).Return(nil),
+		destinationMock.EXPECT().Ack(ctx).Return(toDestinationAcks([]opencdc.Record{splitPieces[2]}, nil), nil),
+		sourceMock.EXPECT().Ack(ctx, []opencdc.Position{p0.Position}).Return(nil),
+		destinationMock.EXPECT().Write(ctx, []opencdc.Record{p1, p2}).Return(nil),
+		destinationMock.EXPECT().Ack(ctx).Return(toDestinationAcks([]opencdc.Record{p1, p2}, nil), nil),
+		sourceMock.EXPECT().Ack(ctx, []opencdc.Position{p1.Position, p2.Position}).Return(nil),
+	)
+
+	batch := NewBatch([]opencdc.Record{p0, p1, p2})
+	err = w.doTask(ctx, aNode, batch, w)
+	is.NoErr(err)
+}
+
+// TestWorker_SubBatchByFlag_NeverPartitionsSplitRun asserts the invariant
+// directly at the seam where the bug lived: given a batch whose split run
+// was left with a non-uniform flag by a naive (propagation-unaware) caller -
+// exactly what Batch.Retry produces once escalation is applied - the first
+// Worker.subBatchByFlag call must consume the WHOLE run in one sub-batch,
+// never just its head.
+func TestWorker_SubBatchByFlag_NeverPartitionsSplitRun(t *testing.T) {
+	is := is.New(t)
+	logger := log.Test(t)
+	ctrl := gomock.NewController(t)
+	_, _, taskNode := newMockTasks(ctrl, "sourceTask", "task1")
+	worker, err := NewWorker(taskNode, nil, logger, noop.Timer{})
+	is.NoErr(err)
+
+	records := randomRecords(3) // p0, p1, p2
+	batch := NewBatch(records)
+	batch.SplitRecord(0, randomRecords(3)) // p0 -> 3 pieces; batch is now 5 records
+
+	// Mirrors a later processor returning fewer records than it received for
+	// pieces 1 and 2 of the split run (see Batch.Retry's doc comment).
+	batch.Retry(1, 3)
+
+	sub, err := worker.subBatchByFlag(batch, 0)
+	is.NoErr(err)
+	// The WHOLE split run (3 pieces), not just the 2 explicitly-marked ones
+	// and definitely not just the 1-record head.
+	is.Equal(len(sub.records), 3)
+	is.Equal(sub.recordStatuses, []RecordStatus{
+		{Flag: RecordFlagRetry},
+		{Flag: RecordFlagRetry},
+		{Flag: RecordFlagRetry},
+	})
+
+	// The next sub-batch starts exactly where the run ended - p1 and p2,
+	// untouched.
+	next, err := worker.subBatchByFlag(batch, 3)
+	is.NoErr(err)
+	is.Equal(len(next.records), 2)
+	is.Equal(next.recordStatuses, []RecordStatus{
+		{Flag: RecordFlagAck},
+		{Flag: RecordFlagAck},
+	})
+}
+
+// TestValidateSplitRunBoundary_CatchesForcedPartition unit-tests the
+// defensive backstop (CodeSplitRunPartitioned) in isolation from whether the
+// tier-escalation that is supposed to make it unreachable actually works: it
+// pokes recordStatuses directly (bypassing Batch.Retry/Filter/Nack
+// entirely) to simulate a hypothetical future flag-setting path that forgot
+// to route through setFlagEscalating/setFlagWithErr, and confirms the
+// boundary check still catches the resulting partition and returns a coded,
+// actionable error rather than silently allowing it.
+func TestValidateSplitRunBoundary_CatchesForcedPartition(t *testing.T) {
+	is := is.New(t)
+
+	records := randomRecords(3)
+	batch := NewBatch(records)
+	batch.SplitRecord(0, randomRecords(3)) // p0 -> 3 pieces
+
+	// Force a partitioned state directly, bypassing every public flag-setting
+	// method's propagation.
+	batch.recordStatuses[0].Flag = RecordFlagAck
+	batch.recordStatuses[1].Flag = RecordFlagRetry
+	batch.recordStatuses[2].Flag = RecordFlagRetry
+
+	// A boundary that would carve off just the head (index 0) - exactly the
+	// #2723 shape.
+	err := validateSplitRunBoundary(batch, 0, 1)
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code.Reason(), CodeSplitRunPartitioned.Reason())
+
+	// A boundary that contains the whole run is fine.
+	is.NoErr(validateSplitRunBoundary(batch, 0, 3))
+	// A boundary entirely before or after the run is also fine.
+	is.NoErr(validateSplitRunBoundary(batch, 3, 4))
+}
+
+// splitOnceThenBlockTask splits the record at splitIdx into 3 identical
+// pieces on its first call and marks 2 of them for Retry (mirroring a real
+// processor returning a partial result for a split run), then - if blockCh
+// and resumeCh are set - signals blockCh and waits on resumeCh before
+// returning, so a test can observe a sibling fan-out branch's progress while
+// this branch's split run is still unresolved. The second call (the Retry
+// resubmission) resolves the run cleanly.
+type splitOnceThenBlockTask struct {
+	id       string
+	splitIdx int
+	calls    int
+	blockCh  chan struct{}
+	resumeCh chan struct{}
+}
+
+func (t *splitOnceThenBlockTask) ID() string                  { return t.id }
+func (t *splitOnceThenBlockTask) Open(context.Context) error  { return nil }
+func (t *splitOnceThenBlockTask) Close(context.Context) error { return nil }
+
+func (t *splitOnceThenBlockTask) Do(_ context.Context, b *Batch) error {
+	t.calls++
+	if t.calls > 1 {
+		return nil // retry pass: resolve cleanly
+	}
+
+	active := b.ActiveRecords()
+	orig := active[t.splitIdx]
+	b.SplitRecord(t.splitIdx, []opencdc.Record{orig, orig, orig})
+	b.Retry(t.splitIdx+1, t.splitIdx+3)
+
+	if t.blockCh != nil {
+		close(t.blockCh)
+	}
+	if t.resumeCh != nil {
+		<-t.resumeCh
+	}
+	return nil
+}
+
+// TestFanOut_SplitRun_NoPrematureUnanimity is the fan-out (M=2) composition
+// test: branch A splits the single source record into a 3-piece run and
+// blocks mid-retry (its run is NOT yet fully resolved); branch B, meanwhile,
+// acks the very same original position straight through with no delay.
+//
+// Before the fix, branch A's first pass would let its run's head sub-batch
+// (a lone, already-collapsed position) reach multiAckNacker as a premature
+// ack vote - and since branch B's vote lands immediately, that would be
+// unanimity (M=2) on the FIRST vote, acking the source before branch A's
+// split run ever finished. This test proves that does not happen: while
+// branch A is deliberately held mid-retry, the source must not be acked at
+// all, even though branch B's side is fully done.
+func TestFanOut_SplitRun_NoPrematureUnanimity(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	records := randomRecords(1)
+	pos := records[0].Position
+
+	src := newFakeSource("src", records)
+	destA := newFakeDestination("destA")
+	destB := newFakeDestination("destB")
+
+	blockCh := make(chan struct{})
+	resumeCh := make(chan struct{})
+	splitTaskA := &splitOnceThenBlockTask{id: "splitA", splitIdx: 0, blockCh: blockCh, resumeCh: resumeCh}
+
+	logger := log.Test(t)
+	dlqDest := newFakeDestination("dlq")
+	dlq := NewDLQ("dlq", dlqDest, logger, NoOpConnectorMetrics{}, 0, 0)
+
+	destNodeA := &TaskNode{Task: NewDestinationTask("destA", destA, logger, NoOpConnectorMetrics{})}
+	branchANode := &TaskNode{Task: splitTaskA, Next: []*TaskNode{destNodeA}}
+	branchBNode := &TaskNode{Task: NewDestinationTask("destB", destB, logger, NoOpConnectorMetrics{})}
+
+	fanoutNode := &TaskNode{Task: passthroughTask{id: "shared"}, Next: []*TaskNode{branchANode, branchBNode}}
+	srcNode := &TaskNode{Task: NewSourceTask("src", src, logger, NoOpConnectorMetrics{}), Next: []*TaskNode{fanoutNode}}
+
+	w, err := NewWorker(srcNode, dlq, logger, noop.Timer{})
+	is.NoErr(err)
+
+	batch := NewBatch(append([]opencdc.Record(nil), records...))
+
+	doneCh := make(chan error, 1)
+	go func() { doneCh <- w.doTask(ctx, fanoutNode, batch, w) }()
+
+	// Wait for branch A to reach its blocking point (split run tainted, head
+	// NOT yet resolvable) ...
+	select {
+	case <-blockCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for branch A to reach its blocking point")
+	}
+	// ... and for branch B to independently finish writing (it has no
+	// splits and nothing blocking it).
+	waitForCondition(t, 5*time.Second, func() bool { return len(destB.receivedPositions()) == 1 })
+
+	// Invariant 1/3: branch B's vote alone must not be unanimity. The source
+	// must not have been acked yet, even though branch B is fully done and
+	// branch A's split run - superficially, on its head alone - "looks"
+	// acked-worthy under the pre-fix behavior.
+	is.Equal(len(src.ackedPositions()), 0)
+
+	close(resumeCh) // let branch A's retry pass resolve
+
+	select {
+	case err := <-doneCh:
+		is.NoErr(err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for doTask to finish")
+	}
+
+	is.Equal(src.ackedPositions(), []opencdc.Position{pos})
+	is.Equal(len(destA.receivedPositions()), 3) // the 3 split pieces
+	is.Equal(len(destB.receivedPositions()), 1) // the untouched original
+}

--- a/pkg/lifecycle-poc/funnel/worker_test.go
+++ b/pkg/lifecycle-poc/funnel/worker_test.go
@@ -227,7 +227,8 @@ func TestWorker_subBatchByFlag(t *testing.T) {
 	batch.Filter(2, 4)                 // Filter 2 and 3
 
 	// Ack and Filter are grouped
-	sub := worker.subBatchByFlag(batch, 0)
+	sub, err := worker.subBatchByFlag(batch, 0)
+	is.NoErr(err)
 	is.Equal(len(sub.records), 4)
 	is.Equal(cap(sub.records), 4) // Ensure capacity is correct
 	is.Equal(sub.recordStatuses, []RecordStatus{
@@ -238,13 +239,15 @@ func TestWorker_subBatchByFlag(t *testing.T) {
 	})
 
 	// Nack is alone
-	sub2 := worker.subBatchByFlag(batch, 4)
+	sub2, err := worker.subBatchByFlag(batch, 4)
+	is.NoErr(err)
 	is.Equal(len(sub2.records), 1)
 	is.Equal(cap(sub2.records), 1)
 	is.Equal(sub2.recordStatuses[0].Flag, RecordFlagNack)
 
 	// Out of bounds
-	sub3 := worker.subBatchByFlag(batch, 5)
+	sub3, err := worker.subBatchByFlag(batch, 5)
+	is.NoErr(err)
 	is.Equal(sub3, nil)
 }
 


### PR DESCRIPTION
## What

Fixes **#2723** — a split-run's head could be acked to the source **before its tail was delivered anywhere** (invariants 1 and 3).

## The bug

A processor that splits a record produces a *split run*: N batch entries belonging to ONE original source position. `Batch.Nack` propagated its flag across a whole run; **`Retry` and `Filter` did not**. `ProcessorTask.Do` emits `Retry` whenever a processor returns fewer records than it received — documented, real behavior.

So `doTask`'s tainted loop could build a sub-batch covering only the run's **head**, which collapses via `originalBatch()` to the original position and gets acked while the rest of the run has gone nowhere. Under fan-out both branches ack it, unanimity fires, `Source.Ack` persists it — then the pipeline errors on the tail, but the position is already durable. On restart the source resumes past it and the derived records are gone.

## Fix — flag escalation across split runs

A tier ranking now governs all flag writes: `Nack`(2) > `Retry`(1) > `Ack`/`Filter`(0). A write may only **escalate** a record's tier, never downgrade it. `Retry`/`Filter` route through `setFlagEscalating` → `escalateFlag`, which applies the write and propagates it to every other piece of the same split run — but only where it is a strict upgrade for that sibling.

**`Ack` and `Filter` deliberately share tier 0**: `subBatchByFlag` already groups them into one sub-batch, so that pair can never partition a run. The asymmetry also matters for correctness — it stops `Filter` from clobbering a legitimate `Ack` sibling it didn't choose (which would silently drop real processor output), while still letting `Retry`/`Nack` force a lagging sibling to wait for the rest of the run.

### Latent bug fixed on the way
The pre-existing `Nack` propagation never adjusted `filterCount` when overwriting a `Filter`-flagged sibling, so `HasActiveRecords`/`ActiveRecords` could go stale. Centralizing every write through `setRecordFlag` fixes that for `Nack` too.

### Defensive backstop
`validateSplitRunBoundary` runs at the actual partition decision point (`subBatchByFlag`, before `sub()`) and raises the coded `pipeline.split_run_partitioned` if a boundary would ever cut a run. Propagation should make this unreachable; it exists because a future flag-setting path that forgets to route through the escalating helpers would otherwise silently reintroduce this bug. Same trade as `CodeEmptySourcePosition`.

## Risk tier: **Tier 1 (data path)** — preview-gated (`Preview.PipelineArchV2`, off by default)

## Failure-mode analysis

| Failure | Before | After |
| --- | --- | --- |
| Processor returns fewer records than received, mid split run | head acked before tail delivered → records lost on restart | whole run escalates to `Retry`, stays intact |
| `Filter` on part of a split run | run partitioned | escalates across the run |
| `Nack` on part of a run | already propagated (correct) — but `filterCount` went stale | propagated, count maintained |
| A future flag path bypasses the helpers | silent premature ack | loud coded error at the boundary |

**Rollback:** revert, or run without the preview flag.

## Verification

Fail-without/pass-with confirmed independently (I disabled only the `Retry` propagation and re-ran):

```text
err: split run spanning batch indices [0,2] was about to be partitioned by a
sub-batch boundary [0,1): this would ack or nack part of a split record before
the rest of it was durably handled
--- FAIL: TestSplitRun_RetryHead_NotAckedBeforeTailResolved
```

— the backstop catching it loudly with the primary fix removed, i.e. defence in depth actually works.

Tests: `Retry`-head and `Filter`-head shapes, a run never partitioned across sub-batches, fan-out composition with no premature unanimity, the forced-partition backstop, and the existing split/DLQ/nack behaviour unchanged.

`go build ./...` clean · `go test -race ./pkg/lifecycle-poc/...` green · `golangci-lint` 0 issues · `make generate` leaves the tree clean (new code in `llms.txt`/`llms-full.txt`).

Chaos: green on two clean runs. One earlier run failed on the known-flaky `/mid-snapshot` timing tests while three agents were running concurrently — reporting that rather than hiding it; CI is the arbiter.

## ADR
The "Known gap" bullet added to `20260731-archv2-fanout-ack-model.md` in the same release described exactly this bug and pointed here. Updated to record the fix and the mechanism. The Decision/Alternatives sections are untouched — this was a forward-looking caveat on an open bug, not a settled decision being reversed.
