### PR TITLE
fix(funnel): normalize split-run flags in one pass (supersedes #2725)

### DIFF
--- a/docs/architecture-decision-records/20260731-archv2-fanout-ack-model.md
+++ b/docs/architecture-decision-records/20260731-archv2-fanout-ack-model.md
@@ -111,13 +111,28 @@ if profiling ever shows otherwise.
   regresses to dropping that map, `multiAckNacker`'s correctness claim above no longer holds for
   pipelines with pre-fan-out splitting.
 
-  **Known gap (narrowing this claim):** convergence assumes a split run carries a _uniform_ status
-  flag. `Batch.Nack` propagates across a run, but `Retry` and `Filter` do not — so a sub-batch can
-  cover only the _head_ of a split run and vote ack for the original position before the tail has
-  been delivered. Tracked as issue #2723; the nil-tail half of that shape is already contained by
-  `validateAckPositions` (an empty position is refused rather than acked, which would otherwise
-  overwrite the durable source position), but the head case remains open. Do not read the
-  convergence claim as covering `Retry`/`Filter`-partitioned split runs.
+  **Gap closed (was: narrowing this claim):** convergence used to assume a split run carries a
+  _uniform_ status flag by construction, which wasn't true — `Batch.Nack` propagated across a run,
+  but `Retry` and `Filter` did not, so a sub-batch could cover only the _head_ of a split run and
+  vote ack for the original position before the tail had been delivered (issue #2723).
+  `validateAckPositions` already contained the nil-tail half of that shape (an empty position is
+  refused rather than acked, which would otherwise overwrite the durable source position), but the
+  head case remained open through two review rounds (PR #2725, reverted after an adversarial
+  review found the fix's per-write flag-escalation mutated `filterCount` mid-`Task.Do` and could
+  corrupt content or hang on a non-converging processor).
+  The fix that closed it does not touch `Do` at all: `Batch.normalizeSplitRuns` runs once, after a
+  task's `Do` returns and before `Worker.doTask` partitions the batch, and resolves each split run
+  by rank (`Nack` > `Retry` > `Filter`/`Ack`). The one deliberate asymmetry — `Filter` is never
+  escalated to `Retry` even when the rest of its run is — is itself load-bearing for this ADR's
+  convergence claim: it is what lets a retry pass on a split run actually shrink (filtered pieces
+  stay excluded from `Batch.ActiveRecords`) instead of re-feeding the processor an identical-sized
+  input forever. `Worker.subBatchByFlag` (via `Batch.groupFlagAt`) treats a normalized run as one
+  indivisible unit when partitioning, so it can no longer be torn apart at all; a defensive
+  `CodeSplitRunPartitioned` guard covers the case where some future write path bypasses
+  normalization. This closes #2723 for `Retry`/`Filter`-partitioned split runs, with M=1 and M>1
+  (fan-out) both covered by test. It does **not** close #2726 (a non-converging processor's retry
+  recursion has no bound) — a separate, still-open concern this fix was required not to make any
+  more likely.
 - **Extending to N sources is out of scope for this decision.** This ADR only covers 1 source, M
   destinations. A future N-source slice would need its own decision about how (or whether) acks
   compose across multiple `funnel.Worker` instances — not addressed here.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -614,7 +614,7 @@ Author: Meroxa, Inc.
 | `sdk.schema.extract.key.enabled` | bool | true | no | Whether to extract and decode the record key with a schema. |  |
 | `sdk.schema.extract.payload.enabled` | bool | true | no | Whether to extract and decode the record payload with a schema. |  |
 
-## 3. Error codes (90)
+## 3. Error codes (91)
 
 | Reason | gRPC status | Description |
 | --- | --- | --- |
@@ -649,6 +649,7 @@ Author: Meroxa, Inc.
 | `pipeline.name_missing` | InvalidArgument | CodePipelineNameMissing is raised when a pipeline config is missing the required name field. |
 | `pipeline.not_running` | FailedPrecondition | CodePipelineNotRunning is raised when an operation requires the pipeline to be running, but it is currently stopped. |
 | `pipeline.running` | FailedPrecondition | CodePipelineRunning is raised when an operation requires the pipeline to be stopped, but it is currently running. |
+| `pipeline.split_run_partitioned` | Internal | pipeline: split run partitioned |
 | `pipelines.init_destination_exists` | AlreadyExists | pipelines: init destination exists |
 | `pipelines.init_template_flags_exclusive` | InvalidArgument | pipelines: init template flags exclusive |
 | `pipelines.init_template_version_mismatch` | FailedPrecondition | pipelines: init template version mismatch |

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@
 (6 built-in connectors; full parameters in llms-full.txt)
 
 ## Error codes
-- 90 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
+- 91 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
 
 ## MCP tools
 - Read: deploy, doctor, dry_run, inspect, lint, repair, validate

--- a/pkg/lifecycle-poc/funnel/batch.go
+++ b/pkg/lifecycle-poc/funnel/batch.go
@@ -21,6 +21,7 @@ import (
 	"slices"
 
 	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 )
 
 // Batch represents a batch of records that are processed together. It keeps
@@ -204,12 +205,41 @@ func (b *Batch) SplitRecord(i int, recs []opencdc.Record) {
 
 	b.records = append(b.records[:i], append(recs, b.records[i+1:]...)...)
 
-	// Extend the record statuses slice to accommodate the new records. By default
-	// the new records are marked as acked. The original record must have been
-	// acked, otherwise the processor wouldn't receive it.
+	// Extend the record statuses slice to accommodate the new records. Each
+	// new piece REPLICATES the CURRENT status of the record being split
+	// (index i) — it is not safe to default them to Ack (the zero value).
+	//
+	// The old comment here ("the original record must have been acked,
+	// otherwise the processor wouldn't receive it") is stale: it assumed the
+	// only way a record ever reaches SplitRecord is fresh off the Ack
+	// default. That is not a guarantee this type upholds — a record already
+	// part of an unresolved split run can be split further with a non-Ack
+	// status (e.g. Nack, which still propagates across a run — see
+	// normalizeSplitRuns). Defaulting the new pieces to Ack in that case
+	// would silently inject wrongly-flagged pieces into an already-Nack'd or
+	// already-Retry'd run, corrupting the run's uniformity — see #2723 and
+	// the adversarial review of #2725 (finding A) for the shape this caused.
+	current := b.recordStatuses[i]
+	if current.Flag == RecordFlagFilter {
+		// Unreachable through SplitRecord's own calling convention: i has
+		// just been translated through activeRecordIndices(), which by
+		// construction only ever yields indices whose current flag is NOT
+		// Filter (filtered records are excluded from ActiveRecords, and
+		// SplitRecord is only ever called — from ProcessorTask.Do's
+		// markBatchRecords — with an index derived from ActiveRecords).
+		// Panic rather than silently mis-accounting filterCount if some
+		// future caller ever violates that contract directly.
+		panic("(bug) SplitRecord: cannot split an already-filtered record - " +
+			"filtered records are excluded from ActiveRecords and unreachable " +
+			"via the active-index calling convention")
+	}
+	newStatuses := make([]RecordStatus, 0, len(recs)-1)
+	for k := 0; k < len(recs)-1; k++ {
+		newStatuses = append(newStatuses, current)
+	}
 	b.recordStatuses = append(
 		b.recordStatuses[:i+1],
-		append(make([]RecordStatus, len(recs)-1), b.recordStatuses[i+1:]...)...,
+		append(newStatuses, b.recordStatuses[i+1:]...)...,
 	)
 
 	// Extend the positions slice to accommodate the new records. The new records
@@ -262,6 +292,23 @@ func (b *Batch) setFlagNoErr(f RecordFlag, i int, j ...int) {
 // assigned to the records starting at index i. If an error is assigned to a
 // split record, all records in the split record are marked with the same flag
 // and error.
+//
+// Only Nack calls this today, and its split-run propagation below is kept
+// exactly as it always was (pre-dating #2723, and confirmed correct by the
+// adversarial review of #2725) — a failed piece condemns its whole run
+// immediately, not deferred to normalizeSplitRuns. This is deliberately NOT
+// generalized to Retry/Filter: those two are written as plain, local,
+// single-index ops during Do and reconciled in exactly one place,
+// normalizeSplitRuns, after Do returns — see its doc comment for why
+// mutating cross-record state DURING Do's own marking pass is the failure
+// mode this whole redesign exists to avoid (findings A and B of that
+// review). Nack does not carry that risk here because propagating it can
+// only ever move a sibling's flag towards Nack — the run's most severe,
+// terminal state — never destabilize the active-index mapping in a way
+// later, lower-index calls in the same pass depend on: activeRecordIndices
+// always re-derives its index list from the records' actual flags, so a
+// stale filterCount can only ever make it (safely) skip its own fast path,
+// not return a wrong index set.
 func (b *Batch) setFlagWithErr(f RecordFlag, i int, errs []error) {
 	// TODO: we should not have to recalculate the active record indices every time.
 	activeIndices := b.activeRecordIndices()
@@ -273,8 +320,7 @@ func (b *Batch) setFlagWithErr(f RecordFlag, i int, errs []error) {
 		}
 
 		// Set the flag and error for this record.
-		b.recordStatuses[idx].Flag = f
-		b.recordStatuses[idx].Error = err
+		b.setRecordFlagWithErr(idx, f, err)
 
 		// Handle split records when nacking.
 		if len(b.splitRecords) > 0 && f == RecordFlagNack {
@@ -285,10 +331,245 @@ func (b *Batch) setFlagWithErr(f RecordFlag, i int, errs []error) {
 				// records in the split record.
 				from, to := b.findSplitRecord(idx)
 				for j := from; j <= to; j++ {
-					b.recordStatuses[j].Flag = f
-					b.recordStatuses[j].Error = err
+					b.setRecordFlagWithErr(j, f, err)
 				}
 			}
+		}
+	}
+}
+
+// setRecordFlagWithErr sets the flag and error for the record at idx,
+// keeping filterCount in sync with any Filter -> non-Filter transition (see
+// setFlagWithErr's Nack-propagation loop, which can overwrite a Filter-
+// flagged sibling elsewhere in the same split run) so
+// HasActiveRecords/ActiveRecords stay accurate afterwards.
+func (b *Batch) setRecordFlagWithErr(idx int, f RecordFlag, err error) {
+	if b.recordStatuses[idx].Flag == RecordFlagFilter && f != RecordFlagFilter {
+		b.filterCount--
+	}
+	b.recordStatuses[idx].Flag = f
+	b.recordStatuses[idx].Error = err
+}
+
+// normalizeSplitRuns walks the batch once, immediately after a task's Do has
+// returned and before Worker.doTask partitions a tainted batch into
+// sub-batches, and resolves every split run (see SplitRecord) to a flag
+// arrangement that Worker.subBatchByFlag can always group as a single unit.
+//
+// This — not per-write escalation during Do — is the fix for #2723: a split
+// run whose pieces disagree (e.g. one piece nacked or marked for retry while
+// another already succeeded) can no longer be torn apart by subBatchByFlag
+// into a sub-batch that acks the run's head while the rest of the run is
+// still outstanding.
+//
+// It must run exactly once, after Do has fully returned. ProcessorTask.Do's
+// own marking loop processes ranges end-to-start specifically so that
+// filterCount and the active-index mapping stay stable for the lower-index
+// calls still to come; mutating either while that loop is still running —
+// the failure mode of an earlier, per-write "escalation" design (see the
+// adversarial review of #2725, findings A and B) — can silently corrupt
+// which physical record a later, lower-index call actually touches.
+// Reconciling once, after Do has committed all of its writes, sidesteps that
+// whole class of bug. It also keeps the operation O(n): every record is
+// visited a constant number of times total, rather than the O(run²) an
+// escalate-on-every-write design pays by re-walking a run's siblings on each
+// individual write (finding D).
+func (b *Batch) normalizeSplitRuns() {
+	if len(b.splitRecords) == 0 {
+		return // Fast path: the batch has no split runs at all.
+	}
+
+	i := 0
+	for i < len(b.recordStatuses) {
+		pos := b.positions[i]
+		_, isHead := b.splitRecords[pos.String()]
+		if pos != nil && !isHead {
+			i++ // An ordinary, unsplit record.
+			continue
+		}
+
+		from, to := b.findSplitRecord(i)
+		b.normalizeRun(from, to)
+		i = to + 1
+	}
+}
+
+// normalizeRun resolves the split run occupying records [from,to] (inclusive)
+// so Worker.subBatchByFlag will always group it as a single unit, regardless
+// of which of its pieces the task that just ran happened to mark first.
+//
+// Resolution, highest severity first (Nack > Retry > Filter/Ack):
+//
+//   - Any piece Nack: the entire run failed. Every piece — including any
+//     that were individually Filter or Ack — is set to Nack, carrying the
+//     first (lowest-index) Nack error found in the run. In practice a run
+//     should already be uniformly Nack by the time this runs: Batch.Nack
+//     (setFlagWithErr) propagates across a split run immediately, unlike
+//     Retry/Filter — see its doc comment for why that is safe to do inline
+//     during Do while Retry/Filter are not. This branch is therefore a
+//     defensive, idempotent restatement of that same rule, not the primary
+//     mechanism — cheap insurance if some future write path ever sets Nack
+//     without going through setFlagWithErr. When more than one piece is
+//     found individually nacked, picking the first (lowest-index) error as
+//     representative is an arbitrary but deterministic tie-break; which
+//     exact message reaches the DLQ record is not itself correctness-
+//     relevant — that the whole run is uniformly treated as failed is.
+//
+//   - No Nack, but any piece Retry: the run is not done. Every piece that
+//     is NOT Filter is set to Retry, so the whole run is resubmitted
+//     together the next time this task runs — without this, an already-
+//     Ack'd piece would stay behind and reach the source's ack path while
+//     the Retry piece(s) were still outstanding (#2723 itself).
+//
+//     Filter pieces are deliberately left untouched — this is the
+//     resolution for a run that contains BOTH Filter and Retry. Filter is a
+//     final decision the processor already made about that specific piece;
+//     escalating it to Retry would silently undo that decision. It would
+//     also re-feed the processor an unchanged-size input on the very next
+//     attempt: for a processor whose output is a deterministic function of
+//     its input (e.g. one that drops everything past a size limit), that is
+//     a fixpoint that never resolves (the unbounded-recursion crash tracked
+//     separately in #2726 — not fixed here, but this choice must not make
+//     it more likely, and preserving Filter shrinks the input instead of
+//     leaving it the same size). Preserving Filter lets a retry pass
+//     actually converge: previously-filtered pieces stay excluded from
+//     Batch.ActiveRecords and are never resubmitted, so the processor sees
+//     strictly less input each time a piece is dropped for good.
+//
+//     A run left in this state carries two distinct flags at once (Retry
+//     and Filter) — see Batch.groupFlagAt for how Worker.subBatchByFlag
+//     still treats the whole run as one group.
+//
+//   - Otherwise every piece is already Ack or Filter, a combination
+//     Worker.subBatchByFlag has always grouped as one bucket. Nothing to do.
+func (b *Batch) normalizeRun(from, to int) {
+	hasNack, hasRetry := false, false
+	var nackErr error
+	for k := from; k <= to; k++ {
+		switch b.recordStatuses[k].Flag { //nolint:exhaustive // only these two flags matter here.
+		case RecordFlagNack:
+			if !hasNack {
+				nackErr = b.recordStatuses[k].Error
+			}
+			hasNack = true
+		case RecordFlagRetry:
+			hasRetry = true
+		}
+	}
+
+	switch {
+	case hasNack:
+		for k := from; k <= to; k++ {
+			b.overwriteRunMember(k, RecordFlagNack, nackErr)
+		}
+	case hasRetry:
+		for k := from; k <= to; k++ {
+			if b.recordStatuses[k].Flag == RecordFlagFilter {
+				continue // Preserved — see the doc comment above.
+			}
+			b.overwriteRunMember(k, RecordFlagRetry, nil)
+		}
+	}
+}
+
+// overwriteRunMember sets the record at idx to flag f (and, for a Nack, error
+// err), keeping filterCount in sync with any Filter -> non-Filter transition
+// so HasActiveRecords/ActiveRecords stay accurate. f is always
+// RecordFlagNack or RecordFlagRetry here — normalizeRun never assigns Filter
+// through this path — so there is no non-Filter -> Filter case to handle.
+func (b *Batch) overwriteRunMember(idx int, f RecordFlag, err error) {
+	if b.recordStatuses[idx].Flag == RecordFlagFilter {
+		b.filterCount--
+	}
+	b.recordStatuses[idx].Flag = f
+	b.recordStatuses[idx].Error = err
+}
+
+// groupFlagAt returns the flag Worker.subBatchByFlag should treat the record
+// at idx as carrying, along with the index one past the span that flag
+// applies to.
+//
+// For an ordinary (non-split) record, that is just its own flag and idx+1.
+// For a member of a split run, the span is always the run's full [from,to]
+// bounds — never a partial slice of it — because normalizeSplitRuns
+// guarantees every run has at most one non-Filter flag (Nack, Retry or Ack)
+// among its pieces by the time this is called; that single flag (or Filter,
+// if literally every piece in the run was filtered) is what is returned.
+//
+// It returns an error if the run is NOT actually uniform — i.e. it finds
+// two DIFFERENT non-Filter flags among the run's pieces. This is what makes
+// the CodeSplitRunPartitioned backstop reachable at all: without checking
+// uniformity here, a physically contiguous run would always be swallowed as
+// one atomic span regardless of whether its pieces actually agree, silently
+// masking exactly the corruption this whole mechanism exists to catch (a
+// boundary check alone, run AFTER this function already collapsed the run
+// to one — possibly wrong — flag, would never see the inconsistency).
+func (b *Batch) groupFlagAt(idx int) (RecordFlag, int, error) {
+	if len(b.splitRecords) == 0 {
+		return b.recordStatuses[idx].Flag, idx + 1, nil
+	}
+	pos := b.positions[idx]
+	_, isHead := b.splitRecords[pos.String()]
+	if pos != nil && !isHead {
+		return b.recordStatuses[idx].Flag, idx + 1, nil // Not a run member.
+	}
+
+	from, to := b.findSplitRecord(idx)
+	flag := RecordFlagFilter
+	found := false
+	for k := from; k <= to; k++ {
+		f := b.recordStatuses[k].Flag
+		if f == RecordFlagFilter {
+			continue
+		}
+		if !found {
+			flag, found = f, true
+			continue
+		}
+		if f != flag {
+			return RecordFlagAck, to + 1, newSplitRunPartitionedError(from, to, -1, -1)
+		}
+	}
+	return flag, to + 1, nil
+}
+
+// newSplitRunPartitionedError builds the CodeSplitRunPartitioned error
+// shared by groupFlagAt (a run's pieces disagree with each other) and
+// validateSplitRunBoundary (a proposed sub-batch boundary would cut a run in
+// two) — the same underlying problem from two different vantage points.
+// firstIndex/lastIndex may be passed as -1 when the caller has no boundary
+// of its own to report (groupFlagAt detects the inconsistency before any
+// boundary is even proposed).
+func newSplitRunPartitionedError(from, to, firstIndex, lastIndex int) error {
+	detail := fmt.Sprintf("split run spanning batch indices [%d,%d] carries inconsistent flags", from, to)
+	if firstIndex >= 0 {
+		detail += fmt.Sprintf(" and was about to be partitioned by a sub-batch boundary [%d,%d)", firstIndex, lastIndex)
+	}
+	detail += ": this would ack or nack part of a split record before the rest of it was durably handled"
+
+	ce := conduiterr.New(CodeSplitRunPartitioned, detail)
+	ce.Suggestion = "this indicates a bug in Conduit's split-run flag normalization (see " +
+		"Batch.normalizeSplitRuns), not a connector or processor bug; please report it with the " +
+		"pipeline's processor chain and, if possible, a reproducing config"
+	return ce
+}
+
+// resetForRetry resets every record currently flagged Retry back to Ack, so
+// a task resubmitted via Worker.doTask's RecordFlagRetry case sees them as
+// fresh input. Records flagged Filter are left untouched.
+//
+// Preserving Filter here — rather than the previous unconditional
+// Ack(0, len(records)) reset — is what makes a retry pass on a split run
+// that mixes Filter and Retry pieces (see normalizeRun) actually shrink: a
+// Filter-flagged piece stays excluded from Batch.ActiveRecords, so the
+// processor is fed fewer records than on the previous attempt instead of an
+// identical-sized batch. That is the difference between a retry that can
+// converge and one that is a fixpoint (see #2726).
+func (b *Batch) resetForRetry() {
+	for i := range b.recordStatuses {
+		if b.recordStatuses[i].Flag == RecordFlagRetry {
+			b.recordStatuses[i].Flag = RecordFlagAck
+			b.recordStatuses[i].Error = nil
 		}
 	}
 }

--- a/pkg/lifecycle-poc/funnel/codes.go
+++ b/pkg/lifecycle-poc/funnel/codes.go
@@ -57,3 +57,26 @@ var CodeDuplicateSourcePosition = conduiterr.Register("pipeline.duplicate_source
 // run (a Retry/Filter that does not propagate across the run). The suggestion
 // therefore points at the processor chain, not the source.
 var CodeEmptySourcePosition = conduiterr.Register("pipeline.empty_source_position", codes.FailedPrecondition)
+
+// CodeSplitRunPartitioned is returned when Worker.subBatchByFlag is about to
+// build a sub-batch whose boundary cuts through the middle of a split run
+// (see Batch.SplitRecord) — some of the run's pieces inside the proposed
+// sub-batch, the rest outside it.
+//
+// This should never happen: Batch.normalizeSplitRuns runs once, right after
+// a task's Do returns and before the batch is partitioned, and resolves
+// every split run to a flag arrangement Worker.subBatchByFlag's
+// groupFlagAt can always treat as a single, indivisible unit. If this error
+// fires anyway, that guarantee has regressed — most likely a new flag-
+// writing code path was added that bypasses normalizeSplitRuns.
+//
+// This is a second line of defense behind that normalization, not a
+// substitute for it: it exists because the alternative is the exact bug this
+// whole mechanism was added to close (#2723) — a sub-batch covering only the
+// head of a split run collapses (via Batch.originalBatch) to the original
+// position and gets acked while the rest of the run has gone nowhere,
+// violating invariants 1 and 3. Failing loud here, before that ack/nack call
+// is ever made, converts a silent data-loss bug into a stopped pipeline with
+// a coded, actionable error — the same trade CodeEmptySourcePosition makes
+// for the nil-tail half of this shape.
+var CodeSplitRunPartitioned = conduiterr.Register("pipeline.split_run_partitioned", codes.Internal)

--- a/pkg/lifecycle-poc/funnel/worker.go
+++ b/pkg/lifecycle-poc/funnel/worker.go
@@ -381,11 +381,20 @@ func (w *Worker) doTask(
 		Str("task_id", t.ID()).
 		Msg("task returned tainted batch, splitting into sub-batches")
 
+	// Invariant 1/3: reconcile every split run into a single, groupable unit
+	// BEFORE partitioning — see Batch.normalizeSplitRuns for why this must
+	// happen exactly once, here, rather than incrementally while t.Do was
+	// still running.
+	b.normalizeSplitRuns()
+
 	// Batch is tainted, we need to go through all statuses and group them by
 	// status before further processing.
 	idx := 0
 	for {
-		subBatch := w.subBatchByFlag(b, idx)
+		subBatch, flag, err := w.subBatchByFlag(b, idx)
+		if err != nil {
+			return err
+		}
 		if subBatch == nil {
 			w.logger.Trace(ctx).Msg("processed last batch")
 			break
@@ -410,10 +419,10 @@ func (w *Worker) doTask(
 		w.logger.Trace(ctx).
 			Str("task_id", t.ID()).
 			Int("batch_size", len(b.records)).
-			Str("record_flag", b.recordStatuses[0].Flag.String()).
+			Str("record_flag", flag.String()).
 			Msg("collected sub-batch")
 
-		switch subBatch.recordStatuses[0].Flag {
+		switch flag {
 		case RecordFlagAck, RecordFlagFilter:
 			if !taskNode.HasNext() || !subBatch.HasActiveRecords() {
 				// Either this is the last task (the batch has made it end-to-end),
@@ -437,9 +446,13 @@ func (w *Worker) doTask(
 				return err
 			}
 		case RecordFlagRetry:
-			// Retry the sub-batch by passing it to the same task. We need to
-			// mark the records as acked, as that's the default record status.
-			subBatch.Ack(0, len(subBatch.records))
+			// Retry the sub-batch by passing it to the same task. Records
+			// still flagged Retry are reset to Ack (the default a task
+			// expects on input); records flagged Filter — part of a split
+			// run that also contains a Retry piece, see
+			// Batch.normalizeRun — are deliberately left alone, so the
+			// retry actually shrinks (see Batch.resetForRetry).
+			subBatch.resetForRetry()
 			err := w.doTask(ctx, taskNode, subBatch, acker)
 			if err != nil {
 				return err
@@ -452,38 +465,102 @@ func (w *Worker) doTask(
 	return nil
 }
 
-// subBatchByFlag collects a sub-batch of records with the same status starting
-// from the given index. It returns nil if firstIndex is out of bounds.
-func (w *Worker) subBatchByFlag(b *Batch, firstIndex int) *Batch {
+// subBatchByFlag collects a sub-batch of records that share the same group
+// flag (see Batch.groupFlagAt), starting from the given index, and returns
+// that flag alongside the sub-batch. It returns a nil batch if firstIndex is
+// out of bounds.
+//
+// Because groupFlagAt always reports a whole split run's span at once —
+// never a partial slice of it — a boundary computed here can never land
+// strictly inside a run.
+//
+// It returns an error if the resulting boundary would partition a split run
+// anyway (see validateSplitRunBoundary): a defensive backstop, not the
+// primary safeguard — by construction this should be unreachable. It exists
+// so that if a future flag-writing code path bypasses normalizeSplitRuns,
+// the failure is a loud, coded error instead of the silent premature ack
+// #2723 was filed for. See CodeSplitRunPartitioned.
+func (w *Worker) subBatchByFlag(b *Batch, firstIndex int) (*Batch, RecordFlag, error) {
 	if firstIndex >= len(b.recordStatuses) {
-		return nil
+		return nil, RecordFlagAck, nil
 	}
 
+	firstFlag, firstEnd, err := b.groupFlagAt(firstIndex)
+	if err != nil {
+		return nil, RecordFlagAck, err
+	}
 	flags := make([]RecordFlag, 0, 2)
-	flags = append(flags, b.recordStatuses[firstIndex].Flag)
+	flags = append(flags, firstFlag)
 	// Collect Filters and Acks together in the same batch.
-	switch flags[0] { //nolint:exhaustive // We only care about two flags.
+	switch firstFlag { //nolint:exhaustive // We only care about two flags.
 	case RecordFlagFilter:
 		flags = append(flags, RecordFlagAck)
 	case RecordFlagAck:
 		flags = append(flags, RecordFlagFilter)
 	}
 
-	lastIndex := firstIndex
-OUTER:
-	for _, status := range b.recordStatuses[firstIndex:] {
+	lastIndex := firstEnd
+	for lastIndex < len(b.recordStatuses) {
+		flag, end, err := b.groupFlagAt(lastIndex)
+		if err != nil {
+			return nil, RecordFlagAck, err
+		}
+
+		matched := false
 		for _, f := range flags {
-			if status.Flag == f {
-				lastIndex++
-				// Record has matching status, let's continue.
-				continue OUTER
+			if flag == f {
+				matched = true
+				break
 			}
 		}
-		// Record has a different status, we're done.
-		break
+		if !matched {
+			// Record (or run) has a different group flag, we're done.
+			break
+		}
+		lastIndex = end
 	}
 
-	return b.sub(firstIndex, lastIndex)
+	if err := validateSplitRunBoundary(b, firstIndex, lastIndex); err != nil {
+		return nil, RecordFlagAck, err
+	}
+
+	return b.sub(firstIndex, lastIndex), firstFlag, nil
+}
+
+// validateSplitRunBoundary reports an error if the proposed sub-batch bounds
+// [firstIndex, lastIndex) cut through the middle of a split run instead of
+// containing it entirely or excluding it entirely. Split runs are always
+// physically contiguous in a batch (see the splitRecords field), so a single
+// interval boundary can only ever partition a run at one of its two edges —
+// checking both edges (the first and last record the proposed sub-batch
+// would contain) is therefore sufficient to catch every possible partition,
+// including the case where the boundary lands mid-run on both sides at once.
+//
+// See CodeSplitRunPartitioned for why this fires loud rather than letting
+// the partition through.
+func validateSplitRunBoundary(b *Batch, firstIndex, lastIndex int) error {
+	if len(b.splitRecords) == 0 {
+		return nil
+	}
+
+	checkEdge := func(idx int) error {
+		pos := b.positions[idx]
+		_, isHead := b.splitRecords[pos.String()]
+		if pos != nil && !isHead {
+			return nil // idx is not part of a split run.
+		}
+
+		from, to := b.findSplitRecord(idx)
+		if from < firstIndex || to >= lastIndex {
+			return newSplitRunPartitionedError(from, to, firstIndex, lastIndex)
+		}
+		return nil
+	}
+
+	if err := checkEdge(firstIndex); err != nil {
+		return err
+	}
+	return checkEdge(lastIndex - 1)
 }
 
 // doNextTask advances the batch b to whatever comes after taskNode. A single

--- a/pkg/lifecycle-poc/funnel/worker_split_run_test.go
+++ b/pkg/lifecycle-poc/funnel/worker_split_run_test.go
@@ -1,0 +1,994 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funnel
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	sdk "github.com/conduitio/conduit-processor-sdk"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/foundation/metrics/noop"
+	"github.com/matryer/is"
+	"go.uber.org/mock/gomock"
+)
+
+// This file is the regression coverage for #2723 (split-run head acked
+// before its tail is delivered) under the redesigned fix: Batch.SplitRecord
+// replicating a split record's current status (closing the review's finding
+// A) plus Batch.normalizeSplitRuns, a single linear pass run once after a
+// task's Do returns (closing findings B, C and D of the adversarial review
+// of #2725). See batch.go's doc comments on SplitRecord, normalizeSplitRuns
+// and normalizeRun for the design; worker.go's groupFlagAt/subBatchByFlag for
+// how a normalized run is kept as one unit when partitioning.
+
+// buildSplitRunRecords returns 3 distinct source records, positions "p0",
+// "p1", "p2".
+func buildSplitRunRecords() (p0, p1, p2 opencdc.Record) {
+	recs := randomRecords(3)
+	recs[0].Position = opencdc.Position("p0")
+	recs[1].Position = opencdc.Position("p1")
+	recs[2].Position = opencdc.Position("p2")
+	return recs[0], recs[1], recs[2]
+}
+
+// TestSplitRun_RetryHead_NotAckedBeforeTailResolved is the exact repro from
+// #2723: processor A splits p0 into 3 pieces; a later processor B (task
+// "procB") returns success for the split run's head but nil (unprocessed,
+// ProcessorTask.Do's documented Retry trigger, see processor.go) for the
+// other two pieces.
+//
+// Before any fix, Worker.subBatchByFlag would partition this into a
+// 1-record Ack sub-batch (just the head) and a 2-record Retry sub-batch (the
+// orphaned tail). The head's sub-batch collapses via Batch.originalBatch to
+// position p0 alone and is acked immediately - before the tail is ever
+// resubmitted to procB. This test wires a REAL two-processor pipeline (not
+// just Batch-level calls) and fails on that premature ack via a strict,
+// ordered gomock expectation: the mocked Source.Ack is only ever set up to
+// accept the position set that is correct AFTER the retry resolves, so any
+// earlier or different call is an unexpected call and fails the test.
+func TestSplitRun_RetryHead_NotAckedBeforeTailResolved(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	logger := log.Test(t)
+	ctrl := gomock.NewController(t)
+
+	p0, p1, p2 := buildSplitRunRecords()
+
+	sourceMock := NewMockSource(ctrl)
+	sourceMock.EXPECT().ID().Return("src").AnyTimes()
+	dlqMock, _ := NewMockDLQ(ctrl, logger)
+
+	processorA := NewMockProcessor(ctrl)
+	processorB := NewMockProcessor(ctrl)
+	destinationMock := NewMockDestination(ctrl)
+
+	srcTask := NewSourceTask("src", sourceMock, logger, NoOpConnectorMetrics{})
+	taskA := NewProcessorTask("procA", processorA, logger, NoOpProcessorMetrics{})
+	taskB := NewProcessorTask("procB", processorB, logger, NoOpProcessorMetrics{})
+	destTask := NewDestinationTask("dest", destinationMock, logger, NoOpConnectorMetrics{})
+
+	destNode := &TaskNode{Task: destTask}
+	bNode := &TaskNode{Task: taskB, Next: []*TaskNode{destNode}}
+	aNode := &TaskNode{Task: taskA, Next: []*TaskNode{bNode}}
+	srcNode := &TaskNode{Task: srcTask, Next: []*TaskNode{aNode}}
+
+	w, err := NewWorker(srcNode, dlqMock, logger, noop.Timer{})
+	is.NoErr(err)
+
+	splitPieces := randomRecords(3) // the 3 pieces processor A splits p0 into
+
+	// Processor A: splits p0 into 3, passes p1/p2 through unchanged.
+	processorA.EXPECT().Process(ctx, []opencdc.Record{p0, p1, p2}).Return(
+		toProcessedRecords([]opencdc.Record{p0, p1, p2}, markMultiRecord(0, splitPieces)),
+	)
+
+	// Processor B, first pass: succeeds for the split run's HEAD (piece 0)
+	// and for p1/p2, but returns nil - "not processed" - for pieces 1 and 2
+	// of the run.
+	firstPassIn := []opencdc.Record{splitPieces[0], splitPieces[1], splitPieces[2], p1, p2}
+	processorB.EXPECT().Process(ctx, firstPassIn).Return([]sdk.ProcessedRecord{
+		sdk.SingleRecord(splitPieces[0]),
+		nil,
+		nil,
+		sdk.SingleRecord(p1),
+		sdk.SingleRecord(p2),
+	})
+
+	// Processor B, retry pass: called again with the WHOLE split run once it
+	// is escalated to Retry as a whole (see Batch.normalizeRun) - never with
+	// just the head, and never with an orphaned tail missing the head.
+	processorB.EXPECT().Process(ctx, splitPieces).Return(toProcessedRecords(splitPieces))
+
+	// The destination must receive the split run's 3 pieces together
+	// (after the retry resolves), and separately p1/p2 - never a lone head.
+	gomock.InOrder(
+		destinationMock.EXPECT().Write(ctx, splitPieces).Return(nil),
+		destinationMock.EXPECT().Ack(ctx).Return(toDestinationAcks(splitPieces, nil), nil),
+		// Invariant 1/3 enforcement: the source may only be acked for p0
+		// once every piece of its split run has been durably written above -
+		// never for p0 alone while pieces 1/2 are still outstanding.
+		sourceMock.EXPECT().Ack(ctx, []opencdc.Position{p0.Position}).Return(nil),
+		destinationMock.EXPECT().Write(ctx, []opencdc.Record{p1, p2}).Return(nil),
+		destinationMock.EXPECT().Ack(ctx).Return(toDestinationAcks([]opencdc.Record{p1, p2}, nil), nil),
+		sourceMock.EXPECT().Ack(ctx, []opencdc.Position{p1.Position, p2.Position}).Return(nil),
+	)
+
+	batch := NewBatch([]opencdc.Record{p0, p1, p2})
+	err = w.doTask(ctx, aNode, batch, w)
+	is.NoErr(err)
+}
+
+// TestSplitRun_FilterHead_NotAckedBeforeTailResolved is the Filter variant,
+// and doubles as the defect-C convergence proof: processor B filters TWO of
+// the run's three pieces on its first pass and defers the third (nil ->
+// Retry). Because Batch.normalizeRun preserves Filter rather than
+// escalating it (the redesign's core resolution — see its doc comment), the
+// retry pass is fed ONLY the one still-undecided piece: the filtered
+// pieces are excluded from Batch.ActiveRecords and never resubmitted. That
+// shrinpeocessing input is what makes convergence provable rather than
+// accidental (the review noted the previous attempt's own test for this
+// shape could not catch its bug because its processor B was an identity
+// transform).
+func TestSplitRun_FilterHead_NotAckedBeforeTailResolved(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	logger := log.Test(t)
+	ctrl := gomock.NewController(t)
+
+	p0, p1, p2 := buildSplitRunRecords()
+
+	sourceMock := NewMockSource(ctrl)
+	sourceMock.EXPECT().ID().Return("src").AnyTimes()
+	dlqMock, _ := NewMockDLQ(ctrl, logger)
+
+	processorA := NewMockProcessor(ctrl)
+	processorB := NewMockProcessor(ctrl)
+	destinationMock := NewMockDestination(ctrl)
+
+	srcTask := NewSourceTask("src", sourceMock, logger, NoOpConnectorMetrics{})
+	taskA := NewProcessorTask("procA", processorA, logger, NoOpProcessorMetrics{})
+	taskB := NewProcessorTask("procB", processorB, logger, NoOpProcessorMetrics{})
+	destTask := NewDestinationTask("dest", destinationMock, logger, NoOpConnectorMetrics{})
+
+	destNode := &TaskNode{Task: destTask}
+	bNode := &TaskNode{Task: taskB, Next: []*TaskNode{destNode}}
+	aNode := &TaskNode{Task: taskA, Next: []*TaskNode{bNode}}
+	srcNode := &TaskNode{Task: srcTask, Next: []*TaskNode{aNode}}
+
+	w, err := NewWorker(srcNode, dlqMock, logger, noop.Timer{})
+	is.NoErr(err)
+
+	splitPieces := randomRecords(3)
+
+	processorA.EXPECT().Process(ctx, []opencdc.Record{p0, p1, p2}).Return(
+		toProcessedRecords([]opencdc.Record{p0, p1, p2}, markMultiRecord(0, splitPieces)),
+	)
+
+	// Processor B, first pass: pieces 0 and 1 of the run are explicitly
+	// Filtered (dropped for good), but piece 2 comes back nil (Retry) - the
+	// run as a whole is NOT done.
+	firstPassIn := []opencdc.Record{splitPieces[0], splitPieces[1], splitPieces[2], p1, p2}
+	processorB.EXPECT().Process(ctx, firstPassIn).Return([]sdk.ProcessedRecord{
+		sdk.FilterRecord{},
+		sdk.FilterRecord{},
+		nil,
+		sdk.SingleRecord(p1),
+		sdk.SingleRecord(p2),
+	})
+
+	// Retry pass: ONLY piece 2 is resubmitted - pieces 0/1 stay Filter and
+	// are excluded from ActiveRecords, so the processor sees a SHRUNK input
+	// (1 record, not 3). If Filter had been escalated back to Retry (the
+	// previous attempt's defect C), this expectation would never be met and
+	// the test would fail with an unexpected call for `splitPieces` (3
+	// records) instead.
+	processorB.EXPECT().Process(ctx, []opencdc.Record{splitPieces[2]}).Return(
+		[]sdk.ProcessedRecord{sdk.SingleRecord(splitPieces[2])},
+	)
+
+	// Only piece 2 is actually active (0 and 1 are filtered, but retained in
+	// the batch - see Batch.Filter), so only it reaches the destination.
+	gomock.InOrder(
+		destinationMock.EXPECT().Write(ctx, []opencdc.Record{splitPieces[2]}).Return(nil),
+		destinationMock.EXPECT().Ack(ctx).Return(toDestinationAcks([]opencdc.Record{splitPieces[2]}, nil), nil),
+		sourceMock.EXPECT().Ack(ctx, []opencdc.Position{p0.Position}).Return(nil),
+		destinationMock.EXPECT().Write(ctx, []opencdc.Record{p1, p2}).Return(nil),
+		destinationMock.EXPECT().Ack(ctx).Return(toDestinationAcks([]opencdc.Record{p1, p2}, nil), nil),
+		sourceMock.EXPECT().Ack(ctx, []opencdc.Position{p1.Position, p2.Position}).Return(nil),
+	)
+
+	batch := NewBatch([]opencdc.Record{p0, p1, p2})
+	err = w.doTask(ctx, aNode, batch, w)
+	is.NoErr(err)
+}
+
+// TestWorker_SubBatchByFlag_NeverPartitionsSplitRun asserts the invariant
+// directly at the seam where the bug lived: given a batch whose split run
+// was left with a non-uniform flag by the task that just ran (exactly what
+// ProcessorTask.Do produces when a later processor returns fewer records
+// than it received), Batch.normalizeSplitRuns resolves it, and the first
+// Worker.subBatchByFlag call must consume the WHOLE run in one sub-batch,
+// never just its head.
+func TestWorker_SubBatchByFlag_NeverPartitionsSplitRun(t *testing.T) {
+	is := is.New(t)
+	logger := log.Test(t)
+	ctrl := gomock.NewController(t)
+	_, _, taskNode := newMockTasks(ctrl, "sourceTask", "task1")
+	worker, err := NewWorker(taskNode, nil, logger, noop.Timer{})
+	is.NoErr(err)
+
+	records := randomRecords(3) // p0, p1, p2
+	batch := NewBatch(records)
+	batch.SplitRecord(0, randomRecords(3)) // p0 -> 3 pieces; batch is now 5 records
+
+	// Mirrors a later processor returning fewer records than it received for
+	// pieces 1 and 2 of the split run (see Batch.Retry's doc comment).
+	batch.Retry(1, 3)
+	batch.normalizeSplitRuns()
+
+	sub, flag, err := worker.subBatchByFlag(batch, 0)
+	is.NoErr(err)
+	is.Equal(flag, RecordFlagRetry)
+	// The WHOLE split run (3 pieces), not just the 2 explicitly-marked ones
+	// and definitely not just the 1-record head.
+	is.Equal(len(sub.records), 3)
+	is.Equal(sub.recordStatuses, []RecordStatus{
+		{Flag: RecordFlagRetry},
+		{Flag: RecordFlagRetry},
+		{Flag: RecordFlagRetry},
+	})
+
+	// The next sub-batch starts exactly where the run ended - p1 and p2,
+	// untouched.
+	next, flag2, err := worker.subBatchByFlag(batch, 3)
+	is.NoErr(err)
+	is.Equal(flag2, RecordFlagAck)
+	is.Equal(len(next.records), 2)
+	is.Equal(next.recordStatuses, []RecordStatus{
+		{Flag: RecordFlagAck},
+		{Flag: RecordFlagAck},
+	})
+}
+
+// TestValidateSplitRunBoundary_CatchesForcedPartition unit-tests the
+// defensive backstop (CodeSplitRunPartitioned) in isolation from whether
+// normalizeSplitRuns actually runs first: it pokes recordStatuses directly
+// (bypassing Batch.Retry/Filter/Nack and normalizeSplitRuns entirely) to
+// simulate a hypothetical future flag-setting path that forgot to route
+// through them, and confirms the boundary check still catches the resulting
+// partition and returns a coded, actionable error rather than silently
+// allowing it.
+func TestValidateSplitRunBoundary_CatchesForcedPartition(t *testing.T) {
+	is := is.New(t)
+
+	records := randomRecords(3)
+	batch := NewBatch(records)
+	batch.SplitRecord(0, randomRecords(3)) // p0 -> 3 pieces
+
+	// Force a partitioned state directly, bypassing every public flag-setting
+	// method and normalizeSplitRuns.
+	batch.recordStatuses[0].Flag = RecordFlagAck
+	batch.recordStatuses[1].Flag = RecordFlagRetry
+	batch.recordStatuses[2].Flag = RecordFlagRetry
+
+	// A boundary that would carve off just the head (index 0) - exactly the
+	// #2723 shape.
+	err := validateSplitRunBoundary(batch, 0, 1)
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code.Reason(), CodeSplitRunPartitioned.Reason())
+	// The error text must not blame the processor/connector chain for what
+	// is, in this case, an internal normalization bug.
+	is.True(!isEmpty(ce.Suggestion))
+
+	// A boundary that contains the whole run is fine.
+	is.NoErr(validateSplitRunBoundary(batch, 0, 3))
+	// A boundary entirely before or after the run is also fine.
+	is.NoErr(validateSplitRunBoundary(batch, 3, 4))
+}
+
+func isEmpty(s string) bool { return s == "" }
+
+// --- Batch-level SplitRecord fix (finding A) ---
+
+// TestBatch_SplitRecord_ReplicatesNackStatus is a direct Batch-level test of
+// the SplitRecord fix: a record that is currently Nack (here, via Nack's
+// own — kept — propagation across an existing split run) must have that
+// status REPLICATED onto any further split of one of its pieces, not
+// defaulted back to Ack. Before the fix (`make([]RecordStatus, n)`, whose
+// zero value is RecordFlagAck), this would silently resurrect an Ack piece
+// inside an already-failed run.
+func TestBatch_SplitRecord_ReplicatesNackStatus(t *testing.T) {
+	is := is.New(t)
+
+	records := randomRecords(2) // p0, p1
+	batch := NewBatch(records)
+
+	batch.SplitRecord(0, randomRecords(2)) // p0 -> 2 pieces: indices 0,1; p1 now at index 2
+	wantErr := cerrors.New("boom")
+	// Nack ONE piece of the run (index 1); Nack propagates across the whole
+	// run (setFlagWithErr), so index 0 becomes Nack too.
+	batch.Nack(1, wantErr)
+	is.Equal(batch.recordStatuses[0].Flag, RecordFlagNack)
+	is.Equal(batch.recordStatuses[0].Error, wantErr)
+
+	// Split index 0 (already Nack, with wantErr) further into 2 more pieces.
+	beforeFilterCount := batch.filterCount
+	batch.SplitRecord(0, randomRecords(2))
+
+	// FAIL-WITHOUT-FIX: with the old zero-value default, recordStatuses[0]
+	// and [1] would be RecordFlagAck here instead of RecordFlagNack.
+	is.Equal(batch.recordStatuses[0].Flag, RecordFlagNack)
+	is.Equal(batch.recordStatuses[0].Error, wantErr)
+	is.Equal(batch.recordStatuses[1].Flag, RecordFlagNack)
+	is.Equal(batch.recordStatuses[1].Error, wantErr)
+	is.Equal(batch.filterCount, beforeFilterCount) // unaffected: Nack, not Filter
+}
+
+// TestBatch_SplitRecord_AlongsideFilteredSibling_FilterCountCorrect is the
+// reachable form of the required "split of a Filter-flagged record" test.
+//
+// SplitRecord's `i` argument is always an ACTIVE index (translated via
+// activeRecordIndices, exactly as ProcessorTask.Do's markBatchRecords calls
+// it — see processor.go). activeRecordIndices, by construction, only ever
+// yields indices whose CURRENT flag is not Filter (filtered records are
+// excluded from ActiveRecords), so a piece that is itself already Filter can
+// never be the direct target of a SplitRecord call through Batch's public
+// calling convention — see TestBatch_SplitRecord_OfAlreadyFilteredRecord_Panics
+// for that boundary. What IS reachable, and what this test covers, is
+// splitting an ACTIVE piece further while a FILTERED sibling already sits
+// alongside it in the batch: filterCount must keep reflecting exactly the
+// filtered sibling, unaffected by the unrelated split.
+func TestBatch_SplitRecord_AlongsideFilteredSibling_FilterCountCorrect(t *testing.T) {
+	is := is.New(t)
+
+	records := randomRecords(2) // p0, p1
+	batch := NewBatch(records)
+
+	batch.Filter(0) // p0 filtered; only p1 remains active.
+	is.Equal(batch.filterCount, 1)
+
+	// Split p1 (the only active record - active index 0) into 4 pieces.
+	batch.SplitRecord(0, randomRecords(4))
+
+	is.Equal(batch.recordStatuses, []RecordStatus{
+		{Flag: RecordFlagFilter}, // p0, untouched
+		{Flag: RecordFlagAck},
+		{Flag: RecordFlagAck},
+		{Flag: RecordFlagAck},
+		{Flag: RecordFlagAck},
+	})
+	// filterCount is unaffected by splitting an unrelated ACTIVE record.
+	is.Equal(batch.filterCount, 1)
+	is.Equal(batch.HasActiveRecords(), true)
+	is.Equal(len(batch.ActiveRecords()), 4)
+}
+
+// TestBatch_SplitRecord_OfAlreadyFilteredRecord_Panics documents and proves
+// the boundary above: forcing (white-box, bypassing the public Filter/
+// SplitRecord calling convention entirely) a record into Filter and then
+// asking SplitRecord to target it via a raw index that activeIndices would
+// never actually produce must panic rather than silently mis-account
+// filterCount. This is the split-run analogue of
+// TestValidateSplitRunBoundary_CatchesForcedPartition: a defensive invariant
+// check for a state that should never occur through the public API, proven
+// by deliberately forcing it.
+func TestBatch_SplitRecord_OfAlreadyFilteredRecord_Panics(t *testing.T) {
+	is := is.New(t)
+
+	records := randomRecords(1)
+	batch := NewBatch(records)
+	batch.recordStatuses[0].Flag = RecordFlagFilter // force, bypassing Batch.Filter
+	batch.filterCount = 0                           // so activeRecordIndices() takes the "no filters" fast path and returns nil, letting i=0 pass through untranslated
+
+	defer func() {
+		r := recover()
+		is.True(r != nil)
+	}()
+	batch.SplitRecord(0, randomRecords(2))
+	t.Fatal("expected SplitRecord to panic when asked to split an already-filtered record")
+}
+
+// --- Shape (a): Retry applied to a run, then SplitRecord at a lower index
+// in the SAME Do pass ---
+
+// retryThenLowerSplitTask reproduces, at the Batch level inside a single
+// Do call, the exact interleaving the review found broke the previous
+// attempt (finding A): within ONE task's Do, a HIGHER-index piece of an
+// existing split run is marked Retry first (mirroring ProcessorTask.Do's
+// end-to-start marking order), and THEN a LOWER-index piece of the SAME
+// run is split further. Under the redesign there is no mid-Do escalation to
+// corrupt, but this proves the END-TO-END outcome (after
+// Batch.normalizeSplitRuns runs, post-Do) is still a single, uniform,
+// unpartitioned run - not a fatal CodeSplitRunPartitioned guard trip.
+type retryThenLowerSplitTask struct {
+	id   string
+	seen bool
+}
+
+func (t *retryThenLowerSplitTask) ID() string                  { return t.id }
+func (t *retryThenLowerSplitTask) Open(context.Context) error  { return nil }
+func (t *retryThenLowerSplitTask) Close(context.Context) error { return nil }
+
+func (t *retryThenLowerSplitTask) Do(_ context.Context, b *Batch) error {
+	if t.seen {
+		// Retry pass: succeed for everything so the pipeline completes.
+		active := b.ActiveRecords()
+		b.SetRecords(0, active)
+		return nil
+	}
+	t.seen = true
+
+	// The batch enters this Do call already containing a pre-existing split
+	// run at indices [0,2] (set up by the test before calling doTask) -
+	// mirrors a run created by an EARLIER task in the pipeline.
+	//
+	// Mark the higher-index piece of the run Retry FIRST (end-to-start
+	// order).
+	b.Retry(2, 3)
+	// Then split the LOWER-index piece of the SAME run further - this is
+	// the shape that broke the previous attempt's escalate-during-Do design:
+	// the new pieces must replicate index 0's CURRENT status (Ack, since
+	// nothing mutates it during Do under this redesign) rather than being
+	// forced to disagree with the Retry just written at index 2.
+	b.SplitRecord(0, randomRecords(2))
+	return nil
+}
+
+func TestDoTask_RetryThenLowerSplit_RunStaysUniform_GuardDoesNotFire(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	records := randomRecords(2) // p0, p1
+	parent := &fakeParentAckNacker{}
+	task := &retryThenLowerSplitTask{id: "retry-then-split"}
+	node := &TaskNode{Task: task}
+
+	w := &Worker{logger: log.Nop(), processingLock: make(chan struct{}, 1)}
+
+	b := NewBatch(records)
+	b.SplitRecord(0, randomRecords(3)) // pre-existing run: p0 -> 3 pieces, indices [0,2]; p1 at index 3
+
+	err := w.doTask(ctx, node, b, parent)
+	is.NoErr(err) // must NOT be CodeSplitRunPartitioned
+
+	// Every original position acked exactly once.
+	got := map[string]int{}
+	for _, call := range parent.ackCalls() {
+		for _, p := range call.positions {
+			got[string(p)]++
+		}
+	}
+	is.Equal(got[string(records[0].Position)], 1)
+	is.Equal(got[string(records[1].Position)], 1)
+}
+
+// Shape (b) — a processor that filters the head piece and skips the rest,
+// asserting convergence (no infinite retry) and that the Filter decision
+// survives — is covered by TestSplitRun_FilterHead_NotAckedBeforeTailResolved
+// above: its gomock expectations are exact and ordered, so the retry pass
+// being fed ONLY the one still-undecided piece (never the filtered ones, and
+// never a third call) is enforced by the mock itself failing the test on any
+// unexpected call.
+
+// --- Content-integrity: Filter + split run + partial-return processor ---
+
+// TestDoTask_ContentIntegrity_FilterPlusSplitRun is the "content shift"
+// regression shape (finding B of the review, TestAdversarial_FilterCountShiftMidDo):
+// a batch with an unrelated filtered record ahead of a split run, and a
+// downstream processor that returns fewer records than it received (padding
+// with Retry). Asserts every record's CONTENT and every filter decision
+// match what an unmodified batch (no escalation, no mid-Do mutation) would
+// produce - no cross-contamination between the filtered record, the split
+// run, and the plain records around them.
+func TestDoTask_ContentIntegrity_FilterPlusSplitRun(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	logger := log.Test(t)
+	ctrl := gomock.NewController(t)
+
+	base := randomRecords(4)
+	base[0].Position = opencdc.Position("p0") // will be filtered by procA
+	base[1].Position = opencdc.Position("p1") // will be split by procA
+	base[2].Position = opencdc.Position("p2") // untouched
+	base[3].Position = opencdc.Position("p3") // untouched
+	p0, p1, p2, p3 := base[0], base[1], base[2], base[3]
+
+	sourceMock := NewMockSource(ctrl)
+	sourceMock.EXPECT().ID().Return("src").AnyTimes()
+	dlqMock, _ := NewMockDLQ(ctrl, logger)
+
+	processorA := NewMockProcessor(ctrl)
+	processorB := NewMockProcessor(ctrl)
+	destinationMock := NewMockDestination(ctrl)
+
+	srcTask := NewSourceTask("src", sourceMock, logger, NoOpConnectorMetrics{})
+	taskA := NewProcessorTask("procA", processorA, logger, NoOpProcessorMetrics{})
+	taskB := NewProcessorTask("procB", processorB, logger, NoOpProcessorMetrics{})
+	destTask := NewDestinationTask("dest", destinationMock, logger, NoOpConnectorMetrics{})
+
+	destNode := &TaskNode{Task: destTask}
+	bNode := &TaskNode{Task: taskB, Next: []*TaskNode{destNode}}
+	aNode := &TaskNode{Task: taskA, Next: []*TaskNode{bNode}}
+	srcNode := &TaskNode{Task: srcTask, Next: []*TaskNode{aNode}}
+
+	w, err := NewWorker(srcNode, dlqMock, logger, noop.Timer{})
+	is.NoErr(err)
+
+	splitPieces := randomRecords(3)
+
+	// procA: filters p0, splits p1 into 3, passes p2/p3 through.
+	processorA.EXPECT().Process(ctx, []opencdc.Record{p0, p1, p2, p3}).Return([]sdk.ProcessedRecord{
+		sdk.FilterRecord{},
+		sdk.MultiRecord(splitPieces),
+		sdk.SingleRecord(p2),
+		sdk.SingleRecord(p3),
+	})
+
+	// procB: called with the 5 active records (p0 excluded, filtered).
+	// Returns fewer than it received - success for the split run's head and
+	// p2, nothing (retry) for the rest, EXCEPT p3 which is also padded-nil
+	// (procB returns only 3 of 5 outputs; ProcessorTask.Do pads the missing
+	// 2 with nil/Retry).
+	firstPassIn := []opencdc.Record{splitPieces[0], splitPieces[1], splitPieces[2], p2, p3}
+	processorB.EXPECT().Process(ctx, firstPassIn).Return([]sdk.ProcessedRecord{
+		sdk.SingleRecord(splitPieces[0]),
+		nil,
+		nil,
+		sdk.SingleRecord(p2),
+		// 5th (p3) omitted entirely - Do pads it as nil/Retry too.
+	})
+
+	// Retry pass: the WHOLE split run (3 pieces) resubmitted together -
+	// content-integrity requires p2's already-accepted content is NOT
+	// touched by this, and p3 is retried entirely independently.
+	processorB.EXPECT().Process(ctx, splitPieces).Return(toProcessedRecords(splitPieces))
+	processorB.EXPECT().Process(ctx, []opencdc.Record{p3}).Return([]sdk.ProcessedRecord{sdk.SingleRecord(p3)})
+
+	// p0 (filtered) is acked alone, with its ORIGINAL content (never
+	// touched by procB at all).
+	destinationMock.EXPECT().Write(ctx, splitPieces).Return(nil)
+	destinationMock.EXPECT().Ack(ctx).Return(toDestinationAcks(splitPieces, nil), nil)
+	sourceMock.EXPECT().Ack(ctx, []opencdc.Position{p0.Position}).Return(nil)
+	sourceMock.EXPECT().Ack(ctx, []opencdc.Position{p1.Position}).Return(nil)
+	destinationMock.EXPECT().Write(ctx, []opencdc.Record{p2}).Return(nil)
+	destinationMock.EXPECT().Ack(ctx).Return(toDestinationAcks([]opencdc.Record{p2}, nil), nil)
+	sourceMock.EXPECT().Ack(ctx, []opencdc.Position{p2.Position}).Return(nil)
+	destinationMock.EXPECT().Write(ctx, []opencdc.Record{p3}).Return(nil)
+	destinationMock.EXPECT().Ack(ctx).Return(toDestinationAcks([]opencdc.Record{p3}, nil), nil)
+	sourceMock.EXPECT().Ack(ctx, []opencdc.Position{p3.Position}).Return(nil)
+
+	batch := NewBatch([]opencdc.Record{p0, p1, p2, p3})
+	err = w.doTask(ctx, aNode, batch, w)
+	is.NoErr(err)
+}
+
+// --- Fan-out composition (M=2): no premature unanimity across branches ---
+
+// splitOnceThenRetryOnceTask splits the record it's given into 2 pieces on
+// its first call, marking one piece Retry; on its second call (the retry
+// pass, fed only the still-pending piece per Batch.resetForRetry), it
+// succeeds. If block/unblock are set, it signals block and waits on
+// unblock before returning from the FIRST call - used to hold one fan-out
+// branch back deterministically while a sibling branch races ahead.
+type splitOnceThenRetryOnceTask struct {
+	id      string
+	seen    bool
+	block   chan struct{}
+	unblock chan struct{}
+}
+
+func (t *splitOnceThenRetryOnceTask) ID() string                  { return t.id }
+func (t *splitOnceThenRetryOnceTask) Open(context.Context) error  { return nil }
+func (t *splitOnceThenRetryOnceTask) Close(context.Context) error { return nil }
+
+func (t *splitOnceThenRetryOnceTask) Do(_ context.Context, b *Batch) error {
+	if t.seen {
+		active := b.ActiveRecords()
+		b.SetRecords(0, active)
+		return nil
+	}
+	t.seen = true
+
+	active := b.ActiveRecords()
+	pieces := []opencdc.Record{active[0], active[0]}
+	b.SplitRecord(0, pieces)
+	b.Retry(1, 2) // one of the two new pieces needs another pass
+
+	if t.block != nil {
+		close(t.block)
+		<-t.unblock
+	}
+	return nil
+}
+
+// TestDoNextTask_FanOut_SplitRunPending_NoPrematureUnanimity is the required
+// M=2 fan-out test: branch A resolves its (independently cloned) split run
+// immediately; branch B's copy of the SAME split run needs a retry pass and
+// is held back deterministically. Asserts the source is not acked for the
+// original position until BOTH branches have actually finished - proving
+// multiAckNacker's unanimity requirement isn't short-circuited by a
+// split-run's internal retry recursion on one branch finishing "early" in
+// some intermediate, partial sense.
+func TestDoNextTask_FanOut_SplitRunPending_NoPrematureUnanimity(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	records := randomRecords(1)
+	src := newFakeSource("src", records)
+	destA := newFakeDestination("destA")
+	destB := newFakeDestination("destB")
+
+	logger := log.Test(t)
+	dlqDest := newFakeDestination("dlq")
+	dlq := NewDLQ("dlq", dlqDest, logger, NoOpConnectorMetrics{}, 0, 0)
+
+	taskA := &splitOnceThenRetryOnceTask{id: "splitA"} // resolves immediately (no block)
+	block := make(chan struct{})
+	unblock := make(chan struct{})
+	taskB := &splitOnceThenRetryOnceTask{id: "splitB", block: block, unblock: unblock}
+
+	destTaskA := NewDestinationTask(destA.id, destA, logger, NoOpConnectorMetrics{})
+	destTaskB := NewDestinationTask(destB.id, destB, logger, NoOpConnectorMetrics{})
+
+	nodeA := &TaskNode{Task: taskA, Next: []*TaskNode{{Task: destTaskA}}}
+	nodeB := &TaskNode{Task: taskB, Next: []*TaskNode{{Task: destTaskB}}}
+	branchNode := &TaskNode{Task: passthroughTask{id: "shared"}, Next: []*TaskNode{nodeA, nodeB}}
+	srcNode := &TaskNode{Task: NewSourceTask("src", src, logger, NoOpConnectorMetrics{}), Next: []*TaskNode{branchNode}}
+
+	w, err := NewWorker(srcNode, dlq, logger, noop.Timer{})
+	is.NoErr(err)
+
+	batch := NewBatch(append([]opencdc.Record(nil), records...))
+
+	doneCh := make(chan error, 1)
+	go func() { doneCh <- w.doTask(ctx, branchNode, batch, w) }()
+
+	select {
+	case <-block:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for branch B to block on its first pass")
+	}
+
+	// Branch A races ahead and fully resolves (bounded wait, not a fixed
+	// sleep) - but the source must NOT be acked yet: branch B hasn't voted.
+	waitForCondition(t, 5*time.Second, func() bool {
+		return len(destA.receivedPositions()) == 2 // both split pieces written
+	})
+	is.Equal(len(src.ackedPositions()), 0)
+
+	close(unblock)
+
+	select {
+	case err := <-doneCh:
+		is.NoErr(err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for doTask to finish after unblocking branch B")
+	}
+
+	acked := src.ackedPositions()
+	is.Equal(len(acked), 1)
+	is.Equal(acked[0], records[0].Position)
+}
+
+// --- Forced-partition backstop ---
+
+// TestSubBatchByFlag_ForcedPartition_ReturnsCodedError is the "forced
+// partition backstop" test: directly corrupt a batch into a mixed-flag
+// split run WITHOUT going through normalizeSplitRuns (simulating a
+// hypothetical future bug that bypasses it), and assert
+// Worker.subBatchByFlag itself - not just validateSplitRunBoundary in
+// isolation - surfaces CodeSplitRunPartitioned rather than silently
+// producing a partial sub-batch.
+func TestSubBatchByFlag_ForcedPartition_ReturnsCodedError(t *testing.T) {
+	is := is.New(t)
+	logger := log.Test(t)
+	ctrl := gomock.NewController(t)
+	_, _, taskNode := newMockTasks(ctrl, "sourceTask", "task1")
+	worker, err := NewWorker(taskNode, nil, logger, noop.Timer{})
+	is.NoErr(err)
+
+	records := randomRecords(2)
+	batch := NewBatch(records)
+	batch.SplitRecord(0, randomRecords(3)) // run at indices [0,2]
+
+	// Bypass normalizeSplitRuns entirely: force a mixed run.
+	batch.recordStatuses[0].Flag = RecordFlagAck
+	batch.recordStatuses[1].Flag = RecordFlagRetry
+	batch.recordStatuses[2].Flag = RecordFlagRetry
+
+	sub, _, err := worker.subBatchByFlag(batch, 0)
+	is.True(sub == nil)
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code.Reason(), CodeSplitRunPartitioned.Reason())
+}
+
+// --- Randomized property test ---
+
+// randomSplitFilterRetryTask is a hand-rolled Task (not going through the
+// generic Processor/ProcessorTask interface, for full control over timing)
+// used by the property test below. It mimics ProcessorTask.Do's contract
+// (single-record ops applied high-to-low over ActiveRecords, using nil for
+// "retry") and tracks, per ORIGINAL record identity (carried in Metadata
+// across splits and retries), how many rounds that identity has been
+// offered a decision. Once a piece has been offered 3 rounds, it is FORCED
+// to succeed - this bounds the harness's own retry recursion depth
+// independently of Conduit's behavior, so a bug in either the harness or
+// the code under test can never manifest as an actual unbounded loop /
+// stack overflow in the test process (the unbounded-recursion crash is
+// #2726, deliberately not fixed here - this cap exists purely so the
+// property test itself stays finite regardless).
+type randomSplitFilterRetryTask struct {
+	id  string
+	rng *rand.Rand
+
+	attempts  map[string]int
+	splitDone map[string]bool
+	calls     int
+}
+
+func newRandomSplitFilterRetryTask(id string, rng *rand.Rand) *randomSplitFilterRetryTask {
+	return &randomSplitFilterRetryTask{
+		id:        id,
+		rng:       rng,
+		attempts:  make(map[string]int),
+		splitDone: make(map[string]bool),
+	}
+}
+
+func (t *randomSplitFilterRetryTask) ID() string                  { return t.id }
+func (t *randomSplitFilterRetryTask) Open(context.Context) error  { return nil }
+func (t *randomSplitFilterRetryTask) Close(context.Context) error { return nil }
+
+const testOrigIDKey = "test.orig_id"
+
+func (t *randomSplitFilterRetryTask) Do(_ context.Context, b *Batch) error {
+	t.calls++
+	if t.calls > 200 {
+		return cerrors.New("randomSplitFilterRetryTask: exceeded safety call cap - harness bug, not a real infinite loop")
+	}
+
+	active := b.ActiveRecords()
+	type decision int
+	const (
+		decideAck decision = iota
+		decideFilter
+		decideNack
+		decideSplit
+		decideRetry
+	)
+	decisions := make([]decision, len(active))
+	splitInto := make([]int, len(active))
+
+	for i, r := range active {
+		id := r.Metadata[testOrigIDKey]
+		t.attempts[id]++
+		forceDone := t.attempts[id] > 3
+
+		roll := t.rng.Float64()
+		switch {
+		case !forceDone && roll < 0.10:
+			decisions[i] = decideNack
+		case !forceDone && roll < 0.35:
+			decisions[i] = decideFilter
+		case !forceDone && !t.splitDone[id] && roll < 0.55:
+			decisions[i] = decideSplit
+			splitInto[i] = 2 + t.rng.Intn(2)
+			t.splitDone[id] = true
+		case !forceDone && roll < 0.80:
+			decisions[i] = decideRetry
+		default:
+			decisions[i] = decideAck
+		}
+	}
+
+	// Apply high-to-low, mirroring ProcessorTask.Do's own end-to-start
+	// marking order (see processor.go).
+	for i := len(active) - 1; i >= 0; i-- {
+		switch decisions[i] {
+		case decideAck:
+			// Leave as-is (already Ack by default).
+		case decideFilter:
+			b.Filter(i, i+1)
+		case decideNack:
+			b.Nack(i, cerrors.New("random nack"))
+		case decideRetry:
+			b.Retry(i, i+1)
+		case decideSplit:
+			id := active[i].Metadata[testOrigIDKey]
+			pieces := make([]opencdc.Record, splitInto[i])
+			for k := range pieces {
+				pieces[k] = opencdc.Record{
+					Metadata: opencdc.Metadata{testOrigIDKey: id},
+					Payload:  active[i].Payload,
+				}
+			}
+			b.SplitRecord(i, pieces)
+		}
+	}
+	return nil
+}
+
+// TestProperty_SplitFilterRetryPartialReturn_NoMixedRuns_NoGuardFire is the
+// required randomized/property test: 3000 iterations (scaled down only if
+// CI proves too slow — see the -short gate below) of random
+// split/filter/retry/ack decisions over a small batch, asserting for every
+// iteration:
+//
+//   - doTask never returns an error (in particular, never
+//     CodeSplitRunPartitioned - "the guard never fires").
+//   - Every original position is acked-once XOR DLQ'd-once (recorded via
+//     acks/nacks on a fakeParentAckNacker) - never both, never neither,
+//     never more than once ("no run is ever mixed": a mixed run is exactly
+//     what would let a position be released twice, or dropped, by
+//     subBatchByFlag partitioning it incorrectly).
+func TestProperty_SplitFilterRetryPartialReturn_NoMixedRuns_NoGuardFire(t *testing.T) {
+	const iterations = 3000
+	seed := time.Now().UnixNano()
+	t.Logf("seed=%d (reproduce a failure by hardcoding this seed)", seed)
+	rng := rand.New(rand.NewSource(seed))
+
+	guardFires := 0
+	mixedRunViolations := 0
+	otherErrors := 0
+
+	for iter := 0; iter < iterations; iter++ {
+		n := 1 + rng.Intn(4) // 1..4 original records
+		records := make([]opencdc.Record, n)
+		positions := make([]opencdc.Position, n)
+		for i := range records {
+			pos := opencdc.Position(fmt.Sprintf("iter%d-p%d", iter, i))
+			records[i] = opencdc.Record{
+				Position: pos,
+				Metadata: opencdc.Metadata{testOrigIDKey: fmt.Sprintf("p%d", i)},
+				Payload:  opencdc.Change{After: opencdc.RawData(fmt.Sprintf("v%d", i))},
+			}
+			positions[i] = pos
+		}
+
+		parent := &fakeParentAckNacker{}
+		task := newRandomSplitFilterRetryTask(fmt.Sprintf("task-%d", iter), rng)
+		node := &TaskNode{Task: task}
+		w := &Worker{logger: log.Nop(), processingLock: make(chan struct{}, 1)}
+
+		batch := NewBatch(records)
+		err := w.doTask(context.Background(), node, batch, parent)
+		if err != nil {
+			ce, ok := conduiterr.Get(err)
+			if ok && ce.Code.Reason() == CodeSplitRunPartitioned.Reason() {
+				guardFires++
+				t.Errorf("iter %d (seed %d): CodeSplitRunPartitioned fired - a split run was "+
+					"partitioned: %v", iter, seed, err)
+				continue
+			}
+			otherErrors++
+			t.Errorf("iter %d (seed %d): unexpected error: %v", iter, seed, err)
+			continue
+		}
+
+		resolved := map[string]int{}
+		for _, call := range parent.ackCalls() {
+			for _, p := range call.positions {
+				resolved[string(p)]++
+			}
+		}
+		for _, call := range parent.nackCalls() {
+			for _, p := range call.positions {
+				resolved[string(p)]++
+			}
+		}
+		for i, p := range positions {
+			if count := resolved[string(p)]; count != 1 {
+				mixedRunViolations++
+				t.Errorf("iter %d (seed %d): position %d (%q) resolved %d times, want exactly 1 "+
+					"(acked-once XOR DLQ'd-once)", iter, seed, i, p, count)
+			}
+		}
+	}
+
+	t.Logf("guard-fire rate: %d/%d; mixed-run violations: %d/%d",
+		guardFires, iterations, mixedRunViolations, iterations)
+	if guardFires != 0 || mixedRunViolations != 0 || otherErrors != 0 {
+		t.Fatalf("guard fires=%d, mixed-run violations=%d, other errors=%d - want all 0 (seed %d)",
+			guardFires, mixedRunViolations, otherErrors, seed)
+	}
+}
+
+// --- Benchmarks: proving normalizeSplitRuns is linear (fixes finding D) ---
+
+// buildBigSplitRunBatch builds a batch containing exactly ONE split run of n
+// pieces, with a realistic mix of flags: every 5th piece Filter, roughly
+// half of the remainder Retry, the rest left at the Ack default - the same
+// "mixed run needing reconciliation" shape normalizeRun is built for.
+func buildBigSplitRunBatch(n int) *Batch {
+	orig := randomRecords(1)
+	batch := NewBatch(orig)
+	pieces := randomRecords(n)
+	batch.SplitRecord(0, pieces)
+
+	for i := 0; i < n; i++ {
+		switch {
+		case i%5 == 0:
+			batch.recordStatuses[i].Flag = RecordFlagFilter
+			batch.filterCount++
+		case i%2 == 0:
+			batch.recordStatuses[i].Flag = RecordFlagRetry
+		}
+	}
+	return batch
+}
+
+// BenchmarkNormalizeSplitRuns is the required benchmark: run sizes 1k/4k/16k
+// must scale linearly (roughly 4x time for a 4x size increase), not
+// quadratically (which would show ~16x for a 4x size increase) - the
+// escalate-on-every-write design this replaces measured 10.5us -> 439ms
+// (~42,000x) going from a smaller run to a 16k-piece one; this benchmark
+// exists to prove that regression cannot recur silently.
+func BenchmarkNormalizeSplitRuns(b *testing.B) {
+	for _, n := range []int{1000, 4000, 16000} {
+		b.Run(fmt.Sprintf("run_size_%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				batch := buildBigSplitRunBatch(n)
+				b.StartTimer()
+				batch.normalizeSplitRuns()
+			}
+		})
+	}
+}
+
+// BenchmarkSubBatchByFlag_AfterNormalize benchmarks the OTHER half of the
+// hot path - partitioning an already-normalized batch containing one big
+// run - to confirm groupFlagAt's run-spanning scan doesn't reintroduce
+// quadratic behavior at the partitioning step either.
+func BenchmarkSubBatchByFlag_AfterNormalize(b *testing.B) {
+	logger := log.Nop()
+	w := &Worker{logger: logger, processingLock: make(chan struct{}, 1)}
+
+	for _, n := range []int{1000, 4000, 16000} {
+		b.Run(fmt.Sprintf("run_size_%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				batch := buildBigSplitRunBatch(n)
+				batch.normalizeSplitRuns()
+				b.StartTimer()
+
+				idx := 0
+				for {
+					sub, _, err := w.subBatchByFlag(batch, idx)
+					if err != nil {
+						b.Fatalf("unexpected error: %v", err)
+					}
+					if sub == nil {
+						break
+					}
+					idx += len(sub.positions)
+				}
+			}
+		})
+	}
+}

--- a/pkg/lifecycle-poc/funnel/worker_test.go
+++ b/pkg/lifecycle-poc/funnel/worker_test.go
@@ -227,7 +227,9 @@ func TestWorker_subBatchByFlag(t *testing.T) {
 	batch.Filter(2, 4)                 // Filter 2 and 3
 
 	// Ack and Filter are grouped
-	sub := worker.subBatchByFlag(batch, 0)
+	sub, flag, err := worker.subBatchByFlag(batch, 0)
+	is.NoErr(err)
+	is.Equal(flag, RecordFlagAck)
 	is.Equal(len(sub.records), 4)
 	is.Equal(cap(sub.records), 4) // Ensure capacity is correct
 	is.Equal(sub.recordStatuses, []RecordStatus{
@@ -238,13 +240,16 @@ func TestWorker_subBatchByFlag(t *testing.T) {
 	})
 
 	// Nack is alone
-	sub2 := worker.subBatchByFlag(batch, 4)
+	sub2, flag2, err := worker.subBatchByFlag(batch, 4)
+	is.NoErr(err)
+	is.Equal(flag2, RecordFlagNack)
 	is.Equal(len(sub2.records), 1)
 	is.Equal(cap(sub2.records), 1)
 	is.Equal(sub2.recordStatuses[0].Flag, RecordFlagNack)
 
 	// Out of bounds
-	sub3 := worker.subBatchByFlag(batch, 5)
+	sub3, _, err := worker.subBatchByFlag(batch, 5)
+	is.NoErr(err)
 	is.Equal(sub3, nil)
 }
 


### PR DESCRIPTION
## What

Fixes **#2723** — a split-run's head could be acked to the source **before its tail was delivered** (invariants 1 and 3).

**Supersedes #2725**, whose per-write escalation design was rejected by adversarial review with four confirmed defects. This is the rework on the design that review recommended. #2725 stays draft and should be closed once this lands.

## Design: normalise once, after `Do` — not on every write

1. **`SplitRecord` replicates the split record's real status** onto the new pieces. Previously it used `make([]RecordStatus, n)`, whose zero value is `RecordFlagAck` — so a `SplitRecord` at a lower index could inject `Ack` pieces into a run already flagged `Retry` (`ProcessorTask.Do` marks end→start). That was the critical defect in #2725: it left the run mixed and fired the guard on **20%** of randomised split+partial-return pipelines. The stale comment ("the original record must have been acked") is corrected.

2. **No flag mutation during `Task.Do`.** `Retry`/`Filter` are plain single-index writes again. After `Do` returns and before partitioning, `doTask` calls `normalizeSplitRuns()` — **one linear pass** that makes each run uniform by rank. This is what fixes the mid-`Do` `filterCount` mutation that corrupted the active-index mapping (#2725 defect B) and the O(n²) blowup (defect D).

3. **`Filter` is never escalated to `Retry`** (defect C). A run may hold both; `groupFlagAt` still treats it as one atomic span, and `resetForRetry` resets only `Retry`-flagged members, leaving `Filter` members excluded from `ActiveRecords`. **That is what makes the retry converge**: the processor's input actually shrinks instead of being re-fed identically. Asserted, not assumed — `TestSplitRun_FilterHead_NotAckedBeforeTailResolved` expects the retry call to receive *only* the undecided piece.

4. **Defensive backstop kept**, wording fixed. `validateSplitRunBoundary` + `CodeSplitRunPartitioned` were confirmed by review to have zero false positives. Its text no longer claims "internal invariant violation… please report it", which was wrong when ordinary processor behaviour triggers it.

A real gap was found during the rework: a naive "always swallow the whole run" grouping would make the backstop **unreachable even when it should fire**. `groupFlagAt` now also detects genuine non-uniformity within a run. Caught by the author's own `TestSubBatchByFlag_ForcedPartition_ReturnsCodedError`, which failed until that check was added.

## Risk tier: **Tier 1 (data path)** — preview-gated (`Preview.PipelineArchV2`, off by default)

## Failure-mode analysis

| Failure | Behavior |
| --- | --- |
| Processor returns fewer records mid split run | whole run normalised to `Retry`; head cannot be acked early |
| `Retry` then `SplitRecord` at a lower index in the same pass | pieces inherit the real status; run stays uniform; guard does **not** fire |
| `Filter` + `Retry` in one run | both preserved; retry input shrinks; converges |
| Split of a `Filter`-flagged record | `filterCount` accounted correctly (tested) |
| A future path leaves a run genuinely mixed | loud coded error at the partition point, not a silent premature ack |

**Rollback:** revert, or run without the preview flag.

## Verification

Three fail-without/pass-with reverts, each rerun explicitly:
- `SplitRecord` zero-value restored → `ack != nack` in `TestBatch_SplitRecord_ReplicatesNackStatus`, and the already-filtered guard stopped panicking.
- `Filter`-escalation reintroduced → gomock `Unexpected call to Process([...3 records...])` — proving the run-shrink (and therefore convergence) never happened.
- `normalizeSplitRuns` disabled → the backstop fired instead of a silent premature ack: `split run spanning batch indices [0,2] carries inconsistent flags`. Defence in depth working as intended.

**Property test: 3000 iterations of split+filter+retry+nack+partial-return — guard-fire 0/3000, mixed-run violations 0/3000** (#2725's design measured 607/3000).

**Benchmark, `normalizeSplitRuns`** (zero allocs): 1k → 3,602 ns · 4k → 11,577 ns · 16k → 56,290 ns. Roughly linear per 4× step; #2725's design went 10.5 µs → 439 ms at 16k.

`go build ./...` clean · `go test -race ./pkg/lifecycle-poc/...` green · full chaos suite green (109s) · `golangci-lint` 0 issues · `make generate` leaves the tree clean (90→91 error codes).

## Not fixed here
**#2726** (unbounded self-recursion in `doTask`'s retry branch — a non-converging processor grows the stack to Go's 1 GB limit and kills the whole process) is pre-existing on `main` and gets its own PR. This change does not make it more likely; the one scenario review named is proven to converge. General convergence is **not** claimed.

## ADR
The known-gap bullet in `20260731-archv2-fanout-ack-model.md` now describes the normalisation design and records the gap as closed.
