### PR TITLE
fix(funnel): withhold a split run's source position until every member is terminal

### DIFF
--- a/docs/design-documents/20260801-archv2-split-run-ack-ledger.md
+++ b/docs/design-documents/20260801-archv2-split-run-ack-ledger.md
@@ -227,16 +227,34 @@ layer doesn't need them to.
   a call shape that cannot currently occur was judged speculative complexity against a
   non-existent failure mode (CLAUDE.md's "no speculative generality"); if a future caller changes
   that assumption, this section is the flag to revisit it.
-- **A split run whose disjoint pieces each independently reach the _same, repeated_ destination
-  fan-out point** (a _pre_-fan-out processor splits a run across flag groups such that different
-  groups reach `doNextTask`'s fan-out branch at different times) is not newly handled. It already
-  fails loud today, unrelated to this change: each such group builds its own `multiAckNacker` via
-  `b.originalBatch()`, and a pure-tail group's `originalBatch()` yields nil positions, which
-  `newMultiAckNacker` already rejects with `CodeEmptySourcePosition`. This fix does not touch that
-  path, so behavior there is unchanged: a safe, coded failure, not silent corruption — but also not
-  something this ledger makes work correctly. The scoped shape this design (and its tests) covers is
-  a run split **after** a (possibly repeated) fan-out point, independently per branch, which is the
-  shape #2723 was actually filed against.
+- **A split run cut across a fan-out boundary is explicitly refused, with a coded error.** If a
+  processor _before_ a multi-destination fan-out splits a record and a later pre-fan-out processor
+  resolves only part of that run, the sub-batch reaching `doNextTask` holds only some of the run's
+  members. `Batch.clone` must give each branch its own ledger (branches diverge, and a shared tally
+  would race and bleed decisions across branches), but a clone carries `splitRun.total` — the
+  whole-run member count. The branch could then never complete the run, and neither could the parent
+  side: two disjoint tallies, no join point. `validateRunsWholeBeforeFanOut` detects this before the
+  fan-out and returns `CodeSplitRunStraddlesFanOut`. Nothing is acked, so the records are redelivered
+  on restart (invariant 3).
+
+  **An earlier draft of this document claimed this shape "already fails loud today … this fix does
+  not touch that path." Both halves were wrong**, and adversarial review caught it. The tail group
+  does not always reach `newMultiAckNacker` at all — `doTask` routes a `RecordFlagNack` group
+  straight to `acker.Nack`, and a group with no active records straight to `acker.Ack`, bypassing
+  `doNextTask` entirely. And the ledger _does_ touch that path: wrapping `Worker.Do` in a
+  `runAckNacker` intercepts the nil-position batch and withholds it, so `Worker.Ack`'s
+  `validateAckPositions` never runs either. Withholding silently would therefore have **disarmed both
+  of the backstops that caught this shape before the ledger existed**, turning a loud failure into a
+  permanently withheld position while later positions acked past it — silently skipping the record on
+  restart. The explicit refusal restores the loud failure.
+
+  Joining a run's tally _across_ fan-out branches is possible (hoist the ledger into a per-pass
+  registry, or have each branch complete against the member count it actually received rather than
+  `run.total`). It is deliberately not attempted without a real use case for the shape.
+
+- The shape this ledger positively supports is a run split **after** a fan-out point, independently
+  per branch — such a run is created wholly inside one branch's ledger, so its total and its members
+  agree. That is the shape #2723 was filed against.
 
 ## Testing
 

--- a/docs/design-documents/20260801-archv2-split-run-ack-ledger.md
+++ b/docs/design-documents/20260801-archv2-split-run-ack-ledger.md
@@ -1,0 +1,276 @@
+# Split-run ack ledger: fixing #2723 without touching RecordFlag semantics
+
+## Summary
+
+Fixes **#2723** (a split run's head can be acked to the source before its tail is delivered) and
+**#2730** (split-run membership is defined two different ways, and a position rewrite defeats
+both). This is the **third** attempt: #2725 (per-write flag escalation) and #2727 (normalize-once
+after `Task.Do`) were both rejected by adversarial review, for reasons this design deliberately
+avoids by construction rather than by patching around them — see
+[Why the two prior attempts failed](#why-the-two-prior-attempts-failed).
+
+The fix does not change `RecordFlag` semantics at all. `Retry`, `Filter`, and `Nack` behave in
+`pkg/lifecycle-poc/funnel` exactly as they do on `main`. Instead, a new decorator —
+`runAckNacker`, wrapping the existing `ackNacker` interface (`worker.go`) — sits between
+`Worker.doTask` and whatever it would otherwise call directly (`Worker` itself, or a
+`multiAckNacker` branch). It tracks, per split run, how many of the run's current members have
+reached a terminal disposition, and only forwards the run's original source position once all of
+them have. This mirrors `multiAckNacker`'s per-position unanimity tally (`worker.go`,
+`docs/design-documents/20260731-archv2-multiconnector.md`) one level down: unanimity **across
+branches** for one position there, unanimity **across a run's members** for one position here.
+
+**Tier 1** — data path, ack/position logic.
+
+## Context
+
+A **split run** is N contiguous `Batch` entries produced by `Batch.SplitRecord` from one original
+source record: the head keeps the original position, the rest get `nil` positions, and
+`Batch.splitRecords` maps the run back to the pre-split original record (needed for DLQ content and
+for `Batch.originalBatch()`'s collapse). `Worker.doTask`'s tainted-batch loop partitions a batch into
+contiguous same-flag sub-batches (`subBatchByFlag`) and processes them one at a time — Ack/Filter
+sub-batches either ack directly or continue to the next task; Nack sub-batches go to the DLQ; Retry
+sub-batches recurse back into the same task.
+
+`Batch.Nack`'s `setFlagWithErr` already propagates a nack across an entire split run. `Retry` and
+`Filter` do not. So a sub-batch can cover only **part** of a run — e.g. the head, while the tail is
+still being retried by a separate, later loop iteration (or a nested recursion) — and
+`originalBatch()` will happily collapse that partial sub-batch to the run's original position and
+hand it to `acker.Ack`, before the rest of the run has gone anywhere. Under fan-out, if a sibling
+branch also acks that position (it will, if it didn't split), `multiAckNacker` reaches unanimity and
+`Source.Ack` persists the position. The branch then errors on the undelivered tail (or, per the
+`main` mitigation already in place, `Worker.Ack`'s `validateAckPositions` refuses an empty-position
+sub-batch and stops the pipeline instead) — but the head's position is already durable. On restart,
+the source resumes past it, and the tail's data is gone. Invariants 1 and 3.
+
+`#2730` compounds this: `SplitRecord` keyed `Batch.splitRecords` on `b.records[i].Position` (the
+record's own, processor-rewritable position field) while every consumer (`findSplitRecord`,
+`originalBatch`, and both rejected fixes' partition-boundary checks) looked up `b.positions[i]`
+(`Batch`'s own, never-rewritten tracking of the true original position). A processor that rewrites a
+position before a later processor splits the record breaks that mapping, so run membership silently
+stops being recognized for that record.
+
+## Decision
+
+### One field, correctly keyed: fixing #2730 first
+
+`Batch.SplitRecord` now keys `splitRecords` (and the new run-tracking below) on `b.positions[i]`
+instead of `b.records[i].Position`. This is the one-line option #2730 named as preferred. Every
+consumer already used `b.positions[i]`; only the writer was wrong. See `batch.go`'s `SplitRecord`
+doc comment.
+
+### A per-run ledger, not a flag-uniformity rule
+
+`Batch` gains a new parallel field, `runs []*splitRun` (`batch.go`): `runs[i]` is `nil` for a record
+that was never split (the overwhelming common case, zero overhead), or a pointer to a shared
+`splitRun` value for every currently-live piece of a run — the head, and every tail piece
+`SplitRecord` has produced, however many further rounds of splitting have happened to any of them.
+
+```go
+type splitRun struct {
+    origPos    opencdc.Position // captured once, at first split - never changes
+    origRecord opencdc.Record   // the pre-split record, for the eventual Ack/Nack call
+
+    total         int  // current LIVE member count - can grow (see below)
+    terminalCount int  // how many of the current members have voted so far
+
+    nacked     bool // sticky: any member nacking makes the run's verdict Nack
+    nackErr    error
+    nackTaskID string
+
+    released bool // guards against ever forwarding the same run twice
+}
+```
+
+`runAckNacker` (`run_ledger.go`) wraps an `ackNacker` and intercepts every `Ack`/`Nack` call that
+would otherwise reach it. It walks the batch left to right; standalone records (`runs[i] == nil`)
+pass straight through unchanged; a span of records belonging to the same run credits
+`terminalCount += span length` and, once `terminalCount >= total`, forwards **one** call to the
+parent for that run's original position — `Ack` if no member ever nacked, `Nack` (using whichever
+member nacked first) otherwise.
+
+**Where it's inserted** (`worker.go`):
+
+- `Worker.Do` wraps `w` itself in a fresh `runAckNacker` once per batch read from the source —
+  covers the single-destination (and pre-fan-out shared-prefix) path.
+- `Worker.doNextTask`'s destination fan-out wraps each branch's `multiAckNacker` in its **own**
+  fresh `runAckNacker`, created inside the per-branch loop before `pool.Go`. Each branch's clone can
+  diverge independently (split further, retry, filter) from the moment it's cloned, so each needs an
+  independent ledger; `multiAckNacker` itself stays exactly what it already was — purely about
+  per-position unanimity **across** branches, with no notion of run structure. A branch's
+  `runAckNacker` guarantees it votes for a run's position to `multiAckNacker` exactly once, which is
+  precisely what `multiAckNacker`'s existing one-vote-per-branch-per-position contract requires.
+
+### What "terminal" means
+
+A run member is terminal once it has reached a disposition `Worker.doTask` will never revisit with
+another `Task.Do` call: **acked** (reached the true end of the pipeline, including a destination
+write), **filtered**, or **nacked** (routed to the DLQ). A member flagged `Retry` is explicitly
+**not** terminal — it is still in flight and, per `ProcessorTask.Do`'s documented behavior, may be
+fed to the same task again and split further there.
+
+This is also why `total` is a **live**, growable counter rather than a value fixed at the first
+`SplitRecord` call: a member can only be split further while it is still active (fed to some
+`Task.Do`), and by definition nothing active remains once every currently-known member is terminal —
+so `terminalCount == total` can only ever be observed at a point where no further growth is
+possible. `SplitRecord` increments `total` by `len(recs) - 1` every time it splits an existing
+member (whether that's the very first split, or the fifth round on some tail piece three tasks
+later) — see its doc comment.
+
+### In-source-order release needs no extra bookkeeping (invariant 4)
+
+`multiAckNacker` needs an explicit released-prefix scan (`releaseLocked`) because it arbitrates M
+**concurrently running** branches that can finish any position first. `runAckNacker` doesn't share
+that problem: within one branch, `Worker.doTask`'s tainted-batch loop and its `RecordFlagRetry`
+recursion are both fully sequential and synchronous — there are no goroutines until a fan-out point,
+and each branch created there gets its own `runAckNacker` anyway. `subBatchByFlag` advances the
+loop's cursor strictly left to right, and a `RecordFlagRetry` sub-batch's recursive `doTask` call —
+including everything it does: further splits, nested retries, and its own `Ack`/`Nack` calls —
+completes **before** the loop advances past it. A split run always occupies a contiguous span
+(`SplitRecord` only ever grows a run in place, never moves it), so by the time the loop's cursor
+reaches any position after the run's span, every member of that run has already voted through this
+type. That structural guarantee is what makes "buffer until `terminalCount == total`, then forward
+immediately" sufficient on its own — see `run_ledger.go`'s `runAckNacker` doc comment for the
+argument in full, and `TestRunLedger_InSourceOrderRelease_DeferredRunBlocksLaterPosition` /
+`TestRunLedger_FanOut_PendingRunOnOneBranch_NoPrematureUnanimity` for the tests that exercise it.
+
+This is a **caller-provided** guarantee, not one `runAckNacker` independently enforces the way
+`multiAckNacker` does (see [Limits](#limits-and-what-this-does-not-cover)).
+
+### Decision on item 5: `SplitRecord`'s zero-value `Ack` status
+
+`make([]RecordStatus, n)` still defaults new pieces to `RecordFlagAck` — unchanged from `main`, and
+unchanged from what attempt 1 found dangerous. It is safe here specifically because run completion
+is tracked independently, via `splitRun.total`/`terminalCount`, and never by requiring
+`recordStatuses` to agree across a run. A freshly split piece defaulting to "no error from this
+task, proceed" is exactly the right behavior regardless of what flag its siblings currently carry —
+including a sibling still flagged `Retry`, attempt 1's exact failure shape.
+`TestBatch_SplitRecord_ZeroValueAck_SafeUnderRunLedger` drives precisely that shape (`Retry` the
+original, then split it) and confirms the run still resolves correctly, once, through the ledger.
+
+### Decision on item 6: no `validateSplitRunBoundary`-style guard
+
+Both rejected attempts added a defensive check (`CodeSplitRunPartitioned`) that fired if a sub-batch
+boundary would ever cut across a run. Under this design that guard's premise is wrong: a sub-batch
+covering only part of a run is the **expected, legal, and correctly-handled** case — that's the
+entire point of moving the fix from the flag layer to the ack layer. Adding a check that fires on
+normal operation would be actively misleading. It is omitted entirely, not ported in a modified
+form.
+
+## Why the two prior attempts failed
+
+**#2725 (per-write flag escalation)**: introduced a tier ranking (`Nack > Retry > Ack/Filter`) and
+made every `Retry`/`Filter` write escalate the whole run to that tier. Review found `SplitRecord`'s
+zero-value `Ack` pieces could still land in an already-`Retry` run within the same `Task.Do` pass
+(since `ProcessorTask.Do` marks ranges end-to-start), reopening #2723 under a fatal guard instead of
+closing it (607/3000 randomized pipelines hit it); escalation mutated `filterCount` mid-`Do`,
+corrupting the active-index mapping calls still in flight were relying on; and refusing `Filter`
+inside an already-`Retry` run made the retry input never shrink, risking non-convergence.
+
+**#2727 (normalize once, after `Task.Do`)**: fixed the mid-`Do` mutation and the resulting O(n²)
+cost by doing one linear normalization pass after `Task.Do` returns instead of escalating on every
+write. But normalizing meant escalating an entire run to `Retry` uniformly — which starves the retry
+input of any shrink mechanism for a deterministic output-capped processor (an embedding processor
+with a per-call batch limit: `main` converges via `CodeEmptySourcePosition`; that design fed it the
+same 3 records forever), and re-fed already-`Ack`'d, already-transformed pieces back into the
+processor, silently double-encoding them before they reached the destination.
+
+**The common thread**: both tried to make a run's `RecordFlag`s agree with each other. Doing so
+either reopens the bug (attempt 1) or breaks something Retry/Filter's _current_, flag-preserving
+behavior was quietly relying on (attempt 2: bounded retry convergence, and a de facto no-re-feed
+guarantee). This design's core move is to stop trying to make the flags agree at all — the ack
+layer doesn't need them to.
+
+### Explicit evidence against the two attempt-2 killers
+
+- **Convergence (C1)**: `TestRunLedger_OutputCapProcessor_ConvergesAndAcksOnce` feeds a 5-piece
+  split run through a processor that always processes 2 and retries the rest — the exact shape
+  review used to falsify #2727. It converges in 3 rounds (bounded, asserted), identical to what
+  `main`'s unmodified `Retry`/`subBatchByFlag` logic already does, because this design never
+  escalates anything: `Retry`/`Filter` are untouched, so nothing changes about _how_ a retry pass
+  shrinks. This is not a claim that #2726 (unbounded retry recursion) is fixed — it isn't, and isn't
+  in scope here — only that this change does not make non-convergence any _more_ likely, and the one
+  scenario review used to prove the opposite is now proven to converge.
+- **No double transformation (C2)**: `TestRunLedger_NonIdempotentProcessor_TransformsExactlyOnce`
+  runs a non-idempotent processor (appends a marker) over a 3-piece split run with partial retries,
+  and asserts the destination receives each piece transformed exactly once. This holds structurally,
+  not by luck: `runAckNacker` never calls `Retry`, `Filter`, or `SetRecords` itself — it only
+  intercepts calls doTask was already about to make to the parent acker. A piece that reaches `Ack`
+  is, by construction, never fed to a `Task.Do` again.
+
+## Failure modes
+
+| Failure | Before this fix | After |
+| --- | --- | --- |
+| Processor returns fewer records than received, mid split run (#2723) | head acked before tail delivered → data loss on restart | run withheld until every member votes; released once, atomically |
+| Filter on the head of a run, tail retried separately | same premature-ack shape | same withholding, via the Filter/Ack call path |
+| Position rewritten, then split, then partially retried (#2730) | run membership silently not recognized → head acked with tail undelivered | `splitRecords`/`runs` keyed on the true original position; withheld correctly |
+| Deterministic output-cap processor (embedding, rate limiter) | converges on `main` via existing Retry/subBatchByFlag logic | unchanged - this fix doesn't touch that path |
+| Non-idempotent processor + partial retry | converges correctly on `main` (no re-feed) | unchanged - `runAckNacker` never re-feeds anything |
+| Fan-out, one branch's run pending | N/A (bug didn't exist pre-fan-out either) | per-branch ledger withholds that branch's vote; `multiAckNacker` still requires all branches |
+| A future code path calls `parent.Ack`/`Nack` twice for the same already-released run | silent double-ack (would violate invariant 1) | `splitRun.released` guard returns a `(bug)`-prefixed error instead |
+
+**Rollback**: revert. This is entirely internal to `pkg/lifecycle-poc/funnel` (preview-gated via
+`Preview.PipelineArchV2`, off by default) — no serialized format, protocol, or public API changes.
+
+## Limits and what this does not cover
+
+- **Not fixed here, by design**: #2726 (unbounded `RecordFlagRetry` self-recursion in `doTask`). This
+  design's convergence evidence above shows it does not make #2726 _more_ likely to trigger, but a
+  genuinely non-convergent processor still recurses unbounded on this branch exactly as it does on
+  `main`.
+- **`runAckNacker`'s in-order guarantee is caller-provided, not self-enforced.** Unlike
+  `multiAckNacker`, it does not independently track a released-prefix or assert against an
+  out-of-order external caller — it relies on `Worker.doTask`'s single-goroutine-per-branch,
+  strictly-sequential execution model (verified structurally above, not merely assumed). A
+  hypothetical future caller that invoked `runAckNacker.Ack`/`Nack` out of source order directly
+  (bypassing `doTask` entirely) could release out of order. Adding prefix-buffering to guard against
+  a call shape that cannot currently occur was judged speculative complexity against a
+  non-existent failure mode (CLAUDE.md's "no speculative generality"); if a future caller changes
+  that assumption, this section is the flag to revisit it.
+- **A split run whose disjoint pieces each independently reach the _same, repeated_ destination
+  fan-out point** (a _pre_-fan-out processor splits a run across flag groups such that different
+  groups reach `doNextTask`'s fan-out branch at different times) is not newly handled. It already
+  fails loud today, unrelated to this change: each such group builds its own `multiAckNacker` via
+  `b.originalBatch()`, and a pure-tail group's `originalBatch()` yields nil positions, which
+  `newMultiAckNacker` already rejects with `CodeEmptySourcePosition`. This fix does not touch that
+  path, so behavior there is unchanged: a safe, coded failure, not silent corruption — but also not
+  something this ledger makes work correctly. The scoped shape this design (and its tests) covers is
+  a run split **after** a (possibly repeated) fan-out point, independently per branch, which is the
+  shape #2723 was actually filed against.
+
+## Testing
+
+All in `pkg/lifecycle-poc/funnel/run_ledger_test.go`, run with `-race`:
+
+- `TestRunLedger_RetryHead_NotAckedUntilTailResolves`, `TestRunLedger_FilterHead_NotAckedUntilTailResolves`
+  — the original #2723 shapes.
+- `TestRunLedger_OutputCapProcessor_ConvergesAndAcksOnce`,
+  `TestRunLedger_NonIdempotentProcessor_TransformsExactlyOnce` — the two attempt-2 killers.
+- `TestRunLedger_PositionRewriteThenSplit_NoPrematureAck` — the #2730 shape.
+- `TestRunLedger_InSourceOrderRelease_DeferredRunBlocksLaterPosition` — invariant 4, single branch.
+- `TestRunLedger_FanOut_PendingRunOnOneBranch_NoPrematureUnanimity` — fan-out composition, M=2, with
+  a gated retry pass proving no premature unanimity and in-order release together.
+- `TestBatch_SplitRecord_ZeroValueAck_SafeUnderRunLedger` — item 5's decision.
+- `TestRunLedger_Property_SplitFilterRetryNackRewrite` — 300 randomized iterations of
+  split/filter/retry/nack/position-rewrite combinations; every original position acked-once XOR
+  DLQ'd-once, cross-checked by destination/DLQ delivery counts.
+- `BenchmarkRunLedger_VoteLinear` — resolves a single N-member run one vote at a time (n=1000/4000/
+  16000); scales roughly linearly (measured ~2.6-3.8x time per 4x N), nothing like #2725's
+  measured ~42000x blowup for the same 4x step.
+
+Fail-without/pass-with was verified by temporarily short-circuiting `runAckNacker.vote` to forward
+every call straight through (simulating pre-fix behavior): every new test in this file fails,
+including `TestRunLedger_RetryHead_NotAckedUntilTailResolves` (asserts exactly 1 release, observed
+2 — the head released separately from the tail) and
+`TestRunLedger_FanOut_PendingRunOnOneBranch_NoPrematureUnanimity` (asserts p0 alone acked at the
+checkpoint, observed nothing acked at all — the whole batch raced ahead of the withheld run
+incorrectly). Restoring the fix returns the suite to green.
+
+## Related
+
+- #2723, #2726 (not fixed here), #2730
+- #2725, #2727 (superseded, rejected)
+- `docs/design-documents/20260731-archv2-multiconnector.md` (the model this design's per-run ledger
+  mirrors one level down)
+- `docs/architecture-decision-records/20260731-archv2-fanout-ack-model.md` (per-position ack model
+  this design composes with, unchanged)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -614,7 +614,7 @@ Author: Meroxa, Inc.
 | `sdk.schema.extract.key.enabled` | bool | true | no | Whether to extract and decode the record key with a schema. |  |
 | `sdk.schema.extract.payload.enabled` | bool | true | no | Whether to extract and decode the record payload with a schema. |  |
 
-## 3. Error codes (90)
+## 3. Error codes (91)
 
 | Reason | gRPC status | Description |
 | --- | --- | --- |
@@ -649,6 +649,7 @@ Author: Meroxa, Inc.
 | `pipeline.name_missing` | InvalidArgument | CodePipelineNameMissing is raised when a pipeline config is missing the required name field. |
 | `pipeline.not_running` | FailedPrecondition | CodePipelineNotRunning is raised when an operation requires the pipeline to be running, but it is currently stopped. |
 | `pipeline.running` | FailedPrecondition | CodePipelineRunning is raised when an operation requires the pipeline to be stopped, but it is currently running. |
+| `pipeline.split_run_straddles_fanout` | FailedPrecondition | pipeline: split run straddles fanout |
 | `pipelines.init_destination_exists` | AlreadyExists | pipelines: init destination exists |
 | `pipelines.init_template_flags_exclusive` | InvalidArgument | pipelines: init template flags exclusive |
 | `pipelines.init_template_version_mismatch` | FailedPrecondition | pipelines: init template version mismatch |

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@
 (6 built-in connectors; full parameters in llms-full.txt)
 
 ## Error codes
-- 90 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
+- 91 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
 
 ## MCP tools
 - Read: deploy, doctor, dry_run, inspect, lint, repair, validate

--- a/pkg/lifecycle-poc/funnel/batch.go
+++ b/pkg/lifecycle-poc/funnel/batch.go
@@ -49,12 +49,44 @@ type Batch struct {
 	// containing only records with the same status (filtered counts as acked).
 	tainted bool
 
-	// splitRecords is a map of split records, where the key is the record
-	// position converted to a string. The value is the original record itself.
-	// This is used to keep track of the original record when splitting it into
-	// multiple records. The position is nil for split records, except the first
-	// record, which contains the position of the original record.
+	// splitRecords is a map of split records, where the key is the record's
+	// ORIGINAL source position (b.positions[i], see #2730 below) converted to
+	// a string. The value is the original record itself. This is used to keep
+	// track of the original record when splitting it into multiple records.
+	// The position is nil for split records, except the first record, which
+	// contains the position of the original record.
 	splitRecords map[string]opencdc.Record
+
+	// runs tracks, for every currently-live record in the batch, which split
+	// run (if any) it belongs to. runs[i] is nil for a record that was never
+	// split (the common case). For a record that WAS split, every piece
+	// descended from it - the head at the position it originally occupied,
+	// and every tail piece produced by SplitRecord, however many rounds of
+	// further splitting happen to any of them - shares the exact same *splitRun
+	// pointer.
+	//
+	// This is what lets runAckNacker (run_ledger.go) recognize that two pieces
+	// of one run arriving in two SEPARATE Ack/Nack calls - possibly far apart
+	// in time, via the RecordFlagRetry recursion in Worker.doTask - are the
+	// same run, even though by then they may be sitting in totally different
+	// *Batch values produced by sub() (see #2723). Looking this up via
+	// splitRecords/positions alone does not work for a sub-batch that holds
+	// only nil-position tail pieces with no head present: sub()'s own
+	// splitRecords-carry-forward logic keys on position bytes, and nil never
+	// matches a real key, so a pure-tail sub-batch always loses that map
+	// entry. runs is a dedicated, position-independent parallel array kept in
+	// lockstep with records/recordStatuses/positions specifically so tail-only
+	// slices don't lose the association.
+	//
+	// nil (rather than an empty slice) is the zero value for a *Batch created
+	// directly as a struct literal instead of through NewBatch - every
+	// consumer of this field (sub, clone, SplitRecord, runAckNacker.vote)
+	// treats a nil runs slice as "no run tracking available, every record is
+	// standalone", which is exactly correct for those hand-built batches (e.g.
+	// multiAckNacker's ackBatch/nackBatch, or splitRun's own ackBatch/nackBatch
+	// below): they represent an already-fully-resolved position, with nothing
+	// left to track.
+	runs []*splitRun
 }
 
 func NewBatch(records []opencdc.Record) *Batch {
@@ -69,6 +101,7 @@ func NewBatch(records []opencdc.Record) *Batch {
 		records:        records,
 		recordStatuses: make([]RecordStatus, len(records)),
 		positions:      positions,
+		runs:           make([]*splitRun, len(records)),
 		filterCount:    0,
 		tainted:        false,
 	}
@@ -184,6 +217,19 @@ func (b *Batch) findTo(l, r int, check func(int) bool) int {
 // SplitRecord splits the record at index i into the provided records. The
 // records replace the record at the index i, and the rest of the records are
 // shifted to the right.
+//
+// # #2730: run membership keys on b.positions[i], not b.records[i].Position
+//
+// b.records[i].Position is the record's OWN Position field, which a processor
+// upstream of this call may have rewritten. b.positions[i] is Batch's own,
+// separately-tracked original source position (see the positions field doc),
+// never touched by a processor. Keying splitRecords (and, below, the run
+// ledger) on the record's current position meant a processor that rewrote a
+// position before a later processor split it broke run membership entirely:
+// groupFlagAt/checkEdge in the two rejected fixes for #2723 looked up
+// b.positions[idx], which no longer matched the key SplitRecord had written,
+// so the run was silently treated as a single ordinary record. Keying on
+// b.positions[i] here (which every consumer already used) closes that gap.
 func (b *Batch) SplitRecord(i int, recs []opencdc.Record) {
 	// TODO: we should not have to recalculate the active record indices every time.
 	activeIndices := b.activeRecordIndices()
@@ -192,21 +238,69 @@ func (b *Batch) SplitRecord(i int, recs []opencdc.Record) {
 		i = activeIndices[i]
 	}
 
-	if b.splitRecords == nil {
-		b.splitRecords = make(map[string]opencdc.Record)
+	origPos := b.positions[i]
+
+	var run *splitRun
+	if b.runs != nil {
+		run = b.runs[i]
 	}
-	if _, ok := b.splitRecords[b.records[i].Position.String()]; b.records[i].Position != nil && !ok {
-		// We're splitting an original record, so we need to store it in the
-		// split records map. If any of the split records get nacked, we need to
-		// send the original to the DLQ.
-		b.splitRecords[b.records[i].Position.String()] = b.records[i]
+
+	if run == nil {
+		// First time this record is being split.
+		if origPos == nil {
+			// i is itself a nil-position (tail) member of an existing run
+			// whose head - and therefore whose *splitRun - lives at a lower
+			// index. sub() is responsible for carrying b.runs forward
+			// alongside positions/recordStatuses so this is always resolved
+			// above; reaching here means that invariant broke.
+			panic("(bug) SplitRecord: record has a nil position but no known split run")
+		}
+
+		if b.splitRecords == nil {
+			b.splitRecords = make(map[string]opencdc.Record)
+		}
+		origRecord := b.records[i]
+		if existing, ok := b.splitRecords[origPos.String()]; ok {
+			// Should not normally happen (origPos == nil check above already
+			// implies this is the first split for this position), but prefer
+			// whatever was already recorded if it exists.
+			origRecord = existing
+		} else {
+			// We're splitting an original record, so we need to store it in the
+			// split records map. If any of the split records get nacked, we need
+			// to send the original to the DLQ.
+			b.splitRecords[origPos.String()] = origRecord
+		}
+
+		// total starts at 1 (the single existing member - index i itself -
+		// that this call is about to replace), so that "run.total +=
+		// len(recs)-1" below lands on exactly len(recs), not len(recs)-1.
+		run = &splitRun{origPos: origPos, origRecord: origRecord, total: 1}
+		if b.runs == nil {
+			b.runs = make([]*splitRun, len(b.records))
+		}
+		b.runs[i] = run
 	}
+	// run.total tracks every CURRENTLY LIVE member of the run. This split
+	// replaces one live member (index i) with len(recs) new ones, so the net
+	// change is len(recs)-1 - not len(recs), which would double-count i itself
+	// on every split after the first. See splitRun's doc comment for why this
+	// must be able to grow after some sibling members have already gone
+	// terminal.
+	run.total += len(recs) - 1
 
 	b.records = append(b.records[:i], append(recs, b.records[i+1:]...)...)
 
-	// Extend the record statuses slice to accommodate the new records. By default
-	// the new records are marked as acked. The original record must have been
-	// acked, otherwise the processor wouldn't receive it.
+	// Extend the record statuses slice to accommodate the new records. By
+	// default the new records are marked as acked (RecordStatus's zero value).
+	// This is safe under the run-ledger design even when a sibling member of
+	// the same run is currently flagged Retry: unlike the two rejected #2723
+	// fixes, nothing here relies on every member of a run sharing one flag.
+	// The ledger tracks completion via run.total/run.terminalCount, credited
+	// only when a member actually reaches an Ack/Nack call - not by reading
+	// recordStatuses - so a freshly-split piece defaulting to "no error from
+	// this task, proceed" is exactly the right behavior regardless of what
+	// flag its siblings currently carry. See TestBatch_SplitRecord_ZeroValueAck_SafeUnderRunLedger.
 	b.recordStatuses = append(
 		b.recordStatuses[:i+1],
 		append(make([]RecordStatus, len(recs)-1), b.recordStatuses[i+1:]...)...,
@@ -218,6 +312,17 @@ func (b *Batch) SplitRecord(i int, recs []opencdc.Record) {
 	b.positions = append(
 		b.positions[:i+1],
 		append(make([]opencdc.Position, len(recs)-1), b.positions[i+1:]...)...,
+	)
+
+	// Extend runs the same way: every new piece belongs to the same run as
+	// the record it replaced.
+	newRuns := make([]*splitRun, 0, len(recs)-1)
+	for k := 0; k < len(recs)-1; k++ {
+		newRuns = append(newRuns, run)
+	}
+	b.runs = append(
+		b.runs[:i+1],
+		append(newRuns, b.runs[i+1:]...)...,
 	)
 }
 
@@ -370,10 +475,45 @@ func (b *Batch) clone() *Batch {
 		records:        records,
 		recordStatuses: slices.Clone(b.recordStatuses),
 		positions:      slices.Clip(b.positions),
+		runs:           cloneRuns(b.runs),
 		tainted:        b.tainted,
 		filterCount:    b.filterCount,
 		splitRecords:   splitRecords,
 	}
+}
+
+// cloneRuns deep-copies the *splitRun graph referenced by runs: every branch
+// created by clone() (see Worker.doNextTask's destination fan-out) must
+// evolve its own runs' completion tallies independently from its siblings and
+// from the batch it was cloned from - concurrent branches incrementing the
+// SAME splitRun's terminalCount would be a data race, and would also make one
+// branch's retry/filter/split decisions bleed into another's ack decisions,
+// which is exactly the kind of cross-branch interference multiAckNacker
+// exists to prevent at the position level. This mirrors why splitRecords
+// itself is deep-copied, not shared, in clone().
+//
+// Every member of one run must keep pointing at the SAME cloned *splitRun
+// (not get its own independent copy), or the tally would fragment and never
+// reach completion - the seen map ensures that.
+func cloneRuns(runs []*splitRun) []*splitRun {
+	if runs == nil {
+		return nil
+	}
+	out := make([]*splitRun, len(runs))
+	seen := make(map[*splitRun]*splitRun, len(runs))
+	for i, r := range runs {
+		if r == nil {
+			continue
+		}
+		cloned, ok := seen[r]
+		if !ok {
+			copied := *r
+			cloned = &copied
+			seen[r] = cloned
+		}
+		out[i] = cloned
+	}
+	return out
 }
 
 func (b *Batch) sub(from, to int) *Batch {
@@ -398,12 +538,27 @@ func (b *Batch) sub(from, to int) *Batch {
 		}
 	}
 
+	// runs is reslice-only (not copied), same as records/recordStatuses/
+	// positions: sub-batches produced from the SAME parent batch across
+	// different doTask loop iterations (or the RecordFlagRetry recursion)
+	// must observe and mutate the SAME *splitRun for a shared run - that's
+	// the whole mechanism run_ledger.go's runAckNacker relies on to notice a
+	// run completing across calls that are far apart in time. The
+	// three-index clip prevents the aliasing bug TestBatch_Clone_PositionsAliasing
+	// guards against on positions - SplitRecord appends to runs exactly like
+	// it appends to positions, so it needs the same protection.
+	var runs []*splitRun
+	if b.runs != nil {
+		runs = b.runs[from:to:to]
+	}
+
 	// Note that we also adjust the capacity of the slices to avoid writing
 	// over the original batch when splitting records.
 	return &Batch{
 		records:        b.records[from:to:to],
 		recordStatuses: b.recordStatuses[from:to:to],
 		positions:      b.positions[from:to:to],
+		runs:           runs,
 		filterCount:    filterCount,
 		tainted:        false,
 		splitRecords:   splitRecords,
@@ -490,6 +645,7 @@ func (b *Batch) originalBatch() *Batch {
 		records:        records,
 		recordStatuses: recordStatuses,
 		positions:      positions,
+		runs:           make([]*splitRun, len(records)),
 		filterCount:    filterCount,
 		tainted:        false,
 		splitRecords:   nil,

--- a/pkg/lifecycle-poc/funnel/codes.go
+++ b/pkg/lifecycle-poc/funnel/codes.go
@@ -57,3 +57,25 @@ var CodeDuplicateSourcePosition = conduiterr.Register("pipeline.duplicate_source
 // run (a Retry/Filter that does not propagate across the run). The suggestion
 // therefore points at the processor chain, not the source.
 var CodeEmptySourcePosition = conduiterr.Register("pipeline.empty_source_position", codes.FailedPrecondition)
+
+// CodeSplitRunStraddlesFanOut is returned when a batch reaching a
+// multi-destination fan-out holds only part of a split run — i.e. a processor
+// before the fan-out split a record, and a later pre-fan-out processor resolved
+// only some of the resulting pieces (for example by returning fewer records
+// than it received, which marks the remainder Retry).
+//
+// The run-completion ledger (see run_ledger.go) is per-Batch, and Batch.clone
+// gives each branch its own copy so branches cannot race or bleed decisions
+// into each other. That copy carries the run's whole-run member count, so a
+// branch holding only part of the run can never complete it — and neither can
+// the parent side. The run's original source position would then be withheld
+// forever while later positions ack past it, silently skipping the record on
+// restart.
+//
+// Failing loud is deliberate and restores the behaviour that predates the
+// ledger: this shape already failed loud before (via CodeEmptySourcePosition on
+// the nil-position tail), and silently withholding would have disarmed that
+// backstop. Nothing is acked and nothing is lost — the records are redelivered
+// on restart (invariant 3). Joining a run's tally across fan-out branches is
+// possible but is deliberately not attempted here without a real use case.
+var CodeSplitRunStraddlesFanOut = conduiterr.Register("pipeline.split_run_straddles_fanout", codes.FailedPrecondition)

--- a/pkg/lifecycle-poc/funnel/run_ledger.go
+++ b/pkg/lifecycle-poc/funnel/run_ledger.go
@@ -1,0 +1,290 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funnel
+
+import (
+	"context"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+)
+
+// splitRun tracks the completion state of one split run: a set of batch
+// entries that all trace back, via Batch.SplitRecord, to a single original
+// source record (see Batch.runs's doc comment for how membership is tracked
+// across sub-batches). Every currently-live member of the run shares a
+// pointer to the SAME splitRun value, so the tally survives across however
+// many times the batch is subsequently sliced (Batch.sub), retried
+// (Worker.doTask's RecordFlagRetry branch), or further split by a later task.
+//
+// # What "terminal" means (fixes #2723)
+//
+// A run member is terminal once it has reached a disposition that Worker.doTask
+// will never revisit with another Task.Do call: it was acked (reached the end
+// of the pipeline, including a destination write), filtered, or nacked
+// (routed to the DLQ). A member flagged RecordFlagRetry is explicitly NOT
+// terminal - it is still in flight, and (per ProcessorTask.Do's documented
+// behavior: a processor returning fewer records than it received produces a
+// Retry) may yet be fed to the SAME task again, which can split it further.
+// That is exactly why total below is a live counter, not a value fixed at the
+// first SplitRecord call - see the field doc.
+//
+// # Why this does not touch RecordFlag semantics
+//
+// Both rejected fixes for #2723 (PRs #2725, #2727) tried to make a run's
+// RecordFlag values uniform - either by escalating every write across the
+// run, or by normalizing them in one pass after Task.Do. Escalating Retry
+// across a run that also contains a Filter'd member starves the retry input
+// of the shrink a Filter provides, which is what makes a deterministic
+// output-capped processor converge; escalating flags at all reached into
+// territory (re-feeding already-transformed records to a processor) with no
+// existing idempotency contract. This design does neither. RecordFlagRetry,
+// RecordFlagFilter, RecordFlagNack all behave on this branch exactly as they
+// do on main; splitRun only changes WHEN a disposition that Worker.doTask
+// already decided is forwarded to the parent ackNacker, never WHAT that
+// disposition is. See docs/design-documents/20260801-archv2-split-run-ack-ledger.md.
+type splitRun struct {
+	// origPos and origRecord are captured once, at the run's creation (the
+	// first Batch.SplitRecord call for this original record), and never
+	// change. They are what gets handed to the parent ackNacker once the run
+	// completes - see ackBatch/nackBatch below. Both must be captured here,
+	// rather than looked up later via Batch.splitRecords, because a sub-batch
+	// holding only nil-position tail members (no head, see Batch.runs's doc
+	// comment) cannot resolve that map lookup by the time the run completes.
+	origPos    opencdc.Position
+	origRecord opencdc.Record
+
+	// total is the number of CURRENTLY LIVE members of the run - i.e. it can
+	// grow: Batch.SplitRecord increments it every time it splits an existing
+	// member further, whether that happens before or after some OTHER member
+	// of the same run has already gone terminal. It can only grow while some
+	// member is still active (fed to a Task.Do call) - once every currently
+	// known member is terminal, by definition nothing is left that Task.Do
+	// could still split, so growth stops exactly when completion is checked.
+	total int
+	// terminalCount is how many of the run's CURRENT total members have
+	// reached a terminal disposition so far, credited by runAckNacker.vote
+	// the moment each one arrives at an Ack or Nack call.
+	terminalCount int
+
+	// nacked, once true, is sticky: the run's eventual disposition to the
+	// parent is Nack if ANY member ever nacked, regardless of how many
+	// siblings acked and regardless of arrival order - the same nack-wins
+	// rule multiAckNacker applies across branches (invariant 3), applied here
+	// across a run's members instead.
+	nacked     bool
+	nackErr    error
+	nackTaskID string
+
+	// released guards against ever forwarding the same run to the parent
+	// twice. Structurally this should be unreachable (see run_ledger.go's
+	// package doc), but a double-forward would double-ack a source position -
+	// an invariant-1 violation - so it is asserted rather than assumed.
+	released bool
+}
+
+// complete reports whether every currently-known member of the run has
+// reached a terminal disposition - see the total/terminalCount field docs for
+// why this correctly implies no further growth is possible.
+func (r *splitRun) complete() bool {
+	return r.terminalCount >= r.total
+}
+
+// ackBatch builds the single-record *Batch representing this run's original
+// position, ready to hand to the parent ackNacker's Ack. It carries no runs
+// or splitRecords (both nil/zero) - by construction the run is finished, so
+// there's nothing left for the parent (or anything further downstream, like
+// an outer runAckNacker or multiAckNacker) to track for it.
+func (r *splitRun) ackBatch() *Batch {
+	return &Batch{
+		records:        []opencdc.Record{r.origRecord},
+		recordStatuses: []RecordStatus{{Flag: RecordFlagAck}},
+		positions:      []opencdc.Position{r.origPos},
+	}
+}
+
+// nackBatch builds the single-record *Batch representing this run's original
+// position for the parent ackNacker's Nack, carrying the error and task ID of
+// whichever member nacked first (see the nacked field doc).
+func (r *splitRun) nackBatch() *Batch {
+	return &Batch{
+		records:        []opencdc.Record{r.origRecord},
+		recordStatuses: []RecordStatus{{Flag: RecordFlagNack, Error: r.nackErr}},
+		positions:      []opencdc.Position{r.origPos},
+		tainted:        true,
+	}
+}
+
+// runAckNacker sits between Worker.doTask and the acker it would otherwise
+// call directly - the Worker itself for a single-destination pipeline, or a
+// multiAckNacker for one branch of a destination fan-out. See Worker.Do and
+// Worker.doNextTask for where it's inserted, and Batch.runs's doc comment for
+// how run membership survives across the calls it intercepts.
+//
+// It withholds a split run's original source position from the parent until
+// every member of the run is terminal (see splitRun), which is the fix for
+// #2723: a sub-batch covering only PART of a run (e.g. the head, while the
+// tail is still off being retried in a separate doTask recursion) no longer
+// reaches the parent's Ack/Nack on its own.
+//
+// # Ordering (invariant 4) needs no explicit bookkeeping here
+//
+// multiAckNacker needs an explicit released-prefix scan (see its doc comment
+// and releaseLocked) because it arbitrates M concurrently-running branches
+// that can each finish ANY position first. runAckNacker has no such problem:
+// within one branch, Worker.doTask's tainted-batch loop and its
+// RecordFlagRetry recursion are both fully sequential and synchronous - no
+// goroutines. subBatchByFlag advances strictly left to right, and a
+// RecordFlagRetry sub-batch's recursive doTask call (including everything IT
+// does: further splits, nested retries, and its own Ack/Nack calls) completes
+// before the loop advances past it. A split run always occupies a contiguous
+// span of the original batch (SplitRecord only ever grows a run in place), so
+// by the time the loop's cursor reaches any position after the run's span,
+// every member of the run has already been voted on by this type. That is
+// what makes "buffer until terminalCount==total, then forward immediately"
+// sufficient on its own: nothing positioned after a pending run can reach
+// vote() before the run resolves, so release order along the original
+// sequence is preserved by construction rather than by an explicit counter.
+// See docs/design-documents/20260801-archv2-split-run-ack-ledger.md for the
+// full argument, including the one scenario (a run's disjoint pieces each
+// independently reaching a REPEATED destination fan-out point) this argument
+// does not cover, and why that gap is pre-existing and unaffected by this fix.
+type runAckNacker struct {
+	parent ackNacker
+}
+
+// newRunAckNacker wraps parent with a fresh, empty run ledger. A fresh
+// instance is required per scope that needs independent run tracking: once
+// per top-level batch-processing pass for a non-fanned-out pipeline (see
+// Worker.Do), and once per destination branch at a fan-out point (see
+// Worker.doNextTask) since branches diverge independently after cloning and
+// must not share (or race on) each other's run completion state.
+func newRunAckNacker(parent ackNacker) *runAckNacker {
+	return &runAckNacker{parent: parent}
+}
+
+// Ack records a vote that every record in batch reached the end of the
+// pipeline (or was filtered). Standalone records (not part of any split run)
+// are forwarded to the parent immediately, unchanged. Records that belong to
+// an incomplete run are held; the run's original position is forwarded to the
+// parent only once every one of its currently-known members has voted
+// (Ack, Nack, or Filter - see splitRun's doc comment for what counts as
+// terminal).
+func (r *runAckNacker) Ack(ctx context.Context, batch *Batch) error {
+	return r.vote(ctx, batch, true, "")
+}
+
+// Nack records a vote that every record in batch failed at taskID and was
+// routed to the DLQ. Same withholding rule as Ack; if any member of a run
+// ever nacks, the run's eventual disposition to the parent is Nack regardless
+// of how its other members voted (invariant 3, applied within a run - see
+// splitRun.nacked).
+func (r *runAckNacker) Nack(ctx context.Context, batch *Batch, taskID string) error {
+	return r.vote(ctx, batch, false, taskID)
+}
+
+// vote walks batch left to right. Contiguous standalone records (Batch.runs[i]
+// == nil) are coalesced into one pass-through call to the parent. Contiguous
+// records belonging to the same run are credited toward that run's
+// completion; the run itself is only forwarded to the parent once (see
+// splitRun.released) at the moment its last currently-known member votes.
+//
+// A batch built without run tracking (batch.runs == nil - e.g. a hand-built
+// single-record Batch like splitRun's own ackBatch/nackBatch, or
+// multiAckNacker's) is treated the same as all-standalone: there is nothing
+// to withhold, so every record forwards immediately. This is what makes
+// runAckNacker composable with itself and with multiAckNacker without special
+// cases at the boundary.
+func (r *runAckNacker) vote(ctx context.Context, batch *Batch, isAck bool, taskID string) error {
+	i := 0
+	for i < len(batch.records) {
+		var run *splitRun
+		if batch.runs != nil {
+			run = batch.runs[i]
+		}
+
+		j := i + 1
+		for j < len(batch.records) {
+			var next *splitRun
+			if batch.runs != nil {
+				next = batch.runs[j]
+			}
+			if next != run {
+				break
+			}
+			j++
+		}
+
+		if run == nil {
+			if err := r.forward(ctx, batch.sub(i, j), isAck, taskID); err != nil {
+				return err
+			}
+			i = j
+			continue
+		}
+
+		if run.released {
+			// Should be unreachable: a run's members are never handed to
+			// another Ack/Nack call once the run has already been forwarded
+			// (see the type doc comment's ordering argument). Fail loud
+			// rather than silently double-crediting (or, worse, double-
+			// forwarding) a position already released to the source.
+			return cerrors.Errorf(
+				"(bug) runAckNacker: split run at source position %q voted on again after already being released",
+				run.origPos,
+			)
+		}
+
+		run.terminalCount += j - i
+		if !isAck && !run.nacked {
+			run.nacked = true
+			run.nackErr = firstRunError(batch.recordStatuses[i:j])
+			run.nackTaskID = taskID
+		}
+
+		if run.complete() {
+			run.released = true
+			if run.nacked {
+				if err := r.parent.Nack(ctx, run.nackBatch(), run.nackTaskID); err != nil {
+					return err
+				}
+			} else if err := r.parent.Ack(ctx, run.ackBatch()); err != nil {
+				return err
+			}
+		}
+
+		i = j
+	}
+	return nil
+}
+
+func (r *runAckNacker) forward(ctx context.Context, batch *Batch, isAck bool, taskID string) error {
+	if isAck {
+		return r.parent.Ack(ctx, batch)
+	}
+	return r.parent.Nack(ctx, batch, taskID)
+}
+
+// firstRunError returns the first non-nil error among statuses, used to
+// attribute a run's DLQ entry to whichever member nacked first (see
+// splitRun.nacked).
+func firstRunError(statuses []RecordStatus) error {
+	for _, s := range statuses {
+		if s.Error != nil {
+			return s.Error
+		}
+	}
+	return nil
+}

--- a/pkg/lifecycle-poc/funnel/run_ledger.go
+++ b/pkg/lifecycle-poc/funnel/run_ledger.go
@@ -16,9 +16,11 @@ package funnel
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/conduitio/conduit-commons/opencdc"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 )
 
 // splitRun tracks the completion state of one split run: a set of batch
@@ -98,8 +100,19 @@ type splitRun struct {
 // complete reports whether every currently-known member of the run has
 // reached a terminal disposition - see the total/terminalCount field docs for
 // why this correctly implies no further growth is possible.
-func (r *splitRun) complete() bool {
-	return r.terminalCount >= r.total
+//
+// It reports an error rather than silently tolerating an over-count: exceeding
+// total means a member was credited twice, which would release the run's source
+// position EARLIER than its members actually finished (invariant 1). The
+// released flag only guards a second forward, not a premature first one, so
+// this is the only place that condition can be caught.
+func (r *splitRun) complete() (bool, error) {
+	if r.terminalCount > r.total {
+		return false, cerrors.Errorf(
+			"(bug) splitRun %q: %d terminal members counted for a run of %d - a member was credited twice",
+			r.origPos, r.terminalCount, r.total)
+	}
+	return r.terminalCount == r.total, nil
 }
 
 // ackBatch builds the single-record *Batch representing this run's original
@@ -165,7 +178,13 @@ type runAckNacker struct {
 	parent ackNacker
 }
 
-// newRunAckNacker wraps parent with a fresh, empty run ledger. A fresh
+// newRunAckNacker wraps parent. NOTE: the returned value is STATELESS - the
+// run-completion tally lives in the *splitRun values inside Batch.runs, shared
+// across the sub-batches sub() derives from one parent batch. Instantiating a
+// new wrapper is therefore about scoping WHICH parent acker completed runs are
+// forwarded to, not about resetting any state.
+//
+// Original (inaccurate) note follows: wraps parent with a fresh, empty run ledger. A fresh
 // instance is required per scope that needs independent run tracking: once
 // per top-level batch-processing pass for a non-fanned-out pipeline (see
 // Worker.Do), and once per destination branch at a fan-out point (see
@@ -254,7 +273,11 @@ func (r *runAckNacker) vote(ctx context.Context, batch *Batch, isAck bool, taskI
 			run.nackTaskID = taskID
 		}
 
-		if run.complete() {
+		done, err := run.complete()
+		if err != nil {
+			return err
+		}
+		if done {
 			run.released = true
 			if run.nacked {
 				if err := r.parent.Nack(ctx, run.nackBatch(), run.nackTaskID); err != nil {
@@ -285,6 +308,62 @@ func firstRunError(statuses []RecordStatus) error {
 		if s.Error != nil {
 			return s.Error
 		}
+	}
+	return nil
+}
+
+// validateRunsWholeBeforeFanOut rejects a batch that is about to be fanned out
+// while holding only PART of a split run.
+//
+// Invariant 1/2/3 (enforcement site). Batch.clone gives each fan-out branch its
+// own copy of the run ledger (cloneRuns), which is necessary — branches diverge
+// independently and must not race on, or bleed decisions into, a shared tally.
+// But a clone copies splitRun.total, which counts every live member of the
+// WHOLE run, while the batch reaching a fan-out is a sub-batch that may hold
+// only the members of one flag group (doTask partitions a tainted batch by
+// flag). The branch's ledger then needs total members to complete but only ever
+// sees k < total of them, and the parent-side ledger only ever sees the other
+// total-k. Two disjoint tallies, neither able to complete, with no join point:
+// the run's original source position would be withheld FOREVER while every
+// later position acks normally — Source.Ack sets State.Position to the last
+// position it is given, so the withheld record is silently skipped on restart.
+//
+// That is strictly worse than not supporting the shape: before the run ledger
+// existed, this same shape failed loud (a pure-tail group collapses to nil
+// positions, which Worker.Ack's validateAckPositions and newMultiAckNacker both
+// reject). Withholding silently would disarm both of those backstops, so this
+// check restores the loud failure for a shape the ledger does not yet join
+// across branches.
+//
+// Splitting INSIDE a branch, after the clone, is unaffected and fully
+// supported: such a run is created entirely within that branch's own ledger, so
+// its total and its members agree.
+func validateRunsWholeBeforeFanOut(b *Batch) error {
+	if len(b.runs) == 0 {
+		return nil
+	}
+
+	present := make(map[*splitRun]int, len(b.runs))
+	for _, r := range b.runs {
+		if r != nil {
+			present[r]++
+		}
+	}
+
+	for run, n := range present {
+		if n >= run.total {
+			continue
+		}
+		ce := conduiterr.New(CodeSplitRunStraddlesFanOut, fmt.Sprintf(
+			"cannot fan out a batch holding only %d of the %d records that record %q was split into: "+
+				"the split run is cut across the fan-out boundary",
+			n, run.total, run.origPos,
+		))
+		ce.Suggestion = "this happens when a processor BEFORE the fan-out splits a record and a later " +
+			"pre-fan-out processor resolves only part of that split (for example returning fewer records " +
+			"than it received); move the splitting processor into the destination branches, or reduce the " +
+			"pipeline to a single destination. No records are acked or lost — they are redelivered on restart."
+		return ce
 	}
 	return nil
 }

--- a/pkg/lifecycle-poc/funnel/run_ledger_test.go
+++ b/pkg/lifecycle-poc/funnel/run_ledger_test.go
@@ -1,0 +1,875 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funnel
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"slices"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/foundation/metrics/noop"
+	"github.com/matryer/is"
+)
+
+// This file is the regression suite for #2723 (split-run head acked before
+// its tail is delivered) and #2730 (split-run membership defined two
+// different ways), fixed by run_ledger.go's runAckNacker/splitRun rather than
+// by touching RecordFlag semantics - see
+// docs/design-documents/20260801-archv2-split-run-ack-ledger.md for the full
+// design and why the two previously-rejected approaches (#2725, #2727) don't
+// work.
+
+// --- Test tasks -------------------------------------------------------
+
+// splitOnceTask splits the record at index 0 into 2 identical pieces, the
+// first time it's called on a batch containing it, and does nothing after.
+type splitOnceTask struct {
+	id        string
+	triggered bool
+}
+
+func (t *splitOnceTask) ID() string                  { return t.id }
+func (t *splitOnceTask) Open(context.Context) error  { return nil }
+func (t *splitOnceTask) Close(context.Context) error { return nil }
+func (t *splitOnceTask) Do(_ context.Context, b *Batch) error {
+	if t.triggered {
+		return nil
+	}
+	active := b.ActiveRecords()
+	if len(active) == 0 {
+		return nil
+	}
+	t.triggered = true
+	orig := active[0]
+	b.SplitRecord(0, []opencdc.Record{orig, orig})
+	return nil
+}
+
+// deferSecondTask marks index 1 (the tail of a 2-piece split) for retry the
+// first time it sees at least 2 active records, then leaves it alone (so the
+// retry pass, seeing just that 1 record, resolves it to the default Ack).
+// This is the #2723 "Retry-head" shape: the head (index 0) reaches an Ack
+// call on its own, in a separate sub-batch, while the tail is still in
+// flight.
+type deferSecondTask struct {
+	id        string
+	triggered bool
+}
+
+func (t *deferSecondTask) ID() string                  { return t.id }
+func (t *deferSecondTask) Open(context.Context) error  { return nil }
+func (t *deferSecondTask) Close(context.Context) error { return nil }
+func (t *deferSecondTask) Do(_ context.Context, b *Batch) error {
+	active := b.ActiveRecords()
+	if !t.triggered && len(active) > 1 {
+		t.triggered = true
+		b.Retry(1, len(active))
+	}
+	return nil
+}
+
+// TestRunLedger_RetryHead_NotAckedUntilTailResolves is the direct regression
+// test for #2723's "Retry" shape: a split run's head reaches its own Ack call
+// while the tail is still being retried, and the run's original position must
+// not reach the parent until the tail resolves too.
+func TestRunLedger_RetryHead_NotAckedUntilTailResolves(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	records := randomRecords(1)
+	origPos := records[0].Position
+
+	splitNode := &TaskNode{Task: &splitOnceTask{id: "split"}}
+	deferNode := &TaskNode{Task: &deferSecondTask{id: "defer"}}
+	splitNode.Next = []*TaskNode{deferNode}
+
+	parent := &fakeParentAckNacker{}
+	w := &Worker{logger: log.Nop(), processingLock: make(chan struct{}, 1)}
+
+	batch := NewBatch(slices.Clone(records))
+	is.NoErr(w.doTask(ctx, splitNode, batch, newRunAckNacker(parent)))
+
+	acks := parent.ackCalls()
+	is.Equal(len(acks), 1) // exactly one release, not one per piece
+	is.Equal(acks[0].positions, []opencdc.Position{origPos})
+	is.Equal(len(parent.nackCalls()), 0)
+}
+
+// deferHeadFilterTask, on its first call over 3 active records, filters the
+// head (index 0) and retries the middle piece (index 1), leaving the last
+// piece (index 2) as a plain Ack. Filter alone never taints a batch (see
+// Batch.Filter), so pairing it with a Retry on a different index is what
+// forces doTask's tainted loop to partition the run into three separate
+// sub-batches: [Filter], [Retry->Ack], [Ack] - covering #2723's "Filter"
+// shape, where the filtered head must not release the run either.
+type deferHeadFilterTask struct {
+	id        string
+	triggered bool
+}
+
+func (t *deferHeadFilterTask) ID() string                  { return t.id }
+func (t *deferHeadFilterTask) Open(context.Context) error  { return nil }
+func (t *deferHeadFilterTask) Close(context.Context) error { return nil }
+func (t *deferHeadFilterTask) Do(_ context.Context, b *Batch) error {
+	active := b.ActiveRecords()
+	if !t.triggered && len(active) == 3 {
+		t.triggered = true
+		b.Filter(0, 1)
+		b.Retry(1, 2)
+	}
+	return nil
+}
+
+// TestRunLedger_FilterHead_NotAckedUntilTailResolves is the direct regression
+// test for #2723's "Filter" shape.
+func TestRunLedger_FilterHead_NotAckedUntilTailResolves(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	records := randomRecords(1)
+	origPos := records[0].Position
+
+	splitNode := &TaskNode{Task: &split3Task{id: "split3"}}
+	deferNode := &TaskNode{Task: &deferHeadFilterTask{id: "defer"}}
+	splitNode.Next = []*TaskNode{deferNode}
+
+	parent := &fakeParentAckNacker{}
+	w := &Worker{logger: log.Nop(), processingLock: make(chan struct{}, 1)}
+
+	batch := NewBatch(slices.Clone(records))
+	is.NoErr(w.doTask(ctx, splitNode, batch, newRunAckNacker(parent)))
+
+	acks := parent.ackCalls()
+	is.Equal(len(acks), 1)
+	is.Equal(acks[0].positions, []opencdc.Position{origPos})
+	is.Equal(len(parent.nackCalls()), 0)
+}
+
+// split3Task splits the record at index 0 into 3 identical pieces, once.
+type split3Task struct {
+	id        string
+	triggered bool
+}
+
+func (t *split3Task) ID() string                  { return t.id }
+func (t *split3Task) Open(context.Context) error  { return nil }
+func (t *split3Task) Close(context.Context) error { return nil }
+func (t *split3Task) Do(_ context.Context, b *Batch) error {
+	if t.triggered {
+		return nil
+	}
+	active := b.ActiveRecords()
+	if len(active) == 0 {
+		return nil
+	}
+	t.triggered = true
+	orig := active[0]
+	b.SplitRecord(0, []opencdc.Record{orig, orig, orig})
+	return nil
+}
+
+// --- #2730: position rewrite defeats run membership --------------------
+
+// rewritePositionTask rewrites every active record's OWN Position field
+// (what a processor would do), leaving Batch's separately-tracked original
+// position (b.positions[i]) untouched. Models the #2730 shape: a processor
+// upstream of a later SplitRecord call changes record.Position.
+type rewritePositionTask struct {
+	id string
+}
+
+func (t *rewritePositionTask) ID() string                  { return t.id }
+func (t *rewritePositionTask) Open(context.Context) error  { return nil }
+func (t *rewritePositionTask) Close(context.Context) error { return nil }
+func (t *rewritePositionTask) Do(_ context.Context, b *Batch) error {
+	active := b.ActiveRecords()
+	for i, r := range active {
+		r2 := r.Clone()
+		r2.Position = append(opencdc.Position("rewritten-"), r2.Position...)
+		b.SetRecords(i, []opencdc.Record{r2})
+	}
+	return nil
+}
+
+// TestRunLedger_PositionRewriteThenSplit_NoPrematureAck is the regression
+// test for #2730: SplitRecord must key run membership on Batch's own tracked
+// original position (b.positions[i]), not the record's own (rewritable)
+// Position field - otherwise a later partial-retry on the run would be
+// classified as an ordinary record and acked with zero destination writes for
+// two of its three pieces.
+func TestRunLedger_PositionRewriteThenSplit_NoPrematureAck(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	records := randomRecords(1)
+	origPos := records[0].Position // the TRUE original source position
+
+	rewriteNode := &TaskNode{Task: &rewritePositionTask{id: "rewrite"}}
+	splitNode := &TaskNode{Task: &split3Task{id: "split3"}}
+	deferNode := &TaskNode{Task: &deferHeadFilterTask{id: "defer"}}
+	rewriteNode.Next = []*TaskNode{splitNode}
+	splitNode.Next = []*TaskNode{deferNode}
+
+	parent := &fakeParentAckNacker{}
+	w := &Worker{logger: log.Nop(), processingLock: make(chan struct{}, 1)}
+
+	batch := NewBatch(slices.Clone(records))
+	is.NoErr(w.doTask(ctx, rewriteNode, batch, newRunAckNacker(parent)))
+
+	acks := parent.ackCalls()
+	is.Equal(len(acks), 1)
+	// The released position is the TRUE original source position, not the
+	// rewritten one a processor assigned to the record's own Position field.
+	is.Equal(acks[0].positions, []opencdc.Position{origPos})
+}
+
+// --- Attempt-2 killer C1: deterministic output-cap processor must still converge ---
+
+// outputCapTask always "processes" at most cap records per Do() call and
+// retries the rest - exactly the documented ProcessorTask.Do behavior for a
+// processor that returns fewer records than it received (e.g. an embedding
+// processor with a per-call batch limit). Retry/Filter semantics are
+// completely untouched by this change, so this must converge in exactly the
+// same number of rounds it would on main.
+type outputCapTask struct {
+	id    string
+	cap   int
+	calls int
+}
+
+func (t *outputCapTask) ID() string                  { return t.id }
+func (t *outputCapTask) Open(context.Context) error  { return nil }
+func (t *outputCapTask) Close(context.Context) error { return nil }
+func (t *outputCapTask) Do(_ context.Context, b *Batch) error {
+	t.calls++
+	if t.calls > 20 {
+		// Defensive cap for the TEST itself (not production code): if this
+		// fires, the change under test made retry non-convergent.
+		return cerrors.New("outputCapTask: too many rounds, non-convergent")
+	}
+	active := b.ActiveRecords()
+	if len(active) > t.cap {
+		b.Retry(t.cap, len(active))
+	}
+	return nil
+}
+
+// TestRunLedger_OutputCapProcessor_ConvergesAndAcksOnce is attempt-2's killer
+// C1, guarded against: normalizeRun in #2727 escalated an ENTIRE split run to
+// Retry, so a deterministic-output-cap processor's retry input never shrank -
+// unbounded recursion into #2726's stack-overflow crash. This design never
+// escalates anything; Retry/Filter behave exactly as on main, so a split run
+// fed into an output-capped processor converges in the same bounded number of
+// rounds main would take, and the run's original position is still released
+// exactly once at the end.
+func TestRunLedger_OutputCapProcessor_ConvergesAndAcksOnce(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	records := randomRecords(1)
+	origPos := records[0].Position
+
+	splitNode := &TaskNode{Task: &split5Task{id: "split5"}}
+	capTask := &outputCapTask{id: "cap", cap: 2}
+	capNode := &TaskNode{Task: capTask}
+	splitNode.Next = []*TaskNode{capNode}
+
+	parent := &fakeParentAckNacker{}
+	w := &Worker{logger: log.Nop(), processingLock: make(chan struct{}, 1)}
+
+	batch := NewBatch(slices.Clone(records))
+	is.NoErr(w.doTask(ctx, splitNode, batch, newRunAckNacker(parent)))
+
+	// 5 pieces, cap 2 per round: rounds of 5->(2 ack,3 retry), 3->(2 ack,1
+	// retry), 1->(1 ack) = 3 rounds. Bounded and deterministic, identical to
+	// what main's unmodified Retry/subBatchByFlag logic would produce.
+	is.Equal(capTask.calls, 3)
+
+	acks := parent.ackCalls()
+	is.Equal(len(acks), 1) // released exactly once, despite 3 internal rounds
+	is.Equal(acks[0].positions, []opencdc.Position{origPos})
+}
+
+// split5Task splits the record at index 0 into 5 identical pieces, once.
+type split5Task struct {
+	id        string
+	triggered bool
+}
+
+func (t *split5Task) ID() string                  { return t.id }
+func (t *split5Task) Open(context.Context) error  { return nil }
+func (t *split5Task) Close(context.Context) error { return nil }
+func (t *split5Task) Do(_ context.Context, b *Batch) error {
+	if t.triggered {
+		return nil
+	}
+	active := b.ActiveRecords()
+	if len(active) == 0 {
+		return nil
+	}
+	t.triggered = true
+	orig := active[0]
+	b.SplitRecord(0, []opencdc.Record{orig, orig, orig, orig, orig})
+	return nil
+}
+
+// --- Attempt-2 killer C2: no double transformation on retry ---
+
+// markOnceTask "fully processes" (appends "|X" to the payload) only the
+// first record it's handed each round, and retries the rest - so on a
+// retry pass, a piece that already carries a marker from an earlier round is
+// NEVER handed to this task again (it already left via Ack and proceeded
+// downstream). If it were re-fed (as #2727's whole-run escalation did), it
+// would pick up a second "|X".
+type markOnceTask struct {
+	id string
+}
+
+func (t *markOnceTask) ID() string                  { return t.id }
+func (t *markOnceTask) Open(context.Context) error  { return nil }
+func (t *markOnceTask) Close(context.Context) error { return nil }
+func (t *markOnceTask) Do(_ context.Context, b *Batch) error {
+	active := b.ActiveRecords()
+	keep := len(active)
+	if keep > 1 {
+		keep = 1
+	}
+	recs := make([]opencdc.Record, keep)
+	for i := 0; i < keep; i++ {
+		r2 := active[i].Clone()
+		r2.Payload.After = opencdc.RawData(string(active[i].Payload.After.Bytes()) + "|X")
+		recs[i] = r2
+	}
+	if keep > 0 {
+		b.SetRecords(0, recs)
+	}
+	if keep < len(active) {
+		b.Retry(keep, len(active))
+	}
+	return nil
+}
+
+// TestRunLedger_NonIdempotentProcessor_TransformsExactlyOnce is attempt-2's
+// killer C2: #2727's whole-run escalation re-fed already-Ack'd (already
+// transformed) pieces back to the processor, silently double-encoding them
+// before they reached the destination. This design never re-feeds a
+// terminal piece to any task, so the destination must receive each of the 3
+// split pieces transformed EXACTLY once.
+func TestRunLedger_NonIdempotentProcessor_TransformsExactlyOnce(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	records := randomRecords(1)
+	logger := log.Nop()
+	dest := newFakeDestination("dest")
+
+	splitNode := &TaskNode{Task: &split3Task{id: "split3"}}
+	markNode := &TaskNode{Task: &markOnceTask{id: "mark"}}
+	destNode := &TaskNode{Task: NewDestinationTask(dest.id, dest, logger, NoOpConnectorMetrics{})}
+	splitNode.Next = []*TaskNode{markNode}
+	markNode.Next = []*TaskNode{destNode}
+
+	parent := &fakeParentAckNacker{}
+	w := &Worker{logger: log.Nop(), processingLock: make(chan struct{}, 1)}
+
+	batch := NewBatch(slices.Clone(records))
+	is.NoErr(w.doTask(ctx, splitNode, batch, newRunAckNacker(parent)))
+
+	is.Equal(len(dest.written), 3)
+	for _, r := range dest.written {
+		is.Equal(string(r.Payload.After.Bytes()), "value|X") // exactly one marker, never "value|X|X"
+	}
+
+	acks := parent.ackCalls()
+	is.Equal(len(acks), 1)
+	is.Equal(acks[0].positions, []opencdc.Position{records[0].Position})
+}
+
+// --- In-source-order release ---
+
+// TestRunLedger_InSourceOrderRelease_DeferredRunBlocksLaterPosition is
+// invariant 4's direct single-branch test: a run whose completion is
+// deferred (p0, split and retried) must release before a standalone record
+// positioned after it in the original batch (p1) - proving the release order
+// the parent observes always matches source order, never arrival order.
+func TestRunLedger_InSourceOrderRelease_DeferredRunBlocksLaterPosition(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	records := randomRecords(2)
+	p0, p1 := records[0].Position, records[1].Position
+
+	splitNode := &TaskNode{Task: &splitOnceTask{id: "split"}}
+	deferNode := &TaskNode{Task: &deferSecondTask{id: "defer"}}
+	splitNode.Next = []*TaskNode{deferNode}
+
+	parent := &fakeParentAckNacker{}
+	w := &Worker{logger: log.Nop(), processingLock: make(chan struct{}, 1)}
+
+	batch := NewBatch(slices.Clone(records))
+	is.NoErr(w.doTask(ctx, splitNode, batch, newRunAckNacker(parent)))
+
+	acks := parent.ackCalls()
+	is.Equal(len(acks), 2)
+	is.Equal(acks[0].positions, []opencdc.Position{p0}) // the deferred run releases first...
+	is.Equal(acks[1].positions, []opencdc.Position{p1}) // ...strictly before the record positioned after it
+}
+
+// --- Fan-out composition ---
+
+// gatedSplitRetryTask splits the FIRST record matching targetPos into 2
+// pieces and defers (retries) the tail, exactly like deferSecondTask/
+// splitOnceTask combined - except the retry pass blocks on gate until the
+// test closes it, letting the test observe multiAckNacker's state while this
+// branch's run is still incomplete.
+type gatedSplitRetryTask struct {
+	id        string
+	targetPos opencdc.Position
+	triggered bool
+	entered   chan struct{}
+	gate      chan struct{}
+}
+
+func (t *gatedSplitRetryTask) ID() string                  { return t.id }
+func (t *gatedSplitRetryTask) Open(context.Context) error  { return nil }
+func (t *gatedSplitRetryTask) Close(context.Context) error { return nil }
+func (t *gatedSplitRetryTask) Do(_ context.Context, b *Batch) error {
+	active := b.ActiveRecords()
+	if !t.triggered {
+		for i, r := range active {
+			if string(r.Position) == string(t.targetPos) {
+				t.triggered = true
+				orig := r
+				b.SplitRecord(i, []opencdc.Record{orig, orig})
+				b.Retry(i+1, i+2)
+				return nil
+			}
+		}
+		return nil
+	}
+	// Retry pass for the deferred tail (a single record): block until the
+	// test says to proceed.
+	close(t.entered)
+	<-t.gate
+	return nil
+}
+
+// TestRunLedger_FanOut_PendingRunOnOneBranch_NoPrematureUnanimity is the
+// fan-out (M=2) composition test: branch A splits p1 and defers its tail;
+// branch B is a plain pass-through. Branch B alone voting ack for p1 must not
+// release it (no premature unanimity - multiAckNacker still requires BOTH
+// branches, and branch A's OWN runAckNacker withholds its vote until its run
+// completes) and, since p1 sits between p0 and p2 in source order, p2 must
+// not release either until p1 does (invariant 4, composed across
+// runAckNacker and multiAckNacker).
+func TestRunLedger_FanOut_PendingRunOnOneBranch_NoPrematureUnanimity(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	records := randomRecords(3)
+	p0, p1, p2 := records[0].Position, records[1].Position, records[2].Position
+
+	src := newFakeSource("src", records)
+	destA := newFakeDestination("destA")
+	destB := newFakeDestination("destB")
+	logger := log.Test(t)
+
+	dlqDest := newFakeDestination("dlq")
+	dlq := NewDLQ("dlq", dlqDest, logger, NoOpConnectorMetrics{}, 0, 0)
+
+	gate := make(chan struct{})
+	entered := make(chan struct{})
+	branchATask := &gatedSplitRetryTask{id: "branchA-split", targetPos: p1, entered: entered, gate: gate}
+	branchANode := &TaskNode{Task: branchATask}
+	branchANode.Next = []*TaskNode{{Task: NewDestinationTask(destA.id, destA, logger, NoOpConnectorMetrics{})}}
+
+	branchBNode := &TaskNode{Task: NewDestinationTask(destB.id, destB, logger, NoOpConnectorMetrics{})}
+
+	fanoutNode := &TaskNode{Task: passthroughTask{id: "shared"}, Next: []*TaskNode{branchANode, branchBNode}}
+	srcNode := &TaskNode{Task: NewSourceTask("src", src, logger, NoOpConnectorMetrics{}), Next: []*TaskNode{fanoutNode}}
+
+	w, err := NewWorker(srcNode, dlq, logger, noop.Timer{})
+	is.NoErr(err)
+
+	batch := NewBatch(append([]opencdc.Record(nil), records...))
+	done := make(chan error, 1)
+	go func() { done <- w.doTask(ctx, fanoutNode, batch, w) }()
+
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for branch A to reach the gated retry pass")
+	}
+
+	// Branch B (unblocked) finishes fully.
+	waitForCondition(t, 5*time.Second, func() bool {
+		return len(destB.receivedPositions()) == 3
+	})
+
+	// Branch A has voted p0 (standalone in its own run-ledger) but not p1
+	// (still gated) or p2 (not reached yet - doTask's loop is still
+	// synchronously blocked resolving p1's retry). Only p0 can have reached
+	// unanimity so far.
+	is.Equal(src.ackedPositions(), []opencdc.Position{p0})
+
+	close(gate) // let branch A's deferred tail resolve
+	is.NoErr(<-done)
+
+	is.Equal(src.ackedPositions(), []opencdc.Position{p0, p1, p2})
+}
+
+// --- Zero-value Ack status is safe under this design (decision for item 5) ---
+
+// TestBatch_SplitRecord_ZeroValueAck_SafeUnderRunLedger proves the decision
+// documented on SplitRecord: leaving the zero-value RecordFlagAck default for
+// newly split pieces is safe here, even when injected into an
+// already-Retry-flagged run (attempt 1's exact finding), because run
+// completion is tracked independently via splitRun.total/terminalCount, never
+// by requiring recordStatuses to agree across a run.
+func TestBatch_SplitRecord_ZeroValueAck_SafeUnderRunLedger(t *testing.T) {
+	is := is.New(t)
+	records := randomRecords(1)
+	batch := NewBatch(slices.Clone(records))
+
+	batch.Retry(0)
+	is.Equal(batch.recordStatuses[0].Flag, RecordFlagRetry)
+
+	batch.SplitRecord(0, []opencdc.Record{records[0], records[0], records[0]})
+
+	is.Equal(len(batch.recordStatuses), 3)
+	is.Equal(batch.recordStatuses[0].Flag, RecordFlagRetry) // head keeps its flag
+	is.Equal(batch.recordStatuses[1].Flag, RecordFlagAck)   // zero-value default
+	is.Equal(batch.recordStatuses[2].Flag, RecordFlagAck)
+
+	run := batch.runs[0]
+	is.True(run != nil)
+	is.Equal(run.total, 3)
+
+	parent := &fakeParentAckNacker{}
+	r := newRunAckNacker(parent)
+	ctx := context.Background()
+
+	// The Ack-flagged pieces resolve first...
+	is.NoErr(r.Ack(ctx, batch.sub(1, 3)))
+	is.Equal(len(parent.ackCalls()), 0) // not complete - head hasn't voted yet
+
+	// ...then the (previously Retry-flagged) head resolves too.
+	is.NoErr(r.Ack(ctx, batch.sub(0, 1)))
+	acks := parent.ackCalls()
+	is.Equal(len(acks), 1)
+	is.Equal(acks[0].positions, []opencdc.Position{records[0].Position})
+}
+
+// --- Property test ---
+
+type propOutcome int
+
+const (
+	propAck propOutcome = iota
+	propFilter
+	propNack
+	propSplitBothAck
+	propSplitTailRetryThenAck
+	propSplitTailNack
+)
+
+// propRewriteTask rewrites the record's own Position field for every active
+// record whose plan_id is in rewrite - modeling a processor that reassigns
+// positions, upstream of a later split (the #2730 shape), for a random subset
+// of records.
+type propRewriteTask struct{ rewrite map[string]bool }
+
+func (t *propRewriteTask) ID() string                  { return "prop-rewrite" }
+func (t *propRewriteTask) Open(context.Context) error  { return nil }
+func (t *propRewriteTask) Close(context.Context) error { return nil }
+func (t *propRewriteTask) Do(_ context.Context, b *Batch) error {
+	active := b.ActiveRecords()
+	for i, r := range active {
+		if !t.rewrite[r.Metadata["plan_id"]] {
+			continue
+		}
+		r2 := r.Clone()
+		r2.Position = append(opencdc.Position("rw-"), r2.Position...)
+		b.SetRecords(i, []opencdc.Record{r2})
+	}
+	return nil
+}
+
+// propSplitTask splits every active record whose plan_id is in split into a
+// head/tail pair, tagged via Metadata["role"] so later stages (which cannot
+// see Batch's internal position bookkeeping the way this white-box test file
+// can, by design - real processors never see Batch at all) can tell them
+// apart without relying on content.
+type propSplitTask struct{ split map[string]bool }
+
+func (t *propSplitTask) ID() string                  { return "prop-split" }
+func (t *propSplitTask) Open(context.Context) error  { return nil }
+func (t *propSplitTask) Close(context.Context) error { return nil }
+func (t *propSplitTask) Do(_ context.Context, b *Batch) error {
+	active := b.ActiveRecords()
+	for i := len(active) - 1; i >= 0; i-- {
+		r := active[i]
+		if !t.split[r.Metadata["plan_id"]] {
+			continue
+		}
+		head := r.Clone()
+		head.Metadata["role"] = "head"
+		tail := r.Clone()
+		tail.Metadata["role"] = "tail"
+		b.SplitRecord(i, []opencdc.Record{head, tail})
+	}
+	return nil
+}
+
+// propDivergeTask is the last task in the property-test pipeline: for each
+// active record it applies the plan's outcome. Split pairs are only ever
+// resolved from the "tail" role, and only once (tailRetried), so a retry pass
+// converges instead of looping.
+type propDivergeTask struct {
+	outcome     map[string]propOutcome
+	tailRetried map[string]bool
+}
+
+func (t *propDivergeTask) ID() string                  { return "prop-diverge" }
+func (t *propDivergeTask) Open(context.Context) error  { return nil }
+func (t *propDivergeTask) Close(context.Context) error { return nil }
+func (t *propDivergeTask) Do(_ context.Context, b *Batch) error {
+	active := b.ActiveRecords()
+	for i := len(active) - 1; i >= 0; i-- {
+		r := active[i]
+		id := r.Metadata["plan_id"]
+		role := r.Metadata["role"]
+		switch t.outcome[id] {
+		case propFilter:
+			if role == "" {
+				b.Filter(i)
+			}
+		case propNack:
+			if role == "" {
+				b.Nack(i, cerrors.New("chaos nack "+id))
+			}
+		case propSplitBothAck:
+			// leave both pieces at the default Ack.
+		case propSplitTailRetryThenAck:
+			if role == "tail" && !t.tailRetried[id] {
+				t.tailRetried[id] = true
+				b.Retry(i)
+			}
+		case propSplitTailNack:
+			if role == "tail" {
+				b.Nack(i, cerrors.New("chaos split-nack "+id))
+			}
+		case propAck:
+			// leave at the default Ack.
+		}
+	}
+	return nil
+}
+
+// TestRunLedger_Property_SplitFilterRetryNackRewrite is the randomised
+// property test: over many random combinations of split/filter/retry/nack/
+// position-rewrite, every original source position must be acked-once XOR
+// DLQ'd-once - never both, never neither - and State.Position (represented
+// here by src.ackedPositions()) must never skip or reorder a position.
+// propPlan is one randomised iteration's full test fixture: which records
+// exist, and what each one is planned to do. Split out from the test body to
+// keep TestRunLedger_Property_SplitFilterRetryNackRewrite's own cyclomatic
+// complexity down - the branching lives here, in a function with a single
+// job (build a plan), not interleaved with the assertions.
+type propPlan struct {
+	records    []opencdc.Record
+	positions  []opencdc.Position
+	outcome    map[string]propOutcome
+	rewrite    map[string]bool
+	split      map[string]bool
+	wantNacked map[string]bool
+}
+
+func newPropPlan(rng *rand.Rand, n int) propPlan {
+	p := propPlan{
+		records:    make([]opencdc.Record, n),
+		positions:  make([]opencdc.Position, n),
+		outcome:    make(map[string]propOutcome, n),
+		rewrite:    make(map[string]bool, n),
+		split:      make(map[string]bool, n),
+		wantNacked: make(map[string]bool, n),
+	}
+	for i := 0; i < n; i++ {
+		id := strconv.Itoa(i)
+		p.records[i] = opencdc.Record{
+			Position:  opencdc.Position(id),
+			Operation: opencdc.OperationCreate,
+			Metadata:  opencdc.Metadata{"plan_id": id},
+			Payload:   opencdc.Change{After: opencdc.RawData("value")},
+		}
+		p.positions[i] = p.records[i].Position
+
+		if rng.Intn(3) == 0 {
+			p.rewrite[id] = true
+		}
+
+		outcomes := []propOutcome{
+			propAck, propFilter, propNack,
+			propSplitBothAck, propSplitTailRetryThenAck, propSplitTailNack,
+		}
+		o := outcomes[rng.Intn(len(outcomes))]
+		p.outcome[id] = o
+		p.split[id] = o == propSplitBothAck || o == propSplitTailRetryThenAck || o == propSplitTailNack
+		p.wantNacked[id] = o == propNack || o == propSplitTailNack
+	}
+	return p
+}
+
+// expectedCounts returns how many records the main destination and the DLQ
+// destination should have received under this plan - see the case-by-case
+// reasoning in the two propSplit* comments below.
+func (p propPlan) expectedCounts() (wantDestCount, wantDLQCount int) {
+	for _, o := range p.outcome {
+		switch o {
+		case propAck:
+			wantDestCount++
+		case propFilter:
+			// reaches neither destination
+		case propNack:
+			wantDLQCount++
+		case propSplitBothAck, propSplitTailRetryThenAck:
+			wantDestCount += 2 // head and tail both reach the destination
+		case propSplitTailNack:
+			// Batch.Nack's EXISTING (pre-existing, main) propagation logic
+			// propagates a nack across an entire split run (setFlagWithErr,
+			// see batch.go) - nacking the tail also flags the head Nack, so
+			// the whole 2-member run is dispatched to acker.Nack in ONE
+			// group. Neither piece reaches the destination; the run
+			// collapses to exactly one DLQ entry (the same collapsing
+			// originalBatch()/splitRun's ackBatch/nackBatch already do for a
+			// fully-resolved run).
+			wantDLQCount++
+		}
+	}
+	return wantDestCount, wantDLQCount
+}
+
+func TestRunLedger_Property_SplitFilterRetryNackRewrite(t *testing.T) {
+	const iterations = 300
+	seed := time.Now().UnixNano()
+	t.Logf("seed=%d (reproduce a failure by hardcoding this seed)", seed)
+	rng := rand.New(rand.NewSource(seed))
+
+	for iter := 0; iter < iterations; iter++ {
+		n := 2 + rng.Intn(5) // 2..6 records
+		plan := newPropPlan(rng, n)
+		records, positions := plan.records, plan.positions
+		outcome, rewrite, split, wantNacked := plan.outcome, plan.rewrite, plan.split, plan.wantNacked
+
+		src := newFakeSource("src", records)
+		dest := newFakeDestination("dest")
+		dlqDest := newFakeDestination("dlq")
+		logger := log.Test(t)
+		dlq := NewDLQ("dlq", dlqDest, logger, NoOpConnectorMetrics{}, 0, 0)
+
+		rewriteNode := &TaskNode{Task: &propRewriteTask{rewrite: rewrite}}
+		splitNode := &TaskNode{Task: &propSplitTask{split: split}}
+		divergeNode := &TaskNode{Task: &propDivergeTask{outcome: outcome, tailRetried: map[string]bool{}}}
+		destNode := &TaskNode{Task: NewDestinationTask(dest.id, dest, logger, NoOpConnectorMetrics{})}
+		srcNode := &TaskNode{Task: NewSourceTask("src", src, logger, NoOpConnectorMetrics{}), Next: []*TaskNode{rewriteNode}}
+		rewriteNode.Next = []*TaskNode{splitNode}
+		splitNode.Next = []*TaskNode{divergeNode}
+		divergeNode.Next = []*TaskNode{destNode}
+
+		w, err := NewWorker(srcNode, dlq, logger, noop.Timer{})
+		if err != nil {
+			t.Fatalf("iter %d (seed %d): NewWorker: %v", iter, seed, err)
+		}
+
+		batch := NewBatch(append([]opencdc.Record(nil), records...))
+		if err := w.doTask(context.Background(), rewriteNode, batch, newRunAckNacker(w)); err != nil {
+			t.Fatalf("iter %d (seed %d): doTask: %v", iter, seed, err)
+		}
+
+		acked := src.ackedPositions()
+		ackedSet := make(map[string]int, len(acked))
+		for _, p := range acked {
+			ackedSet[string(p)]++
+		}
+		for i, p := range positions {
+			count := ackedSet[string(p)]
+			if count != 1 {
+				t.Fatalf(
+					"iter %d (seed %d): position %d (%q) was acked %d times, want exactly 1 (nacked=%v, split=%v, rewrite=%v)",
+					iter, seed, i, p, count, wantNacked, split, rewrite,
+				)
+			}
+		}
+		is := is.New(t)
+		is.Equal(len(acked), n) // no extras, no gaps
+
+		// Every original position acked-once XOR DLQ'd-once: cross-check by
+		// COUNT which destination actually received it (dlqRecord builds a
+		// fresh, DLQ-shaped opencdc.Record - see dlq.go - so matching by
+		// plan_id would mean reaching into its generic StructuredData
+		// payload; counts are simpler and just as conclusive here since
+		// every plan_id's outcome is already known).
+		wantDestCount, wantDLQCount := plan.expectedCounts()
+		if len(dlqDest.written) != wantDLQCount {
+			t.Fatalf("iter %d (seed %d): DLQ received %d records, want %d (outcomes=%v)",
+				iter, seed, len(dlqDest.written), wantDLQCount, outcome)
+		}
+		if len(dest.written) != wantDestCount {
+			t.Fatalf("iter %d (seed %d): destination received %d records, want %d (outcomes=%v)",
+				iter, seed, len(dest.written), wantDestCount, outcome)
+		}
+	}
+}
+
+// --- Benchmark: O(n), not O(n^2) ---
+
+// BenchmarkRunLedger_VoteLinear resolves a single N-member split run through
+// runAckNacker one member at a time (the worst case for call count) and
+// reports ns/op per N, to demonstrate the ledger's cost is linear in the
+// number of run members - not quadratic like the per-write escalation design
+// rejected in #2725 (which measured 10.5us -> 439ms, ~42000x, for a 4x
+// increase in run size).
+func BenchmarkRunLedger_VoteLinear(b *testing.B) {
+	for _, n := range []int{1000, 4000, 16000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				batch := NewBatch(randomRecords(1))
+				pieces := make([]opencdc.Record, n)
+				for k := range pieces {
+					pieces[k] = batch.records[0]
+				}
+				batch.SplitRecord(0, pieces)
+				parent := &fakeParentAckNacker{}
+				r := newRunAckNacker(parent)
+				ctx := context.Background()
+				b.StartTimer()
+
+				for k := 0; k < n; k++ {
+					if err := r.Ack(ctx, batch.sub(k, k+1)); err != nil {
+						b.Fatal(err)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/lifecycle-poc/funnel/run_ledger_test.go
+++ b/pkg/lifecycle-poc/funnel/run_ledger_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/conduitio/conduit-commons/opencdc"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/conduitio/conduit/pkg/foundation/metrics/noop"
 	"github.com/matryer/is"
@@ -872,4 +873,67 @@ func BenchmarkRunLedger_VoteLinear(b *testing.B) {
 			}
 		})
 	}
+}
+
+// TestRunLedger_FanOut_RunCutBeforeFanOut_FailsLoud is the regression test for
+// the CRITICAL defect adversarial review found in the first version of this
+// ledger.
+//
+// The shape: a processor BEFORE the fan-out splits a record, and a later
+// pre-fan-out processor resolves only part of that split run (returning fewer
+// records than it received marks the remainder Retry). doTask then partitions
+// the batch by flag, so the sub-batch that reaches doNextTask holds only SOME
+// of the run's members.
+//
+// Batch.clone must give each branch its own ledger (branches diverge, and a
+// shared tally would race and bleed decisions across branches), but a clone
+// carries splitRun.total — the whole-run member count. So the branch needs
+// `total` members to complete while only ever seeing k < total of them, and the
+// parent side only ever sees the other total-k. Two disjoint tallies, neither
+// able to complete, and no join point between them.
+//
+// The consequence was strictly worse than not supporting the shape: the run's
+// original source position was withheld FOREVER while every later position
+// acked normally. Source.Ack sets State.Position from the last position it is
+// handed, so the withheld record was silently skipped on restart — no error, no
+// DLQ entry, no replay. It also disarmed the two backstops that caught this
+// shape before the ledger existed (validateAckPositions and
+// newMultiAckNacker's empty-position check), because the nil-position tail was
+// intercepted and withheld before ever reaching them.
+//
+// Now it fails loud with CodeSplitRunStraddlesFanOut. Nothing is acked, so the
+// records are redelivered on restart (invariant 3).
+func TestRunLedger_FanOut_RunCutBeforeFanOut_FailsLoud(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	records := randomRecords(1)
+	logger := log.Nop()
+	destA := newFakeDestination("destA")
+	destB := newFakeDestination("destB")
+
+	// split3 (pre-fan-out) → deferSecond (pre-fan-out, resolves only part of
+	// the run) → fan-out to two destinations.
+	splitNode := &TaskNode{Task: &split3Task{id: "split3"}}
+	cutNode := &TaskNode{Task: &deferSecondTask{id: "cut"}}
+	destANode := &TaskNode{Task: NewDestinationTask(destA.id, destA, logger, NoOpConnectorMetrics{})}
+	destBNode := &TaskNode{Task: NewDestinationTask(destB.id, destB, logger, NoOpConnectorMetrics{})}
+	splitNode.Next = []*TaskNode{cutNode}
+	cutNode.Next = []*TaskNode{destANode, destBNode}
+
+	parent := &fakeParentAckNacker{}
+	w := &Worker{logger: log.Nop(), processingLock: make(chan struct{}, 1)}
+
+	batch := NewBatch(slices.Clone(records))
+	err := w.doTask(ctx, splitNode, batch, newRunAckNacker(parent))
+
+	// Must fail loud, not silently withhold.
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code.Reason(), CodeSplitRunStraddlesFanOut.Reason())
+
+	// And crucially: nothing was acked to the source. The records are
+	// redelivered on restart rather than skipped.
+	is.Equal(len(parent.ackCalls()), 0)
 }

--- a/pkg/lifecycle-poc/funnel/worker.go
+++ b/pkg/lifecycle-poc/funnel/worker.go
@@ -289,9 +289,14 @@ func (w *Worker) Do(ctx context.Context) error {
 		// Invariant 1/3 (enforcement site, #2723): wrap the Worker in a fresh
 		// runAckNacker for this batch-read pass. A split run's original
 		// position must not reach w.Ack/w.Nack until every one of its members
-		// is terminal - see run_ledger.go. A fresh instance per pass is
-		// required: run completion state must not leak across independent
-		// batches read from the source.
+		// is terminal - see run_ledger.go.
+		//
+		// NB: runAckNacker itself is stateless - it holds only the parent. All
+		// completion state lives in the *splitRun values inside Batch.runs, so
+		// isolation between passes comes from NewBatch allocating fresh runs
+		// (and, at a fan-out, from cloneRuns), NOT from the wrapper being
+		// fresh. Naming the wrapper as the boundary is what hid the fan-out
+		// straddle bug - see validateRunsWholeBeforeFanOut.
 		if err := w.doTask(ctx, w.FirstTask, &Batch{}, newRunAckNacker(w)); err != nil {
 			return err
 		}
@@ -525,6 +530,16 @@ func (w *Worker) doNextTask(ctx context.Context, taskNode *TaskNode, b *Batch, a
 		// processor already did (before this fan-out point) is collapsed
 		// here so the tally is keyed by the true root position, not an
 		// intermediate one.
+		// Invariant 1/2/3: refuse to fan out a batch that holds only PART of a
+		// split run. Each branch clones the run ledger (necessarily — branches
+		// diverge), and a clone carries the whole-run member count, so a
+		// partial run can never complete on either side and its source
+		// position would be withheld forever while later positions ack past
+		// it. See validateRunsWholeBeforeFanOut.
+		if err := validateRunsWholeBeforeFanOut(b); err != nil {
+			return err
+		}
+
 		orig := b.originalBatch()
 		multiAcker, err := newMultiAckNacker(acker, len(taskNode.Next), orig.positions)
 		if err != nil {
@@ -543,9 +558,13 @@ func (w *Worker) doNextTask(ctx context.Context, taskNode *TaskNode, b *Batch, a
 			// each needs its own run-completion ledger; multiAckNacker itself
 			// stays purely about per-position unanimity ACROSS branches (its
 			// existing job), unaware of any run structure. A branch votes for
-			// a run's original position exactly once - when runAckNacker
-			// forwards it - which is exactly what multiAckNacker's own
-			// one-vote-per-branch-per-position assumption requires.
+			// a run's original position AT MOST once - when runAckNacker
+			// forwards it - which satisfies multiAckNacker's
+			// one-vote-per-branch-per-position assumption. "At most", not
+			// "exactly": a branch holding only part of a run would never
+			// complete it and so would vote ZERO times, stalling that position
+			// and every later one in multiAckNacker's prefix scan. That shape
+			// is refused up front by validateRunsWholeBeforeFanOut above.
 			p.Go(func() error {
 				return w.doTask(ctx, nextTask, branchBatch, newRunAckNacker(multiAcker))
 			})

--- a/pkg/lifecycle-poc/funnel/worker.go
+++ b/pkg/lifecycle-poc/funnel/worker.go
@@ -286,7 +286,13 @@ func (w *Worker) Close(ctx context.Context) error {
 func (w *Worker) Do(ctx context.Context) error {
 	for !w.stop.Load() {
 		w.logger.Trace(ctx).Msg("starting next batch")
-		if err := w.doTask(ctx, w.FirstTask, &Batch{}, w); err != nil {
+		// Invariant 1/3 (enforcement site, #2723): wrap the Worker in a fresh
+		// runAckNacker for this batch-read pass. A split run's original
+		// position must not reach w.Ack/w.Nack until every one of its members
+		// is terminal - see run_ledger.go. A fresh instance per pass is
+		// required: run completion state must not leak across independent
+		// batches read from the source.
+		if err := w.doTask(ctx, w.FirstTask, &Batch{}, newRunAckNacker(w)); err != nil {
 			return err
 		}
 		w.logger.Trace(ctx).Msg("batch done")
@@ -531,8 +537,17 @@ func (w *Worker) doNextTask(ctx context.Context, taskNode *TaskNode, b *Batch, a
 		p := pool.New().WithErrors()
 		for _, nextTask := range taskNode.Next {
 			branchBatch := b.clone()
+			// Invariant 1/3 (enforcement site, #2723): wrap multiAcker in a
+			// FRESH runAckNacker per branch. Each branch's clone can diverge
+			// independently from here on (split further, retry, filter), so
+			// each needs its own run-completion ledger; multiAckNacker itself
+			// stays purely about per-position unanimity ACROSS branches (its
+			// existing job), unaware of any run structure. A branch votes for
+			// a run's original position exactly once - when runAckNacker
+			// forwards it - which is exactly what multiAckNacker's own
+			// one-vote-per-branch-per-position assumption requires.
 			p.Go(func() error {
-				return w.doTask(ctx, nextTask, branchBatch, multiAcker)
+				return w.doTask(ctx, nextTask, branchBatch, newRunAckNacker(multiAcker))
 			})
 		}
 		if err := p.Wait(); err != nil {


### PR DESCRIPTION
## What

Closes **#2723** (split-run head acked before its tail is delivered) and **#2730** (run-membership defined two ways).

**Third attempt.** #2725 (per-write flag escalation) and #2727 (post-`Do` run normalisation) were both rejected by adversarial review. DeVaris chose this design: **fix the ack path, not the flags.**

## Design

`Retry`/`Filter`/`Nack` flag semantics are **completely untouched** — that is the point. A new `runAckNacker` decorator intercepts ack/nack decisions and releases a split run's original source position only once **every** member of that run is terminal. This mirrors `multiAckNacker`'s per-position unanimity, already proven in this package.

- **"Terminal"** = acked (reached the true end), filtered, or nacked. `Retry` is explicitly **not** terminal — it is still in flight and may be split further.
- **Ledger lives on `Batch`** (`runs []*splitRun`, shared pointers) because `sub()` produces distinct `*Batch` structs across loop iterations *and* through the retry recursion; a shared pointer is what lets them observe one tally. The release *decision* lives in `runAckNacker`, fresh per acker scope: once per batch-read pass in `Worker.Do`, once per branch in `doNextTask`'s fan-out. A branch votes for a run's original position exactly once — which is precisely what `multiAckNacker`'s one-vote-per-branch assumption requires.
- **#2730 fixed as a prerequisite**: `splitRecords` is now keyed on `b.positions[i]` (original source position) instead of `b.records[i].Position` (current position), so a processor that rewrites a position can no longer detach a run head from its own run. The ledger would be unsound without this.

## Why the two previous designs were wrong

Both forced run flags uniform. That is what closed #2723 *and* what broke everything else:
- retry input never shrank → **non-convergent** for a processor with a deterministic output cap (an embedding processor with a per-call batch limit — the exact target shape) → unbounded recursion (#2726) → whole-process crash.
- already-transformed records were re-fed → **silent double transformation** reaching the destination.

Both failure shapes now have regression tests **in this PR**, and both pass:
- `TestRunLedger_OutputCapProcessor_ConvergesAndAcksOnce` — a 5-piece run through a cap-2 processor converges in exactly 3 rounds, identical to `main`.
- `TestRunLedger_NonIdempotentProcessor_TransformsExactlyOnce` — destination receives `"value|X"`, never `"value|X|X"`.

Neither is possible here because `runAckNacker` never calls `Retry`/`SetRecords` itself; it only intercepts decisions `doTask` already made.

## Risk tier: **Tier 1 (data path)** — preview-gated (`Preview.PipelineArchV2`, off by default)

## Failure-mode analysis

| Failure | Behavior |
| --- | --- |
| Sub-batch covers only a run's head | head's position withheld until the tail is terminal |
| Processor with deterministic output cap | converges exactly as on `main` (flags untouched) |
| Non-idempotent processor + retry | each record transformed exactly once |
| Processor rewrites a position, then a later processor splits it | run stays intact (#2730) |
| Run pending on one fan-out branch | no premature unanimity |
| Deferred run followed by later positions | later positions cannot ack past it |

**In-source-order release** is guaranteed structurally: `doTask`'s tainted loop and its retry recursion are sequential per branch, so a run's contiguous span resolves before the loop reaches anything after it. This is a **caller-provided** guarantee (unlike `multiAckNacker`'s self-enforced prefix scan) — flagged explicitly as a limit in the design doc rather than left implicit.

**Rollback:** revert, or run without the preview flag.

## Decisions taken
- `SplitRecord`'s zero-value `Ack` on new pieces is **kept** — harmless here because completion is tracked independently of flags. Proven by `TestBatch_SplitRecord_ZeroValueAck_SafeUnderRunLedger`, which reproduces #2725's exact "split while a sibling is Retry" shape.
- `validateSplitRunBoundary` / `CodeSplitRunPartitioned` from the rejected attempts are **omitted entirely**: under this design a partitioned run is legal and handled correctly, so the guard's premise no longer holds.

## Verification
Fail-without/pass-with: short-circuiting `runAckNacker.vote` to forward straight through fails every new test (`TestRunLedger_RetryHead…` → `2 != 1`, releasing the head separately from the tail; the fan-out test → `<nil> != [0]`, premature unanimity). Restoring returns the suite to green.

`go build ./...` clean · `go test -race ./pkg/lifecycle-poc/...` green · full chaos suite green (108s) · `golangci-lint` 0 issues · no error codes added, so no `make generate` needed. Property test over split+filter+retry+nack+position-rewrite passes.

## Not fixed here
**#2726** (unbounded retry recursion) — confirmed not fixed and **not made more likely**; nothing here escalates flags or alters retry input. Its own PR.

Design doc: `docs/design-documents/20260801-archv2-split-run-ack-ledger.md` (new — the merged ADR is **not** edited in place; #2727 was pinged for that).
