### PR TITLE
fix(funnel): bound the retry recursion and fail loud on a non-converging processor

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -614,7 +614,7 @@ Author: Meroxa, Inc.
 | `sdk.schema.extract.key.enabled` | bool | true | no | Whether to extract and decode the record key with a schema. |  |
 | `sdk.schema.extract.payload.enabled` | bool | true | no | Whether to extract and decode the record payload with a schema. |  |
 
-## 3. Error codes (91)
+## 3. Error codes (92)
 
 | Reason | gRPC status | Description |
 | --- | --- | --- |
@@ -648,6 +648,7 @@ Author: Meroxa, Inc.
 | `pipeline.name_already_exists` | AlreadyExists | CodePipelineNameAlreadyExists is raised when a pipeline config's name collides with an existing pipeline's name. |
 | `pipeline.name_missing` | InvalidArgument | CodePipelineNameMissing is raised when a pipeline config is missing the required name field. |
 | `pipeline.not_running` | FailedPrecondition | CodePipelineNotRunning is raised when an operation requires the pipeline to be running, but it is currently stopped. |
+| `pipeline.retry_not_converging` | FailedPrecondition | pipeline: retry not converging |
 | `pipeline.running` | FailedPrecondition | CodePipelineRunning is raised when an operation requires the pipeline to be stopped, but it is currently running. |
 | `pipeline.split_run_straddles_fanout` | FailedPrecondition | pipeline: split run straddles fanout |
 | `pipelines.init_destination_exists` | AlreadyExists | pipelines: init destination exists |

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@
 (6 built-in connectors; full parameters in llms-full.txt)
 
 ## Error codes
-- 91 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
+- 92 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
 
 ## MCP tools
 - Read: deploy, doctor, dry_run, inspect, lint, repair, validate

--- a/pkg/lifecycle-poc/funnel/codes.go
+++ b/pkg/lifecycle-poc/funnel/codes.go
@@ -85,16 +85,22 @@ var CodeSplitRunStraddlesFanOut = conduiterr.Register("pipeline.split_run_stradd
 // not making progress on a retried sub-batch, or has exceeded the hard
 // iteration cap that backstops that detection.
 //
-// ProcessorTask.Do marks a sub-batch RecordFlagRetry whenever the processor
-// returns fewer records than it received; Worker.doTask re-feeds that exact
-// sub-batch to the same task. A processor whose short return is a
-// deterministic function of its input (e.g. one that always skips records
-// above a size threshold, or a rate-limit path that returns only what it
-// could process and is handed the identical batch back) never resolves any
-// of those records, so the recursion is a fixpoint: it would recurse forever,
+// ProcessorTask.Do marks a sub-batch RecordFlagRetry for exactly those
+// records the processor returned NO result for, then Worker.doTask re-feeds
+// that sub-batch to the same task. If the same records come back unresolved
+// again and again, the recursion is a fixpoint: it would recurse forever,
 // growing the goroutine stack without bound until it hit Go's 1GB limit and
 // crashed the ENTIRE process - not just the offending pipeline - with an
 // unrecoverable fatal error. See #2726.
+//
+// What actually triggers this, and what does NOT: a processor that simply
+// returns FEWER records than it received is NOT this condition. ProcessorTask.Do
+// rejects an empty result and pads exactly len(in)-len(out) entries, so such a
+// processor shrinks the retry group every round and converges normally - a size
+// threshold or a rate-limit path that returns partial results is fine. The
+// reachable trigger is a record that comes back with no result AT ALL: for a
+// standalone (WASM) processor, a ProcessedRecord whose Record oneof is unset,
+// which in practice means a malformed or version-mismatched plugin.
 //
 // This is fixed loudly instead of silently: nothing in the un-converged
 // sub-batch (or anything after it in the same batch - Worker.doTask's tainted

--- a/pkg/lifecycle-poc/funnel/codes.go
+++ b/pkg/lifecycle-poc/funnel/codes.go
@@ -79,3 +79,27 @@ var CodeEmptySourcePosition = conduiterr.Register("pipeline.empty_source_positio
 // on restart (invariant 3). Joining a run's tally across fan-out branches is
 // possible but is deliberately not attempted here without a real use case.
 var CodeSplitRunStraddlesFanOut = conduiterr.Register("pipeline.split_run_straddles_fanout", codes.FailedPrecondition)
+
+// CodeRetryNotConverging is returned when Worker.doTask's RecordFlagRetry
+// self-recursion (see worker.go's retryAttempt) detects that a processor is
+// not making progress on a retried sub-batch, or has exceeded the hard
+// iteration cap that backstops that detection.
+//
+// ProcessorTask.Do marks a sub-batch RecordFlagRetry whenever the processor
+// returns fewer records than it received; Worker.doTask re-feeds that exact
+// sub-batch to the same task. A processor whose short return is a
+// deterministic function of its input (e.g. one that always skips records
+// above a size threshold, or a rate-limit path that returns only what it
+// could process and is handed the identical batch back) never resolves any
+// of those records, so the recursion is a fixpoint: it would recurse forever,
+// growing the goroutine stack without bound until it hit Go's 1GB limit and
+// crashed the ENTIRE process - not just the offending pipeline - with an
+// unrecoverable fatal error. See #2726.
+//
+// This is fixed loudly instead of silently: nothing in the un-converged
+// sub-batch (or anything after it in the same batch - Worker.doTask's tainted
+// loop never advances its cursor past a Retry group it recursed into) is ever
+// acked or nacked before this error is returned, so every record in it is
+// redelivered on restart (invariant 3). No source position is corrupted or
+// skipped (invariant 2).
+var CodeRetryNotConverging = conduiterr.Register("pipeline.retry_not_converging", codes.FailedPrecondition)

--- a/pkg/lifecycle-poc/funnel/worker.go
+++ b/pkg/lifecycle-poc/funnel/worker.go
@@ -305,12 +305,131 @@ func (w *Worker) Do(ctx context.Context) error {
 	return nil
 }
 
-//nolint:gocyclo // TODO: refactor
+// maxRetryAttempts bounds Worker.doTask's RecordFlagRetry self-recursion (see
+// retryAttempt). It is a pure stack-growth backstop, independent of the
+// non-convergence check below: even a processor that IS making genuine
+// progress (see retryAttempt's doc comment for why that is provably
+// well-founded — each attempt is strictly smaller than the last) recurses
+// once per attempt, and an absurdly large single batch could in principle
+// still need an absurd number of attempts to fully drain one record at a
+// time. This cap gives the recursion a fixed ceiling regardless of batch
+// size, so stack usage can never approach Go's 1GB per-goroutine limit
+// (#2726) even in that corner case. A source Read() call realistically
+// returns at most a few thousand records, so this is a generous multiple of
+// what any real batch needs and is not expected to ever be hit by a
+// legitimately converging processor — see TestDoTask_Retry_IterationCap_*.
+//
+// This is a var, not a const, solely so tests can lower it temporarily
+// (save the old value, defer restoring it) to exercise the cap deterministically
+// without constructing a batch of thousands of records. Production code must
+// never reassign it.
+var maxRetryAttempts = 10_000
+
+// maxRetryStall bounds how many CONSECUTIVE RecordFlagRetry attempts in a row
+// are allowed to make no progress (see retryAttempt.stall) before doTaskAttempt
+// declares the task non-converging. It exists specifically to tolerate a
+// processor whose lack of progress depends on something other than the
+// record content alone - most plausibly a real, wall-clock-based rate limiter
+// that can legitimately return "nothing processed" for a call or two while a
+// token bucket refills, then resume shrinking once it does. Comparing counts
+// (see retryAttempt's doc comment) is an EXACT test for "no progress THIS
+// round", but "no progress for one round" does not imply "will never make
+// progress" for a time-dependent processor the way it does for a purely
+// input-deterministic one (see #2726's own examples). Requiring several
+// consecutive stalls before failing trades a handful of extra (still tightly
+// bounded, still nowhere near maxRetryAttempts) recursion frames for a much
+// lower false-positive rate against that legitimate shape - a false positive
+// here kills a working pipeline with an unrecoverable fatal error, so this
+// errs conservative. A true fixpoint (the deterministic case #2726 is
+// actually about) still fails within maxRetryStall+1 Task.Do calls -
+// effectively immediate from an operator's perspective, and the count is
+// small enough that it adds no meaningful stack growth even if this
+// tolerance turns out to be wrong for some shape we haven't seen.
+//
+// This is a var, not a const, for the same test-override reason as
+// maxRetryAttempts.
+var maxRetryStall = 3
+
+// retryAttempt threads bounded-retry bookkeeping through consecutive
+// RecordFlagRetry self-recursions of Worker.doTask for the SAME task node
+// (see the RecordFlagRetry case in doTask below, and #2726). It is nil on
+// every doTask entry that is NOT itself continuing a retry chain: the
+// top-level call from Worker.Do, and every call doNextTask makes to advance
+// to a DIFFERENT task node both go through the doTask wrapper, which always
+// starts a fresh (nil) chain. Only the RecordFlagRetry case constructs one
+// and passes it to doTaskAttempt directly — that self-recursion is the ONLY
+// place unbounded stack growth was possible.
+//
+// # What "progress" means, and why comparing counts is exact here, not a proxy
+//
+// A retried sub-batch is fed forward completely unchanged in content:
+// Batch.Ack (called just before recursing) only resets recordStatuses, never
+// record data, and a RecordFlagRetry-classified record is by
+// ProcessorTask.Do's contract exactly one the processor returned NOTHING for
+// this round (the "nil" case in markBatchRecords' switch) — so no record
+// outside the current retry group can ever join it; the group fed into
+// attempt N+1 is always a SUBSET of the group fed into attempt N (never a
+// superset, never a disjoint swap). A subset with the SAME cardinality as the
+// set it was drawn from IS that set. So "the retry group's size did not
+// shrink between two consecutive attempts" is not merely correlated with "the
+// exact same records came back unresolved" — under this recursion's own
+// structure it is EQUIVALENT to it. Comparing counts is therefore an exact
+// progress test here, not a heuristic; no deeper (and slower, and
+// non-deterministic-processor-hostile) content comparison is needed to tell
+// whether a SINGLE round made progress.
+//
+// # Why one stalled round is not enough to fail (see maxRetryStall)
+//
+// The very first time a task's Do call marks part of a batch Retry is the
+// normal, universal trigger for this whole mechanism — it says nothing yet
+// about whether the processor will converge, so the FIRST attempt (retry ==
+// nil) is never compared at all. From the second attempt onward, a single
+// non-shrinking round is exact evidence that THAT round made no progress, but
+// not necessarily that the processor never will (see maxRetryStall's doc
+// comment for the time-dependent-processor case this guards against) - so
+// stall counts consecutive non-shrinking rounds, resets to 0 the moment a
+// round DOES shrink, and only trips the failure once it reaches
+// maxRetryStall. A permanently stuck (input-deterministic) processor - #2726's
+// actual failure mode - never shrinks at all, so it hits maxRetryStall
+// immediately regardless of its value.
+type retryAttempt struct {
+	// count is how many consecutive RecordFlagRetry recursions have happened
+	// so far for this task, starting at 1 for the first recursion (i.e. the
+	// second time overall Task.Do has run on data descended from this batch).
+	count int
+	// size is len(b.records) at the doTaskAttempt call this retryAttempt
+	// value was passed into — how many records were fed to Task.Do on the
+	// attempt that produced it. The NEXT retry group's size is compared
+	// against this to detect a stalled (non-shrinking) round.
+	size int
+	// stall counts CONSECUTIVE attempts, up to and including the one that
+	// produced this value, whose retry-group size did not shrink relative to
+	// the attempt before it. It resets to 0 the moment a round shrinks. See
+	// maxRetryStall for why a run of these - not a single occurrence - is
+	// what triggers CodeRetryNotConverging.
+	stall int
+}
+
+// doTask is the entry point into task processing: every caller outside a
+// RecordFlagRetry recursion (Worker.Do, and doNextTask advancing to a new
+// task node) comes through here, which always starts a fresh retry chain.
+// See doTaskAttempt and retryAttempt for the bounded-retry mechanics.
 func (w *Worker) doTask(
 	ctx context.Context,
 	taskNode *TaskNode,
 	b *Batch,
 	acker ackNacker,
+) error {
+	return w.doTaskAttempt(ctx, taskNode, b, acker, nil)
+}
+
+//nolint:gocyclo // TODO: refactor
+func (w *Worker) doTaskAttempt(
+	ctx context.Context,
+	taskNode *TaskNode,
+	b *Batch,
+	acker ackNacker,
+	retry *retryAttempt,
 ) error {
 	t := taskNode.Task
 
@@ -451,7 +570,67 @@ func (w *Worker) doTask(
 			// Retry the sub-batch by passing it to the same task. We need to
 			// mark the records as acked, as that's the default record status.
 			subBatch.Ack(0, len(subBatch.records))
-			err := w.doTask(ctx, taskNode, subBatch, acker)
+
+			size := len(subBatch.records)
+			next := &retryAttempt{count: 1, size: size}
+			if retry != nil {
+				// Invariant 3 (enforcement site, #2726): this is at least the
+				// second consecutive RecordFlagRetry recursion for this task.
+				// If the retry group did not shrink relative to what was fed
+				// into the previous attempt (retry.size), THIS round made no
+				// progress - see retryAttempt's doc comment for why comparing
+				// counts here is an exact test for that, not a heuristic. A
+				// stall run of maxRetryStall consecutive non-shrinking rounds
+				// (see its doc comment for why one round alone isn't enough)
+				// means the processor is a fixpoint: recursing further would
+				// only grow the stack without bound for no benefit (#2726),
+				// so fail the pipeline loudly instead. Nothing in this
+				// sub-batch — or anything after it, since the tainted loop's
+				// idx cursor never advances past a Retry group it recurses
+				// into — has been acked or nacked, so every record here is
+				// redelivered on restart once the pipeline is fixed.
+				stall := retry.stall
+				if size >= retry.size {
+					stall++
+				} else {
+					stall = 0
+				}
+				if stall >= maxRetryStall {
+					ce := conduiterr.New(CodeRetryNotConverging, fmt.Sprintf(
+						"task %s: retry made no progress for %d consecutive attempt(s) "+
+							"(of %d total): %d record(s) were fed to the processor and "+
+							"%d are still unresolved — the processor is returning the "+
+							"same unresolved records without ever processing, filtering, "+
+							"or erroring any of them",
+						t.ID(), stall, retry.count+1, retry.size, size,
+					))
+					ce.Suggestion = fmt.Sprintf(
+						"task %q is not converging on a retry: check its logic for a "+
+							"condition that always returns fewer records than it "+
+							"receives for this input (e.g. a size threshold or "+
+							"rate-limit path that is never satisfied); no records were "+
+							"acked, they will be redelivered on restart", t.ID())
+					return ce
+				}
+				next = &retryAttempt{count: retry.count + 1, size: size, stall: stall}
+			}
+			if next.count > maxRetryAttempts {
+				ce := conduiterr.New(CodeRetryNotConverging, fmt.Sprintf(
+					"task %s: retry exceeded the maximum of %d attempts (%d "+
+						"record(s) still unresolved) before either converging or "+
+						"being detected as stuck; aborting to avoid unbounded "+
+						"recursion", t.ID(), maxRetryAttempts, size,
+				))
+				ce.Suggestion = fmt.Sprintf(
+					"task %q needed more than %d retry attempts to resolve a batch; "+
+						"if it is genuinely converging (shrinking every attempt) on "+
+						"unusually large batches, reduce the source's batch size — "+
+						"no records were acked, they will be redelivered on restart",
+					t.ID(), maxRetryAttempts)
+				return ce
+			}
+
+			err := w.doTaskAttempt(ctx, taskNode, subBatch, acker, next)
 			if err != nil {
 				return err
 			}

--- a/pkg/lifecycle-poc/funnel/worker.go
+++ b/pkg/lifecycle-poc/funnel/worker.go
@@ -599,18 +599,22 @@ func (w *Worker) doTaskAttempt(
 					ce := conduiterr.New(CodeRetryNotConverging, fmt.Sprintf(
 						"task %s: retry made no progress for %d consecutive attempt(s) "+
 							"(of %d total): %d record(s) were fed to the processor and "+
-							"%d are still unresolved — the processor is returning the "+
-							"same unresolved records without ever processing, filtering, "+
-							"or erroring any of them",
+							"%d came back with no result at all — not processed, not "+
+							"filtered, not errored",
 						t.ID(), stall, retry.count+1, retry.size, size,
 					))
 					ce.Suggestion = fmt.Sprintf(
-						"task %q is not converging on a retry: check its logic for a "+
-							"condition that always returns fewer records than it "+
-							"receives for this input (e.g. a size threshold or "+
-							"rate-limit path that is never satisfied); no records were "+
-							"acked, they will be redelivered on restart", t.ID())
-					return ce
+						"task %q returned an empty/unset result for these records rather "+
+							"than a processed record, a filter, or an error. For a "+
+							"standalone (WASM) processor this usually means a malformed or "+
+							"version-mismatched plugin sending a ProcessedRecord with no "+
+							"Record set; check the plugin build and its processor-SDK "+
+							"version. NOTE: a processor that merely returns FEWER records "+
+							"than it received is not this condition — that shrinks the "+
+							"retry group and converges normally. No records were acked; "+
+							"they will be redelivered on restart", t.ID(),
+					)
+					return cerrors.FatalError(ce)
 				}
 				next = &retryAttempt{count: retry.count + 1, size: size, stall: stall}
 			}
@@ -626,8 +630,9 @@ func (w *Worker) doTaskAttempt(
 						"if it is genuinely converging (shrinking every attempt) on "+
 						"unusually large batches, reduce the source's batch size — "+
 						"no records were acked, they will be redelivered on restart",
-					t.ID(), maxRetryAttempts)
-				return ce
+					t.ID(), maxRetryAttempts,
+				)
+				return cerrors.FatalError(ce)
 			}
 
 			err := w.doTaskAttempt(ctx, taskNode, subBatch, acker, next)
@@ -802,7 +807,8 @@ func validateAckPositions(positions []opencdc.Position) error {
 		ce := conduiterr.New(CodeEmptySourcePosition, fmt.Sprintf(
 			"refusing to ack an empty position (index %d of %d) to the source: "+
 				"acking it would overwrite the durable source position and force a full re-read on restart",
-			i, len(positions)))
+			i, len(positions),
+		))
 		ce.Suggestion = "this usually means a processor split a record and a later processor returned " +
 			"only part of the split run; the records are not acked and will be redelivered, but the " +
 			"pipeline is stopped to protect the source position"
@@ -1063,7 +1069,8 @@ func newMultiAckNacker(parent ackNacker, branches int, positions []opencdc.Posit
 		// which is why validateAckPositions guards the corruption site too.
 		if len(p) == 0 {
 			ce := conduiterr.New(CodeEmptySourcePosition, fmt.Sprintf(
-				"record %d of %d in a fanned-out batch has an empty position", i, len(positions)))
+				"record %d of %d in a fanned-out batch has an empty position", i, len(positions),
+			))
 			ce.Suggestion = "this usually means a processor split a record and a later processor " +
 				"returned only part of the split run; fix the processor chain so split runs stay intact"
 			return nil, ce
@@ -1071,7 +1078,8 @@ func newMultiAckNacker(parent ackNacker, branches int, positions []opencdc.Posit
 		if prev, dup := posIndex[string(p)]; dup {
 			ce := conduiterr.New(CodeDuplicateSourcePosition, fmt.Sprintf(
 				"records %d and %d in the same batch carry the identical position %q; "+
-					"a position must uniquely identify a record", prev, i, p))
+					"a position must uniquely identify a record", prev, i, p,
+			))
 			ce.Suggestion = "if these records came straight from the source, this is a source-connector " +
 				"bug: every record in a batch must carry a distinct, non-empty position"
 			return nil, ce

--- a/pkg/lifecycle-poc/funnel/worker_retry_bound_test.go
+++ b/pkg/lifecycle-poc/funnel/worker_retry_bound_test.go
@@ -1,0 +1,359 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funnel
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/matryer/is"
+)
+
+// This file is the regression suite for #2726: Worker.doTask's
+// RecordFlagRetry branch used to recurse into itself directly with no bound,
+// so a processor that never converges (returns the same short result forever)
+// drove unbounded stack growth to a fatal, unrecoverable "goroutine stack
+// exceeds limit" crash - killing the ENTIRE process, not just the offending
+// pipeline. See doTaskAttempt/retryAttempt/maxRetryAttempts in worker.go for
+// the fix: a bounded, count-comparing retry chain that fails loud with
+// CodeRetryNotConverging instead of recursing forever.
+
+// alwaysRetryTask marks its entire active input as RecordFlagRetry on every
+// call, resolving (ack/nack/filter) nothing, ever - the textbook
+// non-converging processor from #2726: a deterministic function of its input
+// that returns nothing useful, fed the identical input every time.
+type alwaysRetryTask struct {
+	id    string
+	calls int
+}
+
+func (t *alwaysRetryTask) ID() string                  { return t.id }
+func (t *alwaysRetryTask) Open(context.Context) error  { return nil }
+func (t *alwaysRetryTask) Close(context.Context) error { return nil }
+func (t *alwaysRetryTask) Do(_ context.Context, b *Batch) error {
+	t.calls++
+	active := b.ActiveRecords()
+	b.Retry(0, len(active))
+	return nil
+}
+
+// TestDoTask_Retry_NonConverging_FailsWithCodedError is the core regression
+// test for #2726. Without the fix, this either recurses until the goroutine's
+// stack hits Go's 1GB limit (a fatal, unrecoverable crash - see the PR
+// description for a verified repro) or, at best, spins forever. With the fix,
+// it must fail fast with a registered, actionable error naming the offending
+// task, after a small, bounded number of attempts.
+func TestDoTask_Retry_NonConverging_FailsWithCodedError(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	task := &alwaysRetryTask{id: "stuck-task"}
+	node := &TaskNode{Task: task}
+	parent := &fakeParentAckNacker{}
+	w := &Worker{logger: log.Nop(), processingLock: make(chan struct{}, 1)}
+
+	batch := randomBatch(4)
+	err := w.doTask(ctx, node, batch, newRunAckNacker(parent))
+
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok) // must be a registered, machine-actionable ConduitError
+	is.Equal(ce.Code.Reason(), CodeRetryNotConverging.Reason())
+	is.True(strings.Contains(err.Error(), "stuck-task")) // names the offending task
+
+	// Bounded: the initial pass, plus maxRetryStall (3) consecutive retry
+	// attempts that each observe zero shrinkage - never anywhere close to
+	// unbounded recursion.
+	is.Equal(task.calls, 1+maxRetryStall)
+
+	// Invariant 1/3 (enforcement site): nothing in the un-converged batch was
+	// ever acked or nacked to the source. Every record is redelivered on
+	// restart, not silently dropped.
+	is.Equal(len(parent.ackCalls()), 0)
+	is.Equal(len(parent.nackCalls()), 0)
+}
+
+// shrinkByCapTask always resolves (acks) up to `cap` records per call and
+// retries the remainder - deterministically converges in ceil(n/cap) rounds.
+// This mirrors TestRunLedger_OutputCapProcessor_ConvergesAndAcksOnce but
+// without a split run, isolating the bounded-retry logic itself from
+// run-ledger accounting.
+type shrinkByCapTask struct {
+	id    string
+	cap   int
+	calls int
+}
+
+func (t *shrinkByCapTask) ID() string                  { return t.id }
+func (t *shrinkByCapTask) Open(context.Context) error  { return nil }
+func (t *shrinkByCapTask) Close(context.Context) error { return nil }
+func (t *shrinkByCapTask) Do(_ context.Context, b *Batch) error {
+	t.calls++
+	active := b.ActiveRecords()
+	if len(active) > t.cap {
+		b.Retry(t.cap, len(active))
+	}
+	return nil
+}
+
+// TestDoTask_Retry_Converging_CompletesNormally guards against the false-
+// positive risk the STOP-and-surface rule calls out: a legitimately
+// converging retry (each pass strictly shrinks, e.g. an output-capped
+// processor) must complete exactly as it does on main today - same number of
+// rounds, every record eventually acked exactly once, no error.
+func TestDoTask_Retry_Converging_CompletesNormally(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	task := &shrinkByCapTask{id: "cap-task", cap: 2}
+	node := &TaskNode{Task: task}
+	parent := &fakeParentAckNacker{}
+	w := &Worker{logger: log.Nop(), processingLock: make(chan struct{}, 1)}
+
+	batch := randomBatch(5)
+	wantPositions := append([]opencdc.Position(nil), batch.positions...)
+
+	err := w.doTask(ctx, node, batch, newRunAckNacker(parent))
+	is.NoErr(err)
+
+	// 5 records, cap 2 per round: 5->(2 ack,3 retry), 3->(2 ack,1 retry),
+	// 1->(1 ack) = 3 calls. Identical to what main's unmodified
+	// Retry/subBatchByFlag logic already produces - the fix changes nothing
+	// about how a genuinely converging retry behaves.
+	is.Equal(task.calls, 3)
+
+	var gotPositions []opencdc.Position
+	for _, call := range parent.ackCalls() {
+		gotPositions = append(gotPositions, call.positions...)
+	}
+	is.Equal(gotPositions, wantPositions) // every record acked, exactly once, in order
+	is.Equal(len(parent.nackCalls()), 0)
+}
+
+// recoveringRateLimiterTask retries its ENTIRE input, unresolved, for a fixed
+// number of calls, then fully resolves everything on the next call - modeling
+// a real, wall-clock-based rate limiter whose token bucket refills after a
+// couple of rounds regardless of record content. This is the motivating
+// shape for maxRetryStall (see its doc comment on worker.go): a lack of
+// progress here does not depend on the records at all, so a small number of
+// stalled rounds must not be conflated with the input-deterministic fixpoint
+// #2726 is actually about.
+type recoveringRateLimiterTask struct {
+	id          string
+	stallRounds int
+	calls       int
+}
+
+func (t *recoveringRateLimiterTask) ID() string                  { return t.id }
+func (t *recoveringRateLimiterTask) Open(context.Context) error  { return nil }
+func (t *recoveringRateLimiterTask) Close(context.Context) error { return nil }
+func (t *recoveringRateLimiterTask) Do(_ context.Context, b *Batch) error {
+	t.calls++
+	if t.calls <= t.stallRounds {
+		b.Retry(0, len(b.ActiveRecords()))
+		return nil
+	}
+	return nil // recovered: resolve everything (default RecordFlagAck)
+}
+
+// TestDoTask_Retry_TemporaryStall_RecoversAndCompletesNormally is the direct
+// test for maxRetryStall's own justification: a processor that stalls for
+// FEWER than maxRetryStall consecutive rounds and then fully recovers must
+// complete normally, with no error - proving the tolerance added on top of
+// the (exact, per-round) count comparison actually prevents the false
+// positive it was added for, not just that the comment claims it does.
+func TestDoTask_Retry_TemporaryStall_RecoversAndCompletesNormally(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	is.True(maxRetryStall > 2) // precondition for stallRounds=2 to stay under the tolerance
+
+	task := &recoveringRateLimiterTask{id: "rate-limiter-task", stallRounds: 2}
+	node := &TaskNode{Task: task}
+	parent := &fakeParentAckNacker{}
+	w := &Worker{logger: log.Nop(), processingLock: make(chan struct{}, 1)}
+
+	batch := randomBatch(3)
+	wantPositions := append([]opencdc.Position(nil), batch.positions...)
+
+	err := w.doTask(ctx, node, batch, newRunAckNacker(parent))
+	is.NoErr(err) // must NOT be treated as non-converging
+
+	is.Equal(task.calls, 3) // 2 stalled rounds + the recovering round
+
+	var gotPositions []opencdc.Position
+	for _, call := range parent.ackCalls() {
+		gotPositions = append(gotPositions, call.positions...)
+	}
+	is.Equal(gotPositions, wantPositions)
+	is.Equal(len(parent.nackCalls()), 0)
+}
+
+// splitThenStuckTask splits its one input record into two identical pieces on
+// the first call (head keeps the original position, tail is nil-positioned -
+// see Batch.SplitRecord), retries the tail, and then - on every subsequent
+// call - retries that tail's entire input forever, never resolving it. This
+// drives the run-ledger interaction: the head's Ack is withheld by
+// runAckNacker pending the tail, and the tail never converges.
+type splitThenStuckTask struct {
+	id        string
+	splitDone bool
+	calls     int
+}
+
+func (t *splitThenStuckTask) ID() string                  { return t.id }
+func (t *splitThenStuckTask) Open(context.Context) error  { return nil }
+func (t *splitThenStuckTask) Close(context.Context) error { return nil }
+func (t *splitThenStuckTask) Do(_ context.Context, b *Batch) error {
+	t.calls++
+	if !t.splitDone {
+		t.splitDone = true
+		active := b.ActiveRecords()
+		orig := active[0]
+		b.SplitRecord(0, []opencdc.Record{orig, orig})
+		b.Retry(1, 2) // tail (index 1) retries; head (index 0) stays Ack
+		return nil
+	}
+	// The tail's retry pass: never resolves, regardless of round.
+	active := b.ActiveRecords()
+	b.Retry(0, len(active))
+	return nil
+}
+
+// TestDoTask_Retry_SplitRun_NonConverging_NoEarlyReleaseOrWithhold guards the
+// interaction called out explicitly in the task: a non-converging retry must
+// not corrupt the run-completion ledger (run_ledger.go) that #2723/#2731
+// added. Specifically:
+//   - the head must NOT be released early just because it individually voted
+//     Ack (that would advance the source position past the still-live tail -
+//     invariant 1);
+//   - once the tail fails to converge, NOTHING for this run may reach the
+//     source acker - the whole record (head + tail) is redelivered on restart
+//     (invariant 3), not partially acked.
+//
+// Without correct withholding, a regression here would look like the head's
+// position reaching the source before the pipeline halts - exactly the data
+// loss #2723 fixed, reopened via a different path.
+func TestDoTask_Retry_SplitRun_NonConverging_NoEarlyReleaseOrWithhold(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	task := &splitThenStuckTask{id: "split-stuck-task"}
+	node := &TaskNode{Task: task}
+	parent := &fakeParentAckNacker{}
+	w := &Worker{logger: log.Nop(), processingLock: make(chan struct{}, 1)}
+
+	batch := randomBatch(1)
+	err := w.doTask(ctx, node, batch, newRunAckNacker(parent))
+
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code.Reason(), CodeRetryNotConverging.Reason())
+
+	// Split (1 call) + maxRetryStall (3) consecutive failed retry attempts on
+	// the tail, each observing zero shrinkage.
+	is.Equal(task.calls, 1+maxRetryStall)
+
+	// Invariant 1: the head's Ack vote was withheld by runAckNacker pending
+	// the tail (which never resolved) - it must never have reached the
+	// parent, early or otherwise.
+	is.Equal(len(parent.ackCalls()), 0)
+	is.Equal(len(parent.nackCalls()), 0)
+}
+
+// shrinkByOneForeverTask acks exactly one record and retries the rest, every
+// round - a genuinely, monotonically converging processor (it always makes
+// progress by the exact definition doTaskAttempt's progress check uses) that
+// nonetheless needs as many rounds as records in the batch. Used to drive
+// Worker.doTask's iteration cap (maxRetryAttempts) on its own, independent of
+// the progress check, by lowering the cap for the duration of the test rather
+// than constructing a batch of thousands of records.
+type shrinkByOneForeverTask struct {
+	id    string
+	calls int
+}
+
+func (t *shrinkByOneForeverTask) ID() string                  { return t.id }
+func (t *shrinkByOneForeverTask) Open(context.Context) error  { return nil }
+func (t *shrinkByOneForeverTask) Close(context.Context) error { return nil }
+func (t *shrinkByOneForeverTask) Do(_ context.Context, b *Batch) error {
+	t.calls++
+	active := b.ActiveRecords()
+	if len(active) <= 1 {
+		return nil // would fully resolve - not reached in this test
+	}
+	b.Retry(1, len(active))
+	return nil
+}
+
+// TestDoTask_Retry_IterationCap_Reached proves the iteration cap
+// (maxRetryAttempts) is itself reachable and produces the same coded error -
+// the backstop the task description asks for, distinct from (and a superset
+// of) the progress check: this task makes real, monotonic progress every
+// single round, so the progress check alone would happily let it run for all
+// 10 rounds it needs. Lowering maxRetryAttempts to 3 forces the cap, not the
+// progress check, to be what stops it.
+func TestDoTask_Retry_IterationCap_Reached(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	oldCap := maxRetryAttempts
+	maxRetryAttempts = 3
+	defer func() { maxRetryAttempts = oldCap }()
+
+	task := &shrinkByOneForeverTask{id: "slow-shrink-task"}
+	node := &TaskNode{Task: task}
+	parent := &fakeParentAckNacker{}
+	w := &Worker{logger: log.Nop(), processingLock: make(chan struct{}, 1)}
+
+	batch := randomBatch(10)
+	wantAckedPrefix := append([]opencdc.Position(nil), batch.positions[:4]...)
+	wantStuck := append([]opencdc.Position(nil), batch.positions[4:]...)
+
+	err := w.doTask(ctx, node, batch, newRunAckNacker(parent))
+
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code.Reason(), CodeRetryNotConverging.Reason())
+	is.True(strings.Contains(err.Error(), "maximum of 3 attempts"))
+
+	// One initial call, then 3 rounds of genuine shrinkage before the
+	// (lowered) cap trips on the 4th recursion - never anywhere close to
+	// unbounded.
+	is.Equal(task.calls, 4)
+
+	var gotAcked []opencdc.Position
+	for _, call := range parent.ackCalls() {
+		gotAcked = append(gotAcked, call.positions...)
+	}
+	// The 4 records legitimately resolved (one per round, before the cap
+	// tripped) are acked exactly as they would be on main - the cap does not
+	// retroactively un-ack legitimate progress.
+	is.Equal(gotAcked, wantAckedPrefix)
+	// The records still stuck in the retry group at the moment the cap
+	// tripped must never be acked (invariant 3: redelivered on restart).
+	for _, stuck := range wantStuck {
+		for _, got := range gotAcked {
+			is.True(string(stuck) != string(got))
+		}
+	}
+	is.Equal(len(parent.nackCalls()), 0)
+}

--- a/pkg/lifecycle-poc/funnel/worker_retry_bound_test.go
+++ b/pkg/lifecycle-poc/funnel/worker_retry_bound_test.go
@@ -16,13 +16,17 @@ package funnel
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/conduitio/conduit-commons/opencdc"
+	sdk "github.com/conduitio/conduit-processor-sdk"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/matryer/is"
+	"go.uber.org/mock/gomock"
 )
 
 // This file is the regression suite for #2726: Worker.doTask's
@@ -75,6 +79,12 @@ func TestDoTask_Retry_NonConverging_FailsWithCodedError(t *testing.T) {
 	ce, ok := conduiterr.Get(err)
 	is.True(ok) // must be a registered, machine-actionable ConduitError
 	is.Equal(ce.Code.Reason(), CodeRetryNotConverging.Reason())
+	// Invariant: must be FATAL. A non-fatal error falls into the lifecycle's
+	// recovery arm, which restarts the pipeline with backoff — and because this
+	// fix deliberately does not advance the source position, every restart
+	// re-reads the identical records and re-hits the identical fixpoint, forever,
+	// with a blank status message and the actionable code visible only in logs.
+	is.True(cerrors.IsFatalError(err))
 	is.True(strings.Contains(err.Error(), "stuck-task")) // names the offending task
 
 	// Bounded: the initial pass, plus maxRetryStall (3) consecutive retry
@@ -266,6 +276,12 @@ func TestDoTask_Retry_SplitRun_NonConverging_NoEarlyReleaseOrWithhold(t *testing
 	ce, ok := conduiterr.Get(err)
 	is.True(ok)
 	is.Equal(ce.Code.Reason(), CodeRetryNotConverging.Reason())
+	// Invariant: must be FATAL. A non-fatal error falls into the lifecycle's
+	// recovery arm, which restarts the pipeline with backoff — and because this
+	// fix deliberately does not advance the source position, every restart
+	// re-reads the identical records and re-hits the identical fixpoint, forever,
+	// with a blank status message and the actionable code visible only in logs.
+	is.True(cerrors.IsFatalError(err))
 
 	// Split (1 call) + maxRetryStall (3) consecutive failed retry attempts on
 	// the tail, each observing zero shrinkage.
@@ -333,6 +349,12 @@ func TestDoTask_Retry_IterationCap_Reached(t *testing.T) {
 	ce, ok := conduiterr.Get(err)
 	is.True(ok)
 	is.Equal(ce.Code.Reason(), CodeRetryNotConverging.Reason())
+	// Invariant: must be FATAL. A non-fatal error falls into the lifecycle's
+	// recovery arm, which restarts the pipeline with backoff — and because this
+	// fix deliberately does not advance the source position, every restart
+	// re-reads the identical records and re-hits the identical fixpoint, forever,
+	// with a blank status message and the actionable code visible only in logs.
+	is.True(cerrors.IsFatalError(err))
 	is.True(strings.Contains(err.Error(), "maximum of 3 attempts"))
 
 	// One initial call, then 3 rounds of genuine shrinkage before the
@@ -355,5 +377,57 @@ func TestDoTask_Retry_IterationCap_Reached(t *testing.T) {
 			is.True(string(stuck) != string(got))
 		}
 	}
+	is.Equal(len(parent.nackCalls()), 0)
+}
+
+// TestDoTask_Retry_ProcessorTask_UnsetProcessedRecord_FailsFatally drives the
+// non-convergence through a REAL ProcessorTask, which is the only production
+// path that marks a batch RecordFlagRetry (processor.go is the sole in-repo
+// caller of Batch.Retry). Every other test in this file hand-rolls a Task that
+// calls b.Retry directly, which proves the mechanism but not the reachable
+// shape.
+//
+// Adversarial review of #2726's fix established what can and cannot trigger it:
+// ProcessorTask.Do rejects an empty result and pads exactly len(in)-len(out)
+// entries, so a processor that merely returns FEWER records than it received
+// always shrinks the retry group and converges. The reachable trigger is a
+// record that comes back with NO result at all — a ProcessedRecord whose Record
+// oneof is unset, which the standalone (WASM) plugin boundary surfaces as a nil
+// entry (pkg/plugin/processor/standalone/proto.go). That means a malformed or
+// version-mismatched plugin.
+//
+// Asserts the bounded coded error AND that it is fatal: a non-fatal error would
+// fall into the lifecycle's recovery arm and restart-loop forever, since the fix
+// deliberately does not advance the source position.
+func TestDoTask_Retry_ProcessorTask_UnsetProcessedRecord_FailsFatally(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	logger := log.Nop()
+
+	records := randomRecords(2)
+
+	proc := NewMockProcessor(ctrl)
+	// Always return nil entries: "no result at all" for every record, every
+	// round — the fixpoint. AnyTimes because the bound decides how many rounds.
+	proc.EXPECT().Process(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, recs []opencdc.Record) []sdk.ProcessedRecord {
+			return make([]sdk.ProcessedRecord, len(recs))
+		}).AnyTimes()
+
+	node := &TaskNode{Task: NewProcessorTask("stuck-proc", proc, logger, NoOpProcessorMetrics{})}
+	parent := &fakeParentAckNacker{}
+	w := &Worker{logger: logger, processingLock: make(chan struct{}, 1)}
+
+	err := w.doTask(ctx, node, NewBatch(slices.Clone(records)), newRunAckNacker(parent))
+
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code.Reason(), CodeRetryNotConverging.Reason())
+	is.True(cerrors.IsFatalError(err)) // must degrade the pipeline, not restart-loop
+
+	// Invariant 1/3: nothing acked or nacked — the records are redelivered.
+	is.Equal(len(parent.ackCalls()), 0)
 	is.Equal(len(parent.nackCalls()), 0)
 }


### PR DESCRIPTION
## What

Closes **#2726** — `doTask`'s retry branch recursed into itself with no depth bound, so a non-converging processor crashed the **whole Conduit process**.

## The bug, reproduced

`ProcessorTask.Do` emits `Retry` whenever a processor returns fewer records than it received (documented behavior). If the retry pass feeds identical input and the processor returns an identical short result, the recursion is a fixpoint.

Not a hang — unbounded **stack** growth to Go's 1 GB limit. Reproduced before fixing:

```text
runtime: goroutine stack exceeds 1000000000-byte limit
fatal error: stack overflow
...funnel.(*Worker).doTask(...) worker.go:454   ← repeated hundreds of thousands of times
```

Under one second to trigger, unrecoverable, kills every pipeline in the instance. It also held the first task's processing lock for the life of the recursion, so SIGTERM never drained (invariant 7).

Reachable without a "buggy" processor — only a non-converging one: a size-threshold skip, or a rate-limit path that returns what it could process and is re-fed the same batch.

## Fix

`doTask` is now a thin wrapper over `doTaskAttempt(..., retry *retryAttempt)`, so **every existing call site compiles unchanged** and only the retry recursion threads state.

- **`maxRetryAttempts = 10_000`** — a hard, unconditional recursion ceiling. The backstop for a converging-but-pathologically-large batch.
- **No-progress detection** → coded `CodeRetryNotConverging`, naming the offending task, after **`maxRetryStall = 3` consecutive** non-shrinking rounds (reset on any shrink).

### Why comparing counts is exact here, not a proxy
Attempt N+1's *input* **is** attempt N's retry group, and a `Retry`-flagged record is by `ProcessorTask.Do`'s contract exactly one the processor returned nothing for. So N+1's group is always a **subset** of N's — never a superset, never a disjoint swap. A subset with the same cardinality as the set it was drawn from **is** that set. No content comparison needed.

### Why 3 consecutive stalls, not 1
A wall-clock rate limiter can legitimately plateau for a round while its token bucket refills. That is not the input-deterministic fixpoint #2726 describes, but a zero-tolerance count check cannot distinguish them and would kill a working pipeline with a fatal error — a false positive here is its own severity. A true fixpoint still fails within 4 `Task.Do` calls, trivial from a stack-safety standpoint. `TestDoTask_Retry_TemporaryStall_RecoversAndCompletesNormally` proves the tolerance actually prevents that false positive rather than merely asserting it.

## Risk tier: **Tier 1 (data path)** — preview-gated (`Preview.PipelineArchV2`, off by default)

## Failure-mode analysis

| Failure | Before | After |
| --- | --- | --- |
| Non-converging processor | whole-process `fatal error: stack overflow` | bounded coded error, pipeline degrades |
| Converging processor (output cap) | works | unchanged — same rounds, every record acked once |
| Temporary stall (rate limiter) | works | works — 3-round tolerance |
| Non-converging **split run** | crash | coded error, **no early release and no permanent withhold** — nothing acked or nacked, records redelivered on restart (invariant 3) |
| Iteration cap reached | n/a | coded error (tested) |

**Rollback:** revert, or run without the preview flag.

## Run-ledger interaction
The retry path threads through the `splitRun` ledger merged in #2731. Verified: on a non-converging split run, `parent.ackCalls()` and `nackCalls()` are both empty after the coded error — the withheld head was never released early, and the call returns synchronously rather than hanging. All pre-existing `run_ledger_test.go` tests pass unmodified.

## Verification
`go build ./...` clean · `go test -race ./pkg/lifecycle-poc/...` green (5 new tests + all existing) · full chaos suite green (109s) · `golangci-lint` 0 issues · `make generate` stable (91→92 error codes, committed).

Fail-without/pass-with verified explicitly: reverting `worker.go` reproduces the stack overflow above; restoring returns the suite to green.

## Not claimed
No benchi run, so no performance claim. The added work is O(1) integer comparisons per retry round; per repo convention I'm not asserting a number without a committed benchmark.
