### PR TITLE
fix(config): stop advertising unverified N×M support in the arch-v2 flag

### DIFF
--- a/cmd/conduit/root/run/run_test.go
+++ b/cmd/conduit/root/run/run_test.go
@@ -55,7 +55,7 @@ func TestRunCommandFlags(t *testing.T) {
 		{longName: "pipelines.error-recovery.max-retries-window", usage: "amount of time running without any errors after which a pipeline is considered healthy"},
 		{longName: "schema-registry.type", usage: "schema registry type; accepts builtin,confluent"},
 		{longName: "schema-registry.confluent.connection-string", usage: "confluent schema registry connection string"},
-		{longName: "preview.pipeline-arch-v2", usage: "enables experimental pipeline architecture v2 (supports multiple sources and multiple destinations per pipeline; a record split before a fan-out point is not yet supported and fails with a coded error)"},
+		{longName: "preview.pipeline-arch-v2", usage: "enables experimental pipeline architecture v2 (supports multiple sources, or multiple destinations, per pipeline; N sources AND M destinations together is wired but not yet verified — see slice 3c. A record split before a fan-out point is not supported and fails with a coded error)"},
 		{longName: "preview.pipeline-arch-v2-disable-metrics", usage: "disables metrics about amount of data (in bytes) moved in pipeline architecture v2 (increases performance)"},
 		{longName: "dev.cpuprofile", usage: "write CPU profile to file"},
 		{longName: "dev.memprofile", usage: "write memory profile to file"},

--- a/pkg/conduit/config.go
+++ b/pkg/conduit/config.go
@@ -263,7 +263,7 @@ type Config struct {
 
 	Preview struct {
 		// PipelineArchV2 enables the new pipeline architecture.
-		PipelineArchV2               bool `long:"preview.pipeline-arch-v2" mapstructure:"pipeline-arch-v2" usage:"enables experimental pipeline architecture v2 (supports multiple sources and multiple destinations per pipeline; a record split before a fan-out point is not yet supported and fails with a coded error)"`
+		PipelineArchV2               bool `long:"preview.pipeline-arch-v2" mapstructure:"pipeline-arch-v2" usage:"enables experimental pipeline architecture v2 (supports multiple sources, or multiple destinations, per pipeline; N sources AND M destinations together is wired but not yet verified — see slice 3c. A record split before a fan-out point is not supported and fails with a coded error)"`
 		PipelineArchV2DisableMetrics bool `long:"preview.pipeline-arch-v2-disable-metrics" mapstructure:"pipeline-arch-v2-disable-metrics" usage:"disables metrics about amount of data (in bytes) moved in pipeline architecture v2 (increases performance)"`
 	}
 


### PR DESCRIPTION
The `--preview.pipeline-arch-v2` usage string (which **I** wrote in #2734) claims arch-v2 "supports multiple sources and multiple destinations per pipeline". That reads as N×M together — wired, but with **zero test coverage, no benchmark and no design doc**. Slice 3c is what verifies it.

3b's own design doc states: *"Operators should not be told N×M works until 3c says so."* So `main` contradicts the document governing it, in the one place operators actually read.

Corrected to say what is verified — multiple sources, **or** multiple destinations — with N×M explicitly flagged as wired-but-unverified and pointing at 3c.

Found while planning 3c. Tier 3, text only; assertion test updated, `make generate` clean.