### PR TITLE
fix(funnel): guard the metrics divide-by-zero panic on an empty batch

### DIFF
--- a/pkg/lifecycle-poc/funnel/connector_metrics.go
+++ b/pkg/lifecycle-poc/funnel/connector_metrics.go
@@ -66,6 +66,27 @@ func NewConnectorMetrics(pipelineName, pluginName string, connType connector.Typ
 func (m ConnectorMetricsImpl) Observe(records []opencdc.Record, start time.Time) {
 	// Precalculate sizes so that we don't need to hold a reference to records
 	// and observations can happen in a goroutine.
+	// An empty batch is legal and reachable, so guard before dividing by the
+	// count. time.Duration(0) makes the division below an integer
+	// divide-by-zero, which PANICS on the worker's own goroutine — not inside
+	// the goroutine spawned below — and a panic on the data path is
+	// unrecoverable: it takes down the whole Conduit process, every pipeline
+	// in it, not just this one.
+	//
+	// Both call sites can pass an empty slice:
+	//   - SourceTask.Do observes whatever source.Read returned, and
+	//     connector.Source.Read does not reject an empty Records slice. The Go
+	//     SDK happens to skip empties, but a non-Go plugin (e.g. the Python
+	//     SDK) is not bound by that.
+	//   - DestinationTask.Do observes records[ackCount:ackCount+len(acks)] and
+	//     validateAcks explicitly permits len(acks) == 0.
+	//
+	// ProcessorTask.Do already guards its own equivalent; the connector path
+	// did not. Nothing to observe means nothing to record — return early.
+	if len(records) == 0 {
+		return
+	}
+
 	sizes := make([]float64, len(records))
 	for i, rec := range records {
 		sizes[i] = m.histogram.SizeOf(rec)

--- a/pkg/lifecycle-poc/funnel/connector_metrics_test.go
+++ b/pkg/lifecycle-poc/funnel/connector_metrics_test.go
@@ -1,0 +1,56 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funnel
+
+import (
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/foundation/metrics"
+	"github.com/conduitio/conduit/pkg/foundation/metrics/noop"
+)
+
+// TestConnectorMetricsImpl_Observe_EmptyBatch_NoPanic is the regression test
+// for a reachable divide-by-zero PANIC in the metrics path — the path
+// v0.20 makes the DEFAULT configuration.
+//
+// Observe computed `time.Since(start) / time.Duration(len(sizes))` before
+// spawning its goroutine, so an empty batch panicked on the WORKER's own
+// goroutine. A panic on the data path is unrecoverable: it kills the whole
+// Conduit process and every pipeline in it, not just the offending one — the
+// same severity class as #2726.
+//
+// Both call sites can pass an empty slice: SourceTask.Do observes whatever
+// source.Read returned (connector.Source.Read does not reject an empty Records
+// slice, and a non-Go plugin is not bound by the Go SDK's habit of skipping
+// empties), and DestinationTask.Do observes records[ackCount:ackCount+len(acks)]
+// where validateAcks explicitly permits len(acks) == 0.
+//
+// Note the contrast that made this easy to miss: ProcessorTask.Do already
+// rejects an empty result. The connector path did not.
+func TestConnectorMetricsImpl_Observe_EmptyBatch_NoPanic(t *testing.T) {
+	m := ConnectorMetricsImpl{
+		timer:     noop.Timer{},
+		histogram: metrics.NewRecordBytesHistogram(noop.Histogram{}),
+	}
+
+	// Would panic with "integer divide by zero" before the guard.
+	m.Observe(nil, time.Now())
+	m.Observe([]opencdc.Record{}, time.Now())
+
+	// A non-empty batch must still be observed normally.
+	m.Observe([]opencdc.Record{{Position: opencdc.Position("p0")}}, time.Now())
+}


### PR DESCRIPTION
## What

`ConnectorMetricsImpl.Observe` computed `time.Since(start) / time.Duration(len(sizes))` **before** spawning its goroutine, so an empty batch is an integer divide-by-zero that panics on the **worker's own goroutine**. A panic on the data path is unrecoverable — it kills the whole Conduit process and every pipeline in it. Same severity class as #2726.

**This is in the path v0.20 makes the default.** metrics-ON is the normal configuration; `--preview.pipeline-arch-v2-disable-metrics` is the opt-out.

## Reachability — both call sites, confirmed

- `SourceTask.Do` observes whatever `source.Read` returned, and `connector.Source.Read` does **not** reject an empty `Records` slice. The Go SDK happens to skip empties; a non-Go plugin (the Python SDK) is not bound by that habit.
- `DestinationTask.Do` observes `records[ackCount:ackCount+len(acks)]`, and `validateAcks` **explicitly permits** `len(acks) == 0`.

What made it easy to miss: `ProcessorTask.Do` already guards its own equivalent. The connector path did not.

## Verification

Fail-without proven — removing the guard reproduces on the first empty batch:

```
panic: runtime error: integer divide by zero
```

`go build` clean · `-race` green on `pkg/lifecycle-poc/...` · `golangci-lint` 0 issues.

## Risk tier: **Tier 1 (data path)** — preview-gated today

**Rollback:** revert, or run without the preview flag.

## How it was found, and the gap behind it

Adversarial review of the benchi-parity plan. It flagged that metrics-ON has reachable panics **and zero chaos coverage** — every chaos scenario builds `NoOpConnectorMetrics`, so the configuration v0.20 ships by default is never exercised there. This PR is the crash; that coverage gap is worth its own issue, because a clean benchi throughput number would not have caught this.