### PR TITLE
test(chaos): make N-source positions genuinely collide

### DIFF
--- a/tests/chaos/fanout_child.go
+++ b/tests/chaos/fanout_child.go
@@ -162,14 +162,20 @@ func parseFanoutChildEnv() fanoutChildEnv {
 
 // fanoutDestination adapts a deliveryLog (recovery_child.go) into a
 // funnel.Destination for this scenario. Write durably records each record's
-// position via deliveryLog.Record (an fsync'd, one-file-per-position ledger
-// that survives this process being SIGKILLed - see deliveryLog's doc
-// comment), optionally after an artificial delay (see fanoutChildConfig.
-// destBDelayMS's doc for why). Ack immediately acks everything just written,
-// matching every other synthetic destination in this package
-// (synthDestination, property4_test.go): DestinationTask.Do's polling
-// contract is one Write followed by repeated Ack calls until every written
-// position has been acknowledged.
+// (sourceID, position) via deliveryLog.Record (an fsync'd, one-file-per-
+// delivery ledger that survives this process being SIGKILLed - see
+// deliveryLog's doc comment), optionally after an artificial delay (see
+// fanoutChildConfig.destBDelayMS's doc for why). sourceID is read off each
+// record's metadataSourceKey (upstream.go's makeRecord/chaosPlugin.sourceTag)
+// - "" if absent, which is every scenario except the N-source
+// shared-destination collision case (nsource_child.go): slice 3a's fan-OUT
+// topology (one source, M destinations, each with its own deliveryLog) has
+// nothing to disambiguate, so its records never carry the salt and this is a
+// no-op there. Ack immediately acks everything just written, matching every
+// other synthetic destination in this package (synthDestination,
+// property4_test.go): DestinationTask.Do's polling contract is one Write
+// followed by repeated Ack calls until every written position has been
+// acknowledged.
 type fanoutDestination struct {
 	id    string
 	log   *deliveryLog
@@ -196,7 +202,8 @@ func (d *fanoutDestination) Write(_ context.Context, recs []opencdc.Record) erro
 		if err != nil {
 			return fmt.Errorf("fanoutDestination %s: decode position %s: %w", d.id, r.Position, err)
 		}
-		if err := d.log.Record(pos); err != nil {
+		sourceID := r.Metadata[metadataSourceKey] // "" if this record carries no salt (see type doc)
+		if err := d.log.Record(sourceID, pos); err != nil {
 			return fmt.Errorf("fanoutDestination %s: %w", d.id, err)
 		}
 		d.pending = append(d.pending, connector.DestinationAck{Position: r.Position})

--- a/tests/chaos/nsource_child.go
+++ b/tests/chaos/nsource_child.go
@@ -71,12 +71,18 @@ const (
 	nsourcePluginA     = "chaos-nsource-plugin-a"
 	nsourcePluginB     = "chaos-nsource-plugin-b"
 
-	// nsourcePosOffsetB gives source B its own disjoint position namespace
-	// ([nsourcePosOffsetB+1, nsourcePosOffsetB+totalB]) so its contributions
-	// to the ONE shared destination ledger can never collide in value with
-	// source A's ([1, totalA]) - see buildNSourceChildSource's doc. Source A
-	// keeps offset 0 (its original, pre-3b-test position space).
-	nsourcePosOffsetB = 1_000_000
+	// nsourceSourceTagA/B are the record-level salts (chaosPlugin.sourceTag,
+	// upstream.go's metadataSourceKey) that let the shared destination's
+	// deliveryLog tell source A's and source B's deliveries apart WITHOUT
+	// giving them disjoint position namespaces. Both sources count
+	// [1, total] independently - positions ARE allowed to collide in value
+	// across sources (that is the entire point of this scenario: positions
+	// are connector-defined and unique only WITHIN a source - see H2,
+	// docs/design-documents/20260801-archv2-multiconnector-nsource.md) - the
+	// tag, not the position, is what disambiguates a delivery's origin. See
+	// buildNSourceChildSource's doc.
+	nsourceSourceTagA = "A"
+	nsourceSourceTagB = "B"
 
 	// markerNSourceDone is the graceful "both sources ran to their own total
 	// and stopped cleanly" completion marker - printed only by the restart
@@ -186,24 +192,21 @@ type nsourceChildSource struct {
 // instanceID/plugin name so two independent instances can coexist in one
 // process.
 //
-// posOffset gives this source its own disjoint numeric position namespace:
-// chaosPlugin.makeRecord (upstream.go) is a pure function of the position
-// number alone (deterministic "key-%d"/"record-%d" content, no per-instance
-// salt), so two chaosPlugin instances both counting 1..total would produce
-// byte-for-byte IDENTICAL records at the same position - indistinguishable
-// once they land in the ONE shared deliveryLog this scenario's destination
-// writes into (see fanoutDestination.Write/deliveryLog.Record, which key
-// purely on the numeric position). Seeding a fresh instance's resume
-// position at posOffset (and bounding chaosPlugin.total at posOffset+total,
-// since produceLoop compares its position counter to total as an ABSOLUTE
-// value, not a relative count - see produceLoop's own doc) makes this
-// source's positions occupy [posOffset+1, posOffset+total], disjoint from
-// any other source using a different posOffset, so the parent test can tell
-// the two sources' contributions to the shared ledger apart and verify each
-// is independently gapless. posOffset is only applied when creating a FRESH
-// instance; a resumed instance's persisted position already reflects
-// whatever offset the original run seeded, so it is left untouched.
-func buildNSourceChildSource(ctx context.Context, dbDir, upstreamDir, instanceID, pluginName string, posOffset, total uint64, paceMS int) (*nsourceChildSource, error) {
+// Both sources count their OWN [1, total] position space - positions are
+// deliberately allowed to collide in value across sources (positions are
+// connector-defined and unique only WITHIN a source; see H2,
+// docs/design-documents/20260801-archv2-multiconnector-nsource.md, and the
+// package doc.go). sourceTag (nsourceSourceTagA/B) is what makes two
+// otherwise byte-identical records (chaosPlugin.makeRecord is a pure
+// function of the position number alone: deterministic "key-%d"/"record-%d"
+// content) distinguishable once they land in the ONE shared deliveryLog this
+// scenario's destination writes into - see chaosPlugin.sourceTag's doc and
+// fanoutDestination.Write, which reads the tag back off each record's
+// metadata and keys deliveryLog.Record on (sourceID, position) rather than
+// position alone. This is what lets the parent test tell the two sources'
+// contributions to the shared ledger apart and verify each is independently
+// gapless WITHOUT hiding the collision the way a disjoint namespace would.
+func buildNSourceChildSource(ctx context.Context, dbDir, upstreamDir, instanceID, pluginName, sourceTag string, total uint64, paceMS int) (*nsourceChildSource, error) {
 	logger := log.New(zerolog.Nop()) // keep stdout clean; it is our progress-line channel
 
 	db, err := badger.New(zerolog.Nop(), dbDir)
@@ -217,8 +220,7 @@ func buildNSourceChildSource(ctx context.Context, dbDir, upstreamDir, instanceID
 	switch {
 	case err == nil:
 		// resumed from a previous (possibly killed) run's persisted state -
-		// its position already reflects whatever posOffset the very first
-		// run for this instance seeded; do not touch it.
+		// left untouched, exactly like buildChild's loadOrCreateInstance.
 	case cerrors.Is(err, database.ErrKeyNotExist):
 		instance = &connector.Instance{
 			ID:            instanceID,
@@ -227,7 +229,6 @@ func buildNSourceChildSource(ctx context.Context, dbDir, upstreamDir, instanceID
 			PipelineID:    instancePipe,
 			Plugin:        pluginName,
 			ProvisionedBy: connector.ProvisionTypeAPI,
-			State:         connector.SourceState{Position: encodePosition(posOffset)},
 		}
 	default:
 		fmt.Printf("%s: %v\n", markerCorruptPo, err)
@@ -240,7 +241,7 @@ func buildNSourceChildSource(ctx context.Context, dbDir, upstreamDir, instanceID
 	if err != nil {
 		return nil, fmt.Errorf("open upstream store (%s): %w", instanceID, err)
 	}
-	plugin := &chaosPlugin{store: upstream, total: posOffset + total, paceMS: paceMS}
+	plugin := &chaosPlugin{store: upstream, total: total, paceMS: paceMS, sourceTag: sourceTag}
 
 	fetcher := staticFetcher{pluginName: staticDispenser{source: plugin}}
 	c, err := instance.Connector(ctx, fetcher)
@@ -269,12 +270,12 @@ func runChildNSource() {
 	ctx := context.Background()
 	cfg := parseNSourceChildEnv()
 
-	builtA, err := buildNSourceChildSource(ctx, cfg.dbDirA, cfg.upstreamDirA, nsourceInstanceIDA, nsourcePluginA, 0, cfg.totalA, cfg.paceMSA)
+	builtA, err := buildNSourceChildSource(ctx, cfg.dbDirA, cfg.upstreamDirA, nsourceInstanceIDA, nsourcePluginA, nsourceSourceTagA, cfg.totalA, cfg.paceMSA)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s: %v\n", markerFatal, err)
 		os.Exit(exitBadArgs)
 	}
-	builtB, err := buildNSourceChildSource(ctx, cfg.dbDirB, cfg.upstreamDirB, nsourceInstanceIDB, nsourcePluginB, nsourcePosOffsetB, cfg.totalB, cfg.paceMSB)
+	builtB, err := buildNSourceChildSource(ctx, cfg.dbDirB, cfg.upstreamDirB, nsourceInstanceIDB, nsourcePluginB, nsourceSourceTagB, cfg.totalB, cfg.paceMSB)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s: %v\n", markerFatal, err)
 		os.Exit(exitBadArgs)
@@ -369,7 +370,7 @@ func runChildNSource() {
 	// fanout_child.go for why reusing that budget here (while both workers
 	// are still actively reading/writing/acking) is the wrong tool.
 	waitNSourceUpstreamCommitted(builtA.upstream, cfg.totalA, doErrA)
-	waitNSourceUpstreamCommitted(builtB.upstream, nsourcePosOffsetB+cfg.totalB, doErrB)
+	waitNSourceUpstreamCommitted(builtB.upstream, cfg.totalB, doErrB)
 
 	if err := workerA.Stop(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "%s: stop worker A: %v\n", markerFatal, err)

--- a/tests/chaos/nsource_sigkill_test.go
+++ b/tests/chaos/nsource_sigkill_test.go
@@ -33,7 +33,23 @@ import (
 // land mid-flight for one source must never affect the other's eventual
 // completeness).
 //
-// This is the load-bearing end-to-end proof for this slice's two central
+// Both sources count their OWN [1, total] position space (nsourceChildConfig
+// no longer gives B a disjoint posOffset - see buildNSourceChildSource's
+// doc): position VALUES are allowed, and in this test's overlapping range
+// [1, min(totalA,totalB)] GUARANTEED, to collide byte-for-byte across A and
+// B. That collision is deliberate, not incidental - it is the exact hazard
+// behind H2 (docs/design-documents/20260801-archv2-multiconnector-
+// nsource.md's H2 section): a worker erroring inside the shared destination
+// subtree can leave unread acks on the shared stream, and a sibling reading
+// them passes validateAcks' byte-for-byte position comparison whenever the
+// bytes happen to match. Proving gapless, correctly-attributed per-source
+// delivery under a REAL collision (not one avoided by construction) is this
+// test's entire reason for existing - see nsourceSourceTagA/B and
+// fanoutDestination.Write for the record-level salt and (sourceID, position)
+// keying that make the two sources' colliding positions distinguishable in
+// the shared deliveryLog without changing the collision itself.
+//
+// This is the load-bearing end-to-end proof for this slice's three central
 // claims:
 //   - Per-source resume independence: source A and source B each persist
 //     and resume from their OWN position, in their OWN on-disk state -
@@ -43,9 +59,17 @@ import (
 //     single deliveryLog ends up gapless for BOTH sources' contributions,
 //     which is only possible if TaskNode.MarkSharedBoundary's serialization
 //     held throughout the run (a lost/corrupted interleaving would show up
-//     as a wrong-position write, caught by deliveryLog's per-position files)
-//     and if Worker.Close/funnel.Sink.Close never tore the shared
-//     destination down while the other source was still writing to it.
+//     as a wrong-(sourceID,position) write, caught by deliveryLog's
+//     per-delivery files) and if Worker.Close/funnel.Sink.Close never tore
+//     the shared destination down while the other source was still writing
+//     to it.
+//   - No cross-source attribution under a genuine position collision: every
+//     delivered record's sourceID (read back from deliveryLog, never
+//     inferred) matches the source that actually produced it, even at
+//     positions where A's and B's records are byte-identical apart from the
+//     salt. See the strict switch below - an unattributed or
+//     wrongly-tagged delivery fails the test immediately, it is never
+//     silently dropped or folded into either source's count.
 func TestSIGKILL_NSource_FastAndSlow_GaplessIndependentResume(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
@@ -93,28 +117,33 @@ func TestSIGKILL_NSource_FastAndSlow_GaplessIndependentResume(t *testing.T) {
 	cp2.waitForMarker(t, markerNSourceDone, 45*time.Second)
 	cp2.waitExit(t, 10*time.Second)
 
-	finalDest, err := destLog.Positions()
+	finalDest, err := destLog.PositionsBySource()
 	is.NoErr(err)
 
-	// Source A occupies [1, totalA]; source B occupies
-	// [nsourcePosOffsetB+1, nsourcePosOffsetB+totalB] - a deliberately
-	// disjoint numeric range (see buildNSourceChildSource's doc for why:
-	// chaosPlugin.makeRecord is a pure function of the position number
-	// alone, so without this the two sources would produce byte-for-byte
-	// identical records at the same position, indistinguishable once both
-	// land in the ONE shared deliveryLog). Splitting finalDest back into
-	// each source's own range and checking each independently for gaps is
-	// the real assertion this test exists to make: a gap in EITHER range
-	// would mean a record from that source was never durably written to the
-	// shared destination - a data-loss bug - and the two ranges being
-	// checked separately (rather than as one combined count) is what proves
-	// each source's delivery is independent of the other's.
+	// Source A and source B both count [1, total] independently - their
+	// position VALUES overlap (and, for positions in [1, min(totalA,totalB)],
+	// are byte-identical - see the test's own doc comment for why that
+	// collision is deliberate). sourceID (deliveryLog's (sourceID, position)
+	// key - see Record's doc) is the ONLY thing that can tell a delivery's
+	// origin apart here; splitting finalDest by sourceID and checking each
+	// independently for gaps is the real assertion this test exists to make:
+	// a gap in EITHER source's range would mean a record from that source
+	// was never durably written to the shared destination - a data-loss bug
+	// - and any record whose sourceID is neither A nor B (unattributed, or
+	// attributed to something else entirely) is exactly the misattribution
+	// H2 was about and fails the test immediately rather than being folded
+	// into either count.
 	var gotA, gotB []uint64
-	for _, p := range finalDest {
-		if p > nsourcePosOffsetB {
-			gotB = append(gotB, p-nsourcePosOffsetB)
-		} else {
-			gotA = append(gotA, p)
+	for _, r := range finalDest {
+		switch r.SourceID {
+		case nsourceSourceTagA:
+			gotA = append(gotA, r.Position)
+		case nsourceSourceTagB:
+			gotB = append(gotB, r.Position)
+		default:
+			t.Fatalf("shared destination delivered position %d with unattributed/unexpected source tag %q "+
+				"(want %q or %q) - this is exactly the cross-source misattribution H2 exists to prevent",
+				r.Position, r.SourceID, nsourceSourceTagA, nsourceSourceTagB)
 		}
 	}
 	assertGaplessDelivery(t, "source A (fast)", gotA, totalA)
@@ -134,5 +163,75 @@ func TestSIGKILL_NSource_FastAndSlow_GaplessIndependentResume(t *testing.T) {
 	is.NoErr(err)
 	committedB, err := upstreamB.Committed()
 	is.NoErr(err)
-	is.Equal(uint64(nsourcePosOffsetB+totalB), committedB)
+	is.Equal(uint64(totalB), committedB)
+}
+
+// TestDeliveryLog_PositionsBySource_DistinguishesCollidingSources is a
+// focused unit-level proof that deliveryLog's (sourceID, position) keying
+// actually disambiguates a genuine collision, independent of the full
+// SIGKILL scenario above - i.e. that the assertions in
+// TestSIGKILL_NSource_FastAndSlow_GaplessIndependentResume would genuinely
+// fail if a record's source attribution were ever lost or conflated, not
+// merely that they happen to pass on the current happy path.
+//
+// It durably records the SAME position from two different sourceIDs (the
+// exact shape TestSIGKILL_NSource_FastAndSlow_GaplessIndependentResume's
+// overlapping [1, total] ranges produce) and checks two things a
+// position-only ledger could not:
+//  1. PositionsBySource reports BOTH deliveries, each correctly tagged - not
+//     one delivery silently standing in for (or overwriting) the other.
+//  2. The now-legacy Positions accessor (still used by every single-source
+//     scenario, which never salts records - see its own doc comment) can no
+//     longer serve as a stand-in for source-attributed correctness here: it
+//     collapses both entries down to the bare position number, which is
+//     precisely why the collision scenario needed PositionsBySource instead
+//     of just calling Positions() and being unable to tell A's and B's
+//     contributions apart - the bug this test exists to make impossible to
+//     reintroduce silently.
+func TestDeliveryLog_PositionsBySource_DistinguishesCollidingSources(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+
+	log, err := openDeliveryLog(dir)
+	is.NoErr(err)
+
+	// Source A and source B both durably deliver position 5 - a genuine,
+	// byte-identical-position collision, the same shape produceLoop's
+	// overlapping counters produce end-to-end in the SIGKILL scenario.
+	is.NoErr(log.Record(nsourceSourceTagA, 5))
+	is.NoErr(log.Record(nsourceSourceTagB, 5))
+
+	bySource, err := log.PositionsBySource()
+	is.NoErr(err)
+	is.Equal(len(bySource), 2) // both deliveries present - neither silently overwrote the other on disk
+
+	var sawA, sawB bool
+	for _, r := range bySource {
+		is.Equal(r.Position, uint64(5))
+		switch r.SourceID {
+		case nsourceSourceTagA:
+			sawA = true
+		case nsourceSourceTagB:
+			sawB = true
+		default:
+			t.Fatalf("unexpected sourceID %q in PositionsBySource result", r.SourceID)
+		}
+	}
+	is.True(sawA) // source A's delivery of position 5 is attributed to A
+	is.True(sawB) // source B's delivery of position 5 is attributed to B, not merged into A's
+
+	// Positions (the plain, pre-collision-scenario accessor) legitimately
+	// cannot make this distinction: both on-disk files parse to the same
+	// bare position 5, so it reports position 5 TWICE with no way to tell
+	// whether that means "one source delivered position 5 twice" (an
+	// ordinary at-least-once duplicate, harmless) or "two DIFFERENT sources
+	// each delivered their own position 5 once" (this test's actual
+	// scenario). That ambiguity is exactly the gap PositionsBySource exists
+	// to close - this is not a bug in Positions (every caller of it predates
+	// sourceID and never collides - see its own doc comment), it is the
+	// reason the collision scenario cannot use it, demonstrated directly
+	// rather than merely asserted.
+	plain, err := log.Positions()
+	is.NoErr(err)
+	is.Equal(plain, []uint64{5, 5})
 }

--- a/tests/chaos/recovery_child.go
+++ b/tests/chaos/recovery_child.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -209,15 +210,28 @@ func parseLCChildEnv() lcChildEnv {
 	return cfg
 }
 
-// deliveryLog durably records every position a destination plugin has
-// written, so a post-crash assertion can verify - from disk, independent of
-// any in-memory state a SIGKILL destroys - exactly what actually reached the
-// destination before the kill (see recoveryDestinationPlugin.loop, and
-// recovery_test.go's invariant-1 assertion). Modeled on upstreamStore's own
-// durability approach (openUpstreamStore/Commit), but as a set of files (one
-// per position) rather than a single watermark, since the destination is not
-// guaranteed to receive positions strictly in increasing order across a
-// restart-induced duplicate delivery.
+// deliveryLog durably records every (sourceID, position) pair a destination
+// plugin has written, so a post-crash assertion can verify - from disk,
+// independent of any in-memory state a SIGKILL destroys - exactly what
+// actually reached the destination before the kill (see
+// recoveryDestinationPlugin.loop, and recovery_test.go's invariant-1
+// assertion). Modeled on upstreamStore's own durability approach
+// (openUpstreamStore/Commit), but as a set of files (one per delivered
+// (sourceID, position) pair) rather than a single watermark, since the
+// destination is not guaranteed to receive positions strictly in increasing
+// order across a restart-induced duplicate delivery.
+//
+// sourceID keys every entry alongside position (see Record/deliveryKey)
+// because positions are connector-defined and unique only WITHIN a source
+// (nsource_child.go's doc): once N sources share a destination and its one
+// deliveryLog, two sources can legitimately deliver byte-identical position
+// values, and keying on position alone would let one source's delivery
+// silently stand in for the other's (see nsource_sigkill_test.go, whose
+// entire point is proving that does NOT happen). Every caller before that
+// scenario (fanout_sigkill_test.go, recovery_test.go) always passes sourceID
+// == "" - a single, un-shared destination per log has nothing to
+// disambiguate - and deliveryKey's "" fast path keeps their on-disk file
+// names byte-for-byte identical to this type's original, pre-sourceID shape.
 type deliveryLog struct {
 	dir string
 }
@@ -229,15 +243,51 @@ func openDeliveryLog(dir string) (*deliveryLog, error) {
 	return &deliveryLog{dir: dir}, nil
 }
 
-// Record durably marks pos as delivered: an empty file, created and fsynced
-// before returning, named after the position. The file's mere existence is
-// the entire signal - unlike upstreamStore's single rewritten watermark file,
-// there is nothing to tear here: a crash before this returns simply means
-// the file doesn't exist yet (equivalent to "not yet delivered"), and a
-// duplicate delivery (expected under at-least-once) is a harmless re-create
-// of a file that's already there.
-func (l *deliveryLog) Record(pos uint64) error {
-	name := filepath.Join(l.dir, strconv.FormatUint(pos, 10))
+// deliveryKey returns the on-disk file name for (sourceID, pos), and
+// parseDeliveryKey is its exact inverse. sourceID == "" (every caller before
+// the N-source collision scenario) maps to the plain position string,
+// unchanged from this type's original naming - so every existing caller's
+// files are completely unaffected by sourceID's addition. A non-empty
+// sourceID is joined with "-": position digits never contain "-", so
+// splitting on the LAST "-" (see parseDeliveryKey) recovers sourceID exactly
+// even if sourceID itself contains one (e.g. "nsource-a").
+func deliveryKey(sourceID string, pos uint64) string {
+	if sourceID == "" {
+		return strconv.FormatUint(pos, 10)
+	}
+	return sourceID + "-" + strconv.FormatUint(pos, 10)
+}
+
+// parseDeliveryKey is deliveryKey's inverse: it recovers (sourceID, pos)
+// from an on-disk file name, or reports ok == false for anything that isn't
+// a name deliveryKey could have produced (e.g. a stray non-delivery file).
+// A name with no "-" is treated as the sourceID == "" case (a plain position
+// string); otherwise the LAST "-" splits sourceID from the trailing position
+// digits - see deliveryKey's doc for why the last, not first, split is safe.
+func parseDeliveryKey(name string) (sourceID string, pos uint64, ok bool) {
+	if n, err := strconv.ParseUint(name, 10, 64); err == nil {
+		return "", n, true
+	}
+	i := strings.LastIndex(name, "-")
+	if i < 0 {
+		return "", 0, false
+	}
+	n, err := strconv.ParseUint(name[i+1:], 10, 64)
+	if err != nil {
+		return "", 0, false
+	}
+	return name[:i], n, true
+}
+
+// Record durably marks (sourceID, pos) as delivered: an empty file, created
+// and fsynced before returning, named per deliveryKey. The file's mere
+// existence is the entire signal - unlike upstreamStore's single rewritten
+// watermark file, there is nothing to tear here: a crash before this returns
+// simply means the file doesn't exist yet (equivalent to "not yet
+// delivered"), and a duplicate delivery (expected under at-least-once) is a
+// harmless re-create of a file that's already there.
+func (l *deliveryLog) Record(sourceID string, pos uint64) error {
+	name := filepath.Join(l.dir, deliveryKey(sourceID, pos))
 	f, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE, 0o644)
 	if err != nil {
 		return fmt.Errorf("deliveryLog: create %s: %w", name, err)
@@ -251,7 +301,15 @@ func (l *deliveryLog) Record(pos uint64) error {
 
 // Positions returns every durably delivered position, read fresh from disk
 // (so a freshly restarted/independent process observes exactly what a
-// previous, possibly killed, process actually delivered), sorted ascending.
+// previous, possibly killed, process actually delivered), sorted ascending -
+// WITHOUT source attribution. Every caller of this method predates the
+// N-source collision scenario and always records with sourceID == "" (a
+// single, un-shared destination has nothing to attribute), so this remains
+// exactly the plain numeric listing it always was. A scenario that shares one
+// deliveryLog across sources with colliding positions must use
+// PositionsBySource instead - conflating two sources' entries into one
+// []uint64 here would silently hide exactly the misattribution bug that
+// scenario exists to catch.
 func (l *deliveryLog) Positions() ([]uint64, error) {
 	entries, err := os.ReadDir(l.dir)
 	if err != nil {
@@ -259,13 +317,42 @@ func (l *deliveryLog) Positions() ([]uint64, error) {
 	}
 	out := make([]uint64, 0, len(entries))
 	for _, e := range entries {
-		n, err := strconv.ParseUint(e.Name(), 10, 64)
-		if err != nil {
-			continue // ignore any stray non-position file
+		_, pos, ok := parseDeliveryKey(e.Name())
+		if !ok {
+			continue // ignore any stray non-delivery file
 		}
-		out = append(out, n)
+		out = append(out, pos)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out, nil
+}
+
+// DeliveryRecord attributes one durably-recorded delivery to the source that
+// produced it - see Record's (sourceID, pos) keying and PositionsBySource.
+type DeliveryRecord struct {
+	SourceID string
+	Position uint64
+}
+
+// PositionsBySource returns every durably delivered (sourceID, position)
+// pair, read fresh from disk (deliveryKey's inverse, via parseDeliveryKey),
+// unsorted. Unlike Positions, this distinguishes two sources' colliding
+// position values instead of conflating them into one []uint64 - the exact
+// case the N-source shared-destination collision scenario
+// (nsource_sigkill_test.go) exists to prove is handled correctly end-to-end.
+func (l *deliveryLog) PositionsBySource() ([]DeliveryRecord, error) {
+	entries, err := os.ReadDir(l.dir)
+	if err != nil {
+		return nil, fmt.Errorf("deliveryLog: readdir %s: %w", l.dir, err)
+	}
+	out := make([]DeliveryRecord, 0, len(entries))
+	for _, e := range entries {
+		sourceID, pos, ok := parseDeliveryKey(e.Name())
+		if !ok {
+			continue // ignore any stray non-delivery file
+		}
+		out = append(out, DeliveryRecord{SourceID: sourceID, Position: pos})
+	}
 	return out, nil
 }
 
@@ -342,7 +429,7 @@ func (p *recoverySourcePlugin) produceLoop(inmemStream *builtin.InMemorySourceRu
 		}
 		pos = next
 
-		rec := makeRecord(pos)
+		rec := makeRecord(pos, "") // recoverySourcePlugin never salts - single-source scenario, no collision to distinguish
 		if err := server.Send(pconnector.SourceRunResponse{Records: []opencdc.Record{rec}}); err != nil {
 			return // stream closed (process exiting, or Teardown ran)
 		}
@@ -459,7 +546,7 @@ func (p *recoveryDestinationPlugin) loop(server pconnector.DestinationRunStreamS
 		acks := make([]pconnector.DestinationRunResponseAck, 0, len(req.Records))
 		for _, r := range req.Records {
 			if pos, err := decodePosition(r.Position); err == nil {
-				if err := p.log.Record(pos); err != nil {
+				if err := p.log.Record("", pos); err != nil { // single-source scenario: no sourceID to disambiguate
 					fmt.Fprintf(os.Stderr, "%s: lc dest plugin: durable record failed: %v\n", markerFatal, err)
 					os.Exit(exitOpenOtherError)
 				}

--- a/tests/chaos/upstream.go
+++ b/tests/chaos/upstream.go
@@ -191,6 +191,21 @@ type chaosPlugin struct {
 	// every existing scenario.
 	driftAt uint64
 
+	// sourceTag is the N-source shared-destination collision scenario's
+	// record-level salt (docs/design-documents/20260801-archv2-multiconnector-
+	// nsource.md's H2 section; nsource_child.go, nsource_sigkill_test.go).
+	// Positions are connector-defined and unique only WITHIN a source (see
+	// nsource_child.go's doc), so two chaosPlugin instances sharing one
+	// destination can legitimately produce byte-IDENTICAL positions - that
+	// collision is deliberate, not a bug, and must stay real (see
+	// makeRecord). sourceTag lets the parent test's delivery ledger tell the
+	// two sources' otherwise-identical records apart WITHOUT touching
+	// Position itself - see metadataSourceKey. The empty string (the default,
+	// every scenario before the collision case) means "no salt": makeRecord's
+	// output is then byte-for-byte identical to DBZ-1's original, unsalted
+	// records.
+	sourceTag string
+
 	mu         sync.Mutex
 	nextToRead uint64 // set by Open, read by the producer goroutine (single-key mode only, see Open)
 
@@ -309,14 +324,14 @@ func (p *chaosPlugin) produceLoop(server pconnector.SourceRunStreamServer, start
 		}
 		pos++
 
-		rec := makeRecord(pos)
+		rec := makeRecord(pos, p.sourceTag)
 		if p.driftAt > 0 && pos == p.driftAt {
 			// Property 4 (docs/design-documents/20260726-dbz2-cdc-correctness-suite.md):
 			// this is the one record in the run carrying the synthetic
 			// drift/poison marker - see the field doc above and
 			// property4_test.go's driftDetectTask, which is the only code
 			// that ever inspects metadataDriftKey.
-			rec = makeDriftRecord(pos)
+			rec = makeDriftRecord(pos, p.sourceTag)
 		}
 		if err := server.Send(pconnector.SourceRunResponse{Records: []opencdc.Record{rec}}); err != nil {
 			return // stream closed (process exiting, or Teardown ran)
@@ -455,15 +470,38 @@ func (p *chaosPlugin) NewStream() pconnector.SourceRunStream {
 // record N ever delivered end-to-end" therefore needs no separate ledger —
 // it's answerable purely from the position, both here and in the parent
 // test's final verification.
-func makeRecord(pos uint64) opencdc.Record {
-	return opencdc.Record{
+//
+// sourceTag, if non-empty, is stamped into metadataSourceKey - see
+// chaosPlugin.sourceTag's field doc for why this exists (the N-source
+// shared-destination collision scenario) and why it deliberately leaves
+// Position (and every other field) untouched: the collision in position
+// BYTES across sources is the thing under test, not something to paper over.
+// sourceTag == "" (every scenario before the collision case) produces a
+// record byte-for-byte identical to this function's original, pre-salt
+// output - Metadata stays the same empty opencdc.Metadata{}.
+func makeRecord(pos uint64, sourceTag string) opencdc.Record {
+	rec := opencdc.Record{
 		Position:  encodePosition(pos),
 		Operation: opencdc.OperationCreate,
 		Metadata:  opencdc.Metadata{},
 		Key:       opencdc.RawData(fmt.Sprintf("key-%d", pos)),
 		Payload:   opencdc.Change{After: opencdc.RawData(fmt.Sprintf("record-%d", pos))},
 	}
+	if sourceTag != "" {
+		rec.Metadata[metadataSourceKey] = sourceTag
+	}
+	return rec
 }
+
+// metadataSourceKey is the record-level source-identity salt the N-source
+// shared-destination collision scenario (nsource_child.go,
+// nsource_sigkill_test.go) uses to make two sources' otherwise byte-identical
+// records (same position, same deterministic key/payload - see makeRecord's
+// doc) distinguishable once they land in the ONE shared deliveryLog, without
+// perturbing Position itself. See fanoutDestination.Write (fanout_child.go),
+// the only reader of this key. Empty/unset (every scenario that doesn't pass
+// a sourceTag to makeRecord) means "no salt".
+const metadataSourceKey = "chaos.source"
 
 func encodePosition(pos uint64) opencdc.Position {
 	return opencdc.Position(strconv.FormatUint(pos, 10))
@@ -490,8 +528,8 @@ const metadataDriftValue = "true"
 // still applies - only the disposition differs, decided entirely by
 // property4_test.go's driftDetectTask + funnel.DLQ policy, never by this
 // plugin.
-func makeDriftRecord(pos uint64) opencdc.Record {
-	rec := makeRecord(pos)
+func makeDriftRecord(pos uint64, sourceTag string) opencdc.Record {
+	rec := makeRecord(pos, sourceTag)
 	rec.Metadata[metadataDriftKey] = metadataDriftValue
 	return rec
 }


### PR DESCRIPTION
## What

Closes a real coverage hole: the N-source chaos scenario deliberately gave each source a **disjoint** position namespace (`posOffset`), so it could never produce the case that matters.

Positions are connector-defined and unique only **within** a source. Once N sources share a downstream, two sources can legitimately emit **byte-identical** positions — that is the hazard behind H2 (#2734). The one end-to-end N-source harness was built specifically to avoid ever producing one.

## Why it was built that way (structural, not lazy)
`chaosPlugin.makeRecord` is a pure function of the position number, and the delivery ledgers keyed purely on that number — so two sources at the same position produced byte-identical records the ledger could not tell apart. Fixing the test required fixing the harness:

- `chaosPlugin` gains a `sourceTag`, stamped into record metadata. **Positions stay byte-identical** — the collision is the point.
- `deliveryLog` keys on `(sourceID, position)`; new `PositionsBySource()`. The legacy `Positions()` is preserved byte-for-byte, so every existing scenario is unchanged (empty `sourceTag` ⇒ identical on-disk keys).
- `nsource_child.go` drops `posOffset` entirely; both sources now count `[1, total]` and genuinely collide.
- The SIGKILL test splits deliveries by source, with a `default:` case that fails on any record attributed to neither.

## Result: no defect found
`sharedMu` fully serializes each worker's Write + drain-Ack pass before a sibling can enter the shared subtree on the happy path, and ack routing is call-stack-bound (`w.Ack`), never `TaskNode`-bound — so cross-source contamination is impossible by construction, as the 3b design doc claims. This test now proves that under **real** collisions instead of assuming it.

## Honest scope — what this does NOT cover
It exercises the **ordinary** SIGKILL/resume path under collisions. It does **not** inject the H2 ack-stream error path, so **H2's poison fix remains proven only by an in-package unit test** (`TestNSource_H2_AckStreamErrorPoisonsSharedDestination`). Closing that needs error injection in the chaos harness under colliding positions — worth doing, filed as follow-up, not claimed here.

## Proof the assertions actually distinguish sources
`TestDeliveryLog_PositionsBySource_DistinguishesCollidingSources` records position 5 from both `"A"` and `"B"` and asserts `PositionsBySource()` reports both distinctly, while the legacy `Positions()` collapses them to `[5, 5]` — the exact ambiguity the new accessor resolves. Demonstrates the mechanism rather than asserting it.

## Verification
`-race -count=10` → 10/10 · under contention (`GOMAXPROCS=1`, 16 busy loops, `-count=5`) → 5/5 · full chaos suite green (101s) · `golangci-lint` 0 issues on touched packages.