### PR TITLE
test: golden-blob format gate + DLQ window v1/v2 differential (pre-flip)

### DIFF
--- a/pkg/connector/golden_test.go
+++ b/pkg/connector/golden_test.go
@@ -1,0 +1,289 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Pre-flip gates for the arch-v2 default flip (v0.20). The persisted
+// connector.Instance blob is plain JSON with no version/schema tag anywhere,
+// and Store.decode never sets DisallowUnknownFields - so an older binary
+// reading a newer blob silently drops fields it doesn't recognize instead of
+// erroring. Worse, Store.PrepareSet copies into an explicit whitelist struct
+// (icopy) rather than marshalling the instance directly, so a field added to
+// Instance is silently un-persisted unless someone remembers to also add it
+// to that whitelist.
+//
+// These tests make both failure modes loud instead of silent:
+//
+//   - TestGolden_*_RoundTrip checks in the actual JSON currently persisted
+//     for a source and a destination connector instance and asserts HEAD's
+//     Store can parse it into a semantically identical Instance AND
+//     re-serialize it back to an equivalent blob. If a future change drops
+//     or renames a field, the re-serialized blob loses a key the checked-in
+//     golden still has, and the semantic JSON comparison fails.
+//   - TestStore_PrepareSet_WhitelistCoversAllFields populates every exported
+//     field of Instance via reflection (so it does not need to be
+//     hand-updated when a field is added), round-trips it through the real
+//     Store.Set/db path, and diffs what actually got persisted against a
+//     direct marshal of the same Instance. Any field PrepareSet's icopy
+//     whitelist forgets to copy shows up as a concrete, named diff.
+package connector
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/database/inmemory"
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/goccy/go-json"
+	"github.com/matryer/is"
+)
+
+// assertJSONSemanticallyEqual parses both blobs into generic
+// map[string]any values and compares them, so differences in key order or
+// whitespace don't matter but a dropped, renamed, or zeroed-out field does.
+func assertJSONSemanticallyEqual(t *testing.T, is *is.I, golden, got []byte) {
+	t.Helper()
+
+	var goldenMap, gotMap map[string]any
+	is.NoErr(json.Unmarshal(golden, &goldenMap))
+	is.NoErr(json.Unmarshal(got, &gotMap))
+
+	if !reflect.DeepEqual(goldenMap, gotMap) {
+		t.Fatalf(
+			"re-serialized instance is not semantically equal to the golden blob "+
+				"(a field was likely dropped or renamed):\ngolden: %s\ngot:    %s",
+			golden, got,
+		)
+	}
+}
+
+func TestGolden_SourceInstance_RoundTrip(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	golden, err := os.ReadFile("testdata/golden_source_instance.json")
+	is.NoErr(err)
+
+	db := &inmemory.DB{}
+	s := NewStore(db, log.Nop())
+	is.NoErr(db.Set(ctx, s.addKeyPrefix("golden-source"), golden))
+
+	got, err := s.Get(ctx, "golden-source")
+	is.NoErr(err)
+
+	ts := time.Date(2026, 6, 15, 9, 30, 0, 0, time.UTC)
+	want := &Instance{
+		ID:   "golden-source",
+		Type: TypeSource,
+		Config: Config{
+			Name:     "golden-source-connector",
+			Settings: map[string]string{"path": "/data/in"},
+		},
+		PipelineID:   "golden-pipeline",
+		Plugin:       "builtin:file",
+		ProcessorIDs: []string{"proc-1", "proc-2"},
+		State: SourceState{
+			Position: opencdc.Position("golden-position-42"),
+		},
+		ProvisionedBy: ProvisionTypeConfig,
+		CreatedAt:     ts,
+		UpdatedAt:     ts.Add(time.Minute),
+		LastActiveConfig: Config{
+			Name:     "golden-source-connector",
+			Settings: map[string]string{"path": "/data/in"},
+		},
+	}
+	is.Equal(want, got)
+
+	// The actual drop/rename detector: re-encode what HEAD decoded and
+	// compare against the golden blob itself, not just against `want` (which
+	// a contributor could forget to update in lockstep with a struct change).
+	reEncoded, err := s.encode(got)
+	is.NoErr(err)
+	assertJSONSemanticallyEqual(t, is, golden, reEncoded)
+}
+
+func TestGolden_DestinationInstance_RoundTrip(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	golden, err := os.ReadFile("testdata/golden_destination_instance.json")
+	is.NoErr(err)
+
+	db := &inmemory.DB{}
+	s := NewStore(db, log.Nop())
+	is.NoErr(db.Set(ctx, s.addKeyPrefix("golden-destination"), golden))
+
+	got, err := s.Get(ctx, "golden-destination")
+	is.NoErr(err)
+
+	ts := time.Date(2026, 6, 15, 9, 30, 0, 0, time.UTC)
+	want := &Instance{
+		ID:   "golden-destination",
+		Type: TypeDestination,
+		Config: Config{
+			Name:     "golden-destination-connector",
+			Settings: map[string]string{"path": "/data/out"},
+		},
+		PipelineID:   "golden-pipeline",
+		Plugin:       "builtin:file",
+		ProcessorIDs: []string{"proc-3"},
+		State: DestinationState{
+			Positions: map[string]opencdc.Position{
+				"golden-source": opencdc.Position("golden-position-42"),
+			},
+		},
+		ProvisionedBy: ProvisionTypeConfig,
+		CreatedAt:     ts,
+		UpdatedAt:     ts.Add(time.Minute),
+		LastActiveConfig: Config{
+			Name:     "golden-destination-connector",
+			Settings: map[string]string{"path": "/data/out"},
+		},
+	}
+	is.Equal(want, got)
+
+	reEncoded, err := s.encode(got)
+	is.NoErr(err)
+	assertJSONSemanticallyEqual(t, is, golden, reEncoded)
+}
+
+// fillNonZero generically populates v with a distinct, non-zero value for
+// common kinds (string, int-family, uint-family, bool, slice, map, struct -
+// recursing into nested structs and specializing time.Time). It exists so
+// TestStore_PrepareSet_WhitelistCoversAllFields does not need to be
+// hand-updated every time a field is added to Instance: a new field of any
+// of these common kinds gets a real value automatically, so the whitelist
+// coverage check actually exercises it.
+//
+// Known limitation: fields of interface, pointer, chan, or func kind are
+// left as their zero value (nothing sensible to synthesize generically).
+// Instance currently has one such field (State any), which callers must set
+// explicitly before/after calling fillNonZero.
+func fillNonZero(v reflect.Value, seed *int) {
+	if !v.CanSet() {
+		return
+	}
+
+	switch v.Kind() {
+	case reflect.String:
+		*seed++
+		v.SetString(fieldSeedString(*seed))
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		*seed++
+		v.SetInt(int64(*seed))
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		*seed++
+		v.SetUint(uint64(*seed))
+	case reflect.Bool:
+		v.SetBool(true)
+	case reflect.Slice:
+		elem := reflect.New(v.Type().Elem()).Elem()
+		fillNonZero(elem, seed)
+		s := reflect.MakeSlice(v.Type(), 1, 1)
+		s.Index(0).Set(elem)
+		v.Set(s)
+	case reflect.Map:
+		m := reflect.MakeMap(v.Type())
+		key := reflect.New(v.Type().Key()).Elem()
+		fillNonZero(key, seed)
+		val := reflect.New(v.Type().Elem()).Elem()
+		fillNonZero(val, seed)
+		m.SetMapIndex(key, val)
+		v.Set(m)
+	case reflect.Struct:
+		if v.Type() == reflect.TypeOf(time.Time{}) {
+			*seed++
+			v.Set(reflect.ValueOf(time.Date(2026, 1, 1, 0, 0, *seed, 0, time.UTC)))
+			return
+		}
+		for i := 0; i < v.NumField(); i++ {
+			if v.Type().Field(i).PkgPath != "" {
+				continue // unexported, not serialized, skip
+			}
+			fillNonZero(v.Field(i), seed)
+		}
+	case reflect.Invalid, reflect.Uintptr, reflect.Float32, reflect.Float64,
+		reflect.Complex64, reflect.Complex128, reflect.Array, reflect.Chan,
+		reflect.Func, reflect.Interface, reflect.Pointer, reflect.UnsafePointer:
+		// Not synthesized: Instance has no fields of these kinds today
+		// besides State (any), which callers set explicitly. See the doc
+		// comment above.
+	}
+}
+
+func fieldSeedString(seed int) string {
+	const alphabet = "abcdefghijklmnopqrstuvwxyz"
+	return "val-" + string(alphabet[seed%len(alphabet)]) + string(rune('0'+seed%10))
+}
+
+// TestStore_PrepareSet_WhitelistCoversAllFields is the trap-detector from
+// the task: Store.PrepareSet builds its own whitelist copy (icopy) of
+// Instance instead of marshalling the instance it was given. This test
+// populates every exported top-level field of Instance via reflection
+// (State is set explicitly per subtest, see fillNonZero's doc comment),
+// persists it through the real Store.Set/db path, and diffs what actually
+// got persisted against a direct marshal of the same Instance. If
+// PrepareSet's icopy ever forgets a field, that field's real value from the
+// direct marshal will not match the zero value written by the whitelist
+// copy, and the diff names the exact field.
+func TestStore_PrepareSet_WhitelistCoversAllFields(t *testing.T) {
+	for _, connType := range []Type{TypeSource, TypeDestination} {
+		t.Run(connType.String(), func(t *testing.T) {
+			is := is.New(t)
+			ctx := context.Background()
+
+			want := &Instance{Type: connType}
+			seed := 0
+			v := reflect.ValueOf(want).Elem()
+			tp := v.Type()
+			for i := 0; i < tp.NumField(); i++ {
+				f := tp.Field(i)
+				if f.PkgPath != "" {
+					continue // unexported runtime field (logger, persister, ...), not serialized
+				}
+				switch f.Name {
+				case "Type", "State":
+					continue // set explicitly below, must stay consistent with connType
+				}
+				fillNonZero(v.Field(i), &seed)
+			}
+			switch connType {
+			case TypeSource:
+				want.State = SourceState{Position: opencdc.Position("whitelist-position")}
+			case TypeDestination:
+				want.State = DestinationState{
+					Positions: map[string]opencdc.Position{"partition-0": opencdc.Position("whitelist-position")},
+				}
+			}
+
+			db := &inmemory.DB{}
+			s := NewStore(db, log.Nop())
+			is.NoErr(s.Set(ctx, want.ID, want))
+
+			// wantRaw: what SHOULD be persisted - a direct marshal of the
+			// fully-populated instance HEAD was handed.
+			wantRaw, err := json.Marshal(want)
+			is.NoErr(err)
+
+			// storedRaw: what PrepareSet's icopy whitelist ACTUALLY wrote.
+			storedRaw, err := db.Get(ctx, s.addKeyPrefix(want.ID))
+			is.NoErr(err)
+
+			assertJSONSemanticallyEqual(t, is, wantRaw, storedRaw)
+		})
+	}
+}

--- a/pkg/connector/golden_test.go
+++ b/pkg/connector/golden_test.go
@@ -169,11 +169,15 @@ func TestGolden_DestinationInstance_RoundTrip(t *testing.T) {
 // of these common kinds gets a real value automatically, so the whitelist
 // coverage check actually exercises it.
 //
-// Known limitation: fields of interface, pointer, chan, or func kind are
-// left as their zero value (nothing sensible to synthesize generically).
-// Instance currently has one such field (State any), which callers must set
-// explicitly before/after calling fillNonZero.
-func fillNonZero(v reflect.Value, seed *int) {
+// It FAILS THE TEST on any kind it cannot populate, rather than silently
+// leaving the field zero. Silently skipping is what would make this whole
+// check vacuous: a zero field matches a zero field, so an unhandled kind
+// means a new Instance field of that kind could be missing from PrepareSet's
+// whitelist and the test would still pass — precisely the trap it exists to
+// catch. Callers exclude State (kind interface, set explicitly per subtest)
+// by name before recursing, so reaching an interface here is a real gap.
+func fillNonZero(t *testing.T, v reflect.Value, seed *int) {
+	t.Helper()
 	if !v.CanSet() {
 		return
 	}
@@ -192,16 +196,16 @@ func fillNonZero(v reflect.Value, seed *int) {
 		v.SetBool(true)
 	case reflect.Slice:
 		elem := reflect.New(v.Type().Elem()).Elem()
-		fillNonZero(elem, seed)
+		fillNonZero(t, elem, seed)
 		s := reflect.MakeSlice(v.Type(), 1, 1)
 		s.Index(0).Set(elem)
 		v.Set(s)
 	case reflect.Map:
 		m := reflect.MakeMap(v.Type())
 		key := reflect.New(v.Type().Key()).Elem()
-		fillNonZero(key, seed)
+		fillNonZero(t, key, seed)
 		val := reflect.New(v.Type().Elem()).Elem()
-		fillNonZero(val, seed)
+		fillNonZero(t, val, seed)
 		m.SetMapIndex(key, val)
 		v.Set(m)
 	case reflect.Struct:
@@ -214,14 +218,28 @@ func fillNonZero(v reflect.Value, seed *int) {
 			if v.Type().Field(i).PkgPath != "" {
 				continue // unexported, not serialized, skip
 			}
-			fillNonZero(v.Field(i), seed)
+			fillNonZero(t, v.Field(i), seed)
 		}
-	case reflect.Invalid, reflect.Uintptr, reflect.Float32, reflect.Float64,
-		reflect.Complex64, reflect.Complex128, reflect.Array, reflect.Chan,
-		reflect.Func, reflect.Interface, reflect.Pointer, reflect.UnsafePointer:
-		// Not synthesized: Instance has no fields of these kinds today
-		// besides State (any), which callers set explicitly. See the doc
-		// comment above.
+	case reflect.Float32, reflect.Float64:
+		*seed++
+		v.SetFloat(float64(*seed) + 0.5)
+	case reflect.Pointer:
+		p := reflect.New(v.Type().Elem())
+		fillNonZero(t, p.Elem(), seed)
+		v.Set(p)
+	case reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			fillNonZero(t, v.Index(i), seed)
+		}
+	case reflect.Invalid, reflect.Uintptr, reflect.Complex64, reflect.Complex128,
+		reflect.Chan, reflect.Func, reflect.Interface, reflect.UnsafePointer:
+		t.Fatalf(
+			"fillNonZero: unhandled kind %s (type %s) — this field would be left at its zero "+
+				"value, which makes TestStore_PrepareSet_WhitelistCoversAllFields VACUOUS for it. "+
+				"Either teach fillNonZero to synthesize this kind, or exclude the field by name at "+
+				"the call site with a comment saying why it is safe.",
+			v.Kind(), v.Type(),
+		)
 	}
 }
 
@@ -259,7 +277,7 @@ func TestStore_PrepareSet_WhitelistCoversAllFields(t *testing.T) {
 				case "Type", "State":
 					continue // set explicitly below, must stay consistent with connType
 				}
-				fillNonZero(v.Field(i), &seed)
+				fillNonZero(t, v.Field(i), &seed)
 			}
 			switch connType {
 			case TypeSource:

--- a/pkg/connector/testdata/golden_destination_instance.json
+++ b/pkg/connector/testdata/golden_destination_instance.json
@@ -1,0 +1,27 @@
+{
+  "ID": "golden-destination",
+  "Type": 2,
+  "Config": {
+    "Name": "golden-destination-connector",
+    "Settings": {
+      "path": "/data/out"
+    }
+  },
+  "PipelineID": "golden-pipeline",
+  "Plugin": "builtin:file",
+  "ProcessorIDs": ["proc-3"],
+  "State": {
+    "Positions": {
+      "golden-source": "Z29sZGVuLXBvc2l0aW9uLTQy"
+    }
+  },
+  "ProvisionedBy": 1,
+  "CreatedAt": "2026-06-15T09:30:00Z",
+  "UpdatedAt": "2026-06-15T09:31:00Z",
+  "LastActiveConfig": {
+    "Name": "golden-destination-connector",
+    "Settings": {
+      "path": "/data/out"
+    }
+  }
+}

--- a/pkg/connector/testdata/golden_source_instance.json
+++ b/pkg/connector/testdata/golden_source_instance.json
@@ -1,0 +1,25 @@
+{
+  "ID": "golden-source",
+  "Type": 1,
+  "Config": {
+    "Name": "golden-source-connector",
+    "Settings": {
+      "path": "/data/in"
+    }
+  },
+  "PipelineID": "golden-pipeline",
+  "Plugin": "builtin:file",
+  "ProcessorIDs": ["proc-1", "proc-2"],
+  "State": {
+    "Position": "Z29sZGVuLXBvc2l0aW9uLTQy"
+  },
+  "ProvisionedBy": 1,
+  "CreatedAt": "2026-06-15T09:30:00Z",
+  "UpdatedAt": "2026-06-15T09:31:00Z",
+  "LastActiveConfig": {
+    "Name": "golden-source-connector",
+    "Settings": {
+      "path": "/data/in"
+    }
+  }
+}

--- a/pkg/lifecycle/dlqparity/dlq_parity_test.go
+++ b/pkg/lifecycle/dlqparity/dlq_parity_test.go
@@ -1,0 +1,382 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dlqparity is a pre-flip gate for the arch-v2 default flip
+// (Preview.PipelineArchV2, targeted for v0.20).
+//
+// pipeline.DLQ.WindowSize and pipeline.DLQ.WindowNackThreshold are persisted
+// pipeline config. Architecture v1 (pkg/lifecycle/stream.DLQHandlerNode) feeds
+// them into a window that counts one message at a time. Architecture v2
+// (pkg/lifecycle-poc/funnel.DLQ) feeds the exact same two numbers into a
+// window that counts a whole destination-write batch at once
+// (funnel/dlq.go calls d.window.Ack(len(batch.records)) /
+// d.window.Nack(len(batch.records))). Nothing in the codebase asserts these
+// two are actually equivalent - it's true "by construction", i.e. by two
+// people copy-pasting the same ring-buffer logic into two packages and hoping
+// batching it doesn't change when the threshold trips.
+//
+// If it did diverge, a pipeline that tolerated its error rate on v1 would
+// either start hard-failing after the v0.20 upgrade, or start DLQ-ing
+// records v1 would have halted on - and the second failure mode is
+// invariant-3-adjacent (a policy a user relied on silently loosens) and is
+// triggered purely by upgrading, with nothing in either package's own test
+// suite positioned to catch it (neither pkg/lifecycle/stream nor
+// pkg/lifecycle-poc/funnel has a test that looks at the other).
+//
+// This test drives both DLQHandlerNode (v1) and DLQ (v2) with the identical
+// logical sequence of per-message acks/nacks, for the identical
+// WindowSize/WindowNackThreshold config, and asserts the two freeze
+// (threshold-exceeded) at the exact same message. For v2 the sequence is
+// grouped into batches the way the real pipeline would produce them -
+// maximal runs of the same outcome for the scripted cases, and randomly
+// sub-chunked runs for the property-based case - since the whole point is to
+// prove that batching does not change the answer.
+package dlqparity
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/connector"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/foundation/metrics"
+	"github.com/conduitio/conduit/pkg/foundation/metrics/noop"
+	"github.com/conduitio/conduit/pkg/lifecycle-poc/funnel"
+	"github.com/conduitio/conduit/pkg/lifecycle/stream"
+	"github.com/matryer/is"
+)
+
+// -- v1 (pkg/lifecycle/stream.DLQHandlerNode) test harness --------------------
+
+// stubDLQHandler is a v1 stream.DLQHandler that always accepts writes. The
+// point of this test is the window/threshold arithmetic, not DLQ I/O, so the
+// handler itself is trivial.
+type stubDLQHandler struct{}
+
+func (stubDLQHandler) Open(context.Context) error                  { return nil }
+func (stubDLQHandler) Write(context.Context, opencdc.Record) error { return nil }
+func (stubDLQHandler) Close(context.Context) error                 { return nil }
+
+// runningV1Node starts a stream.DLQHandlerNode configured with the given
+// window and returns it along with a stop function. Ack/Nack block (via
+// csync.ValueWatcher.Watch) until the node's Run goroutine has flipped its
+// state to "running", so no extra synchronization is needed after starting
+// the goroutine.
+func runningV1Node(t *testing.T, windowSize, windowNackThreshold int) (*stream.DLQHandlerNode, func()) {
+	t.Helper()
+	is := is.New(t)
+
+	n := &stream.DLQHandlerNode{
+		Name:                "dlq-parity-v1",
+		Handler:             stubDLQHandler{},
+		WindowSize:          windowSize,
+		WindowNackThreshold: windowNackThreshold,
+		Timer:               noop.Timer{},
+		Histogram:           metrics.NewRecordBytesHistogram(noop.Histogram{}),
+	}
+	n.Add(1) // kept alive until stop() calls Done
+
+	ctx := context.Background()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		err := n.Run(ctx)
+		is.NoErr(err)
+	}()
+
+	stop := func() {
+		n.Done()
+		<-done
+	}
+	return n, stop
+}
+
+// replayV1 feeds events (true = nack, false = ack) one message at a time
+// through a v1 DLQHandlerNode and records, per event, whether it was
+// accepted (true) or rejected because the nack threshold was exceeded
+// (false). Acks are always "accepted" - Message.Ack has no failure mode.
+func replayV1(t *testing.T, windowSize, windowNackThreshold int, events []bool) []bool {
+	t.Helper()
+
+	n, stop := runningV1Node(t, windowSize, windowNackThreshold)
+	defer stop()
+
+	results := make([]bool, len(events))
+	for i, nack := range events {
+		msg := &stream.Message{
+			Ctx:    context.Background(),
+			Record: opencdc.Record{Position: opencdc.Position(fmt.Sprintf("pos-%d", i))},
+		}
+		if !nack {
+			n.Ack(msg)
+			results[i] = true
+			continue
+		}
+		err := n.Nack(msg, stream.NackMetadata{Reason: cerrors.New("boom"), NodeID: "dlq-parity"})
+		results[i] = err == nil
+	}
+	return results
+}
+
+// -- v2 (pkg/lifecycle-poc/funnel.DLQ) test harness ----------------------------
+
+// stubDestination is a funnel.Destination that always accepts writes and acks
+// everything it was just given, in order. Like stubDLQHandler, it exists so
+// the test isolates window/threshold arithmetic from DLQ I/O.
+type stubDestination struct {
+	pending []opencdc.Position
+}
+
+func (d *stubDestination) ID() string                     { return "dlq-parity-dest" }
+func (d *stubDestination) Open(context.Context) error     { return nil }
+func (d *stubDestination) Teardown(context.Context) error { return nil }
+func (d *stubDestination) Errors() <-chan error           { return nil }
+
+func (d *stubDestination) Write(_ context.Context, recs []opencdc.Record) error {
+	for _, r := range recs {
+		d.pending = append(d.pending, r.Position)
+	}
+	return nil
+}
+
+func (d *stubDestination) Ack(context.Context) ([]connector.DestinationAck, error) {
+	acks := make([]connector.DestinationAck, len(d.pending))
+	for i, p := range d.pending {
+		acks[i] = connector.DestinationAck{Position: p}
+	}
+	d.pending = nil
+	return acks, nil
+}
+
+func newV2DLQ(t *testing.T, windowSize, windowNackThreshold int) *funnel.DLQ {
+	t.Helper()
+	return funnel.NewDLQ(
+		"dlq-parity-v2",
+		&stubDestination{},
+		log.Test(t),
+		funnel.NoOpConnectorMetrics{},
+		windowSize,
+		windowNackThreshold,
+	)
+}
+
+// chunker splits a run of runLen homogeneous events (all acks, or all nacks)
+// into one or more v2 batch sizes summing to runLen.
+type chunker func(runLen int) []int
+
+// maximalChunks puts a whole homogeneous run into a single v2 batch call -
+// the largest, and therefore most adversarial, batch shape for exercising
+// the mid-batch threshold-exceeded path in dlqWindow.store.
+func maximalChunks(runLen int) []int { return []int{runLen} }
+
+// randomChunks splits a homogeneous run into randomly sized sub-batches,
+// modelling the fact that real destination flush batches can land in
+// arbitrary sizes.
+func randomChunks(rng *rand.Rand) chunker {
+	return func(runLen int) []int {
+		var chunks []int
+		remaining := runLen
+		for remaining > 0 {
+			c := rng.Intn(remaining) + 1
+			chunks = append(chunks, c)
+			remaining -= c
+		}
+		return chunks
+	}
+}
+
+// replayV2 feeds events (true = nack, false = ack) through a v2 DLQ, grouping
+// each maximal run of identical outcomes into one or more batches per split.
+// It records, per original message, whether it was accepted (true) or
+// rejected (false), the same shape replayV1 returns, so the two can be
+// compared directly.
+func replayV2(t *testing.T, windowSize, windowNackThreshold int, events []bool, split chunker) []bool {
+	t.Helper()
+	is := is.New(t)
+
+	dlq := newV2DLQ(t, windowSize, windowNackThreshold)
+	ctx := context.Background()
+
+	results := make([]bool, len(events))
+	i := 0
+	for i < len(events) {
+		nack := events[i]
+		j := i
+		for j < len(events) && events[j] == nack {
+			j++
+		}
+		runLen := j - i
+
+		pos := i
+		for _, c := range split(runLen) {
+			recs := make([]opencdc.Record, c)
+			for k := range c {
+				recs[k] = opencdc.Record{Position: opencdc.Position(fmt.Sprintf("pos-%d", pos+k))}
+			}
+			batch := funnel.NewBatch(recs)
+
+			if !nack {
+				dlq.Ack(ctx, batch)
+				for k := 0; k < c; k++ {
+					results[pos+k] = true
+				}
+			} else {
+				errs := make([]error, c)
+				for k := range errs {
+					errs[k] = cerrors.New("boom")
+				}
+				batch.Nack(0, errs...)
+
+				accepted, err := dlq.Nack(ctx, batch, "dlq-parity")
+				is.True(accepted >= 0 && accepted <= c)
+				if err != nil {
+					// accepted..c-1 were rejected by the window (or, if
+					// accepted==0 and threshold==0, all of them were -
+					// either way err must be non-nil for exactly the
+					// rejected tail.
+					is.True(accepted < c)
+				}
+				for k := 0; k < c; k++ {
+					results[pos+k] = k < accepted
+				}
+			}
+			pos += c
+		}
+		i = j
+	}
+	return results
+}
+
+// -- differential assertions --------------------------------------------------
+
+// assertParity replays the same event sequence through v1 and v2 (v2 batched
+// per split) and fails loudly, with the diverging index, if they disagree
+// about which messages were accepted.
+func assertParity(t *testing.T, windowSize, windowNackThreshold int, events []bool, split chunker) {
+	t.Helper()
+	is := is.New(t)
+
+	v1 := replayV1(t, windowSize, windowNackThreshold, events)
+	v2 := replayV2(t, windowSize, windowNackThreshold, events, split)
+
+	is.Equal(len(v1), len(v2))
+	for i := range events {
+		if v1[i] != v2[i] {
+			t.Fatalf(
+				"DLQ v1/v2 parity DIVERGED at message %d (windowSize=%d windowNackThreshold=%d, nack=%v): "+
+					"v1 accepted=%v v2 accepted=%v\nfull v1=%v\nfull v2=%v",
+				i, windowSize, windowNackThreshold, events[i], v1[i], v2[i], v1, v2,
+			)
+		}
+	}
+}
+
+// scriptedEvents reproduces the exact scenario from
+// stream.TestDLQWindow_NackThresholdExceeded: fill the tolerance with nacks,
+// dilute it back to all-acks, fill the tolerance again, push one more nack
+// over the threshold, then prove the freeze is permanent (acks after that
+// don't un-freeze it, and a further nack still fails).
+func scriptedEvents(windowSize, windowNackThreshold int) []bool {
+	var events []bool
+	for range windowNackThreshold {
+		events = append(events, true) // nacks up to the threshold: must be accepted
+	}
+	for range windowSize {
+		events = append(events, false) // acks fill the window back up
+	}
+	for range windowNackThreshold {
+		events = append(events, true) // nacks up to the threshold again: accepted
+	}
+	events = append(events, true) // one more nack: pushes over the threshold
+	for range windowSize {
+		events = append(events, false) // acks after the freeze: must not un-freeze it
+	}
+	events = append(events, true) // still frozen: must still be rejected
+	return events
+}
+
+func TestDLQParity_Scripted(t *testing.T) {
+	// Same (windowSize, windowNackThreshold) pairs as
+	// stream.TestDLQWindow_NackThresholdExceeded, so this test is directly
+	// comparable to the v1-only coverage that already exists.
+	testCases := []struct {
+		windowSize    int
+		nackThreshold int
+	}{
+		{1, 0},
+		{2, 0},
+		{2, 1},
+		{100, 0},
+		{100, 99},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("w%d-t%d", tc.windowSize, tc.nackThreshold), func(t *testing.T) {
+			events := scriptedEvents(tc.windowSize, tc.nackThreshold)
+			assertParity(t, tc.windowSize, tc.nackThreshold, events, maximalChunks)
+		})
+	}
+}
+
+// TestDLQParity_WindowDisabled mirrors stream.TestDLQWindow_WindowDisabled:
+// WindowSize=0 is a distinct sentinel (not "threshold 0"), meaning nacks are
+// never rejected by the window at all.
+func TestDLQParity_WindowDisabled(t *testing.T) {
+	events := []bool{false, true, true, false, true}
+	assertParity(t, 0, 0, events, maximalChunks)
+}
+
+// TestDLQParity_RandomizedBatching stresses the actual concern in the task:
+// that grouping consecutive same-outcome messages into arbitrarily sized v2
+// batches (rather than v1's strictly one-at-a-time processing) must not
+// change which message trips the threshold. Every sub-test uses a fixed seed
+// so a failure is reproducible.
+func TestDLQParity_RandomizedBatching(t *testing.T) {
+	configs := []struct {
+		windowSize    int
+		nackThreshold int
+		nackProb      float64
+	}{
+		{1, 0, 0.5},
+		{5, 2, 0.4},
+		{10, 0, 0.2},
+		{20, 10, 0.5},
+		{50, 25, 0.6},
+		{100, 1, 0.3},
+	}
+
+	for _, cfg := range configs {
+		t.Run(fmt.Sprintf("w%d-t%d-p%.1f", cfg.windowSize, cfg.nackThreshold, cfg.nackProb), func(t *testing.T) {
+			for seed := int64(0); seed < 5; seed++ {
+				t.Run(fmt.Sprintf("seed%d", seed), func(t *testing.T) {
+					eventRng := rand.New(rand.NewSource(seed))
+					events := make([]bool, 300)
+					for i := range events {
+						events[i] = eventRng.Float64() < cfg.nackProb
+					}
+
+					// Use a fresh, independently-seeded rng for batch
+					// splitting so the split shape isn't correlated with
+					// the event sequence itself.
+					splitRng := rand.New(rand.NewSource(seed + 1000))
+					assertParity(t, cfg.windowSize, cfg.nackThreshold, events, randomChunks(splitRng))
+				})
+			}
+		})
+	}
+}

--- a/pkg/lifecycle/dlqparity/dlq_parity_test.go
+++ b/pkg/lifecycle/dlqparity/dlq_parity_test.go
@@ -48,6 +48,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"slices"
 	"testing"
 
 	"github.com/conduitio/conduit-commons/opencdc"
@@ -63,27 +64,61 @@ import (
 
 // -- v1 (pkg/lifecycle/stream.DLQHandlerNode) test harness --------------------
 
-// stubDLQHandler is a v1 stream.DLQHandler that always accepts writes. The
-// point of this test is the window/threshold arithmetic, not DLQ I/O, so the
-// handler itself is trivial.
-type stubDLQHandler struct{}
+// stubDLQHandler is a v1 stream.DLQHandler that always accepts writes and
+// records which record positions actually reached the DLQ.
+//
+// It records rather than discarding because "the two windows agree on the
+// COUNT" is not the property this gate needs to hold. An engine that accepts a
+// nack and then never writes the record anywhere still passes a count-only
+// comparison — and in v2, Worker.Nack acks that position upstream on the
+// strength of the accepted count, so the record is gone for good. Comparing the
+// delivered positions is what makes the gate cover invariant 3.
+type stubDLQHandler struct {
+	written []string
+}
 
-func (stubDLQHandler) Open(context.Context) error                  { return nil }
-func (stubDLQHandler) Write(context.Context, opencdc.Record) error { return nil }
-func (stubDLQHandler) Close(context.Context) error                 { return nil }
+func (*stubDLQHandler) Open(context.Context) error  { return nil }
+func (*stubDLQHandler) Close(context.Context) error { return nil }
+
+func (h *stubDLQHandler) Write(_ context.Context, r opencdc.Record) error {
+	h.written = append(h.written, wrappedPosition(r))
+	return nil
+}
+
+// wrappedPosition digs the FAILED record's position out of a DLQ record.
+//
+// Both engines nest the original in Payload.After via opencdc.Record.Map(),
+// but they disagree on the wrapper's own Position: v1 uses msg.ID()
+// ("<connectorID>/<position>", stream/dlq.go), v2 uses the raw record position
+// (funnel/dlq.go). Comparing the wrapper positions would therefore fail on a
+// formatting difference and say nothing about which records were delivered,
+// so read through to the original. (The wrapper-format divergence is real and
+// worth its own decision, but it is not what this gate is measuring.)
+func wrappedPosition(r opencdc.Record) string {
+	after, ok := r.Payload.After.(opencdc.StructuredData)
+	if !ok {
+		return fmt.Sprintf("UNEXPECTED-PAYLOAD(%T)", r.Payload.After)
+	}
+	pos, ok := after["position"].([]byte)
+	if !ok {
+		return fmt.Sprintf("UNEXPECTED-POSITION(%T)", after["position"])
+	}
+	return string(pos)
+}
 
 // runningV1Node starts a stream.DLQHandlerNode configured with the given
 // window and returns it along with a stop function. Ack/Nack block (via
 // csync.ValueWatcher.Watch) until the node's Run goroutine has flipped its
 // state to "running", so no extra synchronization is needed after starting
 // the goroutine.
-func runningV1Node(t *testing.T, windowSize, windowNackThreshold int) (*stream.DLQHandlerNode, func()) {
+func runningV1Node(t *testing.T, windowSize, windowNackThreshold int) (*stream.DLQHandlerNode, *stubDLQHandler, func()) {
 	t.Helper()
 	is := is.New(t)
 
+	h := &stubDLQHandler{}
 	n := &stream.DLQHandlerNode{
 		Name:                "dlq-parity-v1",
-		Handler:             stubDLQHandler{},
+		Handler:             h,
 		WindowSize:          windowSize,
 		WindowNackThreshold: windowNackThreshold,
 		Timer:               noop.Timer{},
@@ -93,30 +128,48 @@ func runningV1Node(t *testing.T, windowSize, windowNackThreshold int) (*stream.D
 
 	ctx := context.Background()
 	done := make(chan struct{})
+	// Captured, not asserted here: is.NoErr calls t.FailNow, which must run on
+	// the test goroutine. Assert it in stop() instead.
+	var runErr error
 	go func() {
 		defer close(done)
-		err := n.Run(ctx)
-		is.NoErr(err)
+		runErr = n.Run(ctx)
 	}()
 
 	stop := func() {
 		n.Done()
 		<-done
+		is.NoErr(runErr)
 	}
-	return n, stop
+	return n, h, stop
+}
+
+// outcome is what the two engines must agree on, per message.
+//
+// fatal is compared as well as accepted because fatality is not a detail of
+// error formatting - cerrors.IsFatalError is what decides whether a pipeline
+// auto-recovers or goes StatusDegraded (pkg/lifecycle/service.go and
+// pkg/lifecycle-poc/service.go both branch on it). "A pipeline that tolerated
+// its error rate on v1 starts hard-failing after the upgrade" IS a fatality
+// divergence, so a gate that compares only accepted/rejected cannot see the
+// regression it exists to catch.
+type outcome struct {
+	accepted bool
+	fatal    bool
 }
 
 // replayV1 feeds events (true = nack, false = ack) one message at a time
 // through a v1 DLQHandlerNode and records, per event, whether it was
-// accepted (true) or rejected because the nack threshold was exceeded
-// (false). Acks are always "accepted" - Message.Ack has no failure mode.
-func replayV1(t *testing.T, windowSize, windowNackThreshold int, events []bool) []bool {
+// accepted and whether the rejection was fatal. Acks are always accepted and
+// never fatal - Message.Ack has no failure mode. It also returns the record
+// positions that actually reached the DLQ handler.
+func replayV1(t *testing.T, windowSize, windowNackThreshold int, events []bool) ([]outcome, []string) {
 	t.Helper()
 
-	n, stop := runningV1Node(t, windowSize, windowNackThreshold)
+	n, handler, stop := runningV1Node(t, windowSize, windowNackThreshold)
 	defer stop()
 
-	results := make([]bool, len(events))
+	results := make([]outcome, len(events))
 	for i, nack := range events {
 		msg := &stream.Message{
 			Ctx:    context.Background(),
@@ -124,13 +177,13 @@ func replayV1(t *testing.T, windowSize, windowNackThreshold int, events []bool) 
 		}
 		if !nack {
 			n.Ack(msg)
-			results[i] = true
+			results[i] = outcome{accepted: true}
 			continue
 		}
 		err := n.Nack(msg, stream.NackMetadata{Reason: cerrors.New("boom"), NodeID: "dlq-parity"})
-		results[i] = err == nil
+		results[i] = outcome{accepted: err == nil, fatal: cerrors.IsFatalError(err)}
 	}
-	return results
+	return results, handler.written
 }
 
 // -- v2 (pkg/lifecycle-poc/funnel.DLQ) test harness ----------------------------
@@ -140,6 +193,11 @@ func replayV1(t *testing.T, windowSize, windowNackThreshold int, events []bool) 
 // the test isolates window/threshold arithmetic from DLQ I/O.
 type stubDestination struct {
 	pending []opencdc.Position
+	// written accumulates every position ever handed to Write, and is never
+	// drained - pending is transient bookkeeping for Ack, and asserting on it
+	// would only ever observe an empty slice. See stubDLQHandler for why the
+	// delivered set, not just the accepted count, is the property under test.
+	written []string
 }
 
 func (d *stubDestination) ID() string                     { return "dlq-parity-dest" }
@@ -150,6 +208,7 @@ func (d *stubDestination) Errors() <-chan error           { return nil }
 func (d *stubDestination) Write(_ context.Context, recs []opencdc.Record) error {
 	for _, r := range recs {
 		d.pending = append(d.pending, r.Position)
+		d.written = append(d.written, wrappedPosition(r))
 	}
 	return nil
 }
@@ -163,16 +222,17 @@ func (d *stubDestination) Ack(context.Context) ([]connector.DestinationAck, erro
 	return acks, nil
 }
 
-func newV2DLQ(t *testing.T, windowSize, windowNackThreshold int) *funnel.DLQ {
+func newV2DLQ(t *testing.T, windowSize, windowNackThreshold int) (*funnel.DLQ, *stubDestination) {
 	t.Helper()
+	dest := &stubDestination{}
 	return funnel.NewDLQ(
 		"dlq-parity-v2",
-		&stubDestination{},
+		dest,
 		log.Test(t),
 		funnel.NoOpConnectorMetrics{},
 		windowSize,
 		windowNackThreshold,
-	)
+	), dest
 }
 
 // chunker splits a run of runLen homogeneous events (all acks, or all nacks)
@@ -205,14 +265,14 @@ func randomChunks(rng *rand.Rand) chunker {
 // It records, per original message, whether it was accepted (true) or
 // rejected (false), the same shape replayV1 returns, so the two can be
 // compared directly.
-func replayV2(t *testing.T, windowSize, windowNackThreshold int, events []bool, split chunker) []bool {
+func replayV2(t *testing.T, windowSize, windowNackThreshold int, events []bool, split chunker) ([]outcome, []string) {
 	t.Helper()
 	is := is.New(t)
 
-	dlq := newV2DLQ(t, windowSize, windowNackThreshold)
+	dlq, dest := newV2DLQ(t, windowSize, windowNackThreshold)
 	ctx := context.Background()
 
-	results := make([]bool, len(events))
+	results := make([]outcome, len(events))
 	i := 0
 	for i < len(events) {
 		nack := events[i]
@@ -233,7 +293,7 @@ func replayV2(t *testing.T, windowSize, windowNackThreshold int, events []bool, 
 			if !nack {
 				dlq.Ack(ctx, batch)
 				for k := 0; k < c; k++ {
-					results[pos+k] = true
+					results[pos+k] = outcome{accepted: true}
 				}
 			} else {
 				errs := make([]error, c)
@@ -243,23 +303,28 @@ func replayV2(t *testing.T, windowSize, windowNackThreshold int, events []bool, 
 				batch.Nack(0, errs...)
 
 				accepted, err := dlq.Nack(ctx, batch, "dlq-parity")
-				is.True(accepted >= 0 && accepted <= c)
-				if err != nil {
-					// accepted..c-1 were rejected by the window (or, if
-					// accepted==0 and threshold==0, all of them were -
-					// either way err must be non-nil for exactly the
-					// rejected tail.
-					is.True(accepted < c)
+
+				// The contract that actually constrains the caller: a partial
+				// acceptance MUST be reported as an error, because Worker.Nack
+				// acks exactly positions[:accepted] upstream and the rejected
+				// tail has to stop the pipeline rather than vanish. (The old
+				// assertions here - accepted in [0,c], and accepted < c when
+				// err != nil - were tautologies over dlqWindow.store's return
+				// domain and a stub that never fails.)
+				if accepted < c {
+					is.True(err != nil)
 				}
+
+				fatal := cerrors.IsFatalError(err)
 				for k := 0; k < c; k++ {
-					results[pos+k] = k < accepted
+					results[pos+k] = outcome{accepted: k < accepted, fatal: k >= accepted && fatal}
 				}
 			}
 			pos += c
 		}
 		i = j
 	}
-	return results
+	return results, dest.written
 }
 
 // -- differential assertions --------------------------------------------------
@@ -271,19 +336,52 @@ func assertParity(t *testing.T, windowSize, windowNackThreshold int, events []bo
 	t.Helper()
 	is := is.New(t)
 
-	v1 := replayV1(t, windowSize, windowNackThreshold, events)
-	v2 := replayV2(t, windowSize, windowNackThreshold, events, split)
+	v1, v1DLQ := replayV1(t, windowSize, windowNackThreshold, events)
+	v2, v2DLQ := replayV2(t, windowSize, windowNackThreshold, events, split)
 
 	is.Equal(len(v1), len(v2))
 	for i := range events {
 		if v1[i] != v2[i] {
 			t.Fatalf(
 				"DLQ v1/v2 parity DIVERGED at message %d (windowSize=%d windowNackThreshold=%d, nack=%v): "+
-					"v1 accepted=%v v2 accepted=%v\nfull v1=%v\nfull v2=%v",
+					"v1 %+v v2 %+v\nfull v1=%v\nfull v2=%v",
 				i, windowSize, windowNackThreshold, events[i], v1[i], v2[i], v1, v2,
 			)
 		}
 	}
+
+	// Agreeing on which nacks were ACCEPTED is not enough. An engine that
+	// accepts a nack and then writes the record nowhere satisfies every
+	// assertion above, and v2 would still ack that position upstream on the
+	// strength of the accepted count (Worker.Nack) - a silently lost record,
+	// invariant 3, with the gate green. Compare what each engine actually
+	// delivered.
+	//
+	// Sorted, not set-compared: a duplicate delivery is also a divergence
+	// worth failing on, and v1 delivers strictly one record per Nack call
+	// while v2 delivers a whole batch per call.
+	v1Sorted := slices.Clone(v1DLQ)
+	v2Sorted := slices.Clone(v2DLQ)
+	slices.Sort(v1Sorted)
+	slices.Sort(v2Sorted)
+	if !slices.Equal(v1Sorted, v2Sorted) {
+		t.Fatalf(
+			"DLQ v1/v2 DELIVERY DIVERGED (windowSize=%d windowNackThreshold=%d): "+
+				"the engines agreed on which nacks were accepted but not on which records reached the DLQ\n"+
+				"v1 delivered %d: %v\nv2 delivered %d: %v",
+			windowSize, windowNackThreshold, len(v1Sorted), v1Sorted, len(v2Sorted), v2Sorted,
+		)
+	}
+
+	// Guard the guard: if neither engine ever wrote to the DLQ, the comparison
+	// above is vacuously true. Any scenario with an accepted nack must deliver.
+	acceptedNacks := 0
+	for i, nack := range events {
+		if nack && v1[i].accepted {
+			acceptedNacks++
+		}
+	}
+	is.Equal(len(v1Sorted), acceptedNacks)
 }
 
 // scriptedEvents reproduces the exact scenario from

--- a/pkg/pipeline/golden_test.go
+++ b/pkg/pipeline/golden_test.go
@@ -1,0 +1,101 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Pre-flip gate for the arch-v2 default flip (v0.20). The persisted
+// pipeline.Instance blob (including pipeline.DLQ.WindowSize/
+// WindowNackThreshold, the exact config v1 and v2 feed into their DLQ
+// windows) is plain JSON with no version/schema tag anywhere, and
+// Store.decode never sets DisallowUnknownFields - so an older binary reading
+// a newer blob silently drops fields it doesn't recognize.
+//
+// TestGolden_PipelineInstance_RoundTrip checks in the actual JSON currently
+// persisted for a pipeline instance with DLQ window config and asserts HEAD
+// can parse it into a semantically identical Instance AND re-serialize it
+// back to an equivalent blob. If a future change drops or renames a field
+// (DLQ.WindowNackThreshold, for instance), the re-serialized blob loses a
+// key the checked-in golden still has, and the semantic JSON comparison
+// fails.
+package pipeline
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/database/inmemory"
+	"github.com/goccy/go-json"
+	"github.com/matryer/is"
+)
+
+func assertJSONSemanticallyEqual(t *testing.T, is *is.I, golden, got []byte) {
+	t.Helper()
+
+	var goldenMap, gotMap map[string]any
+	is.NoErr(json.Unmarshal(golden, &goldenMap))
+	is.NoErr(json.Unmarshal(got, &gotMap))
+
+	if !reflect.DeepEqual(goldenMap, gotMap) {
+		t.Fatalf(
+			"re-serialized instance is not semantically equal to the golden blob "+
+				"(a field was likely dropped or renamed):\ngolden: %s\ngot:    %s",
+			golden, got,
+		)
+	}
+}
+
+func TestGolden_PipelineInstance_RoundTrip(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	golden, err := os.ReadFile("testdata/golden_pipeline_instance.json")
+	is.NoErr(err)
+
+	db := &inmemory.DB{}
+	s := NewStore(db)
+	is.NoErr(db.Set(ctx, s.addKeyPrefix("golden-pipeline"), golden))
+
+	got, err := s.Get(ctx, "golden-pipeline")
+	is.NoErr(err)
+
+	ts := time.Date(2026, 6, 15, 9, 30, 0, 0, time.UTC)
+	want := &Instance{
+		ID: "golden-pipeline",
+		Config: Config{
+			Name:        "golden-pipeline-name",
+			Description: "golden pipeline for pre-flip format test",
+		},
+		Error:         "",
+		CreatedAt:     ts,
+		UpdatedAt:     ts.Add(time.Minute),
+		ProvisionedBy: ProvisionTypeConfig,
+		DLQ: DLQ{
+			Plugin:              "builtin:log",
+			Settings:            map[string]string{"level": "warn"},
+			WindowSize:          101,
+			WindowNackThreshold: 100,
+		},
+		ConnectorIDs: []string{"golden-source", "golden-destination"},
+		ProcessorIDs: []string{"golden-processor"},
+	}
+	want.SetStatus(StatusRunning)
+	is.Equal(want, got)
+
+	// The actual drop/rename detector: re-encode what HEAD decoded and
+	// compare against the golden blob itself.
+	reEncoded, err := s.encode(got)
+	is.NoErr(err)
+	assertJSONSemanticallyEqual(t, is, golden, reEncoded)
+}

--- a/pkg/pipeline/testdata/golden_pipeline_instance.json
+++ b/pkg/pipeline/testdata/golden_pipeline_instance.json
@@ -1,0 +1,22 @@
+{
+  "ID": "golden-pipeline",
+  "Config": {
+    "Name": "golden-pipeline-name",
+    "Description": "golden pipeline for pre-flip format test"
+  },
+  "Error": "",
+  "CreatedAt": "2026-06-15T09:30:00Z",
+  "UpdatedAt": "2026-06-15T09:31:00Z",
+  "ProvisionedBy": 1,
+  "DLQ": {
+    "Plugin": "builtin:log",
+    "Settings": {
+      "level": "warn"
+    },
+    "WindowSize": 101,
+    "WindowNackThreshold": 100
+  },
+  "ConnectorIDs": ["golden-source", "golden-destination"],
+  "ProcessorIDs": ["golden-processor"],
+  "Status": 1
+}

--- a/pkg/processor/golden_test.go
+++ b/pkg/processor/golden_test.go
@@ -1,0 +1,99 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Pre-flip gate for the arch-v2 default flip (v0.20). The persisted
+// processor.Instance blob is plain JSON with no version/schema tag anywhere,
+// and Store.decode never sets DisallowUnknownFields - so an older binary
+// reading a newer blob silently drops fields it doesn't recognize.
+//
+// TestGolden_ProcessorInstance_RoundTrip checks in the actual JSON currently
+// persisted for a processor instance and asserts HEAD can parse it into a
+// semantically identical Instance AND re-serialize it back to an equivalent
+// blob. If a future change drops or renames a field, the re-serialized blob
+// loses a key the checked-in golden still has, and the semantic JSON
+// comparison fails.
+//
+// This file is intentionally `package processor` (not processor_test, unlike
+// store_test.go) so it can reach Store.encode/addKeyPrefix directly to do
+// the round-trip; Go allows internal and external test files to coexist in
+// one directory.
+package processor
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/database/inmemory"
+	"github.com/goccy/go-json"
+	"github.com/matryer/is"
+)
+
+func assertJSONSemanticallyEqual(t *testing.T, is *is.I, golden, got []byte) {
+	t.Helper()
+
+	var goldenMap, gotMap map[string]any
+	is.NoErr(json.Unmarshal(golden, &goldenMap))
+	is.NoErr(json.Unmarshal(got, &gotMap))
+
+	if !reflect.DeepEqual(goldenMap, gotMap) {
+		t.Fatalf(
+			"re-serialized instance is not semantically equal to the golden blob "+
+				"(a field was likely dropped or renamed):\ngolden: %s\ngot:    %s",
+			golden, got,
+		)
+	}
+}
+
+func TestGolden_ProcessorInstance_RoundTrip(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	golden, err := os.ReadFile("testdata/golden_processor_instance.json")
+	is.NoErr(err)
+
+	db := &inmemory.DB{}
+	s := NewStore(db)
+	is.NoErr(db.Set(ctx, s.addKeyPrefix("golden-processor"), golden))
+
+	got, err := s.Get(ctx, "golden-processor")
+	is.NoErr(err)
+
+	ts := time.Date(2026, 6, 15, 9, 30, 0, 0, time.UTC)
+	want := &Instance{
+		ID:            "golden-processor",
+		CreatedAt:     ts,
+		UpdatedAt:     ts.Add(time.Minute),
+		ProvisionedBy: ProvisionTypeConfig,
+		Plugin:        "builtin:field.set",
+		Condition:     `{{ eq .Metadata["key"] "value" }}`,
+		Parent: Parent{
+			ID:   "golden-pipeline",
+			Type: ParentTypePipeline,
+		},
+		Config: Config{
+			Settings: map[string]string{"field": "value"},
+			Workers:  4,
+		},
+	}
+	is.Equal(want, got)
+
+	// The actual drop/rename detector: re-encode what HEAD decoded and
+	// compare against the golden blob itself.
+	reEncoded, err := s.encode(got)
+	is.NoErr(err)
+	assertJSONSemanticallyEqual(t, is, golden, reEncoded)
+}

--- a/pkg/processor/testdata/golden_processor_instance.json
+++ b/pkg/processor/testdata/golden_processor_instance.json
@@ -1,0 +1,18 @@
+{
+  "ID": "golden-processor",
+  "CreatedAt": "2026-06-15T09:30:00Z",
+  "UpdatedAt": "2026-06-15T09:31:00Z",
+  "ProvisionedBy": 1,
+  "Plugin": "builtin:field.set",
+  "Condition": "{{ eq .Metadata[\"key\"] \"value\" }}",
+  "Parent": {
+    "ID": "golden-pipeline",
+    "Type": 2
+  },
+  "Config": {
+    "Settings": {
+      "field": "value"
+    },
+    "Workers": 4
+  }
+}


### PR DESCRIPTION
## What

The two cheapest parts of the upgrade/downgrade gap, both required green **before** arch-v2 flips to default in v0.20. Milliseconds to seconds — no docker, no release binaries — so they gate every PR rather than only releases.

## Gate 1 — golden-blob format test

**The problem it closes.** The persisted state blob is plain JSON with **no version or schema tag**, and nothing sets `DisallowUnknownFields`, so an older binary reading a newer blob **silently drops** unknown fields. Worse, `PrepareSet` copies into an explicit whitelist struct rather than marshalling the instance — any future field is silently un-persisted unless someone remembers to add it there.

**A downgrade test that only asserts "the old binary starts and resumes" cannot fail on that.** It is vacuous for exactly the failure it exists to catch. These goldens are what make the downgrade claim real.

Covers a source instance with `SourceState`, a destination with its positions map, a pipeline with DLQ window config, and a processor. Each asserts HEAD parses the checked-in blob to a semantically identical struct **and re-serializes equivalently**.

Plus `TestStore_PrepareSet_WhitelistCoversAllFields`, which uses reflection to populate every exported field with a distinct value — so it does **not** need hand-updating when a field is added; only `PrepareSet` does, which is the actual trap.

### Mutation evidence (4 independent, each reverted)
| Mutation | Result |
| --- | --- |
| Drop `Plugin` from `PrepareSet`'s whitelist | whitelist test red, diff shows `"Plugin":""` vs `"Plugin":"val-g6"` |
| Strip `Plugin` in connector `encode` | both connector golden tests red |
| Strip `DLQ.WindowNackThreshold` in pipeline `encode` | pipeline golden red — the exact field Gate 2 depends on |
| Strip `Condition` in processor `encode` | processor golden red |

## Gate 2 — DLQ window v1-vs-v2 differential

**The problem.** `WindowSize`/`WindowNackThreshold` are **persisted config**. v1 feeds them to `stream.DLQHandlerNode` which counts per **message**; v2 feeds the same values to `funnel.DLQ` which counts per **batch** (`d.window.Ack/Nack(len(batch.records))`). Equivalence was asserted by construction with no test. If it were off, a pipeline that tolerated its error rate on v0.19 would either start hard-failing after upgrade or start DLQ-ing records v1 would have halted on — invariant-3-adjacent, triggered purely by upgrade, and invisible to any format check.

**Result: equivalent.** Verified across the 5 scripted edge cases ported from the existing v1 window tests, the `WindowSize=0` sentinel, and 30 randomized configs × 300 events with **randomly sub-chunked batch splits** — the real risk, since v2's `store()` loop is equivalent to N sequential single-item calls only while batches are homogeneous (which matches how `worker.go` actually calls it).

Proved non-vacuous: an off-by-one in v2's threshold check produced an immediate divergence report (`message 37 ... v1 accepted=false v2 accepted=true`), then reverted.

## Honest scope
Closes the two cheapest slivers only. Does **not** touch binary-to-binary upgrade, the docker matrix, or whether an old binary can parse a genuinely newer schema — those need two real binaries and land as the release gate. The DLQ differential drives the real `DLQHandlerNode`/`DLQ` types with stub I/O; it does not exercise concurrent multi-worker ack/nack interleaving, which is a separate concern from the batching-vs-per-message equivalence it targets.

## Verification
`go build ./...` clean · `-race` green on all four packages · `golangci-lint` 0 issues on touched packages · total runtime ~1-3s.