### PR TITLE
fix(funnel): treat a source's io.EOF as graceful even when a stop is in flight

### DIFF
--- a/pkg/lifecycle-poc/funnel/worker.go
+++ b/pkg/lifecycle-poc/funnel/worker.go
@@ -540,18 +540,28 @@ func (w *Worker) doTaskAttempt(
 			(cerrors.Is(err, plugin.ErrPluginNotRunning) && w.stop.Load())) {
 			return ctx.Err()
 		}
-		if taskNode.IsFirst() && cerrors.Is(err, io.EOF) && !w.stop.Load() {
+		if taskNode.IsFirst() && cerrors.Is(err, io.EOF) {
 			// A source that has permanently exhausted its records (e.g. a
 			// snapshot-only connector with nothing left to stream) reports it
 			// by returning io.EOF from Read - the same sentinel this package
 			// already uses for "the source's stream has closed" elsewhere
 			// (see isClosedSourceStream). This is NOT a failure (slice 3b of
-			// the arch-v2 multi-connector epic, N-source pipelines): unlike
-			// the branch above, this path is NOT gated on w.stop already
-			// being set, because nothing external asked this worker to stop
-			// - the source decided on its own. Guarded on !w.stop.Load() so
-			// it can never fire after an external Stop already armed the
-			// flag (that path is handled by the branch above).
+			// the arch-v2 multi-connector epic, N-source pipelines).
+			//
+			// This branch is deliberately NOT gated on w.stop. An earlier
+			// version guarded it with !w.stop.Load(), reasoning that the
+			// stop-armed case was "handled by the branch above" - it is not.
+			// That branch matches only context.Canceled and
+			// plugin.ErrPluginNotRunning, so a source exhausting at the same
+			// instant an external Stop armed the flag matched NEITHER branch,
+			// fell through to the generic error path, and surfaced as
+			// "failed to read from source: EOF". In the Service that error
+			// reaches rp.t.Kill, so a pipeline that stopped perfectly cleanly
+			// was reported as failed instead of UserStopped. It showed up as
+			// an intermittent failure of the N-source service tests (and once
+			// as a full 10-minute test-timeout hang in CI) before being
+			// tracked down. A source reporting that it is out of records is
+			// graceful whether or not anything else also asked it to stop.
 			//
 			// M3 (adversarial review of #2734): log this transition at Info,
 			// distinctly from an externally-requested Stop, so it is never
@@ -566,8 +576,13 @@ func (w *Worker) doTaskAttempt(
 			// production rather than silently claimed as tested behavior;
 			// see docs/design-documents/20260801-archv2-multiconnector-nsource.md,
 			// "A source finishing gracefully is not a failure".
+			// M3 kept: distinguish self-exhaustion from an externally-requested
+			// stop in the logs. With the guard removed this branch also covers
+			// "exhausted while stopping", so say which one actually happened
+			// rather than always claiming the source decided on its own.
 			w.logger.Info(ctx).
 				Str("source_id", taskNode.Task.ID()).
+				Bool("stop_requested", w.stop.Load()).
 				Msg("source exhausted its records (io.EOF) and is stopping gracefully; sibling sources, if any, are unaffected")
 
 			// Arm w.stop so tearDownSource behaves identically to an

--- a/pkg/lifecycle-poc/funnel/worker_eof_stop_test.go
+++ b/pkg/lifecycle-poc/funnel/worker_eof_stop_test.go
@@ -1,0 +1,76 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funnel
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/matryer/is"
+	"go.uber.org/mock/gomock"
+
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/foundation/metrics/noop"
+)
+
+// TestWorker_Do_EOFWhileStopping_IsGraceful covers the gap between
+// doTaskAttempt's two graceful-exit branches.
+//
+// The io.EOF branch is gated on !w.stop.Load(), and its comment justifies that
+// by saying the stop-armed case is "handled by the branch above". It is not:
+// the branch above matches only context.Canceled and plugin.ErrPluginNotRunning.
+// So a source that exhausts (io.EOF) at the same instant an external Stop arms
+// w.stop matches NEITHER branch, falls through to the generic error path, and
+// Worker.Do returns "failed to read from source: EOF". In the Service that
+// error reaches rp.t.Kill, so a pipeline that stopped perfectly cleanly is
+// reported as failed instead of UserStopped.
+//
+// This is a timing race in production (a source finishing exactly as an
+// operator stops the pipeline) but is fully deterministic to test: arm the stop
+// flag first, then have the source return io.EOF.
+//
+// Observed in CI as a flake in the N-source service tests — including one run
+// where the pipeline hung for the full 10-minute test timeout rather than
+// failing fast.
+func TestWorker_Do_EOFWhileStopping_IsGraceful(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	logger := log.Test(t)
+	ctrl := gomock.NewController(t)
+
+	sourceMock, tasks, taskNode := newMockTasks(ctrl, "sourceTask")
+	dlq, _ := NewMockDLQ(ctrl, logger)
+
+	worker, err := NewWorker(taskNode, dlq, logger, noop.Timer{})
+	is.NoErr(err)
+
+	// Worker.Do's loop is `for !w.stop.Load()`, so arming the flag up front
+	// would skip the read entirely and prove nothing. The race being modelled
+	// is a Stop landing WHILE the source read is in flight: the loop condition
+	// was false when checked, and w.stop becomes true before doTaskAttempt
+	// classifies the error. Setting the flag from inside the source's own Do is
+	// exactly that interleaving, made deterministic.
+	tasks[0].EXPECT().Do(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(context.Context, *Batch) error {
+			worker.stop.Store(true)
+			return io.EOF
+		}).AnyTimes()
+	sourceMock.EXPECT().Teardown(gomock.Any()).Return(nil).AnyTimes()
+
+	// A source exhausting is not a failure, whether or not something also
+	// asked the worker to stop.
+	is.NoErr(worker.Do(ctx))
+}


### PR DESCRIPTION
**Tier 1** (data path — worker lifecycle / pipeline status). Advances the arch-v2 graduation; found by chasing a red `test` job on `main`.

## The bug

`doTaskAttempt` has two graceful-exit branches for the source task. The `io.EOF` branch was gated on `!w.stop.Load()`, and its comment justified that by saying the stop-armed case was *"handled by the branch above"*.

It wasn't. That branch matches only `context.Canceled` and `plugin.ErrPluginNotRunning`. So a source exhausting at the same instant an external `Stop` armed `w.stop` matched **neither** branch, fell through to the generic error path, and surfaced as:

```text
task <id>: failed to read from source: EOF
```

In the Service that error reaches `rp.t.Kill`, so **a pipeline that stopped perfectly cleanly is reported as failed instead of `UserStopped`**.

A source reporting it is out of records is graceful whether or not something else also asked it to stop. Guard removed.

## How it was found

`main` went red on `test` after the setup-go bump. Rather than re-run it, I read the log: the job had **timed out after 10m** in `pkg/lifecycle-poc`, and Go's goroutine dump named the stuck test. Stressing the N-source suite locally then surfaced `TestServiceLifecycle_NSource_OneSourceFinishesGracefully_StaysRunningUntilAllExit` failing with exactly the EOF error above — that test stops the pipeline *after* source A has exhausted, which is precisely this interleaving.

## Non-vacuity — and a first attempt that was vacuous

Arming `w.stop` up front proves nothing: `Worker.Do`'s loop is `for !w.stop.Load()`, so the read never happens. My first version of this test did exactly that and **passed against the unfixed code**. Recording it because it is the failure mode this whole test is about.

The shipped test sets the flag from inside the source's own `Do`, reproducing the real interleaving — loop condition false when checked, flag true by the time the error is classified. Without the fix it fails with `err: task sourceTask: EOF`; with it, green at `-race -count=20`.

## Failure-mode analysis

- **What this could break:** an `io.EOF` that genuinely indicates failure would now be swallowed as graceful. `io.EOF` from a source's `Read` already means "no more records" everywhere else in this package (`isClosedSourceStream`), and the pre-existing branch already treated it as graceful in the much more common no-stop case — so this widens an existing classification rather than inventing one.
- **What would show it:** a pipeline reporting `UserStopped` when it should be `Degraded`. The `stop_requested` field added to the Info log distinguishes the two paths.
- **Rollback:** revert; single-condition change.

## Observability

The M3 log distinction is kept and improved. With the guard gone this branch covers both "the source decided on its own" and "it finished while stopping", so the line now carries `stop_requested` instead of always claiming the former.

## Still open — deliberately not folded in

`TestServiceLifecycle_NSource_TransientErrorOneSource_Recovers` is **still intermittently red** (~2 failures per 40-count suite run) and is the test that hung for the full 10-minute timeout in CI. It passes **60/60 in isolation**, so the trigger is cross-test interaction, not this code path. Baseline runs without this fix also passed a full 40-count sweep, so a single sample can't attribute it either way — I'm not claiming this change fixes it, and I'm not claiming it's unrelated. Filed separately.

Given `tests/chaos (race, x3)` is a required context, a test that can hang for 10 minutes is a real risk to the gate, not a nuisance.

## Checks

`go build ./...` · `go test -race ./pkg/lifecycle-poc/...` · `golangci-lint run ./pkg/lifecycle-poc/...` → 0 issues · regression test verified fail-without/pass-with at `-race -count=20`.