### PR TITLE
fix: use embedded metrics gatherer

### DIFF
--- a/conduit.go
+++ b/conduit.go
@@ -61,7 +61,9 @@ type Options struct {
 	// *object*, but pkg/foundation/metrics' process-global metric
 	// definitions still fan values out across every registry in the process.
 	// When API is enabled, a registerer that does not also implement Gatherer
-	// requires MetricsGatherer or the first Run or Import returns an error.
+	// cannot back /metrics. Conduit warns and keeps serving the default
+	// Prometheus registry for this release; the next minor turns that into an
+	// error (issue #2800). Set MetricsGatherer to fix it — see that field.
 	MetricsRegisterer promclient.Registerer
 
 	// MetricsGatherer is served by the embedded HTTP API's /metrics endpoint.
@@ -386,14 +388,18 @@ func New(_ context.Context, opts Options) (*Engine, error) {
 		return nil, cerrors.Errorf("invalid config: %w", err)
 	}
 
-	// Fail fast on a metrics pairing that cannot work, using the SAME rule
-	// NewRuntime applies later (pkgconduit.ResolveMetricsGatherer). This check
-	// needs no I/O, so deferring it to the first Run or Import would only mean
-	// the caller wires up an Engine, starts a pipeline, and learns about a
-	// typo'd option then — for the same reason cfg.Validate() runs here rather
-	// than at open time.
-	if _, err := pkgconduit.ResolveMetricsGatherer(opts.MetricsRegisterer, opts.MetricsGatherer, cfg.API.Enabled); err != nil {
+	// Apply the SAME metrics rule NewRuntime applies later
+	// (pkgconduit.ResolveMetricsGatherer), here where the options are already
+	// known and no I/O is needed — for the same reason cfg.Validate() runs here
+	// rather than at open time. A rejected pairing fails New; a degraded one
+	// warns now rather than at first Run, so the operator sees it while they
+	// are still looking at their own wiring code.
+	metricsResolution, err := pkgconduit.ResolveMetricsGatherer(opts.MetricsRegisterer, opts.MetricsGatherer, cfg.API.Enabled)
+	if err != nil {
 		return nil, err
+	}
+	if metricsResolution.Degraded {
+		logger.Warn(pkgconduit.MetricsDegradedWarning)
 	}
 
 	runtimeOpts := []pkgconduit.RuntimeOption{

--- a/conduit.go
+++ b/conduit.go
@@ -60,12 +60,14 @@ type Options struct {
 	// section — two Engines each get an isolated Registerer/Registry
 	// *object*, but pkg/foundation/metrics' process-global metric
 	// definitions still fan values out across every registry in the process.
+	// When API is enabled, a registerer that does not also implement Gatherer
+	// requires MetricsGatherer or the first Run or Import returns an error.
 	MetricsRegisterer promclient.Registerer
 
 	// MetricsGatherer is served by the embedded HTTP API's /metrics endpoint.
 	// Set it when MetricsRegisterer does not also implement Gatherer, such as
 	// when using WrapRegistererWithPrefix or WrapRegistererWith. It must gather
-	// the metrics registered through MetricsRegisterer.
+	// the metrics registered through MetricsRegisterer and cannot be set alone.
 	MetricsGatherer promclient.Gatherer
 
 	// DB configures the embedded storage backend. The zero value (Type =="")

--- a/conduit.go
+++ b/conduit.go
@@ -68,6 +68,15 @@ type Options struct {
 	// Set it when MetricsRegisterer does not also implement Gatherer, such as
 	// when using WrapRegistererWithPrefix or WrapRegistererWith. It must gather
 	// the metrics registered through MetricsRegisterer and cannot be set alone.
+	//
+	// Security: Conduit's HTTP API is unauthenticated (see API.HTTP's CORS
+	// documentation for what that already implies). Everything this gatherer
+	// exposes is therefore readable by anyone who can reach the API address —
+	// including metrics the host application registered for its own purposes,
+	// and every label on them. If that registry carries tenant identifiers,
+	// customer names, internal hostnames, or anything else you would not
+	// publish, bind the API to loopback, front it with an authenticating
+	// proxy, or pass a registry that holds only what you are happy to serve.
 	MetricsGatherer promclient.Gatherer
 
 	// DB configures the embedded storage backend. The zero value (Type =="")
@@ -375,6 +384,16 @@ func New(_ context.Context, opts Options) (*Engine, error) {
 	// database — cfg.Validate() does no I/O of its own.
 	if err := cfg.Validate(); err != nil {
 		return nil, cerrors.Errorf("invalid config: %w", err)
+	}
+
+	// Fail fast on a metrics pairing that cannot work, using the SAME rule
+	// NewRuntime applies later (pkgconduit.ResolveMetricsGatherer). This check
+	// needs no I/O, so deferring it to the first Run or Import would only mean
+	// the caller wires up an Engine, starts a pipeline, and learns about a
+	// typo'd option then — for the same reason cfg.Validate() runs here rather
+	// than at open time.
+	if _, err := pkgconduit.ResolveMetricsGatherer(opts.MetricsRegisterer, opts.MetricsGatherer, cfg.API.Enabled); err != nil {
+		return nil, err
 	}
 
 	runtimeOpts := []pkgconduit.RuntimeOption{

--- a/conduit.go
+++ b/conduit.go
@@ -62,6 +62,12 @@ type Options struct {
 	// definitions still fan values out across every registry in the process.
 	MetricsRegisterer promclient.Registerer
 
+	// MetricsGatherer is served by the embedded HTTP API's /metrics endpoint.
+	// Set it when MetricsRegisterer does not also implement Gatherer, such as
+	// when using WrapRegistererWithPrefix or WrapRegistererWith. It must gather
+	// the metrics registered through MetricsRegisterer.
+	MetricsGatherer promclient.Gatherer
+
 	// DB configures the embedded storage backend. The zero value (Type =="")
 	// defaults to an in-memory store — convenient for examples and tests, but
 	// every pipeline configuration is lost once the Engine stops. A
@@ -374,6 +380,9 @@ func New(_ context.Context, opts Options) (*Engine, error) {
 	}
 	if opts.MetricsRegisterer != nil {
 		runtimeOpts = append(runtimeOpts, pkgconduit.WithMetricsRegisterer(opts.MetricsRegisterer))
+	}
+	if opts.MetricsGatherer != nil {
+		runtimeOpts = append(runtimeOpts, pkgconduit.WithMetricsGatherer(opts.MetricsGatherer))
 	}
 
 	return &Engine{

--- a/conduit_test.go
+++ b/conduit_test.go
@@ -658,14 +658,15 @@ func TestRun_MalformedPipelinesDir_ReturnsError(t *testing.T) {
 	is.Equal(ce.Code, conduiterr.CodeInvalidArgument)
 }
 
-// TestNew_WrappedRegistererWithoutGatherer_FailsFast proves the metrics
-// pairing is validated at construction, not on the first Run or Import.
+// TestNew_WrappedRegistererWithoutGatherer_Degrades proves the pairing rule is
+// applied at construction — but as a WARNING, not a refusal.
 //
-// New already validates config in-memory for exactly this reason, and this
-// check is a type assertion — no I/O. Deferring it would mean an embedder
-// wires up an Engine, starts a pipeline, and only then discovers their
-// registerer cannot back the /metrics endpoint.
-func TestNew_WrappedRegistererWithoutGatherer_FailsFast(t *testing.T) {
+// Such a configuration started in earlier releases. Turning it into a startup
+// failure would kill an operator's application on upgrade over a scrape target
+// that is wrong but harmless, which inverts the cost; the deprecation policy
+// (announce, warn, remove) exists for exactly this. The next minor makes it an
+// error.
+func TestNew_WrappedRegistererWithoutGatherer_Degrades(t *testing.T) {
 	is := is.New(t)
 	registry := promclient.NewRegistry()
 	wrapped := promclient.WrapRegistererWithPrefix("myapp_", registry)
@@ -680,6 +681,22 @@ func TestNew_WrappedRegistererWithoutGatherer_FailsFast(t *testing.T) {
 	opts.API.HTTPAddress = "127.0.0.1:0"
 
 	e, err := conduit.New(context.Background(), opts)
+
+	is.NoErr(err)
+	is.True(e != nil)
+}
+
+// TestNew_GathererWithoutRegisterer_FailsFast: this pairing IS rejected,
+// because MetricsGatherer is new API — there is no existing configuration to
+// break — and a gatherer with nothing registering into it cannot work.
+func TestNew_GathererWithoutRegisterer_FailsFast(t *testing.T) {
+	is := is.New(t)
+
+	e, err := conduit.New(context.Background(), conduit.Options{
+		PipelinesDir:    t.TempDir(),
+		DB:              conduit.DBOptions{Type: "inmemory"},
+		MetricsGatherer: promclient.NewRegistry(),
+	})
 
 	is.True(err != nil)
 	is.True(e == nil)

--- a/conduit_test.go
+++ b/conduit_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -655,4 +656,61 @@ func TestRun_MalformedPipelinesDir_ReturnsError(t *testing.T) {
 	ce, ok := conduiterr.Get(err)
 	is.True(ok)
 	is.Equal(ce.Code, conduiterr.CodeInvalidArgument)
+}
+
+// TestNew_WrappedRegistererWithoutGatherer_FailsFast proves the metrics
+// pairing is validated at construction, not on the first Run or Import.
+//
+// New already validates config in-memory for exactly this reason, and this
+// check is a type assertion — no I/O. Deferring it would mean an embedder
+// wires up an Engine, starts a pipeline, and only then discovers their
+// registerer cannot back the /metrics endpoint.
+func TestNew_WrappedRegistererWithoutGatherer_FailsFast(t *testing.T) {
+	is := is.New(t)
+	registry := promclient.NewRegistry()
+	wrapped := promclient.WrapRegistererWithPrefix("myapp_", registry)
+
+	opts := conduit.Options{
+		PipelinesDir:      t.TempDir(),
+		DB:                conduit.DBOptions{Type: "inmemory"},
+		MetricsRegisterer: wrapped,
+	}
+	opts.API.Enabled = true
+	opts.API.GRPCAddress = "127.0.0.1:0"
+	opts.API.HTTPAddress = "127.0.0.1:0"
+
+	e, err := conduit.New(context.Background(), opts)
+
+	is.True(err != nil)
+	is.True(e == nil)
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code, conduiterr.CodeInvalidArgument)
+	// The fix has to name a knob this caller can actually reach: an embedder
+	// sees conduit.Options, never pkg/conduit's WithMetricsGatherer.
+	is.True(strings.Contains(ce.Suggestion, "MetricsGatherer"))
+}
+
+// TestNew_PairedRegistererAndGatherer_Succeeds is the other half: the
+// documented migration (pass the underlying registry alongside the wrapper)
+// constructs cleanly.
+func TestNew_PairedRegistererAndGatherer_Succeeds(t *testing.T) {
+	is := is.New(t)
+	registry := promclient.NewRegistry()
+	wrapped := promclient.WrapRegistererWithPrefix("myapp_", registry)
+
+	opts := conduit.Options{
+		PipelinesDir:      t.TempDir(),
+		DB:                conduit.DBOptions{Type: "inmemory"},
+		MetricsRegisterer: wrapped,
+		MetricsGatherer:   registry,
+	}
+	opts.API.Enabled = true
+	opts.API.GRPCAddress = "127.0.0.1:0"
+	opts.API.HTTPAddress = "127.0.0.1:0"
+
+	e, err := conduit.New(context.Background(), opts)
+	is.NoErr(err)
+	is.True(e != nil)
 }

--- a/doc.go
+++ b/doc.go
@@ -99,16 +99,11 @@
 // as a follow-up; see pkg/conduit.WithMetricsRegisterer's doc and
 // TestTwoEngines_MetricsCrossTalk_KnownLimitation.
 //
-// Two sharper instances of the same root cause are tracked separately, also
-// accepted for v1: a failed metrics registration during ensureRuntime (first
-// Run or Import, not New — see this package's lazy-open fast-follow above)
-// still leaks a registry into pkg/foundation/metrics' process-global
-// bookkeeping
+// A failed metrics registration during ensureRuntime (first Run or Import,
+// not New — see this package's lazy-open fast-follow above) still leaks a
+// registry into pkg/foundation/metrics' process-global bookkeeping
 // (https://github.com/ConduitIO/conduit/issues/2669, see
-// pkg/conduit.configureEmbeddedMetrics' doc), and the HTTP /metrics route
-// serves promclient.DefaultGatherer rather than a host-supplied
-// MetricsRegisterer (https://github.com/ConduitIO/conduit/issues/2670, see
-// pkg/conduit.(*Runtime).newHTTPMetricsHandler's doc).
+// pkg/conduit.configureEmbeddedMetrics' doc).
 //
 // # Package boundary / deprecation policy
 //

--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -164,6 +164,7 @@ func (r *Runtime) CloseDB() error {
 type runtimeOptions struct {
 	logger            *log.CtxLogger
 	metricsRegisterer promclient.Registerer
+	metricsGatherer   promclient.Gatherer
 	dialCtx           context.Context
 }
 
@@ -193,6 +194,10 @@ func WithLogger(logger log.CtxLogger) RuntimeOption {
 // registered only into the supplied registerer — never
 // promclient.DefaultRegisterer. `conduit run` never passes this option.
 //
+// If reg also implements Gatherer and WithMetricsGatherer is not supplied,
+// the embedded /metrics endpoint serves reg's full contents, including metrics
+// registered by the host application.
+//
 // Known limitation (documented, not fixed by this seam): pkg/foundation/metrics
 // keeps process-global metric *definitions* (metrics.go's `global` slices) —
 // a metric created via metrics.NewCounter et al. (e.g. everything in
@@ -205,6 +210,13 @@ func WithLogger(logger log.CtxLogger) RuntimeOption {
 // Non-goals).
 func WithMetricsRegisterer(reg promclient.Registerer) RuntimeOption {
 	return func(o *runtimeOptions) { o.metricsRegisterer = reg }
+}
+
+// WithMetricsGatherer supplies the gatherer used by the embedded Runtime's
+// /metrics endpoint. It must expose the metrics registered through the value
+// passed to WithMetricsRegisterer.
+func WithMetricsGatherer(gatherer promclient.Gatherer) RuntimeOption {
+	return func(o *runtimeOptions) { o.metricsGatherer = gatherer }
 }
 
 // WithDialContext supplies the context.Context OpenStore's Postgres/SQLite
@@ -251,6 +263,17 @@ func NewRuntime(cfg Config, opts ...RuntimeOption) (*Runtime, error) {
 		opt(&ro)
 	}
 
+	metricsGatherer := ro.metricsGatherer
+	if ro.metricsRegisterer == nil && metricsGatherer != nil {
+		return nil, conduiterr.New(conduiterr.CodeInvalidArgument, "metrics gatherer requires a metrics registerer")
+	}
+	if ro.metricsRegisterer != nil && metricsGatherer == nil {
+		metricsGatherer, _ = ro.metricsRegisterer.(promclient.Gatherer)
+		if metricsGatherer == nil && cfg.API.Enabled {
+			return nil, conduiterr.New(conduiterr.CodeInvalidArgument,
+				"metrics registerer does not implement Gatherer; provide WithMetricsGatherer")
+		}
+	}
 	var logger log.CtxLogger
 	if ro.logger != nil {
 		// Embed path (AC-5.1): use the pre-built logger as-is instead of
@@ -281,15 +304,15 @@ func NewRuntime(cfg Config, opts ...RuntimeOption) (*Runtime, error) {
 	}
 
 	var statsHandler *promgrpc.StatsHandler
-	metricsGatherer := promclient.DefaultGatherer
 	if ro.metricsRegisterer != nil {
 		// Embed path (AC-5.2): isolated per-Runtime metrics, never the
 		// process-global promclient.DefaultRegisterer.
-		statsHandler, metricsGatherer, err = configureEmbeddedMetrics(ro.metricsRegisterer)
+		statsHandler, err = configureEmbeddedMetrics(ro.metricsRegisterer)
 		if err != nil {
 			return nil, err
 		}
 	} else {
+		metricsGatherer = promclient.DefaultGatherer
 		statsHandler = configureMetrics()
 	}
 	measure.ConduitInfo.WithValues(Version(true)).Inc()
@@ -561,34 +584,21 @@ func configureMetrics() *promgrpc.StatsHandler {
 // succeed, so a failed Register (e.g. the name collision this function
 // itself guards against) still leaks reg into pkg/foundation/metrics'
 // process-global bookkeeping — it is never unregistered on this error path.
-func configureEmbeddedMetrics(registerer promclient.Registerer) (*promgrpc.StatsHandler, promclient.Gatherer, error) {
+func configureEmbeddedMetrics(registerer promclient.Registerer) (*promgrpc.StatsHandler, error) {
 	reg := prometheus.NewRegistry(nil)
 	metrics.Register(reg) // documented cross-talk limitation, see WithMetricsRegisterer's doc; leak-on-failure tracked as issue #2669
 	if err := registerer.Register(reg); err != nil {
 		wrapped := cerrors.Errorf("failed to register conduit metrics collector: %w", err)
-		return nil, nil, conduiterr.Wrap(conduiterr.CodeInvalidArgument, wrapped.Error(), wrapped)
+		return nil, conduiterr.Wrap(conduiterr.CodeInvalidArgument, wrapped.Error(), wrapped)
 	}
 
 	statsHandler := promgrpc.ServerStatsHandler()
 	if err := registerer.Register(statsHandler); err != nil {
 		wrapped := cerrors.Errorf("failed to register grpc stats collector: %w", err)
-		return nil, nil, conduiterr.Wrap(conduiterr.CodeInvalidArgument, wrapped.Error(), wrapped)
+		return nil, conduiterr.Wrap(conduiterr.CodeInvalidArgument, wrapped.Error(), wrapped)
 	}
 
-	if gatherer, ok := registerer.(promclient.Gatherer); ok {
-		return statsHandler, gatherer, nil
-	}
-
-	gatherer := promclient.NewRegistry()
-	if err := gatherer.Register(reg); err != nil {
-		wrapped := cerrors.Errorf("failed to register conduit metrics in HTTP gatherer: %w", err)
-		return nil, nil, conduiterr.Wrap(conduiterr.CodeInternal, wrapped.Error(), wrapped)
-	}
-	if err := gatherer.Register(statsHandler); err != nil {
-		wrapped := cerrors.Errorf("failed to register grpc stats in HTTP gatherer: %w", err)
-		return nil, nil, conduiterr.Wrap(conduiterr.CodeInternal, wrapped.Error(), wrapped)
-	}
-	return statsHandler, gatherer, nil
+	return statsHandler, nil
 }
 
 // Run initializes all of Conduit's underlying services and starts the GRPC and

--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -198,8 +198,14 @@ func WithLogger(logger log.CtxLogger) RuntimeOption {
 //
 // If reg also implements Gatherer and WithMetricsGatherer is not supplied,
 // the embedded /metrics endpoint serves reg's full contents, including metrics
-// registered by the host application. When the API is enabled, a reg that
-// does not implement Gatherer requires WithMetricsGatherer.
+// registered by the host application.
+//
+// A reg that does NOT implement Gatherer (prometheus.WrapRegistererWithPrefix
+// and friends return one of these) cannot back /metrics. With the API enabled,
+// Conduit logs MetricsDegradedWarning and keeps serving the process-global
+// default registry — the pre-existing, wrong-but-harmless behavior — for this
+// release. The next minor makes it an error (issue #2800). Supply WithMetricsGatherer with
+// the underlying registry to fix it.
 //
 // Known limitation (documented, not fixed by this seam): pkg/foundation/metrics
 // keeps process-global metric *definitions* (metrics.go's `global` slices) —
@@ -222,58 +228,93 @@ func WithMetricsGatherer(gatherer promclient.Gatherer) RuntimeOption {
 	return func(o *runtimeOptions) { o.metricsGatherer = gatherer }
 }
 
-// ResolveMetricsGatherer decides which Gatherer the /metrics endpoint serves,
-// and rejects the combinations that cannot work.
+// MetricsResolution is what ResolveMetricsGatherer decided.
+type MetricsResolution struct {
+	// Gatherer is what /metrics serves. Never nil once a registerer was
+	// supplied.
+	Gatherer promclient.Gatherer
+
+	// Degraded reports that Gatherer is NOT backed by the supplied registerer:
+	// the registerer does not implement prometheus.Gatherer, so /metrics falls
+	// back to the process-global default and shows metrics unrelated to what
+	// this Runtime registered. The caller is expected to warn — loudly — since
+	// nothing else about the process looks wrong.
+	Degraded bool
+}
+
+// ResolveMetricsGatherer decides which Gatherer the /metrics endpoint serves.
 //
 // It is exported so the embed package (github.com/conduitio/conduit) can apply
 // the SAME rule inside New — where the options are already known and no I/O is
 // needed — instead of letting a caller discover a bad pairing on their first
 // Run or Import. Two copies of this rule would eventually disagree, and the
-// symptom would be an Engine that constructs cleanly and then refuses to run.
+// symptom would be an Engine that behaves differently depending on which entry
+// point constructed it.
 //
 // The rules, in order:
-//   - a gatherer with no registerer is rejected: there would be nothing
-//     registering into what it gathers;
+//   - a gatherer with no registerer is REJECTED. MetricsGatherer is new API, so
+//     there is no existing configuration to break, and the pairing is
+//     nonsensical: nothing would be registering into what it gathers.
+//   - an explicit gatherer is used as given.
 //   - a registerer that also implements Gatherer is used as its own gatherer,
 //     so the endpoint serves everything registered into it, host metrics
-//     included;
+//     included.
 //   - a registerer that does NOT implement Gatherer (prometheus.WrapRegisterer*
-//     returns one of these) needs an explicit gatherer whenever the API is
-//     enabled, because otherwise /metrics would serve unrelated default
-//     metrics — the bug this seam exists to fix;
-//   - with the API disabled there is no /metrics route to be wrong, so the
-//     default gatherer is kept as an inert placeholder.
-func ResolveMetricsGatherer(reg promclient.Registerer, gatherer promclient.Gatherer, apiEnabled bool) (promclient.Gatherer, error) {
+//     returns one of these) is DEGRADED, not rejected: /metrics keeps serving
+//     the default gatherer, exactly as it did before this seam existed, and the
+//     caller warns.
+//
+// # Why the degraded case warns instead of failing
+//
+// Rejecting it outright was the original behavior of this change and is the
+// more obviously correct-looking option: the endpoint is demonstrably serving
+// the wrong metrics, and refusing to start says so. It was rejected anyway.
+//
+// Such a configuration STARTED in previous releases. Turning it into a startup
+// failure means an operator who upgrades Conduit finds their application dead
+// on boot, over a scrape target that is wrong but harmless — nothing about it
+// risks data. Killing a running system to correct an observability defect
+// inverts the cost. The project's deprecation policy (announce, then warn, then
+// remove, over at least two minor versions) exists for precisely this, and a
+// wrong /metrics payload is exactly the kind of defect it was written to pace.
+//
+// The warning is therefore load-bearing, not decorative: it is the entire
+// mitigation for one release. It must name the fix, and it must be impossible
+// to miss in a log. The next minor turns this into an error (tracked in issue
+// #2800); the godoc on
+// WithMetricsRegisterer and conduit.Options.MetricsGatherer both say so.
+func ResolveMetricsGatherer(reg promclient.Registerer, gatherer promclient.Gatherer, apiEnabled bool) (MetricsResolution, error) {
 	if reg == nil {
 		if gatherer != nil {
 			e := conduiterr.New(conduiterr.CodeInvalidArgument,
 				"a metrics gatherer was supplied without a metrics registerer")
 			e.Suggestion = "set both: conduit.Options{MetricsRegisterer: reg, MetricsGatherer: gatherer} " +
 				"(pkg/conduit: WithMetricsRegisterer + WithMetricsGatherer)"
-			return nil, e
+			return MetricsResolution{}, e
 		}
-		return nil, nil //nolint:nilnil // no registerer means the caller gets the CLI defaults, decided by NewRuntime
+		// No registerer: the caller gets the CLI defaults, decided by NewRuntime.
+		return MetricsResolution{}, nil
 	}
 
 	if gatherer != nil {
-		return gatherer, nil
+		return MetricsResolution{Gatherer: gatherer}, nil
 	}
 
 	if g, ok := reg.(promclient.Gatherer); ok {
-		return g, nil
+		return MetricsResolution{Gatherer: g}, nil
 	}
 
-	if apiEnabled {
-		e := conduiterr.New(conduiterr.CodeInvalidArgument,
-			"the metrics registerer does not implement prometheus.Gatherer, so /metrics cannot serve what it registers")
-		e.Suggestion = "pass the underlying registry as well: " +
-			"conduit.Options{MetricsRegisterer: wrapped, MetricsGatherer: registry} " +
-			"(pkg/conduit: WithMetricsGatherer)"
-		return nil, e
-	}
-
-	return promclient.DefaultGatherer, nil
+	// With the API disabled there is no /metrics route at all, so nothing is
+	// being served wrongly and there is nothing to warn about.
+	return MetricsResolution{Gatherer: promclient.DefaultGatherer, Degraded: apiEnabled}, nil
 }
+
+// MetricsDegradedWarning is the text logged when ResolveMetricsGatherer
+// degrades. It is a constant so the embed package and NewRuntime say the same
+// thing, and so a test can assert the operator is actually told.
+const MetricsDegradedWarning = "the metrics registerer does not implement prometheus.Gatherer, so /metrics is serving " +
+	"the default Prometheus registry instead of the metrics Conduit registered; pass the underlying registry too " +
+	"(conduit.Options.MetricsGatherer, or pkg/conduit's WithMetricsGatherer). This becomes an error in the next minor release."
 
 // WithDialContext supplies the context.Context OpenStore's Postgres/SQLite
 // dial uses instead of context.Background(), so a caller-supplied deadline or
@@ -319,10 +360,11 @@ func NewRuntime(cfg Config, opts ...RuntimeOption) (*Runtime, error) {
 		opt(&ro)
 	}
 
-	metricsGatherer, err := ResolveMetricsGatherer(ro.metricsRegisterer, ro.metricsGatherer, cfg.API.Enabled)
+	metricsResolution, err := ResolveMetricsGatherer(ro.metricsRegisterer, ro.metricsGatherer, cfg.API.Enabled)
 	if err != nil {
 		return nil, err
 	}
+	metricsGatherer := metricsResolution.Gatherer
 	var logger log.CtxLogger
 	if ro.logger != nil {
 		// Embed path (AC-5.1): use the pre-built logger as-is instead of
@@ -339,6 +381,15 @@ func NewRuntime(cfg Config, opts ...RuntimeOption) (*Runtime, error) {
 		// CLI path only (AC-5.3): an embed-supplied logger must never become
 		// the ambient global fallback — see WithLogger's doc.
 		zerolog.DefaultContextLogger = &logger.Logger
+	}
+
+	// Warn as soon as there is a logger to warn with. This is the ENTIRE
+	// mitigation for a degraded resolution — /metrics will serve plausible but
+	// unrelated numbers, and nothing else about the process looks wrong — so it
+	// must not be conditional on anything further down, and it must survive an
+	// early return from OpenStore below.
+	if metricsResolution.Degraded {
+		logger.Warn(context.Background()).Msg(MetricsDegradedWarning)
 	}
 
 	dialCtx := context.Background()

--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -131,6 +131,7 @@ type Runtime struct {
 	// (WithMetricsRegisterer set) it is a fresh, per-Runtime instance
 	// registered only into the supplied registerer — see configureEmbeddedMetrics.
 	metricsGrpcStatsHandler *promgrpc.StatsHandler
+	metricsGatherer         promclient.Gatherer
 
 	// closeDBOnce/closeDBErr make CloseDB idempotent regardless of which of
 	// its (potentially multiple) callers gets there first — see CloseDB's doc.
@@ -280,10 +281,11 @@ func NewRuntime(cfg Config, opts ...RuntimeOption) (*Runtime, error) {
 	}
 
 	var statsHandler *promgrpc.StatsHandler
+	metricsGatherer := promclient.DefaultGatherer
 	if ro.metricsRegisterer != nil {
 		// Embed path (AC-5.2): isolated per-Runtime metrics, never the
 		// process-global promclient.DefaultRegisterer.
-		statsHandler, err = configureEmbeddedMetrics(ro.metricsRegisterer)
+		statsHandler, metricsGatherer, err = configureEmbeddedMetrics(ro.metricsRegisterer)
 		if err != nil {
 			return nil, err
 		}
@@ -308,6 +310,7 @@ func NewRuntime(cfg Config, opts ...RuntimeOption) (*Runtime, error) {
 
 		logger:                  logger,
 		metricsGrpcStatsHandler: statsHandler,
+		metricsGatherer:         metricsGatherer,
 	}
 
 	err = createServices(r)
@@ -558,20 +561,34 @@ func configureMetrics() *promgrpc.StatsHandler {
 // succeed, so a failed Register (e.g. the name collision this function
 // itself guards against) still leaks reg into pkg/foundation/metrics'
 // process-global bookkeeping — it is never unregistered on this error path.
-func configureEmbeddedMetrics(registerer promclient.Registerer) (*promgrpc.StatsHandler, error) {
+func configureEmbeddedMetrics(registerer promclient.Registerer) (*promgrpc.StatsHandler, promclient.Gatherer, error) {
 	reg := prometheus.NewRegistry(nil)
 	metrics.Register(reg) // documented cross-talk limitation, see WithMetricsRegisterer's doc; leak-on-failure tracked as issue #2669
 	if err := registerer.Register(reg); err != nil {
 		wrapped := cerrors.Errorf("failed to register conduit metrics collector: %w", err)
-		return nil, conduiterr.Wrap(conduiterr.CodeInvalidArgument, wrapped.Error(), wrapped)
+		return nil, nil, conduiterr.Wrap(conduiterr.CodeInvalidArgument, wrapped.Error(), wrapped)
 	}
 
 	statsHandler := promgrpc.ServerStatsHandler()
 	if err := registerer.Register(statsHandler); err != nil {
 		wrapped := cerrors.Errorf("failed to register grpc stats collector: %w", err)
-		return nil, conduiterr.Wrap(conduiterr.CodeInvalidArgument, wrapped.Error(), wrapped)
+		return nil, nil, conduiterr.Wrap(conduiterr.CodeInvalidArgument, wrapped.Error(), wrapped)
 	}
-	return statsHandler, nil
+
+	if gatherer, ok := registerer.(promclient.Gatherer); ok {
+		return statsHandler, gatherer, nil
+	}
+
+	gatherer := promclient.NewRegistry()
+	if err := gatherer.Register(reg); err != nil {
+		wrapped := cerrors.Errorf("failed to register conduit metrics in HTTP gatherer: %w", err)
+		return nil, nil, conduiterr.Wrap(conduiterr.CodeInternal, wrapped.Error(), wrapped)
+	}
+	if err := gatherer.Register(statsHandler); err != nil {
+		wrapped := cerrors.Errorf("failed to register grpc stats in HTTP gatherer: %w", err)
+		return nil, nil, conduiterr.Wrap(conduiterr.CodeInternal, wrapped.Error(), wrapped)
+	}
+	return statsHandler, gatherer, nil
 }
 
 // Run initializes all of Conduit's underlying services and starts the GRPC and
@@ -827,16 +844,8 @@ func (r *Runtime) registerCleanupV2(t *tomb.Tomb) {
 
 // newHTTPMetricsHandler builds the handler served at /metrics (see
 // serveHTTPAPI).
-//
-// Known limitation, accepted for v1 and tracked as
-// https://github.com/ConduitIO/conduit/issues/2670: promhttp.Handler() always
-// serves promclient.DefaultGatherer, not the Registerer/Gatherer an embedder
-// supplied via WithMetricsRegisterer/configureEmbeddedMetrics. An embedded
-// Runtime with Options.API.Enabled and a custom MetricsRegisterer therefore
-// gets a /metrics route that does not reflect what was actually registered
-// into that registerer.
 func (r *Runtime) newHTTPMetricsHandler() http.Handler {
-	return promhttp.Handler()
+	return promhttp.HandlerFor(r.metricsGatherer, promhttp.HandlerOpts{})
 }
 
 func (r *Runtime) serveGRPCAPI(ctx context.Context, t *tomb.Tomb) (net.Addr, error) {

--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -131,6 +131,7 @@ type Runtime struct {
 	// (WithMetricsRegisterer set) it is a fresh, per-Runtime instance
 	// registered only into the supplied registerer — see configureEmbeddedMetrics.
 	metricsGrpcStatsHandler *promgrpc.StatsHandler
+	metricsRegisterer       promclient.Registerer
 	metricsGatherer         promclient.Gatherer
 
 	// closeDBOnce/closeDBErr make CloseDB idempotent regardless of which of
@@ -196,7 +197,8 @@ func WithLogger(logger log.CtxLogger) RuntimeOption {
 //
 // If reg also implements Gatherer and WithMetricsGatherer is not supplied,
 // the embedded /metrics endpoint serves reg's full contents, including metrics
-// registered by the host application.
+// registered by the host application. When the API is enabled, a reg that
+// does not implement Gatherer requires WithMetricsGatherer.
 //
 // Known limitation (documented, not fixed by this seam): pkg/foundation/metrics
 // keeps process-global metric *definitions* (metrics.go's `global` slices) —
@@ -269,9 +271,12 @@ func NewRuntime(cfg Config, opts ...RuntimeOption) (*Runtime, error) {
 	}
 	if ro.metricsRegisterer != nil && metricsGatherer == nil {
 		metricsGatherer, _ = ro.metricsRegisterer.(promclient.Gatherer)
-		if metricsGatherer == nil && cfg.API.Enabled {
-			return nil, conduiterr.New(conduiterr.CodeInvalidArgument,
-				"metrics registerer does not implement Gatherer; provide WithMetricsGatherer")
+		if metricsGatherer == nil {
+			if cfg.API.Enabled {
+				return nil, conduiterr.New(conduiterr.CodeInvalidArgument,
+					"metrics registerer does not implement Gatherer; provide WithMetricsGatherer")
+			}
+			metricsGatherer = promclient.DefaultGatherer
 		}
 	}
 	var logger log.CtxLogger
@@ -303,6 +308,7 @@ func NewRuntime(cfg Config, opts ...RuntimeOption) (*Runtime, error) {
 		return nil, err
 	}
 
+	metricsRegisterer := ro.metricsRegisterer
 	var statsHandler *promgrpc.StatsHandler
 	if ro.metricsRegisterer != nil {
 		// Embed path (AC-5.2): isolated per-Runtime metrics, never the
@@ -312,6 +318,7 @@ func NewRuntime(cfg Config, opts ...RuntimeOption) (*Runtime, error) {
 			return nil, err
 		}
 	} else {
+		metricsRegisterer = promclient.DefaultRegisterer
 		metricsGatherer = promclient.DefaultGatherer
 		statsHandler = configureMetrics()
 	}
@@ -333,6 +340,7 @@ func NewRuntime(cfg Config, opts ...RuntimeOption) (*Runtime, error) {
 
 		logger:                  logger,
 		metricsGrpcStatsHandler: statsHandler,
+		metricsRegisterer:       metricsRegisterer,
 		metricsGatherer:         metricsGatherer,
 	}
 
@@ -855,7 +863,10 @@ func (r *Runtime) registerCleanupV2(t *tomb.Tomb) {
 // newHTTPMetricsHandler builds the handler served at /metrics (see
 // serveHTTPAPI).
 func (r *Runtime) newHTTPMetricsHandler() http.Handler {
-	return promhttp.HandlerFor(r.metricsGatherer, promhttp.HandlerOpts{})
+	return promhttp.InstrumentMetricHandler(
+		r.metricsRegisterer,
+		promhttp.HandlerFor(r.metricsGatherer, promhttp.HandlerOpts{}),
+	)
 }
 
 func (r *Runtime) serveGRPCAPI(ctx context.Context, t *tomb.Tomb) (net.Addr, error) {

--- a/pkg/conduit/runtime.go
+++ b/pkg/conduit/runtime.go
@@ -20,6 +20,7 @@ package conduit
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -221,6 +222,59 @@ func WithMetricsGatherer(gatherer promclient.Gatherer) RuntimeOption {
 	return func(o *runtimeOptions) { o.metricsGatherer = gatherer }
 }
 
+// ResolveMetricsGatherer decides which Gatherer the /metrics endpoint serves,
+// and rejects the combinations that cannot work.
+//
+// It is exported so the embed package (github.com/conduitio/conduit) can apply
+// the SAME rule inside New — where the options are already known and no I/O is
+// needed — instead of letting a caller discover a bad pairing on their first
+// Run or Import. Two copies of this rule would eventually disagree, and the
+// symptom would be an Engine that constructs cleanly and then refuses to run.
+//
+// The rules, in order:
+//   - a gatherer with no registerer is rejected: there would be nothing
+//     registering into what it gathers;
+//   - a registerer that also implements Gatherer is used as its own gatherer,
+//     so the endpoint serves everything registered into it, host metrics
+//     included;
+//   - a registerer that does NOT implement Gatherer (prometheus.WrapRegisterer*
+//     returns one of these) needs an explicit gatherer whenever the API is
+//     enabled, because otherwise /metrics would serve unrelated default
+//     metrics — the bug this seam exists to fix;
+//   - with the API disabled there is no /metrics route to be wrong, so the
+//     default gatherer is kept as an inert placeholder.
+func ResolveMetricsGatherer(reg promclient.Registerer, gatherer promclient.Gatherer, apiEnabled bool) (promclient.Gatherer, error) {
+	if reg == nil {
+		if gatherer != nil {
+			e := conduiterr.New(conduiterr.CodeInvalidArgument,
+				"a metrics gatherer was supplied without a metrics registerer")
+			e.Suggestion = "set both: conduit.Options{MetricsRegisterer: reg, MetricsGatherer: gatherer} " +
+				"(pkg/conduit: WithMetricsRegisterer + WithMetricsGatherer)"
+			return nil, e
+		}
+		return nil, nil //nolint:nilnil // no registerer means the caller gets the CLI defaults, decided by NewRuntime
+	}
+
+	if gatherer != nil {
+		return gatherer, nil
+	}
+
+	if g, ok := reg.(promclient.Gatherer); ok {
+		return g, nil
+	}
+
+	if apiEnabled {
+		e := conduiterr.New(conduiterr.CodeInvalidArgument,
+			"the metrics registerer does not implement prometheus.Gatherer, so /metrics cannot serve what it registers")
+		e.Suggestion = "pass the underlying registry as well: " +
+			"conduit.Options{MetricsRegisterer: wrapped, MetricsGatherer: registry} " +
+			"(pkg/conduit: WithMetricsGatherer)"
+		return nil, e
+	}
+
+	return promclient.DefaultGatherer, nil
+}
+
 // WithDialContext supplies the context.Context OpenStore's Postgres/SQLite
 // dial uses instead of context.Background(), so a caller-supplied deadline or
 // cancellation aborts a slow/unreachable database dial promptly instead of
@@ -265,19 +319,9 @@ func NewRuntime(cfg Config, opts ...RuntimeOption) (*Runtime, error) {
 		opt(&ro)
 	}
 
-	metricsGatherer := ro.metricsGatherer
-	if ro.metricsRegisterer == nil && metricsGatherer != nil {
-		return nil, conduiterr.New(conduiterr.CodeInvalidArgument, "metrics gatherer requires a metrics registerer")
-	}
-	if ro.metricsRegisterer != nil && metricsGatherer == nil {
-		metricsGatherer, _ = ro.metricsRegisterer.(promclient.Gatherer)
-		if metricsGatherer == nil {
-			if cfg.API.Enabled {
-				return nil, conduiterr.New(conduiterr.CodeInvalidArgument,
-					"metrics registerer does not implement Gatherer; provide WithMetricsGatherer")
-			}
-			metricsGatherer = promclient.DefaultGatherer
-		}
+	metricsGatherer, err := ResolveMetricsGatherer(ro.metricsRegisterer, ro.metricsGatherer, cfg.API.Enabled)
+	if err != nil {
+		return nil, err
 	}
 	var logger log.CtxLogger
 	if ro.logger != nil {
@@ -863,10 +907,54 @@ func (r *Runtime) registerCleanupV2(t *tomb.Tomb) {
 // newHTTPMetricsHandler builds the handler served at /metrics (see
 // serveHTTPAPI).
 func (r *Runtime) newHTTPMetricsHandler() http.Handler {
-	return promhttp.InstrumentMetricHandler(
-		r.metricsRegisterer,
-		promhttp.HandlerFor(r.metricsGatherer, promhttp.HandlerOpts{}),
-	)
+	// ContinueOnError, not the promhttp default: with an embedded Runtime the
+	// gatherer holds the HOST application's collectors too, so one broken host
+	// collector would otherwise turn every scrape into a 500 that also hides
+	// Conduit's own metrics — losing our observability because of someone
+	// else's bug. ErrorLog gives that failure somewhere to be seen; the
+	// default is to discard it.
+	handler := promhttp.HandlerFor(r.metricsGatherer, promhttp.HandlerOpts{
+		ErrorHandling: promhttp.ContinueOnError,
+		ErrorLog:      promLogger{logger: r.logger},
+	})
+	return instrumentMetricHandler(r.logger, r.metricsRegisterer, handler)
+}
+
+// instrumentMetricHandler is promhttp.InstrumentMetricHandler with its panic
+// contained.
+//
+// That function panics on any registration error that is not
+// AlreadyRegisteredError, and r.metricsRegisterer can be supplied by the host
+// application (WithMetricsRegisterer). A host collector whose name collides
+// with promhttp's own — "promhttp_metric_handler_requests_total" with
+// different labels — therefore panics inside serveHTTPAPI, which Run calls
+// synchronously with no recover anywhere in the path: the panic unwinds into
+// the embedding application and takes the process down.
+//
+// Serving /metrics without the handler's own scrape counters is a far better
+// outcome than crashing someone's application, so the panic is caught and the
+// uninstrumented handler is used instead. The recover (rather than
+// pre-registering the two collectors here) also keeps this correct if promhttp
+// grows another panic path.
+func instrumentMetricHandler(logger log.CtxLogger, reg promclient.Registerer, handler http.Handler) (h http.Handler) {
+	defer func() {
+		if p := recover(); p != nil {
+			logger.Warn(context.Background()).
+				Msgf("serving /metrics without handler instrumentation: %v", p)
+			h = handler
+		}
+	}()
+	return promhttp.InstrumentMetricHandler(reg, handler)
+}
+
+// promLogger adapts the runtime logger to promhttp.Logger, so a gather error
+// says something instead of vanishing into a 500 with no explanation.
+type promLogger struct {
+	logger log.CtxLogger
+}
+
+func (l promLogger) Println(v ...any) {
+	l.logger.Warn(context.Background()).Msg(strings.TrimSpace(fmt.Sprintln(v...)))
 }
 
 func (r *Runtime) serveGRPCAPI(ctx context.Context, t *tomb.Tomb) (net.Addr, error) {

--- a/pkg/conduit/runtime_metrics_test.go
+++ b/pkg/conduit/runtime_metrics_test.go
@@ -21,27 +21,18 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/matryer/is"
 	promclient "github.com/prometheus/client_golang/prometheus"
 )
 
-func TestNewHTTPMetricsHandlerUsesEmbeddedGatherer(t *testing.T) {
+func TestNewHTTPMetricsHandlerUsesExplicitGatherer(t *testing.T) {
 	is := is.New(t)
-
 	reg := promclient.NewRegistry()
-	gauge := promclient.NewGauge(promclient.GaugeOpts{
-		Name: "conduit_embedded_http_metrics_test",
-		Help: "Metric used to verify the embedded HTTP metrics gatherer.",
-	})
-	gauge.Set(42)
-	reg.MustRegister(gauge)
+	wrapped := promclient.WrapRegistererWithPrefix("myapp_", reg)
 
-	cfg := DefaultConfig()
-	cfg.DB.Type = DBTypeInMemory
-	cfg.API.Enabled = false
-	cfg.Pipelines.Path = t.TempDir()
-
-	runtime, err := NewRuntime(cfg, WithMetricsRegisterer(reg))
+	cfg := newMetricsRuntimeConfig(t)
+	runtime, err := NewRuntime(cfg, WithMetricsRegisterer(wrapped), WithMetricsGatherer(reg))
 	is.NoErr(err)
 	defer runtime.DB.Close()
 
@@ -52,5 +43,48 @@ func TestNewHTTPMetricsHandlerUsesEmbeddedGatherer(t *testing.T) {
 	)
 
 	is.Equal(recorder.Code, http.StatusOK)
-	is.True(strings.Contains(recorder.Body.String(), "conduit_embedded_http_metrics_test 42"))
+	is.True(strings.Contains(recorder.Body.String(), "myapp_conduit_info"))
+}
+
+func TestNewRuntimeRequiresGathererForWrappedRegisterer(t *testing.T) {
+	is := is.New(t)
+	reg := promclient.NewRegistry()
+	wrapped := promclient.WrapRegistererWithPrefix("myapp_", reg)
+
+	_, err := NewRuntime(newMetricsRuntimeConfig(t), WithMetricsRegisterer(wrapped))
+	is.True(err != nil)
+	conduitErr, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(conduitErr.Code, conduiterr.CodeInvalidArgument)
+}
+
+func TestNewRuntimeAllowsWrappedRegistererWhenHTTPDisabled(t *testing.T) {
+	is := is.New(t)
+	reg := promclient.NewRegistry()
+	wrapped := promclient.WrapRegistererWithPrefix("myapp_", reg)
+	cfg := newMetricsRuntimeConfig(t)
+	cfg.API.Enabled = false
+
+	runtime, err := NewRuntime(cfg, WithMetricsRegisterer(wrapped))
+	is.NoErr(err)
+	defer runtime.DB.Close()
+}
+
+func TestNewRuntimeUsesDefaultGatherer(t *testing.T) {
+	is := is.New(t)
+	cfg := newMetricsRuntimeConfig(t)
+	cfg.API.Enabled = false
+
+	runtime, err := NewRuntime(cfg)
+	is.NoErr(err)
+	defer runtime.DB.Close()
+	is.True(runtime.metricsGatherer == promclient.DefaultGatherer)
+}
+
+func newMetricsRuntimeConfig(t *testing.T) Config {
+	cfg := DefaultConfig()
+	cfg.DB.Type = DBTypeInMemory
+	cfg.API.Enabled = true
+	cfg.Pipelines.Path = t.TempDir()
+	return cfg
 }

--- a/pkg/conduit/runtime_metrics_test.go
+++ b/pkg/conduit/runtime_metrics_test.go
@@ -15,6 +15,7 @@
 package conduit
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -47,7 +48,7 @@ func TestNewHTTPMetricsHandlerUsesEmbeddedGatherer(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	runtime.newHTTPMetricsHandler().ServeHTTP(
 		recorder,
-		httptest.NewRequest(http.MethodGet, "/metrics", nil),
+		httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics", nil),
 	)
 
 	is.Equal(recorder.Code, http.StatusOK)

--- a/pkg/conduit/runtime_metrics_test.go
+++ b/pkg/conduit/runtime_metrics_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/matryer/is"
 	promclient "github.com/prometheus/client_golang/prometheus"
@@ -127,4 +128,106 @@ func newMetricsRuntimeConfig(t *testing.T) Config {
 	cfg.API.Enabled = true
 	cfg.Pipelines.Path = t.TempDir()
 	return cfg
+}
+
+// A host collector whose name collides with promhttp's own must never take the
+// embedding process down. promhttp.InstrumentMetricHandler panics on any
+// registration error that is not AlreadyRegisteredError, and this registerer
+// belongs to the host — so without instrumentMetricHandler's recover, building
+// the handler panics inside serveHTTPAPI, which Run calls synchronously with no
+// recover in the path.
+//
+// Remove the recover in instrumentMetricHandler and this test panics instead of
+// failing, which is exactly the production symptom.
+func TestNewHTTPMetricsHandlerSurvivesConflictingHostCollector(t *testing.T) {
+	is := is.New(t)
+	reg := promclient.NewRegistry()
+
+	conflicting := promclient.NewCounterVec(
+		promclient.CounterOpts{
+			Name: "promhttp_metric_handler_requests_total",
+			Help: "the host's own, with a different label set",
+		},
+		[]string{"method"}, // promhttp uses "code"
+	)
+	is.NoErr(reg.Register(conflicting))
+
+	runtime, err := NewRuntime(newMetricsRuntimeConfig(t), WithMetricsRegisterer(reg))
+	is.NoErr(err)
+	defer runtime.DB.Close()
+
+	recorder := httptest.NewRecorder()
+	runtime.newHTTPMetricsHandler().ServeHTTP(
+		recorder,
+		httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics", nil),
+	)
+
+	// Degraded — no scrape counters — but still serving Conduit's metrics.
+	is.Equal(recorder.Code, http.StatusOK)
+	is.True(strings.Contains(recorder.Body.String(), "conduit_info"))
+}
+
+// One broken host collector must not hide Conduit's own metrics. With
+// promhttp's default error handling a single Collect failure turns the whole
+// scrape into a 500; ContinueOnError keeps the rest of the registry readable.
+func TestNewHTTPMetricsHandlerServesConduitMetricsDespiteABrokenHostCollector(t *testing.T) {
+	is := is.New(t)
+	reg := promclient.NewRegistry()
+	is.NoErr(reg.Register(brokenCollector{}))
+
+	runtime, err := NewRuntime(newMetricsRuntimeConfig(t), WithMetricsRegisterer(reg))
+	is.NoErr(err)
+	defer runtime.DB.Close()
+
+	recorder := httptest.NewRecorder()
+	runtime.newHTTPMetricsHandler().ServeHTTP(
+		recorder,
+		httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics", nil),
+	)
+
+	is.True(strings.Contains(recorder.Body.String(), "conduit_info"))
+}
+
+// brokenCollector fails on every Collect, standing in for a host collector that
+// errors in production (a scrape against a dead dependency, say).
+type brokenCollector struct{}
+
+func (brokenCollector) Describe(ch chan<- *promclient.Desc) {
+	ch <- promclient.NewDesc("broken_host_collector", "always fails to collect", nil, nil)
+}
+
+func (brokenCollector) Collect(ch chan<- promclient.Metric) {
+	ch <- promclient.NewInvalidMetric(
+		promclient.NewDesc("broken_host_collector", "always fails to collect", nil, nil),
+		cerrors.New("host collector is broken"),
+	)
+}
+
+// The isolation claim the whole seam rests on: an embedded Runtime's /metrics
+// serves ITS registry, not whatever happens to be in the process-global default
+// one. Without this, "isolated per-Runtime metrics" is an assertion nobody
+// checks.
+func TestNewHTTPMetricsHandlerDoesNotServeTheDefaultRegistry(t *testing.T) {
+	is := is.New(t)
+
+	sentinel := promclient.NewGauge(promclient.GaugeOpts{
+		Name: "default_registry_sentinel_metric",
+		Help: "registered only into the process-global default registry",
+	})
+	sentinel.Set(1)
+	is.NoErr(promclient.DefaultRegisterer.Register(sentinel))
+	defer promclient.DefaultRegisterer.Unregister(sentinel)
+
+	reg := promclient.NewRegistry()
+	runtime, err := NewRuntime(newMetricsRuntimeConfig(t), WithMetricsRegisterer(reg))
+	is.NoErr(err)
+	defer runtime.DB.Close()
+
+	recorder := httptest.NewRecorder()
+	runtime.newHTTPMetricsHandler().ServeHTTP(
+		recorder,
+		httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics", nil),
+	)
+
+	is.True(!strings.Contains(recorder.Body.String(), "default_registry_sentinel_metric"))
 }

--- a/pkg/conduit/runtime_metrics_test.go
+++ b/pkg/conduit/runtime_metrics_test.go
@@ -46,6 +46,29 @@ func TestNewHTTPMetricsHandlerUsesExplicitGatherer(t *testing.T) {
 	is.True(strings.Contains(recorder.Body.String(), "myapp_conduit_info"))
 }
 
+func TestNewHTTPMetricsHandlerUsesRegistererGatherer(t *testing.T) {
+	is := is.New(t)
+	reg := promclient.NewRegistry()
+	hostMetric := promclient.NewGauge(promclient.GaugeOpts{Name: "host_metric"})
+	hostMetric.Set(1)
+	is.NoErr(reg.Register(hostMetric))
+
+	runtime, err := NewRuntime(newMetricsRuntimeConfig(t), WithMetricsRegisterer(reg))
+	is.NoErr(err)
+	defer runtime.DB.Close()
+
+	recorder := httptest.NewRecorder()
+	runtime.newHTTPMetricsHandler().ServeHTTP(
+		recorder,
+		httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics", nil),
+	)
+
+	is.Equal(recorder.Code, http.StatusOK)
+	is.True(strings.Contains(recorder.Body.String(), "host_metric"))
+	is.True(strings.Contains(recorder.Body.String(), "conduit_info"))
+	is.True(strings.Contains(recorder.Body.String(), "promhttp_metric_handler_requests_total"))
+}
+
 func TestNewRuntimeRequiresGathererForWrappedRegisterer(t *testing.T) {
 	is := is.New(t)
 	reg := promclient.NewRegistry()
@@ -68,17 +91,34 @@ func TestNewRuntimeAllowsWrappedRegistererWhenHTTPDisabled(t *testing.T) {
 	runtime, err := NewRuntime(cfg, WithMetricsRegisterer(wrapped))
 	is.NoErr(err)
 	defer runtime.DB.Close()
+	is.True(runtime.metricsGatherer == promclient.DefaultGatherer)
+
+	recorder := httptest.NewRecorder()
+	runtime.newHTTPMetricsHandler().ServeHTTP(
+		recorder,
+		httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics", nil),
+	)
+	is.Equal(recorder.Code, http.StatusOK)
 }
 
 func TestNewRuntimeUsesDefaultGatherer(t *testing.T) {
 	is := is.New(t)
 	cfg := newMetricsRuntimeConfig(t)
-	cfg.API.Enabled = false
 
 	runtime, err := NewRuntime(cfg)
 	is.NoErr(err)
 	defer runtime.DB.Close()
 	is.True(runtime.metricsGatherer == promclient.DefaultGatherer)
+}
+
+func TestNewRuntimeRejectsGathererWithoutRegisterer(t *testing.T) {
+	is := is.New(t)
+
+	_, err := NewRuntime(newMetricsRuntimeConfig(t), WithMetricsGatherer(promclient.NewRegistry()))
+	is.True(err != nil)
+	conduitErr, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(conduitErr.Code, conduiterr.CodeInvalidArgument)
 }
 
 func newMetricsRuntimeConfig(t *testing.T) Config {

--- a/pkg/conduit/runtime_metrics_test.go
+++ b/pkg/conduit/runtime_metrics_test.go
@@ -1,0 +1,55 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conduit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/matryer/is"
+	promclient "github.com/prometheus/client_golang/prometheus"
+)
+
+func TestNewHTTPMetricsHandlerUsesEmbeddedGatherer(t *testing.T) {
+	is := is.New(t)
+
+	reg := promclient.NewRegistry()
+	gauge := promclient.NewGauge(promclient.GaugeOpts{
+		Name: "conduit_embedded_http_metrics_test",
+		Help: "Metric used to verify the embedded HTTP metrics gatherer.",
+	})
+	gauge.Set(42)
+	reg.MustRegister(gauge)
+
+	cfg := DefaultConfig()
+	cfg.DB.Type = DBTypeInMemory
+	cfg.API.Enabled = false
+	cfg.Pipelines.Path = t.TempDir()
+
+	runtime, err := NewRuntime(cfg, WithMetricsRegisterer(reg))
+	is.NoErr(err)
+	defer runtime.DB.Close()
+
+	recorder := httptest.NewRecorder()
+	runtime.newHTTPMetricsHandler().ServeHTTP(
+		recorder,
+		httptest.NewRequest(http.MethodGet, "/metrics", nil),
+	)
+
+	is.Equal(recorder.Code, http.StatusOK)
+	is.True(strings.Contains(recorder.Body.String(), "conduit_embedded_http_metrics_test 42"))
+}

--- a/pkg/conduit/runtime_metrics_test.go
+++ b/pkg/conduit/runtime_metrics_test.go
@@ -15,6 +15,7 @@
 package conduit
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -23,8 +24,10 @@ import (
 
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/foundation/log"
 	"github.com/matryer/is"
 	promclient "github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
 )
 
 func TestNewHTTPMetricsHandlerUsesExplicitGatherer(t *testing.T) {
@@ -70,16 +73,66 @@ func TestNewHTTPMetricsHandlerUsesRegistererGatherer(t *testing.T) {
 	is.True(strings.Contains(recorder.Body.String(), "promhttp_metric_handler_requests_total"))
 }
 
-func TestNewRuntimeRequiresGathererForWrappedRegisterer(t *testing.T) {
+// A registerer that cannot back /metrics DEGRADES rather than failing: the
+// configuration started in previous releases, and killing a running system on
+// upgrade over a wrong-but-harmless scrape target inverts the cost. The warning
+// is the mitigation, so it is asserted, not assumed — see
+// TestNewRuntimeWarnsWhenMetricsResolutionDegrades.
+func TestNewRuntimeDegradesForWrappedRegisterer(t *testing.T) {
 	is := is.New(t)
 	reg := promclient.NewRegistry()
 	wrapped := promclient.WrapRegistererWithPrefix("myapp_", reg)
 
-	_, err := NewRuntime(newMetricsRuntimeConfig(t), WithMetricsRegisterer(wrapped))
-	is.True(err != nil)
-	conduitErr, ok := conduiterr.Get(err)
-	is.True(ok)
-	is.Equal(conduitErr.Code, conduiterr.CodeInvalidArgument)
+	runtime, err := NewRuntime(newMetricsRuntimeConfig(t), WithMetricsRegisterer(wrapped))
+	is.NoErr(err)
+	defer runtime.DB.Close()
+
+	// Serving the default registry is wrong, and is exactly what the warning
+	// says out loud. It is the pre-existing behavior, not a new one.
+	is.True(runtime.metricsGatherer == promclient.DefaultGatherer)
+
+	resolution, err := ResolveMetricsGatherer(wrapped, nil, true)
+	is.NoErr(err)
+	is.True(resolution.Degraded)
+}
+
+// The warning is the ENTIRE mitigation for this release, so an operator has to
+// actually receive it. Without this test the degrade path is silent and nobody
+// finds out until a dashboard is empty.
+func TestNewRuntimeWarnsWhenMetricsResolutionDegrades(t *testing.T) {
+	is := is.New(t)
+	reg := promclient.NewRegistry()
+	wrapped := promclient.WrapRegistererWithPrefix("myapp_", reg)
+
+	var buf bytes.Buffer
+	logger := log.New(zerolog.New(&buf).Level(zerolog.WarnLevel))
+
+	runtime, err := NewRuntime(
+		newMetricsRuntimeConfig(t),
+		WithMetricsRegisterer(wrapped),
+		WithLogger(logger),
+	)
+	is.NoErr(err)
+	defer runtime.DB.Close()
+
+	logged := buf.String()
+	is.True(strings.Contains(logged, "does not implement prometheus.Gatherer"))
+	is.True(strings.Contains(logged, "MetricsGatherer"))         // names the fix
+	is.True(strings.Contains(logged, "error in the next minor")) // and the deadline
+}
+
+// The degrade is scoped to the case that can actually mislead. With the API
+// disabled there is no /metrics route, so there is nothing to warn about and a
+// warning would just be noise in every embedded run that never serves HTTP.
+func TestResolveMetricsGathererDoesNotDegradeWithoutTheAPI(t *testing.T) {
+	is := is.New(t)
+	wrapped := promclient.WrapRegistererWithPrefix("myapp_", promclient.NewRegistry())
+
+	resolution, err := ResolveMetricsGatherer(wrapped, nil, false)
+
+	is.NoErr(err)
+	is.True(!resolution.Degraded)
+	is.True(resolution.Gatherer == promclient.DefaultGatherer)
 }
 
 func TestNewRuntimeAllowsWrappedRegistererWhenHTTPDisabled(t *testing.T) {


### PR DESCRIPTION
### Description

Use the gatherer associated with an embedded runtime when serving /metrics.

A supplied registry now serves both host and Conduit metrics. Wrapped registerers can provide their underlying registry through MetricsGatherer, preserving prefixes and constant labels. The Prometheus handler's request metrics remain available.

Fixes #2670

Roadmap: Phase 1, Embedded v1  
Risk: Tier 2

### Compatibility and migration

This intentionally changes API-enabled embeds that pass a registerer which does not also implement prometheus.Gatherer. That configuration previously started but served unrelated default metrics. It now returns CodeInvalidArgument on the first Run or Import.

Set both values when using a wrapped registerer:

    registry := prometheus.NewRegistry()
    registerer := prometheus.WrapRegistererWithPrefix(myapp_, registry)

    conduit.Options{
        MetricsRegisterer: registerer,
        MetricsGatherer:   registry,
    }

API-disabled embeds keep their existing startup behavior. This change is planned for the next minor release; the hard error was chosen instead of carrying a known-wrong scrape target through another release.

### Tests

- Focused embedded metrics tests
- go vet ./pkg/conduit
- Pinned golangci-lint on changed code

The full package suite reaches an existing Windows Badger cleanup lock in TestRuntime; CI covers the Linux run.

### Quick checks

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.