### PR TITLE
fix(connector): stop the Persister panicking the process on multi-source shutdown

### DIFF
--- a/pkg/connector/persister.go
+++ b/pkg/connector/persister.go
@@ -53,17 +53,36 @@ type Persister struct {
 	bundleCount int
 	batch       map[string]persistData
 	flushTimer  stoppableTimer
-	flushWg     sync.WaitGroup
 
-	// callbackWg tracks every PersistCallback invocation flushNow has
-	// spawned but not yet returned from — distinct from flushWg, which only
-	// tracks flushNow's own function body (the store write). flushNow fires
-	// callbacks in their own goroutines without waiting for them, so a
-	// caller that needs to know a callback's side effects (not just the
-	// store write) have actually happened — e.g. connector.Source's
-	// deferred plugin-ack under Approach A, see source.go's Ack — must wait
-	// on this separately. See WaitPendingWrites.
-	callbackWg sync.WaitGroup
+	// flush is the most recently triggered flush, or nil if none has ever been
+	// triggered. Waiters snapshot this pointer under m and then wait on the
+	// channels it carries.
+	flush *flushState
+}
+
+// flushState is one flush generation: the channels reporting when that specific
+// flush's store write, and then its callbacks, have completed.
+//
+// It replaces two reused sync.WaitGroups (flushWg/callbackWg) whose reuse
+// panicked the process — see WaitPendingWrites for the full account. A
+// WaitGroup forbids a counter-raising Add from running concurrently with a
+// Wait, and that rule is unenforceable here: WaitPendingWrites is called by
+// connectors on their own goroutines with no coordination with whichever other
+// connector happens to trigger a flush at that instant. A per-generation value
+// has no such rule — a waiter reads an immutable snapshot, and a new flush
+// allocates new channels instead of mutating a counter someone may be waiting
+// on.
+type flushState struct {
+	// writeDone closes when flushNow's store write has finished — the point
+	// the old flushWg tracked.
+	writeDone chan struct{}
+	// callbacksDone closes once every PersistCallback this flush spawned has
+	// returned. Distinct from writeDone because flushNow fires callbacks in
+	// their own goroutines without waiting for them, so a caller that needs a
+	// callback's side effects to have actually happened (not just the store
+	// write) — e.g. connector.Source's deferred plugin-ack under Approach A,
+	// see source.go's Ack — needs this one. This is what callbackWg tracked.
+	callbacksDone chan struct{}
 }
 
 // clock abstracts the two time operations the persister needs in order to
@@ -198,8 +217,8 @@ func (p *Persister) Wait() {
 // shared across all pipelines, connWg only reaches zero once every connector
 // on every pipeline has stopped, so calling Wait from a single pipeline's
 // stop-and-drain path would deadlock for as long as any other pipeline stays
-// running. WaitPendingWrites has no such coupling — it only observes flushWg
-// and callbackWg, which a connector's own ConnectorStopped call already
+// running. WaitPendingWrites has no such coupling — it only observes the
+// current flush generation, which a connector's own ConnectorStopped call already
 // increments synchronously (see triggerFlush and flushNow) before that call
 // returns. A caller that calls WaitPendingWrites strictly after learning (e.g.
 // via a WaitGroup/tomb join) that ConnectorStopped has already been called
@@ -208,10 +227,10 @@ func (p *Persister) Wait() {
 // call by construction, and sync.WaitGroup cannot miss a Done that was
 // already pending when Wait was entered.
 //
-// The callbackWg half of this wait matters specifically for
+// The callbacksDone half of this wait matters specifically for
 // connector.Source's Ack (Approach A, see source.go): the plugin-ack it sends
 // is deferred to run *inside* the PersistCallback, once the position is
-// durably flushed. Waiting only on flushWg (as this method did before that
+// durably flushed. Waiting only on the store write (as this method did before that
 // fix) would let a caller proceed — and a graceful shutdown tear down the
 // plugin — after the store write landed but before the plugin was actually
 // told about it, reintroducing an invariant-1 gap on the graceful path even
@@ -224,8 +243,33 @@ func (p *Persister) Wait() {
 // pipelines. See docs/design-documents/20260708-live-server-deploy-apply.md,
 // "Review outcome & required rework", blocker 1.
 func (p *Persister) WaitPendingWrites() {
-	p.flushWg.Wait()
-	p.callbackWg.Wait()
+	// Snapshot the current generation under m, then wait OUTSIDE the lock.
+	//
+	// The lock must not be held across the wait: WaitPendingWritesContext
+	// deliberately returns early on timeout while this goroutine keeps
+	// waiting, so holding m here would let a single stuck flush stall every
+	// connector's Persist process-wide — trading a crash for a global hang.
+	//
+	// This replaces `flushWg.Wait(); callbackWg.Wait()`, which read two
+	// WaitGroups with no lock while triggerFlush/flushNow concurrently raised
+	// them. A WaitGroup Add that lifts the counter off zero during a Wait is
+	// the documented reuse hazard, and it does not merely race — it panics
+	// with "sync: WaitGroup is reused before previous Wait has returned",
+	// killing the process. connector.Service shares ONE Persister across every
+	// connector and Source.Teardown calls WaitPendingWritesContext, so any
+	// pipeline where one source tears down while another still acks hit it.
+	// Confirmed in a shipped binary on ordinary shutdown of a 2-source
+	// pipeline: 3/3 runs under arch-v2 (one Worker per source, so all of them
+	// tear down at once), 1/3 under v1.
+	p.m.Lock()
+	st := p.flush
+	p.m.Unlock()
+
+	if st == nil {
+		return // nothing was ever flushed
+	}
+	<-st.writeDone
+	<-st.callbacksDone
 }
 
 // WaitPendingWritesContext behaves like WaitPendingWrites, but returns early
@@ -297,21 +341,32 @@ func (p *Persister) triggerFlush(ctx context.Context) {
 		return
 	}
 
-	// wait for any running flusher to finish
-	p.flushWg.Wait()
+	// Wait for any running flusher to finish. This blocks while holding m,
+	// exactly as the flushWg.Wait() it replaces did — a flush is serialized
+	// against the next one either way.
+	if p.flush != nil {
+		<-p.flush.writeDone
+	}
 
 	// reset callbacks and bundle count
 	batch := p.batch
 	p.batch = nil
 	p.bundleCount = 0
 
-	p.flushWg.Add(1)
-	go p.flushNow(ctx, batch)
+	// Publish this generation BEFORE starting it, under m, so a concurrent
+	// WaitPendingWrites either misses it entirely (and is correct — it was
+	// called before this flush was triggered) or sees it whole.
+	st := &flushState{
+		writeDone:     make(chan struct{}),
+		callbacksDone: make(chan struct{}),
+	}
+	p.flush = st
+	go p.flushNow(ctx, batch, st)
 }
 
 // flushNow will flush the state to the store.
-func (p *Persister) flushNow(ctx context.Context, batch map[string]persistData) {
-	defer p.flushWg.Done()
+func (p *Persister) flushNow(ctx context.Context, batch map[string]persistData, st *flushState) {
+	defer close(st.writeDone)
 	start := p.clock.Now()
 
 	tx, ctx, err := p.db.NewTransaction(ctx, true)
@@ -333,20 +388,26 @@ func (p *Persister) flushNow(ctx context.Context, batch map[string]persistData) 
 	if err == nil {
 		err = tx.Commit()
 	}
-	// Track every callback this flush is about to spawn so WaitPendingWrites
-	// can observe not just "the write landed" but "every side effect the
-	// write's callback performs has also finished" — see callbackWg's field
-	// doc and WaitPendingWrites. Add happens synchronously, before flushNow
-	// returns (and therefore before this flush's flushWg.Done() fires),
-	// which is what makes a subsequent WaitPendingWrites call race-free.
-	p.callbackWg.Add(len(batch))
+	// Track every callback this flush spawns so WaitPendingWrites can observe
+	// not just "the write landed" but "every side effect the write's callback
+	// performs has also finished" — see flushState.callbacksDone. The
+	// WaitGroup here is local to this flush generation and is never waited on
+	// by anyone else, so it cannot be reused underneath a Wait; the closer
+	// goroutine below converts it into a channel close, which is what callers
+	// actually observe.
+	var cbWg sync.WaitGroup
+	cbWg.Add(len(batch))
 	for _, data := range batch {
 		// execute callbacks in go routines to make sure they can't block this function
 		go func(cb PersistCallback) {
-			defer p.callbackWg.Done()
+			defer cbWg.Done()
 			cb(err)
 		}(data.callback)
 	}
+	go func() {
+		cbWg.Wait()
+		close(st.callbacksDone)
+	}()
 
 	p.logger.Debug(ctx).
 		Err(err).

--- a/pkg/connector/persister_generation_test.go
+++ b/pkg/connector/persister_generation_test.go
@@ -1,0 +1,121 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connector
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/database/inmemory"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+)
+
+// TestPersister_ConcurrentWaitAndPersist_DoesNotPanic reproduces the production
+// crash: connector.Service shares ONE Persister across every connector, and
+// Source.Teardown calls WaitPendingWritesContext — so any pipeline where one
+// source tears down while another is still acking put a Wait and an Add on the
+// same sync.WaitGroup concurrently.
+//
+// That is the documented WaitGroup reuse hazard, and it does not merely race:
+//
+//	panic: sync: WaitGroup is reused before previous Wait has returned
+//
+// which killed the process. It reproduced in a shipped binary on ordinary
+// shutdown of a 2-source pipeline — 3/3 runs under arch-v2 (one Worker per
+// source, so all tear down at once), 1/3 under v1.
+//
+// Without the per-generation fix this panics in well under a second; the
+// panic is a process-level abort, so it fails the test binary outright rather
+// than being recoverable.
+func TestPersister_ConcurrentWaitAndPersist_DoesNotPanic(t *testing.T) {
+	db := &inmemory.DB{}
+	// bundleCountThreshold 1: every Persist triggers a flush, maximizing the
+	// rate at which new generations are created against concurrent waiters.
+	p := NewPersister(log.Nop(), db, DefaultPersisterDelayThreshold, 1)
+
+	conn := &Instance{ID: "conn-b", persister: p}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Connector B keeps persisting — the "Add" side.
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_ = p.Persist(context.Background(), conn, func(error) {})
+			}
+		}()
+	}
+
+	// Connector A keeps doing what Source.Teardown does — the "Wait" side.
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				p.WaitPendingWrites()
+			}
+		}()
+	}
+
+	time.Sleep(2 * time.Second)
+	close(stop)
+	wg.Wait()
+}
+
+// TestPersister_WaitPendingWrites_WaitsForCallbacks pins the half of the
+// contract that is easy to lose when swapping the WaitGroups out: the wait must
+// cover the PersistCallback side effects, not just the store write. Approach A's
+// deferred plugin-ack (see connector.Source.Ack) depends on it.
+func TestPersister_WaitPendingWrites_WaitsForCallbacks(t *testing.T) {
+	db := &inmemory.DB{}
+	p := NewPersister(log.Nop(), db, DefaultPersisterDelayThreshold, 1)
+	conn := &Instance{ID: "conn-a", persister: p}
+
+	var callbackDone bool
+	var mu sync.Mutex
+
+	err := p.Persist(context.Background(), conn, func(error) {
+		time.Sleep(50 * time.Millisecond) // callback with real work in it
+		mu.Lock()
+		callbackDone = true
+		mu.Unlock()
+	})
+	if err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+
+	p.WaitPendingWrites()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !callbackDone {
+		t.Fatal("WaitPendingWrites returned before the PersistCallback finished")
+	}
+}


### PR DESCRIPTION
**Tier 1** (data path — connector state persistence / shutdown). Fixes #2743.

## The bug

`connector.Service` shares **one** `Persister` across every connector, and `Source.Teardown` calls `WaitPendingWritesContext` — the wait added by the #2680 persist-before-ack sev-0 fix. So any pipeline where one source tears down while another is still acking had a `Wait` and an `Add` running concurrently on the same `sync.WaitGroup`.

That's the documented reuse hazard, and it doesn't merely race — it panics:

```text
panic: sync: WaitGroup is reused before previous Wait has returned
	pkg/connector.(*Persister).WaitPendingWrites             persister.go:227
	pkg/connector.(*Persister).WaitPendingWritesContext.func1  persister.go:265
```

**Confirmed in the shipped binary**, on ordinary shutdown of a 2-source pipeline, no test harness involved.

## The fix

`flushWg`/`callbackWg` are replaced by a per-flush `*flushState` holding two channels. `triggerFlush` publishes a new generation under `p.m` before starting it; `WaitPendingWrites` snapshots the pointer under `p.m` and waits on the channels **outside** the lock.

A waiter now reads an immutable snapshot, and a new flush allocates new channels rather than mutating a counter someone may be waiting on — so the WaitGroup rule that was unenforceable here no longer applies.

**Why not just take `p.m` in `WaitPendingWrites`?** It closes the race and replaces a crash with something arguably worse. `WaitPendingWritesContext` deliberately returns early on timeout while its inner goroutine keeps waiting; if that goroutine held `p.m`, one stuck flush would stall **every** connector's `Persist` process-wide. The bounded-wait design that method's doc argues for at length exists precisely to avoid that.

## Verified in the real binary, before vs after

Same pipeline, same image, three runs each:

| engine | before | with fix |
| --- | --- | --- |
| v1 | **1/3 panicked** | **0/3** |
| arch-v2 | **2/3 panicked** | **0/3** |

arch-v2 runs one Worker per source so they all tear down at once, which is why it hit nearly every time. Both engines are affected — this is `pkg/connector`, not funnel.

## Failure-mode analysis

- **Impact was crash/availability, not data loss.** A crash replays from the last durable position, so at-least-once held (invariant 3). But **invariant 7** — SIGTERM drains and checkpoints before exit — was violated on nearly every multi-source shutdown.
- **It also broke anything needing a clean exit.** A `--dev.cpuprofile` run produced a **0-byte profile** because the process died before pprof flushed. That is literally how this was found.
- **What could this change break:** `WaitPendingWrites` now waits on the generation in flight *at call time*. That matches the documented contract ("every flush already triggered"), and a caller that arrives before any flush exists returns immediately, as before.
- **Rollback:** revert; self-contained to `persister.go`.

## Non-vacuity

Two tests, and the concurrency one is verified to fail without the fix:

- Reverting the snapshot read to an unlocked read → `WARNING: DATA RACE` and the test fails under `-race`.
- Against the original WaitGroups it panics outright, killing the test binary.

The second test pins that `WaitPendingWrites` still covers **callback** completion, not just the store write — the part easiest to lose when swapping the WaitGroups out, and the part Approach A's deferred plugin-ack (`Source.Ack`) depends on.

## Adversarial self-review

- *Does `callbacksDone` still mean what `callbackWg` meant?* Yes, and it's kept separate from `writeDone` on purpose: `flushNow` fires callbacks in their own goroutines without waiting, so a caller needing the side effects must be able to wait past the store write.
- *Can the per-flush WaitGroup feeding `callbacksDone` be reused underneath a `Wait`?* No — it is local to one generation, never published, and never waited on by anyone but its own closer goroutine.
- *Does `triggerFlush` still serialize flushes?* Yes. It waits on the previous generation's `writeDone` while holding `p.m`, exactly as `flushWg.Wait()` did.
- *Ordering hazard:* the generation is published under `p.m` **before** the flush goroutine starts, so a concurrent waiter either misses it entirely (correct — it was called before the flush was triggered) or sees it whole.
- *Known adjacent gap, not fixed here:* `connWg` has the same shape — `ConnectorStarted` calls `connWg.Add(1)` with no lock while `Wait()` calls `connWg.Wait()`. I could not construct a reaching path (connectors are registered before the wait is meaningful), so I have not touched it, but it is worth its own look rather than being silently assumed safe.

## Checks

`go build ./...` · `go test -race ./pkg/connector/...` · `golangci-lint run ./pkg/connector/...` → 0 issues · before/after verified in a Docker-built binary.