### PR TITLE
test(mock): wait for the source mock's run goroutine instead of sampling a flag

### DIFF
--- a/pkg/plugin/connector/mock/source.go
+++ b/pkg/plugin/connector/mock/source.go
@@ -19,7 +19,9 @@ import (
 	"io"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/conduitio/conduit-commons/csync"
 	"github.com/conduitio/conduit-commons/opencdc"
 	"github.com/conduitio/conduit-connector-protocol/pconnector"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
@@ -111,13 +113,27 @@ func SourcePluginWithRecords(records []opencdc.Record, wantErr error) Configurab
 		t := p.ctrl.T.(*testing.T)
 		is := is.New(t)
 
-		var done atomic.Bool
+		// onRun functions are launched as DETACHED goroutines by the Run
+		// expectation, and nothing joins them. Sampling a flag in t.Cleanup
+		// (this used to be `is.True(done.Load())` over an atomic.Bool) is
+		// therefore a race by construction: it passes only when the sender
+		// goroutine happened to finish first. It failed most often in tests
+		// that kill the pipeline early on purpose, because the sender is then
+		// still blocked in Send on a cancelled stream — which is exactly the
+		// "passes in isolation, fails ~2 in 40 under load" profile tracked in
+		// #2746. WAIT for the goroutine, bounded, matching what
+		// DestinationPluginWithRecords already does. A source that genuinely
+		// never finishes still fails, just correctly and with a timeout to
+		// say so.
+		var wg csync.WaitGroup
+		wg.Add(1)
 		t.Cleanup(func() {
-			is.True(done.Load()) // run didn't finish
+			err := wg.WaitTimeout(context.Background(), time.Second)
+			is.NoErr(err) // run didn't finish
 		})
 
 		p.onRun = append(p.onRun, func() error {
-			defer done.Store(true)
+			defer wg.Done()
 			serverStream := p.Stream.Server()
 			for _, rec := range records {
 				err := serverStream.Send(pconnector.SourceRunResponse{Records: []opencdc.Record{rec}})
@@ -139,14 +155,23 @@ func SourcePluginWithAcks(wantCount int, assertAckCount bool) ConfigurableSource
 		t := p.ctrl.T.(*testing.T)
 		is := is.New(t)
 
+		// Same detached-goroutine hazard as SourcePluginWithRecords above: the
+		// recv loop below runs unjoined, so reading gotCount straight out of
+		// t.Cleanup could observe a count the loop had not finished
+		// accumulating. Wait for the loop to exit first, then assert.
 		var gotCount atomic.Int64
+		var wg csync.WaitGroup
+		wg.Add(1)
 		if assertAckCount {
 			t.Cleanup(func() {
+				err := wg.WaitTimeout(context.Background(), time.Second)
+				is.NoErr(err)                             // ack loop didn't finish
 				is.Equal(int(gotCount.Load()), wantCount) // number of expected acks don't match
 			})
 		}
 
 		p.onRun = append(p.onRun, func() error {
+			defer wg.Done()
 			serverStream := p.Stream.Server()
 			for {
 				_, err := serverStream.Recv()


### PR DESCRIPTION
**Tier 2** (test harness). Fixes the fast-failure half of #2746 — a pre-flip blocker, since `tests/chaos (race, x3)` is a required context and a suite failing ~2 in 40 corrupts every signal gathered after it.

## The bug

`SourcePluginWithRecords` registered a `t.Cleanup` asserting `is.True(done.Load())` over an `atomic.Bool` its `onRun` function set on exit. But `onRun` functions are launched as **detached** goroutines by the `Run` expectation — `go func(fn)` — and nothing ever joins them.

The assertion was therefore a race by construction: it passed only when the sender goroutine happened to finish before cleanup ran.

It clustered on exactly the tests that **kill the pipeline early on purpose** (`FatalErrorOneSource_DegradesWholePipeline`, `Stop_SourceTeardownFails_NoRecovery`, `TransientErrorOneSource_Recovers`), because the sender is then still blocked in `Send` on a cancelled stream and hasn't returned. That is the "passes 60/60 in isolation, fails ~2 per 40-count sweep under load" profile — and why four different tests all failed on the same line:

```text
source.go:116: not true: done.Load() // run didn't finish
```

## The fix

Wait for the goroutine, bounded — which `DestinationPluginWithRecords` in the sibling file **already does** (`csync.WaitGroup` + `WaitTimeout` in cleanup). No new pattern invented; the source mock never got the same treatment.

A source that genuinely never finishes still fails — but correctly, with a timeout saying so, rather than an instant flag read that cannot distinguish "never finished" from "hasn't finished yet".

`SourcePluginWithAcks` had the identical hazard and is fixed the same way: its recv loop is also detached, so reading `gotCount` straight out of `t.Cleanup` could observe a count the loop hadn't finished accumulating.

## Verification

Three consecutive `-race -count=40` sweeps of `TestServiceLifecycle_NSource`:

| | result |
| --- | --- |
| before | ~2 failures per sweep |
| after | **3/3 sweeps clean** |

Plus `go test -race ./pkg/lifecycle-poc/... ./pkg/lifecycle/...` green, `golangci-lint` 0 issues.

## Not fixed here

The **10-minute hang** of `TestServiceLifecycle_NSource_TransientErrorOneSource_Recovers` seen once in CI. Not reproduced locally, and a different shape from these instant failures — a bounded wait like this one could in principle produce a hang if the goroutine truly never returns, so it deserves its own investigation rather than being assumed fixed by proximity. **#2746 stays open for it.**