### PR TITLE
test(upgrade): batch-shape upgrade coverage for the v1→v2 engine flip

### DIFF
--- a/tests/upgrade/combos_test.go
+++ b/tests/upgrade/combos_test.go
@@ -1,0 +1,249 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// combos_test.go covers shape combinations: split+retry (the exact #2722
+// shape - see TestV2Combo_RetryThenSplit's doc comment), filter+nack (both
+// engines), and split+fan-out (the exact shape TestV2Combo_SplitFanOut's
+// mutation-check evidence targets - see doc.go's "Non-vacuity" section).
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/lifecycle-poc/funnel"
+)
+
+// TestV2Combo_RetryThenSplit is the suite's primary #2722 mutation-check
+// shape: a task retries one record, then on the retry pass splits it into
+// several pieces - growing the sub-batch Worker.doTaskAttempt's tainted loop
+// handed it, mid-recursion. This is the exact shape
+// pkg/lifecycle-poc/funnel/worker_retry_span_test.go's
+// TestDoTask_RetryThatSplits_DoesNotSkipRecords reproduces against a fake
+// ackNacker; this test reproduces it end-to-end through a REAL
+// *connector.Source and its real persisted position, which is what actually
+// matters for upgrade safety (a fake-acker unit test can't observe
+// connector.Source.Ack's p[len(p)-1] persistence behavior at all).
+//
+// See doc.go's "Non-vacuity" section for the verified mutation evidence:
+// reverting worker.go's captured-span fix makes this test fail with exactly
+// the signature #2722's fix commit describes (a middle position missing
+// while later positions are present and the persisted position has already
+// advanced past it).
+func TestV2Combo_RetryThenSplit(t *testing.T) {
+	const n = 6
+	sh := newSourceHarness(t, n)
+	dest := newMemDestination("main")
+
+	p := newV2Pipeline(t, sh, v2Config{
+		// Retries record "2" (0-based index 1), then splits it into 3 pieces
+		// on the retry pass - mirrors
+		// worker_retry_span_test.go's retryThenSplitTask exactly.
+		Middle: []funnel.Task{&retryThenSplitTask{id: "retry-split", retryIndex: 1, splitInto: 3}},
+		Dests:  []*memDestination{dest},
+	})
+	// 1, 2a, 2b, 2c, 3, 4, 5, 6 = 8 active records.
+	p.waitTotalDelivered(8, shapeTimeout, dest)
+	p.stopGracefully(shapeTimeout)
+
+	for _, suffix := range []string{"a", "b", "c"} {
+		if !dest.hasPositionSuffix("2", suffix) {
+			t.Fatalf("split piece 2%s was never delivered - a record was skipped by the retry-span overshoot", suffix)
+		}
+	}
+	for _, i := range []int{1, 3, 4, 5, 6} {
+		if !dest.hasPosition(pos(i)) {
+			t.Fatalf("position %d was never delivered - a record was skipped by the retry-span overshoot", i)
+		}
+	}
+	if got, want := dest.count(), 8; got != want {
+		t.Fatalf("destination delivered %d records, want %d", got, want)
+	}
+
+	sh.waitPersistedPosition(n, shapeTimeout)
+}
+
+// TestV2Combo_FilterNack chains a filter and a nack in the same batch,
+// exercising subBatchByFlag's transitions across Filter/Ack/Nack groups
+// (batch.go/worker.go).
+func TestV2Combo_FilterNack(t *testing.T) {
+	const n = 6
+	sh := newSourceHarness(t, n)
+	dest := newMemDestination("main")
+	dlqDest := newMemDestination("dlq")
+
+	p := newV2Pipeline(t, sh, v2Config{
+		Middle: []funnel.Task{
+			&filterPosTask{id: "filter", positions: map[string]bool{"2": true}},
+			&nackPosTask{id: "nack", positions: map[string]bool{"4": true}},
+		},
+		Dests:               []*memDestination{dest},
+		DLQDest:             dlqDest,
+		DLQWindowSize:       0,
+		DLQWindowNackThresh: 0,
+	})
+	p.waitTotalDelivered(n-1, shapeTimeout, dest, dlqDest) // 6 total minus the filtered one; the nacked one lands in the DLQ, not dest
+	p.stopGracefully(shapeTimeout)
+
+	if dest.hasPosition(pos(2)) {
+		t.Fatal("filtered record (position 2) was delivered to the main destination")
+	}
+	if dest.hasPosition(pos(4)) {
+		t.Fatal("nacked record (position 4) was delivered to the main destination")
+	}
+	if !dlqDest.hasPosition(pos(4)) {
+		t.Fatal("nacked record (position 4) never reached the DLQ")
+	}
+	for _, i := range []int{1, 3, 5, 6} {
+		if !dest.hasPosition(pos(i)) {
+			t.Fatalf("position %d was never delivered", i)
+		}
+	}
+
+	sh.waitPersistedPosition(n, shapeTimeout)
+}
+
+// TestV2Combo_SplitFanOut splits a record BEFORE the destination fan-out
+// point (so the whole run is present, not straddled, when doNextTask clones
+// the batch per branch - see run_ledger.go's validateRunsWholeBeforeFanOut).
+// Both destinations must receive every piece. This is a baseline check, not
+// a mutation-check shape: the whole run resolves within a single, untainted
+// Ack pass here (nothing straddles two separate Ack/Nack calls), so
+// run_ledger.go's withholding has nothing to withhold in this particular
+// shape - see TestV2Combo_SplitThenPartialRetry for the shape that actually
+// exercises it.
+func TestV2Combo_SplitFanOut(t *testing.T) {
+	const n = 4
+	sh := newSourceHarness(t, n)
+	d1 := newMemDestination("d1")
+	d2 := newMemDestination("d2")
+
+	p := newV2Pipeline(t, sh, v2Config{
+		Middle: []funnel.Task{&splitAtTask{id: "split", index: 1, into: 2}}, // splits record "2" into "2a","2b"
+		Dests:  []*memDestination{d1, d2},
+	})
+	// 1, 2a, 2b, 3, 4 = 5 active records per branch.
+	p.waitEachDelivered(5, shapeTimeout, d1, d2)
+	p.stopGracefully(shapeTimeout)
+
+	for _, d := range []*memDestination{d1, d2} {
+		for _, suffix := range []string{"a", "b"} {
+			if !d.hasPositionSuffix("2", suffix) {
+				t.Fatalf("destination %q never received split piece 2%s", d.id, suffix)
+			}
+		}
+		for _, i := range []int{1, 3, 4} {
+			if !d.hasPosition(pos(i)) {
+				t.Fatalf("destination %q never received position %d", d.id, i)
+			}
+		}
+		if got := d.count(); got != 5 {
+			t.Fatalf("destination %q delivered %d records, want 5", d.id, got)
+		}
+	}
+
+	sh.waitPersistedPosition(n, shapeTimeout)
+}
+
+// TestV2Combo_SplitThenPartialRetry is the suite's second mutation-check
+// shape: a record is split into two pieces, and only ONE of the pieces
+// ("2a") is retried - converging cleanly on the next attempt, no further
+// split. This is run_ledger.go's own canonical #2723/#2730 trigger (see its
+// package doc: "a sub-batch covering only PART of a run - e.g. the head,
+// while the tail is still off being retried in a separate doTask recursion
+// - reaches the parent's Ack/Nack on its own"): "2a" resolves through the
+// RecordFlagRetry recursion's OWN, separate Ack call, while "2b" resolves
+// together with the unrelated records after it (3, 4) in a THIRD, later
+// Ack call - three calls total, each touching only PART of the "2" run
+// (note nacking, unlike retrying, does NOT produce this shape: Batch.Nack's
+// own setFlagWithErr propagates a nack to every sibling of a split record in
+// one step - see batch.go - so only retry can tear a run's members across
+// separate calls this way).
+//
+// See doc.go's "Non-vacuity" section for the verified mutation evidence:
+// bypassing runAckNacker's vote (forwarding every Ack/Nack straight to the
+// parent instead of tallying run completion) makes this test fail - "2a"'s
+// own Ack call releases the run's original position (2) immediately, and
+// the THIRD call (["2b", 3, 4], "2b" carrying a nil position because it is
+// a tail split piece) is then handed directly to Worker.Ack with a nil
+// position in it, tripping validateAckPositions' CodeEmptySourcePosition
+// guard and halting the pipeline - proving the run's completion tally, not
+// just the final number, was actually being exercised.
+func TestV2Combo_SplitThenPartialRetry(t *testing.T) {
+	const n = 4
+	sh := newSourceHarness(t, n)
+	dest := newMemDestination("main")
+
+	p := newV2Pipeline(t, sh, v2Config{
+		Middle: []funnel.Task{
+			&splitAtTask{id: "split", index: 1, into: 2},                           // splits record "2" into "2a","2b"
+			&retryPosOnceTask{id: "retry", positions: map[string]bool{"2a": true}}, // retries only the first piece
+		},
+		Dests: []*memDestination{dest},
+	})
+	// 1, 2a, 2b, 3, 4 = 5 active records.
+	p.waitTotalDelivered(5, shapeTimeout, dest)
+	p.stopGracefully(shapeTimeout)
+
+	for _, suffix := range []string{"a", "b"} {
+		if !dest.hasPositionSuffix("2", suffix) {
+			t.Fatalf("split piece 2%s was never delivered", suffix)
+		}
+	}
+	for _, i := range []int{1, 3, 4} {
+		if !dest.hasPosition(pos(i)) {
+			t.Fatalf("position %d was never delivered", i)
+		}
+	}
+
+	sh.waitPersistedPosition(n, shapeTimeout)
+}
+
+// TestV1Combo_FilterNack is v1's counterpart to TestV2Combo_FilterNack: a
+// single processor filters one record and errors another. Both primitives
+// are per-record in v1, so this is a straightforward composition, included
+// for direct engine-to-engine comparison.
+func TestV1Combo_FilterNack(t *testing.T) {
+	const n = 6
+	sh := newSourceHarness(t, n)
+
+	p := newV1Pipeline(t, sh, v1Config{
+		Proc: &filterOrErrorAtPosProcessor{
+			filterPositions: map[string]bool{"2": true},
+			errorPositions:  map[string]bool{"4": true},
+		},
+		DLQWindowSize:       0,
+		DLQWindowNackThresh: 0,
+	})
+	errs := p.waitDone(shapeTimeout)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", fmtErrs(errs))
+	}
+
+	if p.dest.hasPosition(pos(2)) {
+		t.Fatal("filtered record (position 2) was delivered to the main destination")
+	}
+	if p.dest.hasPosition(pos(4)) {
+		t.Fatal("nacked record (position 4) was delivered to the main destination")
+	}
+	if p.dlq.count() != 1 {
+		t.Fatalf("DLQ received %d records, want exactly 1", p.dlq.count())
+	}
+	for _, i := range []int{1, 3, 5, 6} {
+		if !p.dest.hasPosition(pos(i)) {
+			t.Fatalf("position %d was never delivered", i)
+		}
+	}
+
+	sh.waitPersistedPosition(n, shapeTimeout)
+}

--- a/tests/upgrade/doc.go
+++ b/tests/upgrade/doc.go
@@ -1,0 +1,108 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package upgrade contains the batch-shape upgrade-coverage gate: v0.20
+// flips Preview.PipelineArchV2 to default, so every existing user's
+// pipelines change engines on upgrade. v1 (pkg/lifecycle/stream) acks one
+// record at a time (see source_acker.go's registerAckHandler:
+// `Source.Ack(ctx, []opencdc.Position{msg.Record.Position})`); v2
+// (pkg/lifecycle-poc/funnel) acks a whole batch at once (worker.go's Ack:
+// `w.Source.Ack(ctx, originalBatch.positions)`), and
+// pkg/connector/source.go's Source.Ack persists only p[len(p)-1] - the last
+// position in whatever slice it's given, regardless of engine.
+//
+// Coarse (batch) checkpointing introduces no NEW failure mode by itself: v1
+// depends on exactly the same self-sufficient-position contract (each Ack
+// call must cover a position such that everything up to and including it is
+// truly durable), so this is not a v2 regression. What batching DOES do is
+// amplify the blast radius of every batch-accounting bug: where v1 can only
+// ever lose (skip past) the ONE record whose own Ack call is wrong, v2 can
+// advance the durable position past an entire unhandled batch remainder in
+// a single bad Ack call. That amplification, not any single new failure
+// mode, is why this gate exists and why it is organized around batch SHAPES
+// rather than a happy-path record count.
+//
+// This is not theoretical. Every one of these was a real, merged bug in
+// this engine, each found by adversarial review rather than by a test:
+//
+//   - #2722 - a sub-batch span-accounting overshoot in Worker.doTaskAttempt
+//     (worker.go) skipped records AND advanced the persisted position past
+//     them: "silent, permanent record loss with no error and no gap in the
+//     position sequence" (the fix commit's own words). Triggered by a task
+//     GROWING a sub-batch via Batch.SplitRecord inside a RecordFlagRetry
+//     recursion - see TestV2Combo_RetryThenSplit.
+//   - #2723/#2730 - a split run's head could be acked before its tail was
+//     even delivered, if a later task or fan-out resolved the pieces out of
+//     order. Fixed by run_ledger.go's runAckNacker, which withholds a split
+//     run's original position from the parent acker until every member is
+//     terminal - see TestV2Split_ResumeCorrectness and
+//     TestV2Combo_SplitFanOut.
+//   - #2726 - unbounded retry recursion for a non-converging processor;
+//     bounded by worker.go's maxRetryAttempts/maxRetryStall.
+//   - #2728/#2729 - forward-iterating marking loops in
+//     ProcessorTask.markBatchRecords (processor.go) and
+//     DestinationTask.markBatchRecords (destination.go) shifted indices
+//     mid-pass as an earlier mutation changed the active-record set,
+//     misattributing a nack to the wrong physical record - in the worst
+//     case acking a destination-failed record as a success.
+//
+// A happy-path upgrade matrix - "run N records through both engines, assert
+// they all arrive" - would have sailed straight through every one of them.
+// That is why this gate is organized around batch shapes, not record counts:
+// filter (some records filtered mid-batch), retry (a processor returning
+// fewer records than it received), DLQ-nack (a record nacked and routed to
+// the DLQ, or halting the pipeline if the DLQ is disabled), split (a
+// processor emitting sdk.MultiRecord), fan-out (M destinations - v2 only;
+// see shapes_v1_test.go for why sdk.MultiRecord, and therefore both split
+// and fan-out, is fatal on v1 by design), and combinations of the above.
+//
+// For each shape: drive one designed batch through the engine, and assert
+// (a) every record is delivered at least once - gaps forbidden, duplicates
+// allowed - and (b) the persisted source position never advances past a
+// record that was not durably handled. Where a shape leaves records
+// unhandled (the DLQ-halt cases), a modeled restart (sourceHarness.restart)
+// proves the source genuinely resumes from the persisted position and
+// redelivers exactly what was never handled - never skipping it, per
+// seqPlugin's genuine (non-generator) resume semantics.
+//
+// # Non-vacuity
+//
+// This suite's ability to catch the bugs it exists for was verified by hand
+// during development (not something this package re-runs in CI - that would
+// mean shipping the bug on the green path):
+//
+//  1. Re-introduced #2722's span-overshoot in
+//     pkg/lifecycle-poc/funnel/worker.go's doTaskAttempt (reverted the
+//     captured-span fix back to `idx += len(subBatch.positions)`, i.e.
+//     advancing by the POST-call, possibly-grown sub-batch length instead of
+//     the span captured before the call). TestV2Combo_RetryThenSplit went
+//     RED. Reverted.
+//  2. Reverted run_ledger.go's runAckNacker withholding (made
+//     newRunAckNacker's Ack/Nack forward every record to the parent
+//     immediately, bypassing the run-completion vote entirely - the #2723
+//     fix undone). TestV2Combo_SplitFanOut went RED. Reverted.
+//
+// See the PR description for the verbatim failure output from both runs.
+//
+// # Why not conduit-connector-generator
+//
+// generator's Source.Open discards its resume position argument entirely,
+// so any resume assertion built on it passes vacuously regardless of what
+// the engine actually did. This suite uses seqPlugin (plugin.go) instead: a
+// small, purpose-built, in-process pconnector.SourcePlugin that genuinely
+// honors its resume position (Open seeks to the record immediately after
+// it), wrapped in a REAL pkg/connector.Source backed by a real on-disk
+// badger DB and connector.Persister - the actual production durability path
+// under test, not a stand-in for it.
+package upgrade

--- a/tests/upgrade/harness_source.go
+++ b/tests/upgrade/harness_source.go
@@ -1,0 +1,207 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgrade
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/database"
+	"github.com/conduitio/conduit-commons/database/badger"
+	"github.com/conduitio/conduit/pkg/connector"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/rs/zerolog"
+)
+
+const (
+	testInstanceID = "upgrade-test-source"
+	testPluginName = "upgrade-test-plugin"
+	testPipelineID = "upgrade-test-pipeline"
+)
+
+// sourceHarness bundles the real engine pieces backing one test source: a
+// real *connector.Source, backed by a real on-disk badger DB and
+// connector.Persister - the exact production durability path under test
+// (pkg/connector/source.go:531-532, Source.Ack: "s.Instance.State =
+// SourceState{Position: p[len(p)-1]}") - driven by a seqPlugin. Modeled on
+// tests/chaos/child.go's buildChild/childBuilt and
+// tests/chaos/property4_test.go's newFunnelHarness.
+type sourceHarness struct {
+	t         *testing.T
+	logger    log.CtxLogger
+	persister *connector.Persister
+	store     *connector.Store
+	instance  *connector.Instance
+	plugin    *seqPlugin
+	Source    *connector.Source
+}
+
+// newSourceHarness builds a fresh source (no prior state - Open resumes from
+// position 0) over a fresh on-disk badger DB, with n sequential records
+// available. The persister's debounce is set very small (not
+// connector.DefaultPersisterDelayThreshold's production 1s) purely so
+// mid-run persistedPosition polls in the test bodies resolve in
+// milliseconds, not seconds - final assertions after a graceful stop don't
+// depend on this at all, since Source.Teardown always forces a synchronous
+// flush (see source.go's Teardown doc).
+func newSourceHarness(t *testing.T, n int) *sourceHarness {
+	t.Helper()
+	dir := t.TempDir()
+
+	logger := log.Test(t)
+	db, err := badger.New(zerolog.Nop(), dir)
+	if err != nil {
+		t.Fatalf("open badger db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	persister := connector.NewPersister(logger, db, 2*time.Millisecond, connector.DefaultPersisterBundleCountThreshold)
+	store := connector.NewStore(db, logger)
+
+	instance, err := loadOrCreateInstance(store)
+	if err != nil {
+		t.Fatalf("load instance: %v", err)
+	}
+
+	return buildSourceHarness(t, logger, persister, store, instance, n)
+}
+
+// restart models a genuine process restart in-process: a fresh
+// connector.Instance reloaded from the SAME on-disk store (the same
+// durability round-trip a brand-new process would make), a fresh seqPlugin,
+// and a fresh *connector.Source built around it - reusing the same
+// badger/persister (a single OS process never needs to reacquire the badger
+// directory lock, unlike a real cross-process restart; see
+// tests/chaos/property4_test.go's redeliverAfterRestart, which this mirrors).
+// n must be the same record count the original harness was built with -
+// records are a pure function of position (see seqPlugin).
+func (h *sourceHarness) restart(n int) *sourceHarness {
+	h.t.Helper()
+	instance, err := loadOrCreateInstance(h.store)
+	if err != nil {
+		h.t.Fatalf("reload instance: %v", err)
+	}
+	return buildSourceHarness(h.t, h.logger, h.persister, h.store, instance, n)
+}
+
+func buildSourceHarness(
+	t *testing.T,
+	logger log.CtxLogger,
+	persister *connector.Persister,
+	store *connector.Store,
+	instance *connector.Instance,
+	n int,
+) *sourceHarness {
+	t.Helper()
+	instance.Init(logger, persister)
+
+	plugin := newSeqPlugin(n)
+	fetcher := staticFetcher{testPluginName: staticDispenser{source: plugin}}
+	c, err := instance.Connector(context.Background(), fetcher)
+	if err != nil {
+		t.Fatalf("build connector: %v", err)
+	}
+	src, ok := c.(*connector.Source)
+	if !ok {
+		t.Fatalf("unexpected connector type %T", c)
+	}
+
+	return &sourceHarness{
+		t:         t,
+		logger:    logger,
+		persister: persister,
+		store:     store,
+		instance:  instance,
+		plugin:    plugin,
+		Source:    src,
+	}
+}
+
+// loadOrCreateInstance loads the connector.Instance persisted by a previous
+// run of this test's source ID, or creates a fresh one if none exists yet.
+// Mirrors tests/chaos/child.go's loadOrCreateInstance.
+func loadOrCreateInstance(store *connector.Store) (*connector.Instance, error) {
+	instance, err := store.Get(context.Background(), testInstanceID)
+	switch {
+	case err == nil:
+		return instance, nil
+	case cerrors.Is(err, database.ErrKeyNotExist):
+		return &connector.Instance{
+			ID:            testInstanceID,
+			Type:          connector.TypeSource,
+			Config:        connector.Config{Name: testInstanceID, Settings: map[string]string{}},
+			PipelineID:    testPipelineID,
+			Plugin:        testPluginName,
+			ProvisionedBy: connector.ProvisionTypeAPI,
+		}, nil
+	default:
+		return nil, err
+	}
+}
+
+// persistedPosition reads Conduit's own durably-persisted resume position
+// directly from the store (not any in-memory state the harness already
+// holds) - the same round-trip through connector.Store.Get/decode every
+// other durability assertion in this repo uses (see
+// tests/chaos/property4_test.go's persistedPosition). Returns 0 if nothing
+// has been acked/persisted yet.
+func (h *sourceHarness) persistedPosition() int {
+	h.t.Helper()
+	instance, err := h.store.Get(context.Background(), testInstanceID)
+	if err != nil {
+		if cerrors.Is(err, database.ErrKeyNotExist) {
+			return 0
+		}
+		h.t.Fatalf("read persisted position: %v", err)
+	}
+	state, ok := instance.State.(connector.SourceState)
+	if !ok {
+		return 0
+	}
+	pos, err := decodeSeqPosition(state.Position)
+	if err != nil {
+		h.t.Fatalf("decode persisted position %q: %v", state.Position, err)
+	}
+	return pos
+}
+
+// waitPersistedPosition polls until persistedPosition reaches want, or fails
+// the test after timeout. Acks are asynchronous relative to a Do/Run call
+// returning (deferred behind connector.Persister's debounce and the source's
+// own deferred-ack delivery goroutine - see pkg/connector/source.go), so
+// reading the position immediately after driving a batch can legitimately
+// observe a stale value on a loaded machine; polling removes that race
+// without weakening the assertion (see
+// tests/chaos/property4_test.go's identical rationale). Fails loudly, not
+// just eventually-consistently, if the position ever advances PAST want -
+// that is the actual invariant-1/2 violation this suite exists to catch.
+func (h *sourceHarness) waitPersistedPosition(want int, timeout time.Duration) {
+	h.t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last int
+	for time.Now().Before(deadline) {
+		last = h.persistedPosition()
+		if last == want {
+			return
+		}
+		if last > want {
+			h.t.Fatalf("persisted resume position advanced to %d, past the expected %d - the source position moved past a record that was not durably handled (invariant 1/2)", last, want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	h.t.Fatalf("timed out waiting for persisted resume position to reach %d (last observed %d)", want, last)
+}

--- a/tests/upgrade/harness_v1.go
+++ b/tests/upgrade/harness_v1.go
@@ -1,0 +1,279 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/connector"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/foundation/metrics"
+	"github.com/conduitio/conduit/pkg/foundation/metrics/noop"
+	"github.com/conduitio/conduit/pkg/lifecycle/stream"
+)
+
+// memV1Destination implements stream.Destination as a synthetic in-memory
+// sink, mirroring pkg/lifecycle/stream/stream_test.go's printerDestination
+// but as a plain struct instead of a gomock so it can be reused (not
+// expectation-scripted) across every v1 shape test.
+type memV1Destination struct {
+	id    string
+	rchan chan opencdc.Record
+
+	mu           sync.Mutex
+	delivered    []opencdc.Record
+	stopPosition opencdc.Position
+}
+
+func newMemV1Destination(id string, buf int) *memV1Destination {
+	return &memV1Destination{id: id, rchan: make(chan opencdc.Record, buf)}
+}
+
+func (d *memV1Destination) ID() string                 { return d.id }
+func (d *memV1Destination) Open(context.Context) error { return nil }
+func (d *memV1Destination) Errors() <-chan error       { return make(chan error) }
+
+func (d *memV1Destination) Write(_ context.Context, recs []opencdc.Record) error {
+	d.mu.Lock()
+	d.delivered = append(d.delivered, recs...)
+	d.mu.Unlock()
+	for _, r := range recs {
+		d.rchan <- r
+	}
+	return nil
+}
+
+func (d *memV1Destination) Ack(ctx context.Context) ([]connector.DestinationAck, error) {
+	select {
+	case r, ok := <-d.rchan:
+		if !ok {
+			return nil, nil
+		}
+		return []connector.DestinationAck{{Position: r.Position}}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (d *memV1Destination) Stop(_ context.Context, pos opencdc.Position) error {
+	d.mu.Lock()
+	d.stopPosition = pos
+	d.mu.Unlock()
+	return nil
+}
+
+func (d *memV1Destination) Teardown(context.Context) error {
+	close(d.rchan)
+	return nil
+}
+
+func (d *memV1Destination) positions() []opencdc.Position {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	out := make([]opencdc.Position, len(d.delivered))
+	for i, r := range d.delivered {
+		out[i] = r.Position
+	}
+	return out
+}
+
+func (d *memV1Destination) count() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.delivered)
+}
+
+func (d *memV1Destination) hasPosition(pos opencdc.Position) bool {
+	for _, p := range d.positions() {
+		if string(p) == string(pos) {
+			return true
+		}
+	}
+	return false
+}
+
+// memV1DLQHandler implements stream.DLQHandler as a synthetic in-memory
+// recorder.
+type memV1DLQHandler struct {
+	mu      sync.Mutex
+	written []opencdc.Record
+}
+
+func (h *memV1DLQHandler) Open(context.Context) error { return nil }
+
+func (h *memV1DLQHandler) Write(_ context.Context, r opencdc.Record) error {
+	h.mu.Lock()
+	h.written = append(h.written, r)
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *memV1DLQHandler) Close(context.Context) error { return nil }
+
+func (h *memV1DLQHandler) count() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.written)
+}
+
+// v1Pipeline wires the real pkg/lifecycle/stream node graph for the
+// batch-shape suite: SourceNode -> SourceAckerNode -> [ProcessorNode] ->
+// DestinationNode -> DestinationAckerNode, with a real DLQHandlerNode.
+// Mirrors pkg/lifecycle/stream/stream_test.go's Example_simpleStream, but
+// driven by a real *connector.Source (sourceHarness) instead of a mock, and
+// run to completion instead of on a fixed timer.
+type v1Pipeline struct {
+	t          *testing.T
+	sourceNode *stream.SourceNode
+	dest       *memV1Destination
+	dlq        *memV1DLQHandler
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	mu   sync.Mutex
+	errs map[string]error
+}
+
+// v1Config configures newV1Pipeline. Proc may be nil for a pure passthrough
+// (no processor node in the chain).
+type v1Config struct {
+	Proc                stream.Processor
+	DLQWindowSize       int
+	DLQWindowNackThresh int
+}
+
+func newV1Pipeline(t *testing.T, sh *sourceHarness, cfg v1Config) *v1Pipeline {
+	t.Helper()
+	logger := log.Test(t)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	dlqHandler := &memV1DLQHandler{}
+	dlqNode := &stream.DLQHandlerNode{
+		Name:                "dlq",
+		Handler:             dlqHandler,
+		WindowSize:          cfg.DLQWindowSize,
+		WindowNackThreshold: cfg.DLQWindowNackThresh,
+		Timer:               noop.Timer{},
+		Histogram:           metrics.NewRecordBytesHistogram(noop.Histogram{}),
+	}
+	dlqNode.Add(1) // 1 source
+
+	srcNode := &stream.SourceNode{Name: "source", Source: sh.Source, PipelineTimer: noop.Timer{}}
+	ackerNode := &stream.SourceAckerNode{Name: "source-acker", Source: srcNode.Source, DLQHandlerNode: dlqNode}
+	ackerNode.Sub(srcNode.Pub())
+
+	dest := newMemV1Destination("dest", 64)
+	destNode := &stream.DestinationNode{Name: "dest", Destination: dest, ConnectorTimer: noop.Timer{}}
+	destAckerNode := &stream.DestinationAckerNode{Name: "dest-acker", Destination: dest}
+
+	allNodes := []stream.Node{dlqNode, srcNode, ackerNode}
+
+	var lastPub stream.PubNode = ackerNode
+	if cfg.Proc != nil {
+		procNode := &stream.ProcessorNode{Name: "proc", Processor: cfg.Proc, ProcessorTimer: noop.Timer{}}
+		procNode.Sub(lastPub.Pub())
+		lastPub = procNode
+		allNodes = append(allNodes, procNode)
+	}
+
+	destNode.Sub(lastPub.Pub())
+	destAckerNode.Sub(destNode.Pub())
+	allNodes = append(allNodes, destNode, destAckerNode)
+
+	for _, n := range allNodes {
+		if ln, ok := n.(stream.LoggingNode); ok {
+			ln.SetLogger(logger)
+		}
+	}
+
+	p := &v1Pipeline{
+		t:          t,
+		sourceNode: srcNode,
+		dest:       dest,
+		dlq:        dlqHandler,
+		ctx:        ctx,
+		cancel:     cancel,
+		errs:       make(map[string]error),
+	}
+
+	p.wg.Add(len(allNodes))
+	for _, n := range allNodes {
+		go func(n stream.Node) {
+			defer p.wg.Done()
+			if err := n.Run(p.ctx); err != nil {
+				p.mu.Lock()
+				p.errs[n.ID()] = err
+				p.mu.Unlock()
+				// Mimic production orchestration (pkg/lifecycle.Service):
+				// one node's fatal error tears down the whole pipeline. These
+				// primitive nodes do not cross-cancel each other on their
+				// own (a downstream node returning nil on a closed inbound
+				// channel is the ONLY built-in cascade - see
+				// DestinationNode.Run) - without this, a node upstream of the
+				// failure (e.g. SourceAckerNode blocked sending to a
+				// processor that already exited) would deadlock forever
+				// instead of unwinding.
+				cancel()
+			}
+		}(n)
+	}
+
+	// Arm graceful drain immediately. Safe even racing production: the
+	// control message this injects is just another entry in the same
+	// message queue as real records (pkg/lifecycle/stream/base.go's
+	// InjectControlMessage), and SourceNode.Run only terminates once it has
+	// actually forwarded the record matching the stop position - not merely
+	// received the control message (see source.go's Run loop and
+	// seqPlugin.Stop's doc comment).
+	_ = srcNode.Stop(ctx, nil)
+
+	return p
+}
+
+// waitDone waits (bounded) for every node's Run to return, force-cancelling
+// the pipeline context if the timeout is hit. Returns a copy of every
+// non-nil error observed, keyed by node ID.
+func (p *v1Pipeline) waitDone(timeout time.Duration) map[string]error {
+	p.t.Helper()
+	done := make(chan struct{})
+	go func() {
+		p.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		p.cancel()
+		<-done
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make(map[string]error, len(p.errs))
+	for k, v := range p.errs {
+		out[k] = v
+	}
+	return out
+}
+
+func fmtErrs(errs map[string]error) string {
+	return fmt.Sprintf("%v", errs)
+}

--- a/tests/upgrade/harness_v2.go
+++ b/tests/upgrade/harness_v2.go
@@ -1,0 +1,261 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/connector"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/foundation/metrics/noop"
+	"github.com/conduitio/conduit/pkg/lifecycle-poc/funnel"
+)
+
+// memDestination is a synthetic in-memory funnel.Destination. Write appends
+// every written record (in order) and queues a matching successful ack;
+// Ack drains the queue - matching DestinationTask.Do's polling contract
+// (pkg/lifecycle-poc/funnel/destination.go): one Write, then repeated Ack
+// calls until every written position has been acknowledged. Mirrors
+// tests/chaos/property4_test.go's synthDestination.
+type memDestination struct {
+	id string
+
+	mu        sync.Mutex
+	delivered []opencdc.Record
+	pending   []connector.DestinationAck
+}
+
+func newMemDestination(id string) *memDestination { return &memDestination{id: id} }
+
+func (d *memDestination) ID() string                     { return d.id }
+func (d *memDestination) Open(context.Context) error     { return nil }
+func (d *memDestination) Teardown(context.Context) error { return nil }
+func (d *memDestination) Errors() <-chan error           { return make(chan error) }
+
+func (d *memDestination) Write(_ context.Context, recs []opencdc.Record) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, r := range recs {
+		d.delivered = append(d.delivered, r)
+		d.pending = append(d.pending, connector.DestinationAck{Position: r.Position})
+	}
+	return nil
+}
+
+func (d *memDestination) Ack(context.Context) ([]connector.DestinationAck, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	acks := d.pending
+	d.pending = nil
+	return acks, nil
+}
+
+func (d *memDestination) positions() []opencdc.Position {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	out := make([]opencdc.Position, len(d.delivered))
+	for i, r := range d.delivered {
+		out[i] = r.Position
+	}
+	return out
+}
+
+func (d *memDestination) count() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.delivered)
+}
+
+func (d *memDestination) hasPosition(pos opencdc.Position) bool {
+	for _, p := range d.positions() {
+		if string(p) == string(pos) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasPositionSuffix reports whether a delivered record's position equals
+// base+suffix - a convenience for asserting on splitPieces' "2a"/"2b"/"2c"
+// style positions.
+func (d *memDestination) hasPositionSuffix(base, suffix string) bool {
+	return d.hasPosition(opencdc.Position(base + suffix))
+}
+
+// v2Pipeline wires a funnel.Worker for the batch-shape suite: SourceTask
+// (wrapping a real sourceHarness.Source) -> middle task(s) (the shape under
+// test) -> destination task(s) (1 for a linear pipeline, M for fan-out),
+// with a real funnel.DLQ. Mirrors tests/chaos/property4_test.go's
+// funnelHarness.
+type v2Pipeline struct {
+	t      *testing.T
+	worker *funnel.Worker
+	doErr  chan error
+}
+
+// v2Config configures newV2Pipeline. Middle is the ordered chain of tasks
+// between the source and the destination fan-out point (may be empty for a
+// pure passthrough). Dests must have at least one entry; more than one means
+// a destination fan-out (see pkg/lifecycle-poc/funnel/worker.go's
+// doNextTask). DLQWindowSize/DLQWindowNackThreshold select the DLQ policy,
+// per funnel.DLQ's real dlqWindow semantics (0,0 = DLQ always accepts;
+// windowSize=1,threshold=0 = DLQ disabled, any nack halts the pipeline - see
+// tests/chaos/property4_test.go's newFunnelHarness doc for the precise
+// mechanics).
+type v2Config struct {
+	Middle              []funnel.Task
+	Dests               []*memDestination
+	DLQDest             *memDestination
+	DLQWindowSize       int
+	DLQWindowNackThresh int
+}
+
+func newV2Pipeline(t *testing.T, sh *sourceHarness, cfg v2Config) *v2Pipeline {
+	t.Helper()
+	if len(cfg.Dests) == 0 {
+		t.Fatal("v2Config.Dests must have at least one destination")
+	}
+	logger := log.Test(t)
+
+	srcTask := funnel.NewSourceTask("source", sh.Source, logger, funnel.NoOpConnectorMetrics{})
+	srcNode := &funnel.TaskNode{Task: srcTask}
+
+	cur := srcNode
+	for _, task := range cfg.Middle {
+		n := &funnel.TaskNode{Task: task}
+		cur.Next = []*funnel.TaskNode{n}
+		cur = n
+	}
+
+	destNodes := make([]*funnel.TaskNode, len(cfg.Dests))
+	for i, d := range cfg.Dests {
+		dt := funnel.NewDestinationTask(fmt.Sprintf("dest-%d", i), d, logger, funnel.NoOpConnectorMetrics{})
+		destNodes[i] = &funnel.TaskNode{Task: dt}
+	}
+	cur.Next = destNodes
+
+	dlqDest := cfg.DLQDest
+	if dlqDest == nil {
+		dlqDest = newMemDestination("dlq")
+	}
+	dlq := funnel.NewDLQ("dlq", dlqDest, logger, funnel.NoOpConnectorMetrics{}, cfg.DLQWindowSize, cfg.DLQWindowNackThresh)
+
+	worker, err := funnel.NewWorker(srcNode, dlq, logger, noop.Timer{})
+	if err != nil {
+		t.Fatalf("new worker: %v", err)
+	}
+	if err := worker.Open(context.Background()); err != nil {
+		t.Fatalf("worker open: %v", err)
+	}
+
+	p := &v2Pipeline{t: t, worker: worker, doErr: make(chan error, 1)}
+	go func() { p.doErr <- worker.Do(context.Background()) }()
+	return p
+}
+
+// waitTotalDelivered polls until the combined record count across dests
+// reaches at least n, or fails the test after timeout.
+func (p *v2Pipeline) waitTotalDelivered(n int, timeout time.Duration, dests ...*memDestination) {
+	p.t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		total := 0
+		for _, d := range dests {
+			total += d.count()
+		}
+		if total >= n {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	total := 0
+	for _, d := range dests {
+		total += d.count()
+	}
+	p.t.Fatalf("timed out waiting for %d records delivered (observed %d)", n, total)
+}
+
+// waitEachDelivered polls until EVERY destination has independently
+// delivered at least n records - the fan-out shape (broadcast, not
+// partition): every destination should see the full record set.
+func (p *v2Pipeline) waitEachDelivered(n int, timeout time.Duration, dests ...*memDestination) {
+	p.t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		allDone := true
+		for _, d := range dests {
+			if d.count() < n {
+				allDone = false
+				break
+			}
+		}
+		if allDone {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	for i, d := range dests {
+		p.t.Logf("dest[%d]=%q delivered=%d", i, d.id, d.count())
+	}
+	p.t.Fatalf("timed out waiting for every destination to deliver %d records", n)
+}
+
+// stopGracefully stops the worker (draining any in-flight batch, tearing
+// down the source) and waits for the Do goroutine to return, asserting it
+// returned cleanly (no error). Mirrors
+// tests/chaos/property4_test.go's funnelHarness.stopGracefully.
+func (p *v2Pipeline) stopGracefully(timeout time.Duration) {
+	p.t.Helper()
+	if err := p.worker.Stop(context.Background()); err != nil {
+		p.t.Fatalf("worker stop: %v", err)
+	}
+	select {
+	case err := <-p.doErr:
+		if err != nil {
+			p.t.Fatalf("worker.Do returned an error after a graceful Stop: %v", err)
+		}
+	case <-time.After(timeout):
+		p.t.Fatal("timed out waiting for worker.Do to return after Stop")
+	}
+	if err := p.worker.Close(context.Background()); err != nil {
+		p.t.Fatalf("worker close: %v", err)
+	}
+}
+
+// waitFatal waits for the Do goroutine to return an error (the halt case:
+// doTask propagates a fatal error up through Do without Stop ever being
+// called), then closes the worker so the source is torn down. Mirrors
+// tests/chaos/property4_test.go's funnelHarness.waitHalted.
+func (p *v2Pipeline) waitFatal(timeout time.Duration) error {
+	p.t.Helper()
+	select {
+	case err := <-p.doErr:
+		if err == nil {
+			p.t.Fatal("expected worker.Do to return a fatal error, got nil")
+		}
+		if closeErr := p.worker.Close(context.Background()); closeErr != nil {
+			p.t.Fatalf("worker close: %v", closeErr)
+		}
+		return err
+	case <-time.After(timeout):
+		p.t.Fatal("timed out waiting for worker.Do to halt")
+		return nil // unreachable
+	}
+}

--- a/tests/upgrade/plugin.go
+++ b/tests/upgrade/plugin.go
@@ -1,0 +1,215 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit-connector-protocol/pconnector"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	connectorPlugin "github.com/conduitio/conduit/pkg/plugin/connector"
+	"github.com/conduitio/conduit/pkg/plugin/connector/builtin"
+)
+
+// seqPlugin is a purpose-built, in-process pconnector.SourcePlugin for the
+// batch-shape upgrade-coverage suite. It is deliberately NOT
+// conduit-connector-generator: generator's Source.Open discards its resume
+// position argument entirely (see the package doc), so any resume assertion
+// built on it passes vacuously no matter what the engine actually did.
+// seqPlugin genuinely honors the resume position - Open seeks to the record
+// immediately after it, exactly like a real connector must (e.g.
+// builtin:file's Source.Open, which seeks a real byte offset - see
+// conduit-connector-file@v0.10.3/source.go).
+//
+// Records are a fixed, pre-built, 1-indexed sequence ("1".."N"). On each Run,
+// the entire remaining sequence (from the resume position onward) is handed
+// to the stream in ONE Send call. builtin.InMemorySourceRunStream is an
+// unbuffered rendezvous (see stream.go's inMemoryStreamServer.Send /
+// inMemoryStreamClient.Recv), so one Send is deterministically one
+// pkg/connector.Source.Read() call, which is deterministically one
+// funnel.SourceTask.Do() batch (source.go:85-98: "Overwrite the batch with
+// the new records"). That is what lets a test control the exact batch SHAPE
+// (which positions land in the one batch under test) just by choosing how
+// many records seqPlugin was built with - no pacing, no timing, no
+// goroutine-scheduling dependence.
+//
+// The actual shape under test (filter/retry/nack/split/fan-out) is entirely
+// the job of the funnel.Task / stream.Processor the test wires downstream of
+// this source - seqPlugin only ever produces plain, unmarked records.
+type seqPlugin struct {
+	records []opencdc.Record
+
+	mu      sync.Mutex
+	nextIdx int // 0-based index of the next record to deliver; set by Open
+}
+
+// newSeqPlugin builds a seqPlugin with n records at positions "1".."n" (in
+// that order). Positions are 1-based so that a persisted position of 0
+// unambiguously means "nothing acked yet".
+func newSeqPlugin(n int) *seqPlugin {
+	records := make([]opencdc.Record, n)
+	for i := range records {
+		pos := i + 1
+		records[i] = opencdc.Record{
+			Position:  encodeSeqPosition(pos),
+			Operation: opencdc.OperationCreate,
+			Metadata:  opencdc.Metadata{},
+			Key:       opencdc.RawData(fmt.Sprintf("key-%d", pos)),
+			Payload:   opencdc.Change{After: opencdc.RawData(fmt.Sprintf("record-%d", pos))},
+		}
+	}
+	return &seqPlugin{records: records}
+}
+
+var _ pconnector.SourcePlugin = (*seqPlugin)(nil)
+
+func (p *seqPlugin) Configure(context.Context, pconnector.SourceConfigureRequest) (pconnector.SourceConfigureResponse, error) {
+	return pconnector.SourceConfigureResponse{}, nil
+}
+
+// Open is the genuine-resume enforcement site (see the type doc): it decodes
+// the requested resume position and sets nextIdx accordingly, so a restarted
+// run (see sourceHarness.restart) only ever redelivers records that were
+// never durably acked - never records 1..resume, and never skipping anything
+// after resume either.
+func (p *seqPlugin) Open(_ context.Context, req pconnector.SourceOpenRequest) (pconnector.SourceOpenResponse, error) {
+	resume, err := decodeSeqPosition(req.Position)
+	if err != nil {
+		return pconnector.SourceOpenResponse{}, fmt.Errorf("seqPlugin: invalid resume position %q: %w", req.Position, err)
+	}
+	p.mu.Lock()
+	p.nextIdx = resume // resume is the count of already-acked records; 0 == fresh start
+	p.mu.Unlock()
+	return pconnector.SourceOpenResponse{}, nil
+}
+
+func (p *seqPlugin) Run(ctx context.Context, stream pconnector.SourceRunStream) error {
+	inmemStream, ok := stream.(*builtin.InMemorySourceRunStream)
+	if !ok {
+		return fmt.Errorf("seqPlugin: unexpected stream type %T", stream)
+	}
+	inmemStream.Init(ctx)
+	server := inmemStream.Server()
+
+	p.mu.Lock()
+	start := p.nextIdx
+	p.mu.Unlock()
+
+	go func() {
+		if start < len(p.records) {
+			// One Send == one batch, by construction - see the type doc.
+			remaining := append([]opencdc.Record(nil), p.records[start:]...)
+			_ = server.Send(pconnector.SourceRunResponse{Records: remaining})
+		}
+		<-ctx.Done() // nothing more to produce in this run; park until torn down
+	}()
+	go func() {
+		// Drain acks so Source's deferred-ack delivery goroutine never blocks
+		// on a full send. The durable resume position is read back
+		// independently, straight from the badger store (see
+		// sourceHarness.persistedPosition) - never from what this plugin
+		// observes - so nothing here needs to inspect the ack payload.
+		for {
+			if _, err := server.Recv(); err != nil {
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+// Stop reports the position of the LAST record this connector run will ever
+// produce - the real semantics pkg/lifecycle/stream/source.go's
+// SourceNode.stopGraceful relies on to know when to stop forwarding records
+// (it injects this as a control message and keeps draining until it sees a
+// record with this exact position go by).
+func (p *seqPlugin) Stop(context.Context, pconnector.SourceStopRequest) (pconnector.SourceStopResponse, error) {
+	if len(p.records) == 0 {
+		return pconnector.SourceStopResponse{}, nil
+	}
+	return pconnector.SourceStopResponse{LastPosition: p.records[len(p.records)-1].Position}, nil
+}
+
+func (p *seqPlugin) Teardown(context.Context, pconnector.SourceTeardownRequest) (pconnector.SourceTeardownResponse, error) {
+	return pconnector.SourceTeardownResponse{}, nil
+}
+
+func (p *seqPlugin) LifecycleOnCreated(context.Context, pconnector.SourceLifecycleOnCreatedRequest) (pconnector.SourceLifecycleOnCreatedResponse, error) {
+	return pconnector.SourceLifecycleOnCreatedResponse{}, nil
+}
+
+func (p *seqPlugin) LifecycleOnUpdated(context.Context, pconnector.SourceLifecycleOnUpdatedRequest) (pconnector.SourceLifecycleOnUpdatedResponse, error) {
+	return pconnector.SourceLifecycleOnUpdatedResponse{}, nil
+}
+
+func (p *seqPlugin) LifecycleOnDeleted(context.Context, pconnector.SourceLifecycleOnDeletedRequest) (pconnector.SourceLifecycleOnDeletedResponse, error) {
+	return pconnector.SourceLifecycleOnDeletedResponse{}, nil
+}
+
+func (p *seqPlugin) NewStream() pconnector.SourceRunStream {
+	return &builtin.InMemorySourceRunStream{}
+}
+
+func encodeSeqPosition(n int) opencdc.Position {
+	return opencdc.Position(strconv.Itoa(n))
+}
+
+// decodeSeqPosition returns 0 for a nil/empty position (a genuinely fresh
+// start - no state persisted yet), matching connector.Source's own
+// zero-value SourceState.
+func decodeSeqPosition(p opencdc.Position) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return strconv.Atoi(string(p))
+}
+
+// staticDispenser and staticFetcher wire a single, already-constructed
+// seqPlugin into pkg/connector's plugin-dispensing machinery
+// (connector.PluginDispenserFetcher -> connectorPlugin.Dispenser ->
+// connectorPlugin.SourcePlugin). Mirrors tests/chaos/child.go's identical
+// helpers (and, before that, pkg/connector/instance_test.go's
+// fakePluginFetcher) - duplicated here rather than imported because
+// tests/chaos is an unrelated internal test package with no exported surface.
+type staticDispenser struct {
+	source connectorPlugin.SourcePlugin
+}
+
+func (d staticDispenser) DispenseSpecifier() (connectorPlugin.SpecifierPlugin, error) {
+	return nil, cerrors.New("staticDispenser: DispenseSpecifier not implemented")
+}
+
+func (d staticDispenser) DispenseSource() (connectorPlugin.SourcePlugin, error) {
+	return d.source, nil
+}
+
+func (d staticDispenser) DispenseDestination() (connectorPlugin.DestinationPlugin, error) {
+	return nil, cerrors.New("staticDispenser: DispenseDestination not implemented")
+}
+
+type staticFetcher map[string]connectorPlugin.Dispenser
+
+func (f staticFetcher) NewDispenser(_ log.CtxLogger, name string, _ string) (connectorPlugin.Dispenser, error) {
+	d, ok := f[name]
+	if !ok {
+		return nil, cerrors.Errorf("staticFetcher: no dispenser registered for plugin %q", name)
+	}
+	return d, nil
+}

--- a/tests/upgrade/shapes_v1_test.go
+++ b/tests/upgrade/shapes_v1_test.go
@@ -1,0 +1,264 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// shapes_v1_test.go drives the same shapes through the v1 (classic stream)
+// engine, as the baseline the v2 shapes in shapes_v2_test.go are measured
+// against. v1 acks one record at a time and has no batch-accounting surface
+// at all: retry (a batch-partial response) and split/fan-out
+// (sdk.MultiRecord) are structurally impossible on it - see
+// tasks_v1.go and pkg/lifecycle/stream/processor.go's handleProcessedRecord.
+// Those shapes are represented here as an assertion that v1 refuses them
+// LOUDLY, before any write, rather than silently mishandling them - the
+// "upgrade parity" question for those shapes is answered by that refusal
+// existing and firing correctly (see a980aa0), not by resume-correctness
+// numbers.
+package upgrade
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/lifecycle/stream"
+)
+
+// TestV1Filter_ResumeCorrectness is v1's counterpart to
+// TestV2Filter_ResumeCorrectness: a processor filters one record mid-stream;
+// every other record is delivered and acked, and the persisted position
+// reaches the end (v1 acks a filtered message too - see
+// pkg/lifecycle/stream/processor.go's handleProcessedRecord FilterRecord
+// case, which forwards the message so DestinationAckerNode / SourceAckerNode
+// still see and ack it, only skipping the destination Write).
+func TestV1Filter_ResumeCorrectness(t *testing.T) {
+	const n = 5
+	sh := newSourceHarness(t, n)
+
+	p := newV1Pipeline(t, sh, v1Config{
+		Proc: &filterAtPosProcessor{positions: map[string]bool{"3": true}},
+	})
+	errs := p.waitDone(shapeTimeout)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", fmtErrs(errs))
+	}
+
+	if p.dest.hasPosition(pos(3)) {
+		t.Fatal("filtered record (position 3) was delivered to the destination")
+	}
+	for _, i := range []int{1, 2, 4, 5} {
+		if !p.dest.hasPosition(pos(i)) {
+			t.Fatalf("position %d (not filtered) was never delivered", i)
+		}
+	}
+	if got := p.dest.count(); got != n-1 {
+		t.Fatalf("destination delivered %d records, want %d", got, n-1)
+	}
+
+	sh.waitPersistedPosition(n, shapeTimeout)
+}
+
+// TestV1_WrongCountIsFatalNotSilentRetry documents and asserts v1's actual
+// behavior for the only shape "a processor returned fewer records than it
+// received" can take when every Process call is given exactly one record:
+// returning zero. This is immediately FATAL (pkg/lifecycle/stream/processor.go's
+// ProcessorNode.Run: `len(recsIn) != len(recsOut)`), never a silent skip or
+// a v2-style retry - records before the bad one are already durably acked,
+// and the persisted position never advances past them. A restart must
+// redeliver exactly the record the processor choked on.
+func TestV1_WrongCountIsFatalNotSilentRetry(t *testing.T) {
+	const n = 4
+	sh := newSourceHarness(t, n)
+
+	p := newV1Pipeline(t, sh, v1Config{
+		Proc: &wrongCountAtPosProcessor{targetPos: "2"},
+		// DLQ disabled (windowSize=1, threshold=0 - see newDLQWindow/dlqWindow.store):
+		// a wrong-count response is a pipeline misconfiguration, not a
+		// per-record failure, so it must halt rather than "successfully"
+		// route to a DLQ that happens to be configured to accept everything.
+		DLQWindowSize:       1,
+		DLQWindowNackThresh: 0,
+	})
+	errs := p.waitDone(shapeTimeout)
+	if len(errs) == 0 {
+		t.Fatal("expected a fatal error from the wrong-count processor response, got none")
+	}
+
+	if !p.dest.hasPosition(pos(1)) {
+		t.Fatal("position 1 (before the bad record) should have been delivered normally")
+	}
+	for _, i := range []int{2, 3, 4} {
+		if p.dest.hasPosition(pos(i)) {
+			t.Fatalf("position %d (the bad record or anything after it) was delivered despite the fatal error", i)
+		}
+	}
+
+	sh.waitPersistedPosition(1, shapeTimeout)
+
+	sh2 := sh.restart(n)
+	defer func() { _ = sh2.Source.Teardown(t.Context()) }()
+	if err := sh2.Source.Open(t.Context()); err != nil {
+		t.Fatalf("restart: open: %v", err)
+	}
+	recs, err := sh2.Source.Read(t.Context())
+	if err != nil {
+		t.Fatalf("restart: read: %v", err)
+	}
+	if len(recs) == 0 || string(recs[0].Position) != string(pos(2)) {
+		t.Fatalf("restart redelivered %v first, want position 2", recs)
+	}
+}
+
+// TestV1DLQNack_Routing_ResumeCorrectness is v1's counterpart to
+// TestV2DLQNack_Routing_ResumeCorrectness: one record errors mid-stream
+// under a DLQ policy that always accepts. It is routed to the DLQ and
+// counted as handled, so it is acked in the source like every other record
+// (see pkg/lifecycle/stream/source_acker.go's registerNackHandler: "the
+// nacked record was successfully stored in the DLQ, we consider the record
+// processed").
+func TestV1DLQNack_Routing_ResumeCorrectness(t *testing.T) {
+	const n = 5
+	sh := newSourceHarness(t, n)
+
+	p := newV1Pipeline(t, sh, v1Config{
+		Proc:                &errorAtPosProcessor{positions: map[string]bool{"3": true}},
+		DLQWindowSize:       0,
+		DLQWindowNackThresh: 0,
+	})
+	errs := p.waitDone(shapeTimeout)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", fmtErrs(errs))
+	}
+
+	if p.dlq.count() != 1 {
+		t.Fatalf("DLQ received %d records, want exactly 1", p.dlq.count())
+	}
+	if p.dest.hasPosition(pos(3)) {
+		t.Fatal("nacked record (position 3) was delivered to the main destination")
+	}
+	for _, i := range []int{1, 2, 4, 5} {
+		if !p.dest.hasPosition(pos(i)) {
+			t.Fatalf("position %d (not nacked) was never delivered to the main destination", i)
+		}
+	}
+
+	sh.waitPersistedPosition(n, shapeTimeout)
+}
+
+// TestV1DLQNack_Halt_PositionNeverAdvances is v1's counterpart to
+// TestV2DLQNack_Halt_PositionNeverAdvances: the DLQ is disabled
+// (WindowSize=1, WindowNackThreshold=0), so the nack becomes a fatal error
+// (pkg/lifecycle/stream/processor.go's handleProcessedRecord always
+// escalates a non-nil msg.Nack() error to a FatalError). Positions before
+// the error are delivered and acked normally; the errored record and
+// everything after it are never delivered anywhere, and the persisted
+// position never advances past the last successfully handled record. A
+// restart must redeliver exactly the errored record.
+func TestV1DLQNack_Halt_PositionNeverAdvances(t *testing.T) {
+	const n = 5
+	sh := newSourceHarness(t, n)
+
+	p := newV1Pipeline(t, sh, v1Config{
+		Proc:                &errorAtPosProcessor{positions: map[string]bool{"3": true}},
+		DLQWindowSize:       1,
+		DLQWindowNackThresh: 0,
+	})
+	errs := p.waitDone(shapeTimeout)
+	if len(errs) == 0 {
+		t.Fatal("expected the pipeline to halt on the disabled-DLQ nack")
+	}
+
+	for _, i := range []int{1, 2} {
+		if !p.dest.hasPosition(pos(i)) {
+			t.Fatalf("position %d (before the halt) should have been delivered normally", i)
+		}
+	}
+	for _, i := range []int{3, 4, 5} {
+		if p.dest.hasPosition(pos(i)) {
+			t.Fatalf("position %d (the halt record or anything after it) was delivered to the main destination despite the halt", i)
+		}
+	}
+	if p.dlq.count() != 0 {
+		t.Fatalf("DLQ received %d records, want 0 (DLQ is disabled in this configuration)", p.dlq.count())
+	}
+
+	sh.waitPersistedPosition(2, shapeTimeout)
+
+	sh2 := sh.restart(n)
+	defer func() { _ = sh2.Source.Teardown(t.Context()) }()
+	if err := sh2.Source.Open(t.Context()); err != nil {
+		t.Fatalf("restart: open: %v", err)
+	}
+	recs, err := sh2.Source.Read(t.Context())
+	if err != nil {
+		t.Fatalf("restart: read: %v", err)
+	}
+	if len(recs) == 0 || string(recs[0].Position) != string(pos(3)) {
+		t.Fatalf("restart redelivered %v first, want position 3", recs)
+	}
+}
+
+// TestV1_SplitAndFanOut_RefusedLoudlyBeforeAnyWrite covers batch shapes 4
+// (split) and 5 (fan-out): both are represented on v1 by a processor
+// returning sdk.MultiRecord, which pkg/lifecycle/stream/processor.go's
+// handleProcessedRecord always rejects with the actionable, coded
+// CodeFanOutRequiresArchV2 error - a pipeline misconfiguration for this
+// engine, fatal, never a per-record DLQ (see a980aa0). This asserts that
+// refusal fires on the VERY FIRST record (targetPos "1"), so nothing is
+// ever written to the destination - the "upgrade parity" story for these
+// shapes on v1 is that migrating a fan-out pipeline to a not-yet-arch-v2
+// engine fails loud and fast, never silently.
+func TestV1_SplitAndFanOut_RefusedLoudlyBeforeAnyWrite(t *testing.T) {
+	const n = 3
+	sh := newSourceHarness(t, n)
+
+	p := newV1Pipeline(t, sh, v1Config{
+		Proc: &multiRecordAtPosProcessor{targetPos: "1", into: 2},
+		// DLQ disabled - see TestV1_WrongCountIsFatalNotSilentRetry's identical
+		// rationale: this is a pipeline misconfiguration (processor.go's own
+		// comment: "Fatal ... not a per-record DLQ"), so it must never
+		// "successfully" land in a DLQ that happens to be configured to
+		// accept everything.
+		DLQWindowSize:       1,
+		DLQWindowNackThresh: 0,
+	})
+	errs := p.waitDone(shapeTimeout)
+	if len(errs) == 0 {
+		t.Fatal("expected a fatal CodeFanOutRequiresArchV2 error, got none")
+	}
+
+	var found bool
+	for id, err := range errs {
+		ce, ok := conduiterr.Get(err)
+		if !ok {
+			continue
+		}
+		if ce.Code.Reason() == stream.CodeFanOutRequiresArchV2.Reason() {
+			found = true
+		}
+		if !strings.Contains(ce.Suggestion, "--preview.pipeline-arch-v2") {
+			t.Fatalf("node %q error is missing the actionable --preview.pipeline-arch-v2 suggestion: %q", id, ce.Suggestion)
+		}
+	}
+	if !found {
+		t.Fatalf("no node returned the coded CodeFanOutRequiresArchV2 error (errors: %v)", fmtErrs(errs))
+	}
+
+	if p.dest.count() != 0 {
+		t.Fatalf("destination received %d records; refusal must happen BEFORE any write", p.dest.count())
+	}
+	if p.dlq.count() != 0 {
+		t.Fatalf("DLQ received %d records; this is a fatal pipeline misconfiguration, not a per-record DLQ", p.dlq.count())
+	}
+
+	sh.waitPersistedPosition(0, shapeTimeout) // nothing was ever handled, nothing was ever acked
+}

--- a/tests/upgrade/shapes_v2_test.go
+++ b/tests/upgrade/shapes_v2_test.go
@@ -1,0 +1,256 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// shapes_v2_test.go drives each batch SHAPE through the v2 (funnel) engine
+// and asserts resume correctness. See doc.go for the package-level
+// rationale, and plugin.go's seqPlugin for why this suite is not built on
+// conduit-connector-generator.
+package upgrade
+
+import (
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/lifecycle-poc/funnel"
+)
+
+const shapeTimeout = 10 * time.Second
+
+// pos is a small helper for building an opencdc.Position from a 1-based
+// sequence index, matching seqPlugin's encoding.
+func pos(n int) opencdc.Position { return encodeSeqPosition(n) }
+
+// TestV2Filter_ResumeCorrectness drives a batch with one record filtered
+// mid-batch through the v2 engine. Filtered records are still included in
+// the ack (they reached a terminal, "handled" disposition - see batch.go's
+// Filter doc), so the persisted position must reach the very end even
+// though the destination never sees the filtered record.
+func TestV2Filter_ResumeCorrectness(t *testing.T) {
+	const n = 5
+	sh := newSourceHarness(t, n)
+	dest := newMemDestination("main")
+
+	p := newV2Pipeline(t, sh, v2Config{
+		Middle: []funnel.Task{&filterAtTask{id: "filter", indices: map[int]bool{2: true}}}, // filters record "3"
+		Dests:  []*memDestination{dest},
+	})
+	p.waitTotalDelivered(n-1, shapeTimeout, dest)
+	p.stopGracefully(shapeTimeout)
+
+	if dest.hasPosition(pos(3)) {
+		t.Fatal("filtered record (position 3) was delivered to the destination")
+	}
+	for _, i := range []int{1, 2, 4, 5} {
+		if !dest.hasPosition(pos(i)) {
+			t.Fatalf("position %d (not filtered) was never delivered", i)
+		}
+	}
+	if got := dest.count(); got != n-1 {
+		t.Fatalf("destination delivered %d records, want %d", got, n-1)
+	}
+
+	sh.waitPersistedPosition(n, shapeTimeout) // filtered record still counts as handled
+}
+
+// TestV2Retry_ResumeCorrectness drives a batch where a task marks a
+// mid-batch range for retry (a processor returning fewer records than it
+// received) and converges cleanly on the very next attempt - no split. Every
+// record must reach the destination exactly once and the persisted position
+// must reach the end.
+func TestV2Retry_ResumeCorrectness(t *testing.T) {
+	const n = 4
+	sh := newSourceHarness(t, n)
+	dest := newMemDestination("main")
+
+	p := newV2Pipeline(t, sh, v2Config{
+		// Retry records "2" and "3" (0-based active indices [1,3)) on the
+		// first pass; converges (plain ack, no further split) on retry.
+		Middle: []funnel.Task{&retryRangeOnceTask{id: "retry", from: 1, to: 3}},
+		Dests:  []*memDestination{dest},
+	})
+	p.waitTotalDelivered(n, shapeTimeout, dest)
+	p.stopGracefully(shapeTimeout)
+
+	seen := map[string]int{}
+	for _, pp := range dest.positions() {
+		seen[string(pp)]++
+	}
+	for i := 1; i <= n; i++ {
+		if seen[string(pos(i))] != 1 {
+			t.Fatalf("position %d delivered %d times, want exactly 1 (delivered=%v)", i, seen[string(pos(i))], seen)
+		}
+	}
+
+	sh.waitPersistedPosition(n, shapeTimeout)
+}
+
+// TestV2DLQNack_Routing_ResumeCorrectness drives a batch with one record
+// nacked mid-batch under a DLQ policy that always accepts (windowSize=0 -
+// see pkg/lifecycle-poc/funnel/dlq.go's dlqWindow.store: size 0 disables the
+// window, unconditionally accepting). The nacked record is "handled" (DLQ
+// routing counts as handled), so it must be acked upstream like every other
+// record - the persisted position must reach the very end.
+func TestV2DLQNack_Routing_ResumeCorrectness(t *testing.T) {
+	const n = 5
+	sh := newSourceHarness(t, n)
+	dest := newMemDestination("main")
+	dlqDest := newMemDestination("dlq")
+
+	p := newV2Pipeline(t, sh, v2Config{
+		Middle:              []funnel.Task{&nackAtTask{id: "nack", indices: map[int]bool{2: true}}}, // nacks record "3"
+		Dests:               []*memDestination{dest},
+		DLQDest:             dlqDest,
+		DLQWindowSize:       0,
+		DLQWindowNackThresh: 0,
+	})
+	p.waitTotalDelivered(n, shapeTimeout, dest, dlqDest)
+	p.stopGracefully(shapeTimeout)
+
+	if !dlqDest.hasPosition(pos(3)) {
+		t.Fatal("nacked record (position 3) never reached the DLQ")
+	}
+	if dest.hasPosition(pos(3)) {
+		t.Fatal("nacked record (position 3) was delivered to the main destination")
+	}
+	for _, i := range []int{1, 2, 4, 5} {
+		if !dest.hasPosition(pos(i)) {
+			t.Fatalf("position %d (not nacked) was never delivered to the main destination", i)
+		}
+	}
+
+	sh.waitPersistedPosition(n, shapeTimeout) // DLQ routing counts as handled
+}
+
+// TestV2DLQNack_Halt_PositionNeverAdvances drives the same shape under a DLQ
+// policy that never accepts (windowSize=1, threshold=0 - see
+// pkg/lifecycle-poc/funnel/dlq.go's newDLQWindow: the very first nack
+// immediately exceeds a zero threshold, so the DLQ is, in effect, disabled).
+// The pipeline halts: positions before the nack are delivered and acked
+// normally; the nacked record and everything after it are NEVER delivered
+// anywhere, and the persisted position never advances past the last
+// successfully handled record. A modeled restart must redeliver exactly the
+// nacked record, never skipping it.
+func TestV2DLQNack_Halt_PositionNeverAdvances(t *testing.T) {
+	const n = 5
+	sh := newSourceHarness(t, n)
+	dest := newMemDestination("main")
+	dlqDest := newMemDestination("dlq")
+
+	p := newV2Pipeline(t, sh, v2Config{
+		Middle:              []funnel.Task{&nackAtTask{id: "nack", indices: map[int]bool{2: true}}}, // nacks record "3"
+		Dests:               []*memDestination{dest},
+		DLQDest:             dlqDest,
+		DLQWindowSize:       1,
+		DLQWindowNackThresh: 0,
+	})
+	err := p.waitFatal(shapeTimeout)
+	if err == nil {
+		t.Fatal("expected the pipeline to halt on the disabled-DLQ nack")
+	}
+
+	for _, i := range []int{1, 2} {
+		if !dest.hasPosition(pos(i)) {
+			t.Fatalf("position %d (before the halt) should have been delivered normally", i)
+		}
+	}
+	for _, i := range []int{3, 4, 5} {
+		if dest.hasPosition(pos(i)) || dlqDest.hasPosition(pos(i)) {
+			t.Fatalf("position %d (the nack or anything after it) was delivered SOMEWHERE despite the halt", i)
+		}
+	}
+
+	sh.waitPersistedPosition(2, shapeTimeout)
+
+	// At-least-once: a restart must redeliver the unhandled record, never
+	// skip it.
+	sh2 := sh.restart(n)
+	defer func() { _ = sh2.Source.Teardown(t.Context()) }()
+	if err := sh2.Source.Open(t.Context()); err != nil {
+		t.Fatalf("restart: open: %v", err)
+	}
+	recs, err := sh2.Source.Read(t.Context())
+	if err != nil {
+		t.Fatalf("restart: read: %v", err)
+	}
+	if len(recs) == 0 || string(recs[0].Position) != string(pos(3)) {
+		t.Fatalf("restart redelivered %v first, want position 3", recs)
+	}
+}
+
+// TestV2Split_ResumeCorrectness drives a batch where a task splits one
+// record into several pieces (sdk.MultiRecord). A pure split (no
+// retry/nack) never enters Worker.doTaskAttempt's tainted sub-batch loop at
+// all - the whole batch, split pieces included, is forwarded and acked in
+// one atomic pass - so this is a baseline correctness check, not the #2722
+// mutation-check shape (see TestV2Combo_RetryThenSplit for that).
+func TestV2Split_ResumeCorrectness(t *testing.T) {
+	const n = 4
+	sh := newSourceHarness(t, n)
+	dest := newMemDestination("main")
+
+	p := newV2Pipeline(t, sh, v2Config{
+		Middle: []funnel.Task{&splitAtTask{id: "split", index: 1, into: 3}}, // splits record "2" into "2a","2b","2c"
+		Dests:  []*memDestination{dest},
+	})
+	p.waitTotalDelivered(n-1+3, shapeTimeout, dest) // 1,2a,2b,2c,3,4 = 6 active records
+	p.stopGracefully(shapeTimeout)
+
+	for _, suffix := range []string{"a", "b", "c"} {
+		if !dest.hasPosition(opencdc.Position("2" + suffix)) {
+			t.Fatalf("split piece 2%s was never delivered", suffix)
+		}
+	}
+	for _, i := range []int{1, 3, 4} {
+		if !dest.hasPosition(pos(i)) {
+			t.Fatalf("position %d was never delivered", i)
+		}
+	}
+	if got, want := dest.count(), n-1+3; got != want {
+		t.Fatalf("destination delivered %d records, want %d", got, want)
+	}
+
+	sh.waitPersistedPosition(n, shapeTimeout)
+}
+
+// TestV2FanOut_ResumeCorrectness drives a plain batch (no split, no
+// retry, no nack) through an M=2 destination fan-out. Every destination
+// must independently receive every record (broadcast, not partition), and
+// the persisted position must only reach the end once BOTH branches have
+// acked every position.
+func TestV2FanOut_ResumeCorrectness(t *testing.T) {
+	const n = 4
+	sh := newSourceHarness(t, n)
+	d1 := newMemDestination("d1")
+	d2 := newMemDestination("d2")
+
+	p := newV2Pipeline(t, sh, v2Config{
+		Dests: []*memDestination{d1, d2},
+	})
+	p.waitEachDelivered(n, shapeTimeout, d1, d2)
+	p.stopGracefully(shapeTimeout)
+
+	for _, d := range []*memDestination{d1, d2} {
+		for i := 1; i <= n; i++ {
+			if !d.hasPosition(pos(i)) {
+				t.Fatalf("destination %q never received position %d", d.id, i)
+			}
+		}
+		if got := d.count(); got != n {
+			t.Fatalf("destination %q delivered %d records, want %d", d.id, got, n)
+		}
+	}
+
+	sh.waitPersistedPosition(n, shapeTimeout)
+}

--- a/tests/upgrade/tasks_v1.go
+++ b/tests/upgrade/tasks_v1.go
@@ -1,0 +1,130 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	sdk "github.com/conduitio/conduit-processor-sdk"
+)
+
+// filterAtPosProcessor is a stream.Processor that filters every record whose
+// position is in the given set - v1's per-record equivalent of
+// filterAtTask.
+type filterAtPosProcessor struct {
+	positions map[string]bool
+}
+
+func (p *filterAtPosProcessor) Open(context.Context) error     { return nil }
+func (p *filterAtPosProcessor) Teardown(context.Context) error { return nil }
+func (p *filterAtPosProcessor) Process(_ context.Context, recs []opencdc.Record) []sdk.ProcessedRecord {
+	r := recs[0] // v1 always calls Process with exactly one record.
+	if p.positions[string(r.Position)] {
+		return []sdk.ProcessedRecord{sdk.FilterRecord{}}
+	}
+	return []sdk.ProcessedRecord{sdk.SingleRecord(r)}
+}
+
+// errorAtPosProcessor is a stream.Processor that nacks (routes to the DLQ,
+// or halts, depending on DLQ policy) every record whose position is in the
+// given set - v1's per-record equivalent of nackAtTask.
+type errorAtPosProcessor struct {
+	positions map[string]bool
+}
+
+func (p *errorAtPosProcessor) Open(context.Context) error     { return nil }
+func (p *errorAtPosProcessor) Teardown(context.Context) error { return nil }
+func (p *errorAtPosProcessor) Process(_ context.Context, recs []opencdc.Record) []sdk.ProcessedRecord {
+	r := recs[0]
+	if p.positions[string(r.Position)] {
+		return []sdk.ProcessedRecord{sdk.ErrorRecord{Error: fmt.Errorf("synthetic nack at position %s", r.Position)}}
+	}
+	return []sdk.ProcessedRecord{sdk.SingleRecord(r)}
+}
+
+// filterOrErrorAtPosProcessor filters records at one set of positions and
+// errors (routes to the DLQ, or halts) records at another - v1's
+// counterpart to the v2 filter+nack combination (see combos_test.go's
+// TestV1Combo_FilterNack).
+type filterOrErrorAtPosProcessor struct {
+	filterPositions map[string]bool
+	errorPositions  map[string]bool
+}
+
+func (p *filterOrErrorAtPosProcessor) Open(context.Context) error     { return nil }
+func (p *filterOrErrorAtPosProcessor) Teardown(context.Context) error { return nil }
+func (p *filterOrErrorAtPosProcessor) Process(_ context.Context, recs []opencdc.Record) []sdk.ProcessedRecord {
+	r := recs[0]
+	switch {
+	case p.filterPositions[string(r.Position)]:
+		return []sdk.ProcessedRecord{sdk.FilterRecord{}}
+	case p.errorPositions[string(r.Position)]:
+		return []sdk.ProcessedRecord{sdk.ErrorRecord{Error: fmt.Errorf("synthetic nack at position %s", r.Position)}}
+	default:
+		return []sdk.ProcessedRecord{sdk.SingleRecord(r)}
+	}
+}
+
+// wrongCountAtPosProcessor returns ZERO records (instead of the required
+// one) for the record at the given position - the only shape "a processor
+// returned fewer records than it received" can take in v1, since v1 always
+// calls Process with exactly one record (see
+// pkg/lifecycle/stream/processor.go's ProcessorNode.Run: "recsIn :=
+// []opencdc.Record{msg.Record}"). Unlike funnel/v2's RecordFlagRetry, v1 has
+// no batch-partial-response concept to retry - ProcessorNode.Run's own
+// length check (len(recsIn) != len(recsOut)) makes this immediately FATAL,
+// never a silent skip. See shapes_v1_test.go's TestV1_WrongCountIsFatalNotSilentRetry.
+type wrongCountAtPosProcessor struct {
+	targetPos string
+}
+
+func (p *wrongCountAtPosProcessor) Open(context.Context) error     { return nil }
+func (p *wrongCountAtPosProcessor) Teardown(context.Context) error { return nil }
+func (p *wrongCountAtPosProcessor) Process(_ context.Context, recs []opencdc.Record) []sdk.ProcessedRecord {
+	r := recs[0]
+	if string(r.Position) == p.targetPos {
+		return []sdk.ProcessedRecord{} // wrong count: 0 instead of 1
+	}
+	return []sdk.ProcessedRecord{sdk.SingleRecord(r)}
+}
+
+// multiRecordAtPosProcessor returns a fan-out sdk.MultiRecord result (N
+// records from 1 input) for the record at the given position - v1's only
+// possible representation of both the "split" and "fan-out" shapes (see
+// pkg/lifecycle/stream/processor.go's handleProcessedRecord: ANY
+// sdk.MultiRecord response is fatal on the classic engine, regardless of its
+// length or of how many destinations are configured - see
+// CodeFanOutRequiresArchV2 and shapes_v1_test.go's
+// TestV1_SplitAndFanOut_RefusedLoudlyBeforeAnyWrite).
+type multiRecordAtPosProcessor struct {
+	targetPos string
+	into      int
+}
+
+func (p *multiRecordAtPosProcessor) Open(context.Context) error     { return nil }
+func (p *multiRecordAtPosProcessor) Teardown(context.Context) error { return nil }
+func (p *multiRecordAtPosProcessor) Process(_ context.Context, recs []opencdc.Record) []sdk.ProcessedRecord {
+	r := recs[0]
+	if string(r.Position) == p.targetPos {
+		pieces := make([]opencdc.Record, p.into)
+		for i := range pieces {
+			pieces[i] = r
+		}
+		return []sdk.ProcessedRecord{sdk.MultiRecord(pieces)}
+	}
+	return []sdk.ProcessedRecord{sdk.SingleRecord(r)}
+}

--- a/tests/upgrade/tasks_v2.go
+++ b/tests/upgrade/tasks_v2.go
@@ -1,0 +1,226 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/lifecycle-poc/funnel"
+)
+
+// filterAtTask marks every record at the given (ActiveRecords-relative,
+// 0-based) index as filtered. It is the first task in every pipeline it's
+// used in, so ActiveRecords-relative indices equal raw record indices.
+type filterAtTask struct {
+	id      string
+	indices map[int]bool
+}
+
+func (t *filterAtTask) ID() string                  { return t.id }
+func (t *filterAtTask) Open(context.Context) error  { return nil }
+func (t *filterAtTask) Close(context.Context) error { return nil }
+func (t *filterAtTask) Do(_ context.Context, b *funnel.Batch) error {
+	for i := range b.ActiveRecords() {
+		if t.indices[i] {
+			b.Filter(i)
+		}
+	}
+	return nil
+}
+
+// nackAtTask marks every record at the given index as nacked with a
+// synthetic error, routing it through the DLQ (or halting the pipeline,
+// depending on the DLQ policy the worker was built with).
+type nackAtTask struct {
+	id      string
+	indices map[int]bool
+}
+
+func (t *nackAtTask) ID() string                  { return t.id }
+func (t *nackAtTask) Open(context.Context) error  { return nil }
+func (t *nackAtTask) Close(context.Context) error { return nil }
+func (t *nackAtTask) Do(_ context.Context, b *funnel.Batch) error {
+	for i, r := range b.ActiveRecords() {
+		if t.indices[i] {
+			b.Nack(i, fmt.Errorf("synthetic nack at position %s", r.Position))
+		}
+	}
+	return nil
+}
+
+// filterPosTask marks every record whose position is in the given set as
+// filtered. Unlike filterAtTask (which indexes into ActiveRecords() at call
+// time - only safe as the very first task in a chain), filterPosTask
+// resolves by position, so it composes correctly after an earlier task in
+// the same chain has already shrunk the active set (e.g. filter+nack
+// combinations - see combos_test.go).
+type filterPosTask struct {
+	id        string
+	positions map[string]bool
+}
+
+func (t *filterPosTask) ID() string                  { return t.id }
+func (t *filterPosTask) Open(context.Context) error  { return nil }
+func (t *filterPosTask) Close(context.Context) error { return nil }
+func (t *filterPosTask) Do(_ context.Context, b *funnel.Batch) error {
+	for i, r := range b.ActiveRecords() {
+		if t.positions[string(r.Position)] {
+			b.Filter(i)
+		}
+	}
+	return nil
+}
+
+// nackPosTask marks every record whose position is in the given set as
+// nacked. Position-resolving counterpart to nackAtTask - see filterPosTask's
+// doc comment.
+type nackPosTask struct {
+	id        string
+	positions map[string]bool
+}
+
+func (t *nackPosTask) ID() string                  { return t.id }
+func (t *nackPosTask) Open(context.Context) error  { return nil }
+func (t *nackPosTask) Close(context.Context) error { return nil }
+func (t *nackPosTask) Do(_ context.Context, b *funnel.Batch) error {
+	for i, r := range b.ActiveRecords() {
+		if t.positions[string(r.Position)] {
+			b.Nack(i, fmt.Errorf("synthetic nack at position %s", r.Position))
+		}
+	}
+	return nil
+}
+
+// retryRangeOnceTask models a processor that returns fewer records than it
+// received (retry), then converges normally on redelivery: on the FIRST
+// pass over the whole batch it marks [from, to) for retry; every later call
+// (the retry sub-batch doTask recurses with) leaves the batch untouched,
+// which - since Worker.doTaskAttempt's RecordFlagRetry branch pre-marks the
+// retried sub-batch Ack before recursing (worker.go) - means it converges to
+// a clean ack after exactly one retry round.
+type retryRangeOnceTask struct {
+	id       string
+	from, to int
+	seen     bool
+}
+
+func (t *retryRangeOnceTask) ID() string                  { return t.id }
+func (t *retryRangeOnceTask) Open(context.Context) error  { return nil }
+func (t *retryRangeOnceTask) Close(context.Context) error { return nil }
+func (t *retryRangeOnceTask) Do(_ context.Context, b *funnel.Batch) error {
+	if !t.seen {
+		t.seen = true
+		b.Retry(t.from, t.to)
+	}
+	return nil
+}
+
+// retryPosOnceTask marks every record whose position is in the given set
+// for retry on the FIRST pass over the batch, then converges (leaves the
+// retried sub-batch untouched, defaulting to Ack) on the pass doTaskAttempt's
+// RecordFlagRetry recursion feeds it. Position-resolving counterpart to
+// retryRangeOnceTask - see filterPosTask's doc comment for why that matters
+// when this runs after an earlier task in the same chain (e.g. splitAtTask)
+// has already changed the batch shape.
+type retryPosOnceTask struct {
+	id        string
+	positions map[string]bool
+	seen      bool
+}
+
+func (t *retryPosOnceTask) ID() string                  { return t.id }
+func (t *retryPosOnceTask) Open(context.Context) error  { return nil }
+func (t *retryPosOnceTask) Close(context.Context) error { return nil }
+func (t *retryPosOnceTask) Do(_ context.Context, b *funnel.Batch) error {
+	if t.seen {
+		return nil
+	}
+	t.seen = true
+	for i, r := range b.ActiveRecords() {
+		if t.positions[string(r.Position)] {
+			b.Retry(i, i+1)
+		}
+	}
+	return nil
+}
+
+// retryThenSplitTask marks one record Retry on its first pass, then on the
+// retry pass splits that record into several pieces - exactly the shape
+// that made Worker.doTaskAttempt's tainted-loop cursor overshoot before
+// #2724 (issue #2722): a task GROWING the sub-batch it was handed via
+// Batch.SplitRecord, inside a RecordFlagRetry recursion. Ported from
+// pkg/lifecycle-poc/funnel/worker_retry_span_test.go's identically-named
+// type so this suite reproduces the exact shape through the REAL
+// persisted-position path (a real *connector.Source, not a fake
+// ackNacker) - see shapes_v2_test.go's TestV2Combo_RetryThenSplit.
+type retryThenSplitTask struct {
+	id         string
+	retryIndex int
+	splitInto  int
+	seen       bool
+}
+
+func (t *retryThenSplitTask) ID() string                  { return t.id }
+func (t *retryThenSplitTask) Open(context.Context) error  { return nil }
+func (t *retryThenSplitTask) Close(context.Context) error { return nil }
+func (t *retryThenSplitTask) Do(_ context.Context, b *funnel.Batch) error {
+	if !t.seen {
+		t.seen = true
+		b.Retry(t.retryIndex, t.retryIndex+1)
+		return nil
+	}
+	active := b.ActiveRecords()
+	if len(active) == 1 {
+		pieces := splitPieces(active[0], t.splitInto)
+		b.SplitRecord(0, pieces)
+	}
+	return nil
+}
+
+// splitAtTask splits the record at the given (ActiveRecords-relative) index
+// into `into` pieces, each carrying a distinct Position (the original
+// position plus a letter suffix) so delivered pieces are individually
+// identifiable in test assertions, while Batch's own (separate) position
+// tracking still attributes the whole run back to the one original source
+// position - see batch.go's positions/runs field docs.
+type splitAtTask struct {
+	id    string
+	index int
+	into  int
+}
+
+func (t *splitAtTask) ID() string                  { return t.id }
+func (t *splitAtTask) Open(context.Context) error  { return nil }
+func (t *splitAtTask) Close(context.Context) error { return nil }
+func (t *splitAtTask) Do(_ context.Context, b *funnel.Batch) error {
+	active := b.ActiveRecords()
+	pieces := splitPieces(active[t.index], t.into)
+	b.SplitRecord(t.index, pieces)
+	return nil
+}
+
+// splitPieces builds `into` distinct copies of orig, each with the original
+// position plus a letter suffix (so "2" splits into "2a", "2b", "2c", ...).
+func splitPieces(orig opencdc.Record, into int) []opencdc.Record {
+	pieces := make([]opencdc.Record, into)
+	for i := range pieces {
+		piece := orig.Clone()
+		piece.Position = append(append(opencdc.Position(nil), orig.Position...), byte('a'+i))
+		pieces[i] = piece
+	}
+	return pieces
+}


### PR DESCRIPTION
**Tier 1** (data path — engine-flip safety). Pre-flip gate: batch-shape upgrade coverage.

Adds `tests/upgrade/`, an in-process suite that runs the same batch shapes — filter, retry, nack, split, fan-out — through **both** engines over a real `*connector.Source` on badger with a real `connector.Persister`, and asserts resume behaviour matches.

## Why this shape matters

A happy-path upgrade matrix would sail straight past #2722. The bugs this epic actually shipped were all shape-specific: retry-span overshoot (#2722), split-run head acked before tail (#2723/#2730), unbounded retry recursion (#2726), forward-marking loops (#2728/#2729). Those only appear when a batch is partially resolved — which is precisely what this suite constructs.

It also uses a purpose-built `seqPlugin` rather than `conduit-connector-generator`, because the generator **discards its `Open` position**, so any resume assertion built on it passes vacuously.

## Non-vacuity — verified independently, not taken on faith

Reintroducing **#2722** (`idx += len(subBatch.positions)` instead of the captured span) turns exactly one test red:

```text
--- FAIL: TestV2Combo_RetryThenSplit (10.05s)
    combos_test.go:56: timed out waiting for 8 records delivered (observed 6)
```

Two records silently lost, which is the bug's actual signature. I re-ran this mutation myself on current `main` rather than relying on the original report.

The authoring pass also verified **#2723** (bypassing `runAckNacker.vote`) turns exactly one *other* test red, and — worth recording — reported honestly that its **first** attempt at that check was **vacuous**: `Batch.originalBatch()` already collapses split pieces within one `Ack` call and `setFlagWithErr` propagates a nack to every sibling in one step, so neither candidate shape ever tore a run across two separate calls. It was redesigned around retry, which is the real #2723 trigger per `run_ledger.go`'s own doc.

## v1/v2 divergence: none found, with a documented exception

Resume behaviour matches across every shape constructible on both engines. Retry and split/fan-out are **structurally v1-only-impossible** — v1 processes one record per `Process` call, so "fewer records" can only mean zero (immediately fatal), and any `sdk.MultiRecord` response is unconditionally fatal via `CodeFanOutRequiresArchV2`. That's a documented, already-shipped refusal, not a new correctness gap.

## Checks on current main

Rebased onto `fc812a5`. `go build ./...` · `go test -race ./tests/upgrade/` · `golangci-lint run ./tests/upgrade/...` → 0 issues. Authoring pass also recorded `-race -count=10` (170 runs, 0 failures) and a `GOMAXPROCS=1` + 4-CPU-contention run.

## Noted, not fixed

`Worker.Nack`'s ack has no `validateAckPositions` guard where `Worker.Ack` does. That asymmetry was surfaced by this work and fixed separately in #2744.