### PR TITLE
test(lifecycle-poc): N×M shape coverage for arch-v2 (N sources × M destinations)

### DIFF
--- a/pkg/lifecycle-poc/funnel/worker_fanout_test.go
+++ b/pkg/lifecycle-poc/funnel/worker_fanout_test.go
@@ -152,6 +152,17 @@ type fakeDestination struct {
 	blockOn  opencdc.Position
 	blocked  chan struct{}
 	unblockC chan struct{}
+
+	// nackMatch, if set, is consulted for every written record IN ADDITION to
+	// nackErr. nackErr is keyed by raw position bytes, which is fine when
+	// positions are unique across every record this destination ever sees -
+	// but positions are only guaranteed unique WITHIN a single source (see
+	// funnel's package doc on N-source pipelines), so two different sources'
+	// records can carry byte-identical positions. nackMatch lets a test
+	// target ONE specific record by its full identity (e.g. its Key) even
+	// when its position collides with a different source's record - see the
+	// N×M DLQ-attribution-under-collision test in worker_nxm_test.go.
+	nackMatch func(opencdc.Record) error
 }
 
 func newFakeDestination(id string) *fakeDestination {
@@ -185,6 +196,14 @@ func (d *fakeDestination) setNackErr(pos opencdc.Position, err error) {
 	d.nackErr[string(pos)] = err
 }
 
+// setNackMatch installs fn as this destination's nackMatch hook - see the
+// field doc for why this exists alongside setNackErr.
+func (d *fakeDestination) setNackMatch(fn func(opencdc.Record) error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.nackMatch = fn
+}
+
 func (d *fakeDestination) Write(_ context.Context, recs []opencdc.Record) error {
 	d.mu.Lock()
 	blockOn, blocked, unblockC := d.blockOn, d.blocked, d.unblockC
@@ -207,6 +226,9 @@ func (d *fakeDestination) Write(_ context.Context, recs []opencdc.Record) error 
 		var ackErr error
 		if d.nackErr != nil {
 			ackErr = d.nackErr[string(r.Position)]
+		}
+		if ackErr == nil && d.nackMatch != nil {
+			ackErr = d.nackMatch(r)
 		}
 		d.pending = append(d.pending, connector.DestinationAck{Position: r.Position, Error: ackErr})
 	}

--- a/pkg/lifecycle-poc/funnel/worker_nxm_test.go
+++ b/pkg/lifecycle-poc/funnel/worker_nxm_test.go
@@ -1,0 +1,610 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funnel
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/foundation/metrics/noop"
+	"github.com/matryer/is"
+)
+
+// This file tests N sources x M destinations TOGETHER - the combination
+// slice 3a (M destinations, worker_fanout_test.go) and slice 3b (N sources,
+// worker_nsource_test.go) each shipped independently, but which nothing
+// exercised at the combination until now. See
+// docs/design-documents/20260801-archv2-multiconnector-nsource.md and
+// pkg/lifecycle-poc.Service.buildSharedTail's doc for the structural fact
+// this file is built around:
+//
+// buildSharedTail returns TWO STRUCTURALLY DIFFERENT graphs depending on
+// whether the pipeline has any pipeline-level processors:
+//
+//   - >=1 processor: ONE shared root (the processor chain, which itself fans
+//     out internally to every destination branch) - funnel.NewSink marks
+//     exactly that one node, so EVERY worker serializes on ONE mutex that
+//     spans the processor AND every destination branch. A second source
+//     cannot even begin writing to an otherwise-idle destination while a
+//     first source is still mid-write to a DIFFERENT destination.
+//   - 0 processors: M INDEPENDENT roots, one per destination branch - each
+//     individually marked by funnel.NewSink, each with its OWN mutex. Two
+//     different sources can write to two different destinations at the same
+//     time.
+//
+// Adding a single pipeline-level processor to an N×M pipeline therefore
+// silently collapses M independent per-destination locks into one global
+// lock - no error, no warning, no metric. buildSharedTail's own shape is
+// covered directly at the service level
+// (TestBuildSharedTail_ShapeByProcessorPresence in
+// pkg/lifecycle-poc/service_nxm_test.go); this file covers the RUNTIME
+// CONSEQUENCE of that shape - the thing an operator would actually feel - by
+// making the two shapes' concurrency behavior directly observable:
+//
+//   - TestNxM_NegativeSpace_NoProcessor_CrossDestinationConcurrency proves
+//     two different sources CAN write to two different destinations at the
+//     same time when there is no shared processor.
+//   - TestNxM_PositiveComplement_WithProcessor_NoOverlapInSharedSubtree proves
+//     they CANNOT when there is one.
+//
+// The remaining tests cover the other N×M-specific risk: source positions are
+// only unique WITHIN a source, so two sources sharing M destinations can emit
+// byte-identical positions, and the DLQ/ack routing must stay correctly
+// attributed per source despite that collision.
+
+// buildNxMWorkers wires len(sources) independent Workers (N), each with its
+// own per-source DLQ, converging on a shared tail spanning len(dests)
+// destination branches (M) - built exactly the way
+// lifecycle-poc.Service.buildSharedTail does in production (see that
+// function's doc, mirrored here):
+//
+//   - withProcessor == true: ONE shared root (a passthrough stand-in for a
+//     pipeline-level processor chain) fans out internally to all M
+//     destination branches, and is the ONLY node funnel.NewSink marks -
+//     every source serializes on a SINGLE mutex spanning the "processor" and
+//     every destination branch.
+//   - withProcessor == false: M INDEPENDENT roots, one per destination
+//     branch, each individually marked by funnel.NewSink - M separate
+//     mutexes, so different destinations can proceed without blocking each
+//     other.
+//
+// Returns the workers (index i is source i's own Worker), the Sink owning the
+// shared tail's lifecycle, and the per-source DLQ fakeDestinations (index i
+// is source i's own DLQ - windowSize/windowNackThreshold are both nonzero so
+// the DLQ actually accepts nacks, needed by the collision/attribution tests
+// below; see DLQ.Nack's windowNackThreshold==0-disables-the-DLQ behavior).
+func buildNxMWorkers(t *testing.T, withProcessor bool, dests []Destination, sources ...Source) ([]*Worker, *Sink, []*fakeDestination) {
+	t.Helper()
+	is := is.New(t)
+	logger := log.Test(t)
+
+	destBranches := make([]*TaskNode, len(dests))
+	for i, d := range dests {
+		task := NewDestinationTask(fmt.Sprintf("dest-%d", i), d, logger, NoOpConnectorMetrics{})
+		destBranches[i] = &TaskNode{Task: task}
+	}
+
+	var sharedRoots []*TaskNode
+	if withProcessor {
+		procRoot := &TaskNode{Task: passthroughTask{id: "shared-proc"}}
+		is.NoErr(procRoot.AppendToEnd(destBranches...))
+		sharedRoots = []*TaskNode{procRoot}
+	} else {
+		sharedRoots = destBranches
+	}
+
+	sink, err := NewSink(sharedRoots...)
+	is.NoErr(err)
+
+	workers := make([]*Worker, len(sources))
+	dlqs := make([]*fakeDestination, len(sources))
+	for i, src := range sources {
+		dlqDest := newFakeDestination(fmt.Sprintf("dlq-%d", i))
+		dlqs[i] = dlqDest
+		dlq := NewDLQ(fmt.Sprintf("dlq-%d", i), dlqDest, logger, NoOpConnectorMetrics{}, 10, 10)
+
+		srcNode := &TaskNode{Task: NewSourceTask(fmt.Sprintf("src-%d", i), src, logger, NoOpConnectorMetrics{})}
+		is.NoErr(srcNode.AppendToEnd(sharedRoots...))
+
+		w, err := NewWorker(srcNode, dlq, logger, noop.Timer{})
+		is.NoErr(err)
+		workers[i] = w
+	}
+	return workers, sink, dlqs
+}
+
+// recordsWithPositions builds records carrying the given raw position values,
+// distinguishable by a keyPrefix-derived Key even when two calls are given
+// the same positions - used to deliberately construct colliding positions
+// across two different sources (positions are only unique WITHIN a source).
+func recordsWithPositions(keyPrefix string, positions []string) []opencdc.Record {
+	recs := make([]opencdc.Record, len(positions))
+	for i, p := range positions {
+		recs[i] = opencdc.Record{
+			Key: opencdc.RawData(fmt.Sprintf("%s-%d", keyPrefix, i)),
+			Payload: opencdc.Change{
+				Before: opencdc.RawData{},
+				After:  opencdc.RawData(keyPrefix),
+			},
+			Position: opencdc.Position(p),
+		}
+	}
+	return recs
+}
+
+func positionsOf(recs []opencdc.Record) []opencdc.Position {
+	out := make([]opencdc.Position, len(recs))
+	for i, r := range recs {
+		out[i] = r.Position
+	}
+	return out
+}
+
+// TestNxM_CollidingPositionsAcrossSources_EachSourceAcksOwnOnly is the direct
+// N×M collision test: two sources emit records at byte-IDENTICAL positions
+// (legal - positions are only unique within a source), fanned out to M=2
+// shared destinations. Each source's Source.Ack must receive EXACTLY its own
+// positions, once each, in order - never a sibling's, and never duplicated -
+// and both destinations must receive every record from BOTH sources.
+func TestNxM_CollidingPositionsAcrossSources_EachSourceAcksOwnOnly(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	posA := recordsWithPositions("A", []string{"p0", "p1", "p2"})
+	posB := recordsWithPositions("B", []string{"p0", "p1", "p2"})
+	srcA := newFakeSource("srcA", posA)
+	srcB := newFakeSource("srcB", posB)
+	destX := newFakeDestination("destX")
+	destY := newFakeDestination("destY")
+
+	workers, sink, _ := buildNxMWorkers(t, false, []Destination{destX, destY}, srcA, srcB)
+	wA, wB := workers[0], workers[1]
+
+	is.NoErr(sink.Open(ctx))
+	is.NoErr(wA.Open(ctx))
+	is.NoErr(wB.Open(ctx))
+
+	doErrA := make(chan error, 1)
+	doErrB := make(chan error, 1)
+	go func() { doErrA <- wA.Do(ctx) }()
+	go func() { doErrB <- wB.Do(ctx) }()
+
+	waitForCondition(t, 5*time.Second, func() bool {
+		return len(srcA.ackedPositions()) == len(posA) && len(srcB.ackedPositions()) == len(posB)
+	})
+
+	is.NoErr(wA.Stop(ctx))
+	is.NoErr(<-doErrA)
+	is.NoErr(wB.Stop(ctx))
+	is.NoErr(<-doErrB)
+	is.NoErr(wA.Close(ctx))
+	is.NoErr(wB.Close(ctx))
+	is.NoErr(sink.Close(ctx))
+
+	// Each source's Ack calls carried EXACTLY its own positions, once each,
+	// in order - never a sibling's, despite the byte-identical values.
+	is.Equal(positionsOf(posA), srcA.ackedPositions())
+	is.Equal(positionsOf(posB), srcB.ackedPositions())
+
+	// Both destinations received all 6 records (3 from A + 3 from B).
+	wantKeys := make(map[string]bool, 6)
+	for _, r := range append(append([]opencdc.Record{}, posA...), posB...) {
+		wantKeys[string(r.Key.(opencdc.RawData))] = true
+	}
+	for _, d := range []*fakeDestination{destX, destY} {
+		is.Equal(6, len(d.written))
+		gotKeys := make(map[string]bool, 6)
+		for _, r := range d.written {
+			gotKeys[string(r.Key.(opencdc.RawData))] = true
+		}
+		is.Equal(wantKeys, gotKeys)
+	}
+}
+
+// TestNxM_DLQAttribution_CollidingPositions_NackedOnlyInFailingSourcesDLQ
+// covers DLQ attribution under the same collision: destination Y nacks
+// source A's "p2" specifically (matched by content, not position - see
+// fakeDestination.nackMatch's doc), while source B's byte-identical "p2" is
+// left alone. The nacked record must land in A's own DLQ exactly once,
+// tagged with destY's task ID ("dest-1"), and B's DLQ must stay empty. Both
+// sources must still be fully acked (invariant 3: the DLQ write earns the
+// ack, it is never dropped).
+func TestNxM_DLQAttribution_CollidingPositions_NackedOnlyInFailingSourcesDLQ(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	posA := recordsWithPositions("A", []string{"p0", "p1", "p2"})
+	posB := recordsWithPositions("B", []string{"p0", "p1", "p2"})
+	srcA := newFakeSource("srcA", posA)
+	srcB := newFakeSource("srcB", posB)
+
+	destX := newFakeDestination("destX") // dest-0: never fails
+	destY := newFakeDestination("destY") // dest-1: fails A's p2 only
+	failKey := string(posA[2].Key.(opencdc.RawData))
+	wantErr := cerrors.New("destY: simulated failure for source A's p2")
+	destY.setNackMatch(func(r opencdc.Record) error {
+		if string(r.Key.(opencdc.RawData)) == failKey {
+			return wantErr
+		}
+		return nil
+	})
+
+	workers, sink, dlqs := buildNxMWorkers(t, false, []Destination{destX, destY}, srcA, srcB)
+	wA, wB := workers[0], workers[1]
+	dlqA, dlqB := dlqs[0], dlqs[1]
+
+	is.NoErr(sink.Open(ctx))
+	is.NoErr(wA.Open(ctx))
+	is.NoErr(wB.Open(ctx))
+
+	doErrA := make(chan error, 1)
+	doErrB := make(chan error, 1)
+	go func() { doErrA <- wA.Do(ctx) }()
+	go func() { doErrB <- wB.Do(ctx) }()
+
+	waitForCondition(t, 5*time.Second, func() bool {
+		return len(srcA.ackedPositions()) == len(posA) && len(srcB.ackedPositions()) == len(posB)
+	})
+
+	is.NoErr(wA.Stop(ctx))
+	is.NoErr(<-doErrA)
+	is.NoErr(wB.Stop(ctx))
+	is.NoErr(<-doErrB)
+	is.NoErr(wA.Close(ctx))
+	is.NoErr(wB.Close(ctx))
+	is.NoErr(sink.Close(ctx))
+
+	// A's p2 landed in A's own DLQ exactly once, tagged with destY's task ID.
+	is.Equal(1, len(dlqA.written))
+	is.Equal(posA[2].Position, dlqA.written[0].Position)
+	gotTaskID, err := dlqA.written[0].Metadata.GetConduitDLQNackNodeID()
+	is.NoErr(err)
+	is.Equal("dest-1", gotTaskID)
+	gotErr, err := dlqA.written[0].Metadata.GetConduitDLQNackError()
+	is.NoErr(err)
+	is.Equal(wantErr.Error(), gotErr)
+
+	// B's byte-identical position was never nacked: B's DLQ is empty.
+	is.Equal(0, len(dlqB.written))
+
+	// Both sources were still fully (and correctly ordered) acked, including
+	// A's p2 - it was handled via the DLQ, not dropped.
+	is.Equal(positionsOf(posA), srcA.ackedPositions())
+	is.Equal(positionsOf(posB), srcB.ackedPositions())
+}
+
+// rendezvousPair is a hard, deadlocking 2-party barrier: it only resolves
+// once BOTH parties have called Done, at which point both Waits unblock
+// together. See rendezvousDestination for why a barrier - not merely an
+// assertion - is what makes the negative-space concurrency test below fail
+// LOUD (as a timeout) rather than possibly passing by accident on a
+// regression that only partially serializes access.
+type rendezvousPair struct {
+	wg sync.WaitGroup
+}
+
+func newRendezvousPair() *rendezvousPair {
+	p := &rendezvousPair{}
+	p.wg.Add(2)
+	return p
+}
+
+// rendezvousDestination wraps a fakeDestination and blocks the Write call
+// that carries the record at gatePos until the SIBLING rendezvousDestination
+// sharing the same pair has simultaneously reached its own gated Write. If
+// the two destinations can never be written to concurrently - e.g.
+// buildSharedTail's no-processor, M-independent-root shape ever regressed
+// into a single shared lock - this deadlocks rather than merely failing an
+// assertion, which is what makes the regression this test targets ("an
+// M-fold throughput regression that no correctness test would otherwise
+// notice") impossible to pass by accident.
+type rendezvousDestination struct {
+	*fakeDestination
+	gatePos opencdc.Position
+	pair    *rendezvousPair
+}
+
+func (d *rendezvousDestination) Write(ctx context.Context, recs []opencdc.Record) error {
+	for _, r := range recs {
+		if string(r.Position) == string(d.gatePos) {
+			d.pair.wg.Done()
+			d.pair.wg.Wait()
+			break
+		}
+	}
+	return d.fakeDestination.Write(ctx, recs)
+}
+
+// TestNxM_NegativeSpace_NoProcessor_CrossDestinationConcurrency is the
+// negative-space concurrency test (buildSharedTail's no-processor shape):
+// with NO pipeline-level processor, source A writing to destination A and
+// source B writing to destination B (a DIFFERENT source, a DIFFERENT
+// destination) must be able to be inside Write AT THE SAME TIME - proven by a
+// hard rendezvous barrier both must reach. This fails LOUD (a timeout, not a
+// wrong assertion) if buildSharedTail's M-independent-root shape were ever
+// collapsed to a single shared root: a regression that would otherwise be an
+// invisible M-fold throughput loss, since nothing about per-record
+// correctness would change.
+func TestNxM_NegativeSpace_NoProcessor_CrossDestinationConcurrency(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	recA := randomRecords(1)
+	recB := randomRecords(1)
+	recB[0].Position = opencdc.Position("b-0") // distinct from A's - this test is about lock independence, not collision
+
+	srcA := newFakeSource("srcA", recA)
+	srcB := newFakeSource("srcB", recB)
+
+	pair := newRendezvousPair()
+	destA := &rendezvousDestination{fakeDestination: newFakeDestination("destA"), gatePos: recA[0].Position, pair: pair}
+	destB := &rendezvousDestination{fakeDestination: newFakeDestination("destB"), gatePos: recB[0].Position, pair: pair}
+
+	workers, sink, _ := buildNxMWorkers(t, false, []Destination{destA, destB}, srcA, srcB)
+	wA, wB := workers[0], workers[1]
+
+	is.NoErr(sink.Open(ctx))
+	is.NoErr(wA.Open(ctx))
+	is.NoErr(wB.Open(ctx))
+
+	doErrA := make(chan error, 1)
+	doErrB := make(chan error, 1)
+	go func() { doErrA <- wA.Do(ctx) }()
+	go func() { doErrB <- wB.Do(ctx) }()
+
+	// The rendezvous only resolves if A's write into destA and B's write
+	// into destB are simultaneously in progress - i.e. genuinely concurrent
+	// across two DIFFERENT sources' passes into two DIFFERENT destination
+	// branches, each behind its own independent lock.
+	rendezvousDone := make(chan struct{})
+	go func() {
+		pair.wg.Wait()
+		close(rendezvousDone)
+	}()
+	select {
+	case <-rendezvousDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("rendezvous never resolved: destA and destB (written by DIFFERENT sources) were never " +
+			"simultaneously inside Write - buildSharedTail's no-processor shape must give each destination " +
+			"branch its own independent lock, not one shared lock across all M branches")
+	}
+
+	waitForCondition(t, 5*time.Second, func() bool {
+		return len(srcA.ackedPositions()) == 1 && len(srcB.ackedPositions()) == 1
+	})
+
+	is.NoErr(wA.Stop(ctx))
+	is.NoErr(<-doErrA)
+	is.NoErr(wB.Stop(ctx))
+	is.NoErr(<-doErrB)
+	is.NoErr(wA.Close(ctx))
+	is.NoErr(wB.Close(ctx))
+	is.NoErr(sink.Close(ctx))
+}
+
+// TestNxM_PositiveComplement_WithProcessor_NoOverlapInSharedSubtree is the
+// positive complement of the negative-space test above: WITH a pipeline-level
+// processor (buildSharedTail's single-shared-root shape), no two workers may
+// ever be inside the shared subtree at the same time - not even to write to a
+// destination branch neither of them is currently contending over. Source A
+// is stuck writing to destA; source B must NOT be able to enter destB (which
+// is otherwise completely free) until A's ENTIRE pass - across every branch -
+// has released the single shared mutex.
+func TestNxM_PositiveComplement_WithProcessor_NoOverlapInSharedSubtree(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	recA := randomRecords(1)
+	recB := randomRecords(1)
+	recB[0].Position = opencdc.Position("b-0")
+
+	srcA := newFakeSource("srcA", recA)
+	srcB := newFakeSource("srcB", recB)
+	destA := newFakeDestination("destA")
+	destB := newFakeDestination("destB")
+
+	workers, sink, _ := buildNxMWorkers(t, true, []Destination{destA, destB}, srcA, srcB)
+	wA, wB := workers[0], workers[1]
+
+	is.NoErr(sink.Open(ctx))
+	is.NoErr(wA.Open(ctx))
+	is.NoErr(wB.Open(ctx))
+
+	// A gets stuck writing to destA. With withProcessor=true this holds the
+	// ONE shared-root mutex for A's ENTIRE pass (destA AND destB), not just
+	// destA's own branch - see buildSharedTail's doc.
+	blockedA, unblockA := destA.blockWrites(recA[0].Position)
+
+	doErrA := make(chan error, 1)
+	go func() { doErrA <- wA.Do(ctx) }()
+
+	select {
+	case <-blockedA:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for worker A to block on destA")
+	}
+
+	// B tries to enter destB - nothing else is touching it, and in the
+	// M-independent-root shape (see the negative-space test above) it would
+	// be free to write to immediately. Gated on the exact record B will
+	// write, so "entered" only fires once B actually reaches this Write
+	// call.
+	enteredB, unblockB := destB.blockWrites(recB[0].Position)
+
+	doErrB := make(chan error, 1)
+	go func() { doErrB <- wB.Do(ctx) }()
+
+	select {
+	case <-enteredB:
+		t.Fatal("worker B entered destB while worker A still held the single shared-root mutex (A was still " +
+			"blocked inside destA) - buildSharedTail's with-processor shape must serialize EVERY branch " +
+			"behind ONE lock, not just the branch A happened to be using")
+	case <-time.After(300 * time.Millisecond):
+		// Expected: B is still blocked trying to acquire the single shared
+		// mutex. 300ms is generous relative to how fast an uncontended
+		// acquire+entry would be if the lock were ever missing.
+	}
+
+	// Release A - B must now be able to make progress, promptly: it only
+	// needed the SAME single shared-root mutex A just released, and that
+	// release happens the instant A's own synchronous pass through the
+	// shared subtree returns.
+	unblockA()
+
+	select {
+	case <-enteredB:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker B never entered destB even after worker A released the shared lock")
+	}
+	unblockB()
+
+	// Every source writes to every destination (the shared tail is attached
+	// identically to each source - see buildRunnablePipeline), so each of
+	// destA/destB ends up with ONE record from A and ONE from B: 2 each.
+	waitForCondition(t, 5*time.Second, func() bool {
+		return len(destA.receivedPositions()) == 2 && len(destB.receivedPositions()) == 2
+	})
+
+	is.NoErr(wA.Stop(ctx))
+	is.NoErr(<-doErrA)
+	is.NoErr(wB.Stop(ctx))
+	is.NoErr(<-doErrB)
+	is.NoErr(wA.Close(ctx))
+	is.NoErr(wB.Close(ctx))
+	is.NoErr(sink.Close(ctx))
+}
+
+// TestNxM_SharedBoundary_RetryDoesNotSelfDeadlock_MultipleDestinations
+// generalizes TestNSource_SharedBoundary_RetryDoesNotSelfDeadlock (M=1) to
+// M>1: a retry inside a shared-boundary node must not self-deadlock on the
+// non-reentrant sharedMu (the lock lives in the doTask WRAPPER precisely
+// because the retry recursion re-enters doTaskAttempt directly - see
+// worker.go's doTask doc), and once the retry resolves, the fan-out to every
+// one of the M destination branches beneath it must still run correctly.
+func TestNxM_SharedBoundary_RetryDoesNotSelfDeadlock_MultipleDestinations(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	records := randomRecords(4)
+
+	retryOnce := &retryOnceThenPassTask{id: "shared-retry"}
+	node := &TaskNode{Task: retryOnce}
+
+	destX := newFakeDestination("destX")
+	destY := newFakeDestination("destY")
+	destXNode := &TaskNode{Task: NewDestinationTask("destX", destX, log.Nop(), NoOpConnectorMetrics{})}
+	destYNode := &TaskNode{Task: NewDestinationTask("destY", destY, log.Nop(), NoOpConnectorMetrics{})}
+	is.NoErr(node.AppendToEnd(destXNode, destYNode))
+	node.MarkSharedBoundary() // exactly what funnel.Sink does for a shared root
+
+	parent := &fakeParentAckNacker{}
+	w := &Worker{logger: log.Nop(), processingLock: make(chan struct{}, 1)}
+
+	done := make(chan error, 1)
+	go func() { done <- w.doTask(ctx, node, NewBatch(slices.Clone(records)), parent) }()
+
+	select {
+	case err := <-done:
+		is.NoErr(err)
+		is.True(retryOnce.calls >= 2) // the retry actually happened
+	case <-time.After(10 * time.Second):
+		t.Fatal("doTask deadlocked: a retry inside a shared-boundary node with M>1 destination branches " +
+			"re-entered the shared mutex. The lock must be acquired in the doTask wrapper, not in " +
+			"doTaskAttempt (which the retry recursion calls directly).")
+	}
+
+	is.Equal(4, len(destX.receivedPositions()))
+	is.Equal(4, len(destY.receivedPositions()))
+}
+
+// TestNxM_OneSourceExhausts_OtherStreams_BothDestinationsWritable covers the
+// Service-level scenario the arch-v2 N×M gate requires ("one source exhausts
+// while another streams, pipeline stays Running, both destinations still
+// writable") at the funnel level, with a GENUINELY, concurrently-streaming
+// second source - unlike the Service-level counterpart in
+// pkg/lifecycle-poc/service_nxm_test.go
+// (TestServiceLifecycle_NxM_OneSourceExhausts_OtherStreams_BothDestinationsWritable),
+// which had to fall back to an IDLE sibling because a genuinely concurrent
+// second source at that layer reliably reproduces a pre-existing,
+// independent data race/panic in connector.Persister (see that test's doc
+// comment for the full finding). This package never touches
+// connector.Persister, so the real property - a second source actually
+// writing new records through both shared destinations AFTER the first
+// source has exhausted and torn itself down - is provable here directly.
+func TestNxM_OneSourceExhausts_OtherStreams_BothDestinationsWritable(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	recordsA := randomRecords(2)
+	recordsB := randomRecords(3)
+	for i := range recordsB {
+		recordsB[i].Position = opencdc.Position(fmt.Sprintf("b-%d", i)) // distinct from A's
+	}
+
+	srcA := newFiniteSource("srcA", recordsA) // exhausts via io.EOF, nobody calls Stop
+	srcB := newFakeSource("srcB", recordsB)
+	destX := newFakeDestination("destX")
+	destY := newFakeDestination("destY")
+
+	workers, sink, _ := buildNxMWorkers(t, false, []Destination{destX, destY}, srcA, srcB)
+	wA, wB := workers[0], workers[1]
+
+	is.NoErr(sink.Open(ctx))
+	is.NoErr(wA.Open(ctx))
+	is.NoErr(wB.Open(ctx))
+
+	doErrA := make(chan error, 1)
+	doErrB := make(chan error, 1)
+	go func() { doErrA <- wA.Do(ctx) }()
+	go func() { doErrB <- wB.Do(ctx) }()
+
+	// A must exit on its own (nil, not an error) once it runs out of records.
+	select {
+	case err := <-doErrA:
+		is.NoErr(err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for srcA's worker to finish gracefully on io.EOF")
+	}
+	is.NoErr(wA.Close(ctx))
+
+	// B keeps streaming AFTER A is fully gone, through the SAME two shared
+	// destinations - proof both are still writable post-A's exit.
+	waitForCondition(t, 5*time.Second, func() bool { return len(srcB.ackedPositions()) == len(recordsB) })
+
+	is.NoErr(wB.Stop(ctx))
+	is.NoErr(<-doErrB)
+	is.NoErr(wB.Close(ctx))
+	is.NoErr(sink.Close(ctx))
+
+	wantKeys := make(map[string]bool, len(recordsA)+len(recordsB))
+	for _, r := range append(append([]opencdc.Record{}, recordsA...), recordsB...) {
+		wantKeys[string(r.Position)] = true
+	}
+	for _, d := range []*fakeDestination{destX, destY} {
+		is.Equal(len(recordsA)+len(recordsB), len(d.written))
+		gotKeys := make(map[string]bool, len(d.written))
+		for _, r := range d.written {
+			gotKeys[string(r.Position)] = true
+		}
+		is.Equal(wantKeys, gotKeys)
+	}
+}

--- a/pkg/lifecycle-poc/service_nxm_test.go
+++ b/pkg/lifecycle-poc/service_nxm_test.go
@@ -1,0 +1,789 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lifecycle
+
+import (
+	"context"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/cchan"
+	"github.com/conduitio/conduit-commons/database/inmemory"
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit/pkg/connector"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	"github.com/conduitio/conduit/pkg/lifecycle-poc/funnel"
+	"github.com/conduitio/conduit/pkg/pipeline"
+	pmock "github.com/conduitio/conduit/pkg/plugin/connector/mock"
+	"github.com/google/uuid"
+	"github.com/matryer/is"
+	"github.com/rs/zerolog"
+	"go.uber.org/mock/gomock"
+)
+
+// This file is the N×M shape-coverage gate for arch-v2 (see
+// docs/design-documents/20260801-archv2-multiconnector-nsource.md): N sources
+// x M destinations together already RUNS on main (slice 3a shipped M
+// destinations from one source, slice 3b shipped N sources onto one shared
+// destination), but nobody had tested the COMBINATION. This file - together
+// with pkg/lifecycle-poc/funnel/worker_nxm_test.go, which covers the funnel
+// level - is that missing verification.
+
+// fakeTask is a minimal funnel.Task double for testing buildSharedTail
+// directly: it doesn't need to run any real logic, just to be identifiable by
+// ID and walkable in the TaskNode graph buildSharedTail returns.
+type fakeTask struct{ id string }
+
+func (f *fakeTask) ID() string                              { return f.id }
+func (f *fakeTask) Open(context.Context) error              { return nil }
+func (f *fakeTask) Close(context.Context) error             { return nil }
+func (f *fakeTask) Do(context.Context, *funnel.Batch) error { return nil }
+
+// TestBuildSharedTail_ShapeByProcessorPresence is test 1 of the N×M shape
+// coverage gate: it calls the REAL buildSharedTail directly and asserts the
+// two structurally different graphs it documents actually come out that way.
+//
+//   - >=1 pipeline-level processor: buildSharedTail returns exactly ONE root
+//     (the processor chain), and that root's own tail fans out internally to
+//     every destination branch - so funnel.NewSink marks exactly ONE shared
+//     boundary, and every source Worker serializes on ONE mutex spanning the
+//     processor AND every destination branch.
+//   - 0 pipeline-level processors: buildSharedTail returns M INDEPENDENT
+//     roots (one per destination branch) - funnel.NewSink marks M shared
+//     boundaries, each with its own mutex.
+//
+// This locks the SHAPE in so a future buildSharedTail refactor that silently
+// collapses M independent roots into one (or the reverse) fails here, rather
+// than only showing up as an invisible throughput regression. The RUNTIME
+// CONSEQUENCE of this shape (that M independent roots give real
+// cross-destination concurrency, and one shared root forces full
+// serialization) is proven separately, where it's actually observable: see
+// funnel.TestNxM_NegativeSpace_NoProcessor_CrossDestinationConcurrency and
+// funnel.TestNxM_PositiveComplement_WithProcessor_NoOverlapInSharedSubtree.
+func TestBuildSharedTail_ShapeByProcessorPresence(t *testing.T) {
+	s := &Service{}
+
+	destTasks := [][]funnel.Task{
+		{&fakeTask{id: "dest-0"}},
+		{&fakeTask{id: "dest-1"}},
+		{&fakeTask{id: "dest-2"}},
+	}
+
+	t.Run("with pipeline processor: one shared root fanning out to M branches", func(t *testing.T) {
+		is := is.New(t)
+		procTasks := []funnel.Task{&fakeTask{id: "shared-proc"}}
+
+		roots, err := s.buildSharedTail(procTasks, destTasks)
+		is.NoErr(err)
+		is.Equal(1, len(roots))
+		is.Equal("shared-proc", roots[0].Task.ID())
+		is.Equal(len(destTasks), len(roots[0].Next))
+		for i, branch := range roots[0].Next {
+			is.Equal(destTasks[i][0].ID(), branch.Task.ID())
+		}
+
+		sink, err := funnel.NewSink(roots...)
+		is.NoErr(err)
+		is.True(sink != nil)
+	})
+
+	t.Run("no pipeline processor: M independent roots, one per destination branch", func(t *testing.T) {
+		is := is.New(t)
+		roots, err := s.buildSharedTail(nil, destTasks)
+		is.NoErr(err)
+		is.Equal(len(destTasks), len(roots))
+		for i, root := range roots {
+			is.Equal(destTasks[i][0].ID(), root.Task.ID())
+			is.Equal(0, len(root.Next)) // single-task branch in this test, nothing further attached
+		}
+
+		sink, err := funnel.NewSink(roots...)
+		is.NoErr(err)
+		is.True(sink != nil)
+	})
+}
+
+// TestServiceLifecycle_buildRunnablePipeline_NxM extends
+// TestServiceLifecycle_buildRunnablePipeline_MultipleSources (which only
+// covers N sources x M=1 destination) to N=2 sources x M=2 destinations: both
+// workers' own prefixes must attach the SAME M destination TaskNode pointers
+// - not two independently-built copies - so that got.sink tears down each
+// destination exactly once regardless of how many sources point at it.
+func TestServiceLifecycle_buildRunnablePipeline_NxM(t *testing.T) {
+	is := is.New(t)
+	ctx, killAll := context.WithCancel(context.Background())
+	defer killAll()
+	ctrl := gomock.NewController(t)
+	logger := log.New(zerolog.Nop())
+	db := &inmemory.DB{}
+	persister := connector.NewPersister(logger, db, time.Second, 3)
+
+	sourceA := dummySource(persister)
+	sourceB := dummySource(persister)
+	dest1 := dummyDestination(persister)
+	dest2 := dummyDestination(persister)
+	dlq := dummyDestination(persister)
+	pl := &pipeline.Instance{
+		ID:     uuid.NewString(),
+		Config: pipeline.Config{Name: "test-pipeline"},
+		DLQ: pipeline.DLQ{
+			Plugin:              dlq.Plugin,
+			Settings:            map[string]string{},
+			WindowSize:          3,
+			WindowNackThreshold: 2,
+		},
+		ConnectorIDs: []string{sourceA.ID, sourceB.ID, dest1.ID, dest2.ID},
+	}
+	pl.SetStatus(pipeline.StatusUserStopped)
+
+	connSvc := &recordingConnectorService{
+		testConnectorService: testConnectorService{
+			sourceA.ID: sourceA,
+			sourceB.ID: sourceB,
+			dest1.ID:   dest1,
+			dest2.ID:   dest2,
+			testDLQID:  dlq,
+		},
+	}
+
+	ls := NewService(
+		logger,
+		testErrRecoveryCfg(),
+		connSvc,
+		testProcessorService{},
+		testConnectorPluginService{
+			sourceA.Plugin: pmock.NewDispenser(ctrl),
+			sourceB.Plugin: pmock.NewDispenser(ctrl),
+			dest1.Plugin:   pmock.NewDispenser(ctrl),
+			dest2.Plugin:   pmock.NewDispenser(ctrl),
+			dlq.Plugin:     pmock.NewDispenser(ctrl),
+		},
+		testPipelineService{},
+		false,
+	)
+
+	got, err := ls.buildRunnablePipeline(ctx, pl)
+	is.NoErr(err)
+
+	is.Equal(2, len(got.workers))
+	is.True(got.sink != nil)
+
+	// No pipeline-level processors configured: buildSharedTail's
+	// no-processor shape, so each worker's own tail attaches ALL M=2
+	// destination branches DIRECTLY (M independent shared roots - see
+	// TestBuildSharedTail_ShapeByProcessorPresence).
+	is.Equal(2, len(got.workers[0].FirstTask.Next))
+	is.Equal(2, len(got.workers[1].FirstTask.Next))
+
+	// Both workers converge on the IDENTICAL M destination TaskNode
+	// pointers - not two independently-built copies.
+	for i := range 2 {
+		is.True(got.workers[0].FirstTask.Next[i] == got.workers[1].FirstTask.Next[i])
+	}
+}
+
+// generateRecordsWithPositionPrefix builds count records whose positions are
+// prefixed (so two sources' record sets never collide) - used by the N×M
+// service-level tests below that need multiple sources' records to coexist
+// unambiguously in a shared destination's expectation set.
+func generateRecordsWithPositionPrefix(prefix string, count int) []opencdc.Record {
+	records := make([]opencdc.Record, count)
+	for i := 0; i < count; i++ {
+		records[i] = opencdc.Record{
+			Key: opencdc.RawData(uuid.NewString()),
+			Payload: opencdc.Change{
+				Before: opencdc.RawData{},
+				After:  opencdc.RawData(uuid.NewString()),
+			},
+			Position: opencdc.Position(prefix + "-" + strconv.Itoa(i)),
+		}
+	}
+	return records
+}
+
+// unorderedAsserterDestination is the N-source-safe sibling of
+// asserterDestination: it checks that the destination receives exactly the
+// given records, but (unlike asserterDestination's strict positional match)
+// tolerates ANY arrival order. Needed the moment more than one source can
+// concurrently write to the SAME destination - see
+// pmock.DestinationPluginWithUnorderedRecords's doc for why a fixed-order
+// assertion would be flaky, not merely stricter, in that shape.
+func unorderedAsserterDestination(
+	ctrl *gomock.Controller,
+	persister *connector.Persister,
+	records []opencdc.Record,
+) (*connector.Instance, *pmock.Dispenser) {
+	destinationPlugin := pmock.NewConfigurableDestinationPlugin(ctrl,
+		pmock.DestinationPluginWithConfigure(),
+		pmock.DestinationPluginWithOpen(),
+		pmock.DestinationPluginWithRun(),
+		pmock.DestinationPluginWithUnorderedRecords(records),
+		pmock.DestinationPluginWithTeardown(),
+	)
+
+	dest := dummyDestination(persister)
+
+	dispenser := pmock.NewDispenser(ctrl)
+	dispenser.EXPECT().DispenseDestination().Return(destinationPlugin, nil)
+
+	return dest, dispenser
+}
+
+// TestServiceLifecycle_NxM_StartMovesRecordsStopsCleanly is test 7: an N=2 x
+// M=2 pipeline starts, moves every record from every source to every
+// destination, and stops cleanly.
+func TestServiceLifecycle_NxM_StartMovesRecordsStopsCleanly(t *testing.T) {
+	is := is.New(t)
+	ctx, killAll := context.WithCancel(context.Background())
+	defer killAll()
+	logger := log.New(zerolog.Nop())
+	db := &inmemory.DB{}
+	persister := connector.NewPersister(logger, db, time.Second, 3)
+	defer persister.Wait()
+
+	ps := pipeline.NewService(logger, db)
+	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
+	is.NoErr(err)
+
+	recordsA := generateRecordsWithPositionPrefix("A", 3)
+	recordsB := generateRecordsWithPositionPrefix("B", 3)
+
+	ctrl := gomock.NewController(t)
+	sourceA, sourceADispenser := generatorSource(ctrl, persister, recordsA, nil, false)
+	sourceB, sourceBDispenser := generatorSource(ctrl, persister, recordsB, nil, false)
+
+	allRecords := append(append([]opencdc.Record{}, recordsA...), recordsB...)
+	dest1, dest1Dispenser := unorderedAsserterDestination(ctrl, persister, allRecords)
+	dest2, dest2Dispenser := unorderedAsserterDestination(ctrl, persister, allRecords)
+
+	dlqA, dlqADispenser := asserterDestination(ctrl, persister, nil, false)
+	dlqB, dlqBDispenser := asserterDestination(ctrl, persister, nil, false)
+	connSvc := &multiDLQConnectorService{
+		testConnectorService: testConnectorService{
+			sourceA.ID: sourceA,
+			sourceB.ID: sourceB,
+			dest1.ID:   dest1,
+			dest2.ID:   dest2,
+		},
+		dlqs: []*connector.Instance{dlqA, dlqB},
+	}
+
+	pl, err = ps.AddConnector(ctx, pl.ID, sourceA.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, sourceB.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, dest1.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, dest2.ID)
+	is.NoErr(err)
+
+	ls := NewService(
+		logger,
+		testErrRecoveryCfg(),
+		connSvc,
+		testProcessorService{},
+		testConnectorPluginService{
+			sourceA.Plugin: sourceADispenser,
+			sourceB.Plugin: sourceBDispenser,
+			dest1.Plugin:   dest1Dispenser,
+			dest2.Plugin:   dest2Dispenser,
+			dlqA.Plugin:    dlqADispenser,
+			dlqB.Plugin:    dlqBDispenser,
+		},
+		ps,
+		false,
+	)
+
+	err = ls.Start(ctx, pl.ID)
+	is.NoErr(err)
+
+	waitForRecordsAcked(t, sourceA, recordsA)
+	waitForRecordsAcked(t, sourceB, recordsB)
+	is.Equal(pipeline.StatusRunning, pl.GetStatus())
+
+	err = ls.Stop(ctx, pl.ID, false)
+	is.NoErr(err)
+	is.NoErr(ls.WaitPipeline(pl.ID))
+	is.Equal(pipeline.StatusUserStopped, pl.GetStatus())
+}
+
+// TestServiceLifecycle_NxM_FatalErrorOneDestination_DegradesWholePipeline is
+// test 8: a fatal error on ONE of two destinations (shared across two
+// sources) must degrade the WHOLE pipeline, matching the single-destination
+// and single-source-fatal-error behavior generalized to the N×M shape.
+func TestServiceLifecycle_NxM_FatalErrorOneDestination_DegradesWholePipeline(t *testing.T) {
+	is := is.New(t)
+	ctx, killAll := context.WithCancel(context.Background())
+	defer killAll()
+	logger := log.Test(t)
+	db := &inmemory.DB{}
+	persister := connector.NewPersister(logger, db, time.Second, 3)
+	defer persister.Wait()
+
+	ps := pipeline.NewService(logger, db)
+	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
+	is.NoErr(err)
+
+	wantErr := cerrors.FatalError(cerrors.New("destination 1 write error"))
+	recordsA := generateRecords(1)
+
+	ctrl := gomock.NewController(t)
+
+	// sourceA: NOT generatorSource - the destination fails before the record
+	// is ever acked, so the source's ack count is 0, not len(recordsA).
+	// assertAckCount=false because that count depends on exactly how far the
+	// pipeline got before the fatal error, not a fixed expectation (mirrors
+	// TestServiceLifecycle_NSource_PartialGracefulStop_Escalates's identical
+	// sourceA pattern).
+	sourceAPlugin := pmock.NewConfigurableSourcePlugin(ctrl,
+		pmock.SourcePluginWithConfigure(),
+		pmock.SourcePluginWithOpen(),
+		pmock.SourcePluginWithRun(),
+		pmock.SourcePluginWithRecords(recordsA, nil),
+		pmock.SourcePluginWithAcks(0, false),
+		pmock.SourcePluginWithTeardown(),
+	)
+	sourceA := dummySource(persister)
+	sourceADispenser := pmock.NewDispenser(ctrl)
+	sourceADispenser.EXPECT().DispenseSource().Return(sourceAPlugin, nil).Times(1)
+
+	sourceB, sourceBDispenser := idleSourceTimes(ctrl, persister, 1)
+
+	received := make(chan struct{})
+	release := make(chan struct{})
+	close(release) // fail immediately, no need to hold the batch in flight first
+
+	dest1Plugin := pmock.NewConfigurableDestinationPlugin(ctrl,
+		pmock.DestinationPluginWithConfigure(),
+		pmock.DestinationPluginWithOpen(),
+		pmock.DestinationPluginWithRun(),
+		pmock.DestinationPluginWithControlledError(recordsA, received, release, wantErr),
+		pmock.DestinationPluginWithTeardown(),
+	)
+	dest1 := dummyDestination(persister)
+	dest1Dispenser := pmock.NewDispenser(ctrl)
+	dest1Dispenser.EXPECT().DispenseDestination().Return(dest1Plugin, nil).Times(1)
+
+	// dest2: the M-branch companion, unblocked and healthy - proves the
+	// fatal error on dest1 still degrades the whole pipeline even though
+	// dest2 succeeds.
+	dest2, dest2Dispenser := asserterDestination(ctrl, persister, recordsA, false)
+
+	dlqA, dlqADispenser := asserterDestination(ctrl, persister, nil, false)
+	dlqB, dlqBDispenser := asserterDestination(ctrl, persister, nil, false)
+	connSvc := &multiDLQConnectorService{
+		testConnectorService: testConnectorService{
+			sourceA.ID: sourceA,
+			sourceB.ID: sourceB,
+			dest1.ID:   dest1,
+			dest2.ID:   dest2,
+		},
+		dlqs: []*connector.Instance{dlqA, dlqB},
+	}
+
+	pl, err = ps.AddConnector(ctx, pl.ID, sourceA.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, sourceB.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, dest1.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, dest2.ID)
+	is.NoErr(err)
+
+	ls := NewService(
+		logger,
+		testErrRecoveryCfg(),
+		connSvc,
+		testProcessorService{},
+		testConnectorPluginService{
+			sourceA.Plugin: sourceADispenser,
+			sourceB.Plugin: sourceBDispenser,
+			dest1.Plugin:   dest1Dispenser,
+			dest2.Plugin:   dest2Dispenser,
+			dlqA.Plugin:    dlqADispenser,
+			dlqB.Plugin:    dlqBDispenser,
+		},
+		ps,
+		false,
+	)
+
+	events := make(chan FailureEvent, 1)
+	ls.OnFailure(func(e FailureEvent) { events <- e })
+
+	err = ls.Start(ctx, pl.ID)
+	is.NoErr(err)
+
+	err = ls.WaitPipeline(pl.ID)
+	is.True(err != nil)
+
+	is.Equal(pipeline.StatusDegraded, pl.GetStatus())
+
+	event, eventReceived, err := cchan.Chan[FailureEvent](events).RecvTimeout(ctx, 200*time.Millisecond)
+	is.NoErr(err)
+	is.True(eventReceived)
+	is.Equal(pl.ID, event.ID)
+}
+
+// TestServiceLifecycle_NxM_TransientErrorOneSource_RecoversAllSourcesAndDestinations
+// is test 9: a transient error in one of two sources drives PIPELINE-WIDE
+// recovery, which must rebuild ALL N sources AND ALL M destinations from
+// scratch - and the shared destinations' poison state (see
+// TaskNode.poisoned) is implicitly proven cleared, because the recovered run
+// is an entirely NEW TaskNode graph (a fresh, unpoisoned flag by
+// construction) that successfully accepts writes again post-recovery.
+func TestServiceLifecycle_NxM_TransientErrorOneSource_RecoversAllSourcesAndDestinations(t *testing.T) {
+	is := is.New(t)
+	ctx, killAll := context.WithCancel(context.Background())
+	defer killAll()
+	logger := log.New(zerolog.Nop())
+	db := &inmemory.DB{}
+	persister := connector.NewPersister(logger, db, time.Second, 3)
+	defer persister.Wait()
+
+	ps := pipeline.NewService(logger, db)
+	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
+	is.NoErr(err)
+
+	transientErr := cerrors.New("lost connection to source A")
+	healthyRecords := generateRecords(3)
+
+	ctrl := gomock.NewController(t)
+	sourceA, sourceADispenser := sourceRecoversAfterTransientError(ctrl, persister, healthyRecords, transientErr)
+	sourceB, sourceBDispenser := idleSourceTimes(ctrl, persister, 2) // initial run + recovery restart
+	dest1, dest1Dispenser := destinationRecovers(ctrl, persister, healthyRecords)
+	dest2, dest2Dispenser := destinationRecovers(ctrl, persister, healthyRecords)
+
+	dlqA, dlqADispenser := dlqDispenserTimes(ctrl, persister, 2)
+	dlqB, dlqBDispenser := dlqDispenserTimes(ctrl, persister, 2)
+	connSvc := &multiDLQConnectorService{
+		testConnectorService: testConnectorService{
+			sourceA.ID: sourceA,
+			sourceB.ID: sourceB,
+			dest1.ID:   dest1,
+			dest2.ID:   dest2,
+		},
+		dlqs: []*connector.Instance{dlqA, dlqB},
+	}
+
+	pl, err = ps.AddConnector(ctx, pl.ID, sourceA.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, sourceB.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, dest1.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, dest2.ID)
+	is.NoErr(err)
+
+	rec := newStatusRecorder(ps)
+	ls := NewService(
+		logger,
+		testErrRecoveryCfg(),
+		connSvc,
+		testProcessorService{},
+		testConnectorPluginService{
+			sourceA.Plugin: sourceADispenser,
+			sourceB.Plugin: sourceBDispenser,
+			dest1.Plugin:   dest1Dispenser,
+			dest2.Plugin:   dest2Dispenser,
+			dlqA.Plugin:    dlqADispenser,
+			dlqB.Plugin:    dlqBDispenser,
+		},
+		rec,
+		false,
+	)
+
+	err = ls.Start(ctx, pl.ID)
+	is.NoErr(err)
+
+	// Must have passed through Recovering and be Running again.
+	waitForRecovered(t, rec)
+
+	// Post-recovery records flow cleanly through the REBUILT shared
+	// destinations - proof the poison flag (which never clears in place) is
+	// moot here because recovery builds an entirely fresh TaskNode graph.
+	waitForRecordsAcked(t, sourceA, healthyRecords)
+	is.Equal(pipeline.StatusRunning, pl.GetStatus())
+
+	err = ls.Stop(ctx, pl.ID, false)
+	is.NoErr(err)
+	is.NoErr(ls.WaitPipeline(pl.ID))
+	is.Equal(pipeline.StatusUserStopped, pl.GetStatus())
+
+	is.Equal(rec.snapshot(), []pipeline.Status{
+		pipeline.StatusRunning,
+		pipeline.StatusRecovering,
+		pipeline.StatusRunning,
+		pipeline.StatusUserStopped,
+	})
+}
+
+// TestServiceLifecycle_NxM_OneSourceExhausts_OtherStreams_BothDestinationsWritable
+// is test 10: source A exhausts a fixed record set (io.EOF) while source B
+// (idle, still connected but with nothing to emit) keeps its own worker
+// alive. The pipeline must stay Running through A's exit - proven here by A's
+// M=2 fan-out completing successfully (both destinations receive and durably
+// process every one of A's records) and the pipeline staying Running and
+// gracefully stoppable afterward, with B's worker still registered the whole
+// time.
+//
+// B is deliberately idle here, not a second ACTIVELY streaming/acking source,
+// for two reasons - one still live, one now historical.
+//
+// Still live: asserterDestination asserts records arrive in order, which two
+// concurrently-producing sources would legitimately violate. The funnel-level
+// equivalent, funnel.TestNxM_OneSourceExhausts_OtherStreams_BothDestinationsWritable,
+// covers the SAME property with a second GENUINELY concurrent sibling, using an
+// unordered destination.
+//
+// Historical: this test originally used an active sibling and reliably
+// reproduced a concurrency bug in pkg/connector.Persister that this N×M work
+// discovered - Source.Teardown -> WaitPendingWritesContext -> WaitPendingWrites
+// read p.flushWg/p.callbackWg without holding p.m while another connector's Ack
+// mutated them under p.m, panicking the process with "sync: WaitGroup is reused
+// before previous Wait has returned". Two connectors share one Persister in
+// production (connector.Service passes the SAME *Persister to every connector),
+// so "one source exits while another acks" hit it reliably.
+//
+// That bug is FIXED (#2743, fixed in #2749: the WaitGroups were replaced with a
+// per-flush generation whose channels a waiter snapshots under p.m). It is no
+// longer a reason to keep B idle, and this test could be strengthened to an
+// active sibling once asserterDestination gains an unordered mode. Recorded
+// here so the constraint is not mistaken for a still-open bug.
+func TestServiceLifecycle_NxM_OneSourceExhausts_OtherStreams_BothDestinationsWritable(t *testing.T) {
+	is := is.New(t)
+	ctx, killAll := context.WithCancel(context.Background())
+	defer killAll()
+	logger := log.New(zerolog.Nop())
+	db := &inmemory.DB{}
+	persister := connector.NewPersister(logger, db, time.Second, 3)
+	defer persister.Wait()
+
+	ps := pipeline.NewService(logger, db)
+	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
+	is.NoErr(err)
+
+	recordsA := generateRecordsWithPositionPrefix("A", 2)
+
+	ctrl := gomock.NewController(t)
+
+	// Source A: exhausts its fixed record set with io.EOF - nobody calls
+	// Stop. See Worker.doTaskAttempt's io.EOF branch.
+	sourceAPlugin := pmock.NewConfigurableSourcePlugin(ctrl,
+		pmock.SourcePluginWithConfigure(),
+		pmock.SourcePluginWithOpen(),
+		pmock.SourcePluginWithRun(),
+		pmock.SourcePluginWithRecords(recordsA, io.EOF),
+		pmock.SourcePluginWithAcks(len(recordsA), false),
+		pmock.SourcePluginWithTeardown(),
+	)
+	sourceA := dummySource(persister)
+	sourceADispenser := pmock.NewDispenser(ctrl)
+	sourceADispenser.EXPECT().DispenseSource().Return(sourceAPlugin, nil).Times(1)
+
+	sourceB, sourceBDispenser := idleSourceTimes(ctrl, persister, 1)
+
+	// Both M=2 destinations must fully and correctly receive A's records -
+	// ordered asserterDestination is safe here since A is the only ACTIVE
+	// producer (B never writes).
+	dest1, dest1Dispenser := asserterDestination(ctrl, persister, recordsA, false)
+	dest2, dest2Dispenser := asserterDestination(ctrl, persister, recordsA, false)
+
+	dlqA, dlqADispenser := asserterDestination(ctrl, persister, nil, false)
+	dlqB, dlqBDispenser := asserterDestination(ctrl, persister, nil, false)
+	connSvc := &multiDLQConnectorService{
+		testConnectorService: testConnectorService{
+			sourceA.ID: sourceA,
+			sourceB.ID: sourceB,
+			dest1.ID:   dest1,
+			dest2.ID:   dest2,
+		},
+		dlqs: []*connector.Instance{dlqA, dlqB},
+	}
+
+	pl, err = ps.AddConnector(ctx, pl.ID, sourceA.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, sourceB.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, dest1.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, dest2.ID)
+	is.NoErr(err)
+
+	ls := NewService(
+		logger,
+		testErrRecoveryCfg(),
+		connSvc,
+		testProcessorService{},
+		testConnectorPluginService{
+			sourceA.Plugin: sourceADispenser,
+			sourceB.Plugin: sourceBDispenser,
+			dest1.Plugin:   dest1Dispenser,
+			dest2.Plugin:   dest2Dispenser,
+			dlqA.Plugin:    dlqADispenser,
+			dlqB.Plugin:    dlqBDispenser,
+		},
+		ps,
+		false,
+	)
+
+	err = ls.Start(ctx, pl.ID)
+	is.NoErr(err)
+
+	// A exhausts and acks its own records through BOTH destinations; the
+	// pipeline must stay Running (B's worker is still registered on the
+	// tomb).
+	waitForRecordsAcked(t, sourceA, recordsA)
+	is.Equal(pipeline.StatusRunning, pl.GetStatus())
+
+	err = ls.Stop(ctx, pl.ID, false)
+	is.NoErr(err)
+	is.NoErr(ls.WaitPipeline(pl.ID))
+	is.Equal(pipeline.StatusUserStopped, pl.GetStatus())
+}
+
+// TestServiceLifecycle_NxM_PartialGracefulStop_Escalates is test 11: it
+// generalizes TestServiceLifecycle_NSource_PartialGracefulStop_Escalates (N
+// sources x M=1) to N=2 x M=2 - source A's record is held in flight on
+// destination 1 while destination 2 (the M-branch companion) succeeds
+// normally; source B (idle) arms well within the deadline, source A does
+// not, and the partial-arming escalation path must still trigger exactly as
+// it does at M=1.
+func TestServiceLifecycle_NxM_PartialGracefulStop_Escalates(t *testing.T) {
+	is := is.New(t)
+	ctx, killAll := context.WithCancel(context.Background())
+	defer killAll()
+	logger := log.New(zerolog.Nop())
+	db := &inmemory.DB{}
+	persister := connector.NewPersister(logger, db, time.Second, 3)
+	defer persister.Wait()
+
+	ps := pipeline.NewService(logger, db)
+	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
+	is.NoErr(err)
+
+	recordsA := generateRecords(1)
+
+	ctrl := gomock.NewController(t)
+
+	sourceAPlugin := pmock.NewConfigurableSourcePlugin(ctrl,
+		pmock.SourcePluginWithConfigure(),
+		pmock.SourcePluginWithOpen(),
+		pmock.SourcePluginWithRun(),
+		pmock.SourcePluginWithRecords(recordsA, nil),
+		pmock.SourcePluginWithAcks(0, false),
+		pmock.SourcePluginWithTeardown(),
+	)
+	sourceA := dummySource(persister)
+	sourceADispenser := pmock.NewDispenser(ctrl)
+	sourceADispenser.EXPECT().DispenseSource().Return(sourceAPlugin, nil).Times(1)
+
+	sourceB, sourceBDispenser := idleSourceTimes(ctrl, persister, 1)
+
+	// dest1: A's record is held in flight (processingLock AND sharedMu held
+	// by A's own Do goroutine) until the test releases it. releaseFn is
+	// idempotent and deferred so an assertion failure between here and the
+	// explicit call still unblocks A's write during the t.Fatal unwind - see
+	// TestServiceLifecycle_NSource_PartialGracefulStop_Escalates's identical
+	// comment for the full rationale.
+	received := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseFn := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseFn()
+	dest1Plugin := pmock.NewConfigurableDestinationPlugin(ctrl,
+		pmock.DestinationPluginWithConfigure(),
+		pmock.DestinationPluginWithOpen(),
+		pmock.DestinationPluginWithRun(),
+		pmock.DestinationPluginWithControlledBlock(recordsA, received, release),
+		pmock.DestinationPluginWithTeardown(),
+	)
+	dest1 := dummyDestination(persister)
+	dest1Dispenser := pmock.NewDispenser(ctrl)
+	dest1Dispenser.EXPECT().DispenseDestination().Return(dest1Plugin, nil).Times(1)
+
+	// dest2: the M-branch companion - unblocked, succeeds normally, proving
+	// the M-branch fan-out is genuinely exercised (not just N sources at
+	// M=1).
+	dest2, dest2Dispenser := asserterDestination(ctrl, persister, recordsA, false)
+
+	dlqA, dlqADispenser := asserterDestination(ctrl, persister, nil, false)
+	dlqB, dlqBDispenser := asserterDestination(ctrl, persister, nil, false)
+	connSvc := &multiDLQConnectorService{
+		testConnectorService: testConnectorService{
+			sourceA.ID: sourceA,
+			sourceB.ID: sourceB,
+			dest1.ID:   dest1,
+			dest2.ID:   dest2,
+		},
+		dlqs: []*connector.Instance{dlqA, dlqB},
+	}
+
+	pl, err = ps.AddConnector(ctx, pl.ID, sourceA.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, sourceB.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, dest1.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, dest2.ID)
+	is.NoErr(err)
+
+	ls := NewService(
+		logger,
+		testErrRecoveryCfg(),
+		connSvc,
+		testProcessorService{},
+		testConnectorPluginService{
+			sourceA.Plugin: sourceADispenser,
+			sourceB.Plugin: sourceBDispenser,
+			dest1.Plugin:   dest1Dispenser,
+			dest2.Plugin:   dest2Dispenser,
+			dlqA.Plugin:    dlqADispenser,
+			dlqB.Plugin:    dlqBDispenser,
+		},
+		ps,
+		false,
+	)
+
+	err = ls.Start(ctx, pl.ID)
+	is.NoErr(err)
+
+	<-received // A's record is in flight; A holds its own processingLock + sharedMu
+
+	// A short deadline A can never meet (its own processingLock is held by
+	// its blocked Do goroutine, released only when `release` is closed); B,
+	// idle, arms well within it.
+	stopCtx, stopCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer stopCancel()
+
+	stopErr := ls.Stop(stopCtx, pl.ID, false)
+	is.True(stopErr != nil)
+
+	ce, ok := conduiterr.Get(stopErr)
+	is.True(ok)
+	is.Equal(ce.Code, CodePartialGracefulStopEscalated)
+	is.True(strings.Contains(stopErr.Error(), sourceB.ID)) // names the armed source
+	is.True(strings.Contains(stopErr.Error(), sourceA.ID)) // names the unarmed source
+
+	releaseFn()
+
+	_ = ls.WaitPipeline(pl.ID)
+	waitForStatus(t, pl, pipeline.StatusDegraded)
+}

--- a/pkg/plugin/connector/mock/destination.go
+++ b/pkg/plugin/connector/mock/destination.go
@@ -17,6 +17,7 @@ package mock
 import (
 	"context"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -145,6 +146,80 @@ func DestinationPluginWithRecords(records []opencdc.Record) ConfigurableDestinat
 
 				err = serverStream.Send(pconnector.DestinationRunResponse{Acks: acks})
 				if err != nil {
+					return cerrors.Errorf("destination mock send stream error: %w", err)
+				}
+			}
+		})
+	})
+}
+
+// DestinationPluginWithUnorderedRecords is the concurrent-multi-source
+// sibling of DestinationPluginWithRecords: it accepts the given records in
+// ANY arrival order (matched by position, not by call order) and only
+// requires that, by the time the mock's expectations are checked, every one
+// of them was received exactly once with matching content.
+//
+// DestinationPluginWithRecords' strict positional match (records[offset])
+// assumes a single, ordered producer. That assumption breaks the moment TWO
+// sources share this destination (arch-v2 N-source pipelines): each source's
+// batches arrive over the same stream, but WHICH source's batch lands first
+// is a scheduling race with no defined winner - asserting a fixed order would
+// make the test flaky, not the production code wrong. See
+// pkg/lifecycle-poc's N×M shape-coverage tests, which need this to assert
+// "every expected record arrived, from either source" without pinning an
+// order neither the design nor the operator can rely on.
+func DestinationPluginWithUnorderedRecords(records []opencdc.Record) ConfigurableDestinationPluginOption {
+	return configurableDestinationPluginOptionFunc(func(p *ConfigurableDestinationPlugin) {
+		t := p.ctrl.T.(*testing.T)
+		is := is.New(t)
+
+		var wg csync.WaitGroup
+		wg.Add(1)
+
+		want := make(map[string]opencdc.Record, len(records))
+		for _, r := range records {
+			want[string(r.Position)] = r
+		}
+		var mu sync.Mutex
+
+		t.Cleanup(func() {
+			err := wg.WaitTimeout(context.Background(), time.Second)
+			is.NoErr(err) // run didn't finish
+
+			mu.Lock()
+			remaining := len(want)
+			mu.Unlock()
+			is.Equal(0, remaining) // every expected record must have arrived exactly once
+		})
+
+		p.onRun = append(p.onRun, func() error {
+			defer wg.Done()
+			serverStream := p.Stream.Server()
+
+			for {
+				req, err := serverStream.Recv()
+				if err != nil {
+					if cerrors.Is(err, context.Canceled) || cerrors.Is(err, io.EOF) {
+						return nil // This is expected when the plugin is stopped.
+					}
+					return cerrors.Errorf("destination mock recv stream error: %w", err)
+				}
+
+				acks := make([]pconnector.DestinationRunResponseAck, len(req.Records))
+				mu.Lock()
+				for i, got := range req.Records {
+					wantRec, ok := want[string(got.Position)]
+					if !ok {
+						mu.Unlock()
+						return cerrors.Errorf("destination mock received an unexpected or duplicate record at position %q", got.Position)
+					}
+					is.Equal(got, wantRec)
+					delete(want, string(got.Position))
+					acks[i] = pconnector.DestinationRunResponseAck{Position: got.Position}
+				}
+				mu.Unlock()
+
+				if err := serverStream.Send(pconnector.DestinationRunResponse{Acks: acks}); err != nil {
 					return cerrors.Errorf("destination mock send stream error: %w", err)
 				}
 			}


### PR DESCRIPTION
**Tier 1** (data path). Pre-flip gate: N×M shape coverage, the topology slice 3c wired but never verified.

12 tests across the funnel and Service layers, exercising N sources × M destinations — the shape where arch-v2 diverges structurally from v1 (one Worker per source serialized into a shared destination subtree behind a per-shared-root mutex, versus v1's `FaninNode`/`FanoutNode`).

## `buildSharedTail` shape verified directly, not inferred

`TestBuildSharedTail_ShapeByProcessorPresence` calls the real `buildSharedTail` and asserts the two shapes: **1 root fanning out to M** when a pipeline-level processor exists, **M independent roots** when none does.

Then it proves the runtime consequence rather than trusting the shape:

- **no processor** — two different sources can be inside `Write` on two different destinations simultaneously (hard rendezvous barrier; deadlocks on regression);
- **one processor** — a second source cannot enter *any* branch, even one nothing else is using, until the first source's entire pass releases the single shared lock.

That second case is the operational trap worth having covered: adding one pipeline-level processor silently collapses M per-destination locks into one global lock across all N sources, with no error, no warning and no metric.

## Found a real bug while building this

Constructing "one source exhausts while another streams" at the Service level reliably reproduced a **pre-existing** concurrency bug in `pkg/connector.Persister` — unrelated to N×M ack/DLQ logic, affecting both engines. Reported as #2743 and **since fixed in #2749**.

The stale comment describing it as still-open has been corrected in this branch: the idle-sibling choice is now justified only by `asserterDestination`'s strict-order assertion, and the note records that the test can be strengthened to an active sibling once that destination gains an unordered mode. The funnel-level equivalent already covers the same property with a genuinely concurrent second source, since that layer never touches `Persister`.

## Checks on current main

Rebased onto `fc812a5` (which includes the #2749 Persister fix). `go build ./...` · `go test -race ./pkg/lifecycle-poc/...` · `golangci-lint` → 0 issues. Authoring pass also recorded `-race -count=10` and a `GOMAXPROCS=1` + busy-loop contention run with no flakes.

## One addition outside the test tree

`pkg/plugin/connector/mock/destination.go` gains `DestinationPluginWithUnorderedRecords` — needed once a destination can legitimately receive records from two concurrently-producing sources in either order.