### PR TITLE
feat(foundation): add fuzzymatch for did-you-mean connector suggestions

### DIFF
--- a/pkg/foundation/fuzzymatch/doc.go
+++ b/pkg/foundation/fuzzymatch/doc.go
@@ -1,0 +1,59 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package fuzzymatch answers "you asked for X, which is not a thing — did you
+// mean Y?" for user- and model-supplied names.
+//
+// # Why this exists
+//
+// Two commands have been blocked on it. The `repair` design doc
+// (docs/design-documents/20260712-repair-command.md, §6) left the
+// "connector plugin not found" class unrepairable — "the correct plugin name is
+// not mechanically knowable... Deferred until a did-you-mean index exists".
+// `conduit generate` then made it a hard prerequisite rather than polish: its
+// acceptance bar says an unknown connector must produce a closest match and an
+// install suggestion, *never a fabricated plugin name*
+// (docs/design-documents/20260722-conduit-generate.md, §7).
+//
+// That second use is the demanding one. When an LLM invents a connector,
+// feeding "`postgre` does not exist; did you mean `postgres`?" back into the
+// retry prompt turns a hallucination into a self-correction inside the retry
+// budget, instead of a terminal failure. So this is shared infrastructure with
+// two named consumers, not a helper for one caller.
+//
+// # Invariants
+//
+// Two properties are load-bearing, and both are enforced by test:
+//
+//  1. Output is deterministic. Results are ordered by edit distance, then
+//     lexicographically. An error message whose wording depends on map
+//     iteration order cannot be asserted on, alerted on, or trusted in a
+//     golden file.
+//
+//  2. A suggestion is never fabricated. Every returned string is an element of
+//     candidates, and nothing is returned unless it clears the similarity
+//     floor. Returning a wrong-but-confident name is worse than returning
+//     nothing: the caller prints it as advice, and for `generate` it is fed
+//     back to a model that will act on it.
+//
+// # Scope
+//
+// Plain Levenshtein, not Damerau-Levenshtein. Real connector-name typos are
+// substitutions, omissions, and insertions (`postgre`/`postgres`,
+// `kafak`/`kafka`), not adjacent transpositions, and nothing in the acceptance
+// bar needs the extra operation. Simpler to audit for no loss in coverage.
+//
+// Matching is case-insensitive: names arrive from natural-language prompts,
+// which have no reliable casing convention.
+package fuzzymatch

--- a/pkg/foundation/fuzzymatch/fuzzymatch.go
+++ b/pkg/foundation/fuzzymatch/fuzzymatch.go
@@ -1,0 +1,153 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fuzzymatch
+
+import (
+	"slices"
+	"strings"
+)
+
+// absoluteTolerance is the edit-distance floor that applies regardless of name
+// length. Short names need it: a purely proportional bound on a 5-character
+// name allows only one edit, which rejects most real typos.
+const absoluteTolerance = 2
+
+// relativeTolerancePercent is the edit-distance budget as a percentage of the
+// requested name's length. Long names need it: a flat 2-edit tolerance on a
+// 20-character name is stricter than a user typing it by hand ever manages.
+const relativeTolerancePercent = 30
+
+// Suggest returns the candidates closest to want by case-insensitive
+// Levenshtein distance, nearest first, capped to maxSuggestions.
+//
+// It returns nil rather than a weak guess when nothing clears the similarity
+// floor. That is the point of the floor: callers print the result as advice,
+// and `conduit generate` feeds it back into a model that will act on it, so a
+// confident wrong name is worse than silence. Every returned string is an
+// element of candidates — this never synthesizes a name.
+//
+// Ties are broken lexicographically so output is stable across runs and across
+// the caller's candidate ordering. Callers put these strings in error messages
+// and golden files; a suggestion list that reordered between runs could not be
+// asserted on.
+//
+// An exact (case-insensitive) match is returned rather than filtered out. It
+// costs nothing, and silently dropping it would make the one case where the
+// caller's own lookup and this function disagree the hardest one to debug.
+func Suggest(want string, candidates []string, maxSuggestions int) []string {
+	if maxSuggestions <= 0 || want == "" || len(candidates) == 0 {
+		return nil
+	}
+
+	wantFolded := []rune(strings.ToLower(want))
+	// The budget is the LOOSER of the two bounds, so short and long names are
+	// both served: max(2, 30% of length). Integer division floors, which keeps
+	// the relative bound the stricter of two readings.
+	budget := max(absoluteTolerance, len(wantFolded)*relativeTolerancePercent/100)
+
+	type scored struct {
+		name string
+		dist int
+	}
+
+	matches := make([]scored, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, c := range candidates {
+		if c == "" {
+			continue
+		}
+		// A duplicated candidate must not occupy two of the maxSuggestions
+		// slots and crowd out a genuinely different alternative.
+		if _, dup := seen[c]; dup {
+			continue
+		}
+		seen[c] = struct{}{}
+
+		d := levenshtein(wantFolded, []rune(strings.ToLower(c)))
+		if d <= budget {
+			matches = append(matches, scored{name: c, dist: d})
+		}
+	}
+
+	slices.SortFunc(matches, func(a, b scored) int {
+		if a.dist != b.dist {
+			return a.dist - b.dist
+		}
+		return strings.Compare(a.name, b.name)
+	})
+
+	// nil, not an empty slice: the doc contract is "nil rather than a weak
+	// guess", and callers branch on `len(s) == 0` or `s == nil` interchangeably
+	// only if the two never diverge.
+	if len(matches) == 0 {
+		return nil
+	}
+
+	if len(matches) > maxSuggestions {
+		matches = matches[:maxSuggestions]
+	}
+
+	out := make([]string, len(matches))
+	for i, m := range matches {
+		out[i] = m.name
+	}
+	return out
+}
+
+// levenshtein returns the edit distance between two rune slices: the minimum
+// number of single-character insertions, deletions, or substitutions to turn a
+// into b.
+//
+// Callers must fold case before calling — this compares runes as given.
+//
+// Only two rows of the full matrix are kept. The matrix is O(len(a)*len(b)) in
+// memory and this runs once per candidate against the whole connector catalog,
+// inside a generate retry loop; two rows is the same algorithm with the rows
+// that can no longer be read dropped.
+func levenshtein(a, b []rune) int {
+	if len(a) == 0 {
+		return len(b)
+	}
+	if len(b) == 0 {
+		return len(a)
+	}
+
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+
+	// Row 0: turning an empty prefix of a into b's prefix costs one insertion
+	// per character.
+	for j := range prev {
+		prev[j] = j
+	}
+
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i // delete every character of a's prefix
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min(
+				prev[j]+1,      // deletion
+				curr[j-1]+1,    // insertion
+				prev[j-1]+cost, // substitution (or free match)
+			)
+		}
+		prev, curr = curr, prev
+	}
+
+	return prev[len(b)]
+}

--- a/pkg/foundation/fuzzymatch/fuzzymatch_test.go
+++ b/pkg/foundation/fuzzymatch/fuzzymatch_test.go
@@ -1,0 +1,237 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fuzzymatch
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+// builtins is the real built-in connector list
+// (pkg/plugin/connector/builtin/registry.go). Tests use the actual names rather
+// than invented ones so the similarity floor is tuned against the distances
+// that occur in practice, not against a convenient fixture.
+var builtins = []string{"file", "generator", "kafka", "log", "postgres", "s3"}
+
+func TestSuggest_RealTypos(t *testing.T) {
+	// The cases the design doc cites by name (§7), plus the shapes users
+	// actually produce.
+	tests := []struct {
+		name string
+		want string
+		exp  []string
+	}{
+		{"omission", "postgre", []string{"postgres"}},
+		{"transposition", "kafak", []string{"kafka"}},
+		{"insertion", "postgress", []string{"postgres"}},
+		{"substitution", "kafla", []string{"kafka"}},
+		{"case difference", "POSTGRES", []string{"postgres"}},
+		{"mixed case typo", "Postgre", []string{"postgres"}},
+		{"exact match is returned, not filtered", "kafka", []string{"kafka"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			is := is.New(t)
+			is.Equal(Suggest(tt.want, builtins, 3), tt.exp)
+		})
+	}
+}
+
+// TestSuggest_TranspositionIsCovered pins the design doc's stated reason for
+// choosing plain Levenshtein over Damerau-Levenshtein: transpositions cost 2
+// edits instead of 1, which is still inside the floor for realistic names. If
+// this ever fails, the doc's justification is wrong and the algorithm choice
+// has to be revisited rather than the test relaxed.
+func TestSuggest_TranspositionIsCovered(t *testing.T) {
+	is := is.New(t)
+	is.Equal(levenshtein([]rune("kafak"), []rune("kafka")), 2)
+	is.Equal(Suggest("kafak", builtins, 1), []string{"kafka"})
+}
+
+// TestSuggest_NeverFabricates is the invariant that matters most.
+//
+// `conduit generate` feeds the suggestion back into a model that acts on it, so
+// a confident wrong name is worse than silence. Asking for a connector that
+// genuinely is not installed must produce NOTHING — not the nearest of six
+// unrelated names.
+func TestSuggest_NeverFabricates(t *testing.T) {
+	is := is.New(t)
+
+	// Real connectors that exist but are not built in. None is within edit
+	// distance of any builtin.
+	for _, absent := range []string{"mysql", "mongo", "snowflake", "redis", "bigquery"} {
+		is.Equal(Suggest(absent, builtins, 3), nil)
+	}
+}
+
+// TestSuggest_FloorIsLooserOfTwoBounds pins the max(absolute, relative) rule
+// from the design doc. A flat 2-edit tolerance would reject real typos in long
+// names; a flat 30% would accept nonsense in short ones. Each half of the rule
+// is checked by the case the other half fails.
+func TestSuggest_FloorIsLooserOfTwoBounds(t *testing.T) {
+	is := is.New(t)
+
+	// Short name: 30% of 3 is 0, so only the absolute bound saves this.
+	is.Equal(Suggest("lgo", []string{"log"}, 1), []string{"log"})
+
+	// Long name: 4 edits ("gres" dropped) — past the absolute bound of 2, but
+	// inside 30% of the 22-character request (6). Distance must be strictly
+	// greater than absoluteTolerance or this case passes under an
+	// absolute-only rule too and proves nothing.
+	longName := "conduit-connector-postgres"
+	is.Equal(levenshtein([]rune("conduit-connector-post"), []rune(longName)), 4)
+	is.Equal(Suggest("conduit-connector-post", []string{longName}, 1), []string{longName})
+
+	// ...and the relative bound still has a limit: 12 edits on a 26-character
+	// name is not a typo.
+	is.Equal(Suggest("conduit-connector-postgres", []string{"totally-different-string!!"}, 1), nil)
+}
+
+// TestSuggest_DeterministicAcrossCandidateOrder pins invariant 1. Callers put
+// these strings into error messages and golden files; output that reordered
+// with the caller's map iteration could not be asserted on or alerted on.
+func TestSuggest_DeterministicAcrossCandidateOrder(t *testing.T) {
+	is := is.New(t)
+
+	// All three are edit distance 1 from "xy", so only the tie-break orders them.
+	candidates := []string{"xyc", "xya", "xyb"}
+	expected := []string{"xya", "xyb", "xyc"}
+
+	is.Equal(Suggest("xy", candidates, 3), expected)
+
+	// Reversing the input must not change the output.
+	reversed := slices.Clone(candidates)
+	slices.Reverse(reversed)
+	is.Equal(Suggest("xy", reversed, 3), expected)
+
+	// And nearer matches still outrank the tie-break: distance beats name.
+	is.Equal(Suggest("xya", []string{"xyz", "xya"}, 2), []string{"xya", "xyz"})
+}
+
+// TestSuggest_DuplicatesDoNotConsumeSlots pins that a repeated candidate cannot
+// crowd out a genuinely different alternative. Callers assemble candidate lists
+// by concatenating catalogs (built-in + installed + registry), so duplicates
+// are the normal case, not a pathological one.
+func TestSuggest_DuplicatesDoNotConsumeSlots(t *testing.T) {
+	is := is.New(t)
+
+	candidates := []string{"postgres", "postgres", "postgres", "postgre"}
+	is.Equal(Suggest("postgres", candidates, 2), []string{"postgres", "postgre"})
+}
+
+func TestSuggest_RespectsMaxSuggestions(t *testing.T) {
+	is := is.New(t)
+
+	candidates := []string{"xya", "xyb", "xyc", "xyd"}
+	is.Equal(len(Suggest("xy", candidates, 2)), 2)
+	is.Equal(Suggest("xy", candidates, 1), []string{"xya"})
+	is.Equal(len(Suggest("xy", candidates, 100)), 4)
+}
+
+func TestSuggest_EdgeCases(t *testing.T) {
+	is := is.New(t)
+
+	is.Equal(Suggest("", builtins, 3), nil)          // no request
+	is.Equal(Suggest("postgres", nil, 3), nil)       // no catalog
+	is.Equal(Suggest("postgres", builtins, 0), nil)  // caller wants none
+	is.Equal(Suggest("postgres", builtins, -1), nil) // defensive
+
+	// Empty candidates are skipped rather than matched. An empty plugin name is
+	// not a suggestion anyone can act on, and it is within distance of any
+	// short name.
+	is.Equal(Suggest("s3", []string{"", "s3"}, 3), []string{"s3"})
+}
+
+func TestLevenshtein_KnownDistances(t *testing.T) {
+	tests := []struct {
+		a, b string
+		exp  int
+	}{
+		{"", "", 0},
+		{"", "abc", 3},
+		{"abc", "", 3},
+		{"abc", "abc", 0},
+		{"kitten", "sitting", 3}, // the canonical example
+		{"flaw", "lawn", 2},
+		{"postgres", "postgre", 1},
+		{"kafka", "kafak", 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.a+"/"+tt.b, func(t *testing.T) {
+			is := is.New(t)
+			is.Equal(levenshtein([]rune(tt.a), []rune(tt.b)), tt.exp)
+			// Edit distance is symmetric; an asymmetric implementation would
+			// make results depend on argument order.
+			is.Equal(levenshtein([]rune(tt.b), []rune(tt.a)), tt.exp)
+		})
+	}
+}
+
+// TestLevenshtein_MultiByteRunes pins that distance counts characters, not
+// bytes. The package targets ASCII plugin names, but the input reaches it from
+// natural-language prompts and model output, so it must not mis-slice or
+// over-count on UTF-8.
+func TestLevenshtein_MultiByteRunes(t *testing.T) {
+	is := is.New(t)
+
+	// One character replaced by another, both multi-byte: distance 1, not the
+	// byte-level distance.
+	is.Equal(levenshtein([]rune("café"), []rune("cafè")), 1)
+	is.Equal(levenshtein([]rune("日本語"), []rune("日本")), 1)
+}
+
+// FuzzSuggest asserts the two package invariants hold for arbitrary input:
+// nothing is ever fabricated, and the cap is always respected. It also covers
+// the panic surface — rune slicing and the two-row matrix are the kind of index
+// arithmetic that fails on inputs nobody thought to write a case for.
+func FuzzSuggest(f *testing.F) {
+	f.Add("postgres", "file,generator,kafka,log,postgres,s3", 3)
+	f.Add("", "", 0)
+	f.Add("kafak", "kafka", 1)
+	f.Add("日本語", "日本,語", 2)
+	f.Add("\x00\x00", ",,,", 5)
+
+	f.Fuzz(func(t *testing.T, want, joined string, maxSuggestions int) {
+		candidates := strings.Split(joined, ",")
+
+		got := Suggest(want, candidates, maxSuggestions)
+
+		if maxSuggestions > 0 && len(got) > maxSuggestions {
+			t.Fatalf("returned %d suggestions, cap was %d", len(got), maxSuggestions)
+		}
+
+		for _, g := range got {
+			if !slices.Contains(candidates, g) {
+				t.Fatalf("fabricated suggestion %q not present in candidates", g)
+			}
+		}
+
+		// Results must be ordered nearest-first, or callers cannot present the
+		// first element as "the" suggestion.
+		wantFolded := []rune(strings.ToLower(want))
+		for i := 1; i < len(got); i++ {
+			prev := levenshtein(wantFolded, []rune(strings.ToLower(got[i-1])))
+			curr := levenshtein(wantFolded, []rune(strings.ToLower(got[i])))
+			if prev > curr {
+				t.Fatalf("results out of order: %q (d=%d) before %q (d=%d)", got[i-1], prev, got[i], curr)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Why

Two commands have been blocked on this utility not existing.

- **`repair`** left the "connector plugin not found" class unrepairable — *"the correct plugin name is not mechanically knowable... Deferred until a did-you-mean index exists"* (`20260712-repair-command.md`, §6).
- **`conduit generate`** then made it a hard prerequisite rather than polish: its acceptance bar requires an unknown connector to produce a closest match and an install suggestion, **never a fabricated plugin name** (`20260722-conduit-generate.md`, §7).

The `generate` use is the demanding one. When a model invents a connector, feeding `` `postgre` does not exist; did you mean `postgres`? `` back into the retry prompt converts a hallucination into a self-correction *inside the retry budget*, instead of a terminal failure.

Two named consumers — shared infrastructure, not speculative generality.

## Invariants

Both enforced by test **and** by the fuzzer:

1. **Output is deterministic** — ordered by edit distance, then lexicographically. An error message whose wording depends on map iteration order can't be asserted on, alerted on, or put in a golden file.
2. **A suggestion is never fabricated** — every returned string is an element of `candidates`, and nothing is returned unless it clears the similarity floor. A confident wrong name is worse than silence when a model is going to act on it.

## Design choices (all from §7, not invented here)

| Choice | Reason |
| --- | --- |
| Plain Levenshtein, not Damerau | Real connector typos are substitutions/omissions/insertions (`postgre`, `kafak`), not adjacent transpositions. Simpler to audit, no coverage lost — `TestSuggest_TranspositionIsCovered` pins that a transposition still lands inside the floor at cost 2 |
| Case-insensitive | Names arrive from natural-language prompts with no casing convention |
| Floor = `max(2 edits, 30% of length)` | Neither bound works alone: a flat 2 edits on a 26-char name is stricter than anyone typing by hand manages; 30% of a 3-char name is zero |
| Two-row matrix | Runs once per candidate over the whole catalog inside a retry loop; the discarded rows can't be read again |

## Adversarial self-review

1. **A test that proved nothing.** My first long-name case for the relative bound used a candidate at edit distance **2** — exactly the absolute bound. It passed under an absolute-only rule too, so the mutation survived (see below). My code comment claiming "4 edits, well past the absolute bound" was simply wrong about its own fixture. Replaced with a genuine distance-4 case; the test now asserts the distance explicitly so a future edit can't silently reintroduce a non-discriminating one.
2. **`nil` vs empty slice.** The doc comment promised `nil` on no match; the code returned `[]string{}` via `make([]string, 0)`. Caught by the first test run. Callers branch on `== nil` and `len() == 0` interchangeably only if the two never diverge.
3. **Duplicate candidates.** Callers assemble catalogs by concatenating sources (built-in + installed + registry), so duplicates are the normal case. Without a dedupe, three copies of `postgres` consume all three suggestion slots and crowd out the real alternative.
4. **Multi-byte input.** Targets ASCII plugin names, but input arrives from NL prompts and model output. Rune-based throughout; `TestLevenshtein_MultiByteRunes` pins that distance counts characters, not bytes.

## Tests — every mutation verified

| Mutation | Tests killed |
| --- | --- |
| Absolute bound only (drop relative) | `FloorIsLooserOfTwoBounds` |
| Relative bound only (drop absolute) | `RealTypos`, `TranspositionIsCovered`, `FloorIsLooserOfTwoBounds`, `DeterministicAcrossCandidateOrder`, `RespectsMaxSuggestions` |
| Drop lexicographic tie-break | `DeterministicAcrossCandidateOrder` |
| Drop duplicate skip | `DuplicatesDoNotConsumeSlots` |
| Widen floor 5x | `RealTypos`, `NeverFabricates`, `FloorIsLooserOfTwoBounds` — suggests `kafka` for `mysql` |
| Drop case folding | `RealTypos` |

`FuzzSuggest` asserts both invariants plus the cap on arbitrary input: **9.7M executions, no failures**.

Tests use the real built-in connector list (`file`, `generator`, `kafka`, `log`, `postgres`, `s3`) rather than invented fixtures, so the floor is tuned against distances that occur in practice. `NeverFabricates` checks the connectors people actually ask for and don't have — `mysql`, `mongo`, `snowflake`, `redis`, `bigquery` — and requires **zero** suggestions for each.

## What was run

`go build ./...`, `go vet`, `golangci-lint run` (**0 issues**), `go test -race`, and the 45s fuzz run above.

## Risk tier

**3.** New leaf package, no existing call sites, no data path, no serialized format. No new dependencies.

## Roadmap

v0.20 **WS1** (`conduit generate`) — prerequisite per design doc §7. Once merged, `repair`'s v2 scope should revisit the connector-not-found row it deferred for exactly this reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD
