### PR TITLE
fix(lifecycle-poc): bound the deferred persister wait so a failed assertion fails fast

### DIFF
--- a/pkg/lifecycle-poc/service_nxm_test.go
+++ b/pkg/lifecycle-poc/service_nxm_test.go
@@ -257,7 +257,7 @@ func TestServiceLifecycle_NxM_StartMovesRecordsStopsCleanly(t *testing.T) {
 	logger := log.New(zerolog.Nop())
 	db := &inmemory.DB{}
 	persister := connector.NewPersister(logger, db, time.Second, 3)
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
@@ -336,7 +336,7 @@ func TestServiceLifecycle_NxM_FatalErrorOneDestination_DegradesWholePipeline(t *
 	logger := log.Test(t)
 	db := &inmemory.DB{}
 	persister := connector.NewPersister(logger, db, time.Second, 3)
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
@@ -456,7 +456,7 @@ func TestServiceLifecycle_NxM_TransientErrorOneSource_RecoversAllSourcesAndDesti
 	logger := log.New(zerolog.Nop())
 	db := &inmemory.DB{}
 	persister := connector.NewPersister(logger, db, time.Second, 3)
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
@@ -574,7 +574,7 @@ func TestServiceLifecycle_NxM_OneSourceExhausts_OtherStreams_BothDestinationsWri
 	logger := log.New(zerolog.Nop())
 	db := &inmemory.DB{}
 	persister := connector.NewPersister(logger, db, time.Second, 3)
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
@@ -673,7 +673,7 @@ func TestServiceLifecycle_NxM_PartialGracefulStop_Escalates(t *testing.T) {
 	logger := log.New(zerolog.Nop())
 	db := &inmemory.DB{}
 	persister := connector.NewPersister(logger, db, time.Second, 3)
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)

--- a/pkg/lifecycle-poc/service_test.go
+++ b/pkg/lifecycle-poc/service_test.go
@@ -369,7 +369,7 @@ func TestServiceLifecycle_PipelineSuccess(t *testing.T) {
 	logger := log.New(zerolog.Nop())
 	db := &inmemory.DB{}
 	persister := connector.NewPersister(logger, db, time.Second, 3)
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 
@@ -445,7 +445,7 @@ func TestServiceLifecycle_PipelineError(t *testing.T) {
 	// unrelated concurrently-scheduled tests in the same process. Confirmed by
 	// repro under `-race -shuffle=on -count=1500` under CPU load; the race
 	// detector flags the underlying unsynchronized access to testing.T state.
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 
@@ -545,7 +545,7 @@ func TestServiceLifecycle_PipelineStop(t *testing.T) {
 	// without waiting, the persister's background flush goroutine can outlive this
 	// test function (goroutine leak); harmless here since the logger is a no-op and
 	// db is test-local, but kept consistent with the other tests in this file.
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 
@@ -634,7 +634,7 @@ func TestServiceLifecycle_PipelineForceStop(t *testing.T) {
 	persister := connector.NewPersister(logger, db, time.Second, 3)
 	// See TestServiceLifecycle_PipelineError's defer: prevents the persister's
 	// background flush goroutine from outliving the test.
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 
@@ -723,7 +723,7 @@ func TestServiceLifecycle_Recovery_TransientErrorRecovers(t *testing.T) {
 	logger := log.New(zerolog.Nop())
 	db := &inmemory.DB{}
 	persister := connector.NewPersister(logger, db, time.Second, 3)
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
@@ -805,7 +805,7 @@ func TestServiceLifecycle_Recovery_MaxRetriesExhausted(t *testing.T) {
 	logger := log.New(zerolog.Nop())
 	db := &inmemory.DB{}
 	persister := connector.NewPersister(logger, db, time.Second, 3)
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
@@ -897,7 +897,7 @@ func TestServiceLifecycle_Recovery_GracefulShutdownDuringBackoff(t *testing.T) {
 	logger := log.New(zerolog.Nop())
 	db := &inmemory.DB{}
 	persister := connector.NewPersister(logger, db, time.Second, 3)
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
@@ -996,7 +996,7 @@ func TestServiceLifecycle_Stop_TransientErrorMidDrain_NoRecovery(t *testing.T) {
 	logger := log.New(zerolog.Nop())
 	db := &inmemory.DB{}
 	persister := connector.NewPersister(logger, db, time.Second, 3)
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
@@ -1144,7 +1144,7 @@ func TestServiceLifecycle_Stop_SourceTeardownFails_NoRecovery(t *testing.T) {
 	logger := log.New(zerolog.Nop())
 	db := &inmemory.DB{}
 	persister := connector.NewPersister(logger, db, time.Second, 3)
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
@@ -1357,7 +1357,7 @@ func TestServiceLifecycle_NSource_PartialGracefulStop_Escalates(t *testing.T) {
 	logger := log.New(zerolog.Nop())
 	db := &inmemory.DB{}
 	persister := connector.NewPersister(logger, db, time.Second, 3)
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
@@ -1490,7 +1490,7 @@ func TestServiceLifecycle_NSource_FatalErrorOneSource_DegradesWholePipeline(t *t
 	logger := log.Test(t)
 	db := &inmemory.DB{}
 	persister := connector.NewPersister(logger, db, time.Second, 3)
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
@@ -1572,7 +1572,7 @@ func TestServiceLifecycle_NSource_TransientErrorOneSource_Recovers(t *testing.T)
 	logger := log.New(zerolog.Nop())
 	db := &inmemory.DB{}
 	persister := connector.NewPersister(logger, db, time.Second, 3)
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
@@ -1662,7 +1662,7 @@ func TestServiceLifecycle_NSource_OneSourceFinishesGracefully_StaysRunningUntilA
 	logger := log.New(zerolog.Nop())
 	db := &inmemory.DB{}
 	persister := connector.NewPersister(logger, db, time.Second, 3)
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
@@ -2247,4 +2247,57 @@ func (s testPipelineService) UpdateStatus(_ context.Context, pipelineID string, 
 	p.SetStatus(status)
 	p.Error = errMsg
 	return nil
+}
+
+// persisterDrainTimeout bounds the deferred persister wait. Generously larger
+// than the 1s flush delay these tests configure, so a legitimate drain always
+// finishes inside it.
+const persisterDrainTimeout = 10 * time.Second
+
+// stopAndWaitPersister cancels the pipeline context and waits for the persister
+// to drain, but only for a bounded time.
+//
+// The bound is the whole point. Persister.Wait blocks on connWg, which only
+// reaches zero once every connector has called ConnectorStopped — and that
+// happens through pipeline teardown (ls.Stop), not through context
+// cancellation. Cancelling first is still right, but it cannot substitute for
+// the stop.
+//
+// On the happy path this is free: the test body already called ls.Stop, so the
+// wait returns at once. The bound only matters when an assertion has ALREADY
+// failed. is.NoErr calls t.FailNow, which is runtime.Goexit: the rest of the
+// test body is skipped — including ls.Stop — so the connectors never stop,
+// connWg never reaches zero, and an unbounded Wait blocks until the
+// package-wide timeout fires.
+//
+// That is #2746. An intermittent one-line assertion failure presented as a
+// 10-minute hang that took the whole `test` job down, with a goroutine dump
+// pointing at the recovery path rather than at the assertion that actually
+// failed. All 13 tests here shared the shape, so ANY failing assertion in this
+// file could produce it.
+//
+// This wait is hygiene, not an assertion — the in-file comments that introduced
+// it say so: it exists to stop the persister's background flush goroutine from
+// outliving the test and logging into a finished t. Bounding it preserves that
+// and gives up the deadlock. If the drain genuinely does not finish, that is
+// reported rather than waited on forever.
+//
+// t.Errorf, never t.Fatalf: this runs as a deferred function, and Fatalf's
+// Goexit inside a defer would abandon the remaining cleanup.
+func stopAndWaitPersister(t *testing.T, killAll context.CancelFunc, p *connector.Persister) {
+	t.Helper()
+	killAll()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.Wait()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(persisterDrainTimeout):
+		t.Errorf("persister did not drain within %s: some connector never reported "+
+			"ConnectorStopped (see #2746)", persisterDrainTimeout)
+	}
 }

--- a/pkg/lifecycle-poc/stop_and_wait_test.go
+++ b/pkg/lifecycle-poc/stop_and_wait_test.go
@@ -64,7 +64,7 @@ func TestServiceLifecycle_StopAndWait_DrainsAndPersists(t *testing.T) {
 	const flushDelay = 200 * time.Millisecond
 	db := &delayingDB{DB: &inmemory.DB{}, delay: flushDelay}
 	persister := connector.NewPersister(logger, db, time.Hour, 10000)
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
@@ -176,7 +176,7 @@ func TestServiceLifecycle_StopAndWait_Timeout(t *testing.T) {
 	logger := log.New(zerolog.Nop())
 	db := &inmemory.DB{}
 	persister := connector.NewPersister(logger, db, time.Second, 3)
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)

--- a/pkg/lifecycle/service_test.go
+++ b/pkg/lifecycle/service_test.go
@@ -226,7 +226,7 @@ func TestServiceLifecycle_PipelineSuccess(t *testing.T) {
 	logger := log.New(zerolog.Nop())
 	db := &inmemory.DB{}
 	persister := connector.NewPersister(logger, db, time.Second, 3)
-	defer persister.Wait()
+	defer stopAndWaitPersister(t, killAll, persister)
 
 	ps := pipeline.NewService(logger, db)
 
@@ -1160,4 +1160,46 @@ func (s testPipelineService) UpdateStatus(_ context.Context, pipelineID string, 
 	p.SetStatus(status)
 	p.Error = errMsg
 	return nil
+}
+
+// persisterDrainTimeout bounds the deferred persister wait. See
+// stopAndWaitPersister.
+const persisterDrainTimeout = 10 * time.Second
+
+// stopAndWaitPersister cancels the pipeline context and waits for the persister
+// to drain, but only for a bounded time.
+//
+// Persister.Wait blocks on connWg, which only reaches zero once every connector
+// has called ConnectorStopped — and that happens through pipeline teardown
+// (ls.Stop), not through context cancellation.
+//
+// On the happy path this is free: the test body already called ls.Stop, so the
+// wait returns at once. The bound only matters when an assertion has ALREADY
+// failed. is.NoErr calls t.FailNow, which is runtime.Goexit: the rest of the
+// test body is skipped — including ls.Stop — so the connectors never stop,
+// connWg never reaches zero, and an unbounded Wait blocks until the
+// package-wide timeout fires. A one-line assertion failure becomes a 10-minute
+// hang whose goroutine dump points at the engine instead of the assertion.
+//
+// See #2746. The same shape existed across pkg/lifecycle-poc; this package had
+// one instance of it.
+//
+// t.Errorf, never t.Fatalf: this runs as a deferred function, and Fatalf's
+// Goexit inside a defer would abandon the remaining cleanup.
+func stopAndWaitPersister(t *testing.T, killAll context.CancelFunc, p *connector.Persister) {
+	t.Helper()
+	killAll()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.Wait()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(persisterDrainTimeout):
+		t.Errorf("persister did not drain within %s: some connector never reported "+
+			"ConnectorStopped (see #2746)", persisterDrainTimeout)
+	}
 }


### PR DESCRIPTION
Fixes #2746 (the hang; **not** the underlying flake — see below).

## The 10-minute hang was never a recovery deadlock

It is a test-teardown deadlock that **hides whatever actually failed**.

`Persister.Wait` blocks on `connWg`, which only reaches zero once every connector has called `ConnectorStopped` — and that happens through pipeline teardown (`ls.Stop`), not through context cancellation. When an assertion fails, `is.NoErr` calls `t.FailNow`, which is `runtime.Goexit`: the rest of the test body is skipped, **including `ls.Stop`**, and then the defers run. The deferred, unbounded `persister.Wait` waits on connectors that will never be stopped, so the package timeout fires instead of a one-line failure.

The CI goroutine dump says exactly this, and points at the *assertion*, not the engine:

```text
runtime.Goexit()
  matryer/is.(*I).NoErr(...)
  ...TestServiceLifecycle_NSource_TransientErrorOneSource_Recovers
sync.(*WaitGroup).Wait(0xc0007e80b8)
  connector.(*Persister).Wait(0xc0007e8000)
```

All **13** tests in the file registered `defer killAll()` first and the persister wait second, so any failing assertion in any of them could produce a 10-minute hang.

## A wrong fix, recorded because it looks right

My first attempt reordered the defers so `killAll()` runs before `persister.Wait()`. **It does not work** — verified, still hung for the full timeout. Cancelling the context does not drain the persister; only `ConnectorStopped` does, and only teardown calls that.

So the wait is **bounded** instead. This wait is hygiene, not an assertion — the comments that introduced it say it exists to stop the persister's background flush goroutine from outliving the test and logging into a finished `t`. A bound preserves that and gives up the deadlock. `t.Errorf`, not `t.Fatalf`: this runs in a defer, where `Fatalf`'s `Goexit` would abandon the remaining cleanup.

## Evidence

| Scenario | Result |
| --- | --- |
| Pre-fix, 12 full-package sweeps | **2 hung** at the timeout — matches #2746's reported ~2-per-40 rate |
| Pre-fix, injected assertion failure | Hangs deterministically, 100% of runs |
| Post-fix, same injected failure | Fails in **13s**, naming both the assertion and the drain problem |
| Post-fix, 14 full-package sweeps `-race` | 13 green, **1 caught the real flake in 27s instead of hanging 150s** |
| Post-fix, 10 further runs `-race` | All green, no spurious drain reports |

## What this does NOT fix — and what it revealed

The underlying intermittent failure is still open. But it is now **visible**, which was the point. Post-fix sweep 8:

```text
service_test.go:782: err: task 3dc80e53-...: failed to read from source: lost connection to source
--- FAIL: TestServiceLifecycle_Recovery_TransientErrorRecovers (12.03s)
    panic.go:615: persister did not drain within 10s: some connector never reported ConnectorStopped (see #2746)
```

Line 782 is `is.NoErr(ls.WaitPipeline(pl.ID))`. So: **after a successful recovery and a graceful user stop, `WaitPipeline` returns the pre-recovery transient error.** That answers the question #2746 posed — "test bug or real recovery bug?" — as **a real bug**, and it is in the arch-v2 recovery path being graduated for the v0.20 default flip.

Narrowing (mechanism *not* yet confirmed, so stated as a lead): `service.go:267` already guards this hazard by name —

```go
// A new run supersedes any terminal error recorded by a previous run of this
// pipeline, so a later WaitPipeline can't return a stale result.
s.terminalErrors.Delete(pipelineID)
```

The hazard is known and the guard exists, but nothing sequences that `Delete` (run 2's `Start`) against run 1's `terminalErrors.Set` in the cleanup goroutine. A write-write race there would leave the stale error behind exactly this intermittently. Filed as follow-up on #2746 rather than fixed here — that is a Tier 1 change and deserves its own PR and sign-off.

## Correction: the first commit was an incomplete fix

I originally fixed only `pkg/lifecycle-poc/service_test.go` and reported it as verified. It was not complete: I scoped the search to the one file named in the issue instead of the tree. **CI then hung again** on `TestServiceLifecycle_NxM_TransientErrorOneSource_RecoversAllSourcesAndDestinations` (`service_nxm_test.go:527`) — same deadlock, same stack, different file.

Eight further sites, all converted in the follow-up commit:

| File | Sites |
| --- | --- |
| `pkg/lifecycle-poc/service_nxm_test.go` | 5 |
| `pkg/lifecycle-poc/stop_and_wait_test.go` | 2 |
| `pkg/lifecycle/service_test.go` | 1 — **the v1 engine** |

That last row matters beyond the fix: **the hazard was never arch-v2-specific.** v1's test had the same shape. `pkg/lifecycle` is a separate package, so it gets its own copy of the helper.

`grep -rn "defer persister.Wait()" --include='*_test.go' .` now returns nothing — that is the whole tree, not the files that happened to fail. 21 sites total.

Re-verified after the completing commit:

- injected assertion failure in the exact NxM test that hung CI: fails in **14s** naming both causes (was: 10-minute timeout)
- `pkg/lifecycle-poc` and `pkg/lifecycle`, 3 runs each with `-race`: all green, no spurious drain reports

## Adversarial self-review

0. **My first fix was incomplete** — see the correction section above. Grepping the file named in the bug report instead of the tree missed 8 of 21 sites, and CI caught it rather than my own verification. The lesson is the search scope, not the fix.
1. **My first diagnosis of the fix was wrong**, not just incomplete: I asserted cancelling the context would let the persister drain. Verifying showed it does not. Kept in the code comment so the next person doesn't retry the same reorder.
2. **`t.Errorf` vs `t.Fatalf`** — `Fatalf` inside a deferred function calls `Goexit` again and abandons the remaining defers. Deliberate, commented.
3. **Does bounding hide a real leak?** No: if the drain genuinely doesn't finish, the test now *fails* with a named reason. 24 post-fix `-race` runs produced no spurious report, so the 10s bound is not tight.
4. **Leaked goroutine on timeout** — the `p.Wait()` goroutine outlives a timed-out wait. Acceptable: the test has already failed, and the alternative is the deadlock this fixes.

## Risk tier

**3.** Test-only. No production code, no data path, no serialized format.

## Roadmap

Unblocks the v0.20 arch-v2 graduation gate. A required chaos context that can *time out* rather than *fail* is much harder to attribute — and, as it turns out, was actively masking a real recovery bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD

