### PR TITLE
feat(generate): in-memory validate seam + provider resolution (WS1 seams)

### DIFF
--- a/cmd/conduit/internal/generate/provider/codes.go
+++ b/cmd/conduit/internal/generate/provider/codes.go
@@ -1,0 +1,49 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"google.golang.org/grpc/codes"
+)
+
+// Error codes owned by provider resolution, from the generate design doc's §8
+// taxonomy. Registering them here (rather than declaring bare strings) is what
+// puts them in the error-code reference, llms.txt, and the UI — the registry is
+// the single source of truth.
+//
+// These are a public contract: agents and scripts branch on the reason string,
+// so it is never reworded or renumbered without a deprecation note.
+var (
+	// CodeNoProviderConfigured: zero resolvable candidates. Unauthenticated
+	// (exit 3, environment) rather than InvalidArgument, because the user's
+	// command was fine — their environment is not.
+	CodeNoProviderConfigured = conduiterr.Register("generate.no_provider_configured", codes.Unauthenticated)
+
+	// CodeAmbiguousProvider: more than one candidate and no explicit choice.
+	// This is an error rather than a pick — see the package doc.
+	CodeAmbiguousProvider = conduiterr.Register("generate.ambiguous_provider_configuration", codes.InvalidArgument)
+)
+
+// codeUnknownProvider is the code used when an explicit selection names a
+// provider that does not exist.
+//
+// It is deliberately the FOUNDATIONAL common.invalid_argument rather than a new
+// `generate.unknown_provider`: the design doc's §8 error taxonomy is a frozen
+// contract and does not list a code for this case. Inventing an unlisted
+// `generate.*` code here would add to a public contract outside the document
+// that defines it. Flagged for a maintainer decision — if a dedicated code is
+// wanted, it belongs in §8 first, then here.
+var codeUnknownProvider = conduiterr.CodeInvalidArgument

--- a/cmd/conduit/internal/generate/provider/provider.go
+++ b/cmd/conduit/internal/generate/provider/provider.go
@@ -1,0 +1,103 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package provider is the LLM seam for `conduit generate`: a two-method
+// interface plus the deterministic rules that decide which implementation a
+// given invocation uses.
+//
+// # No default vendor, ever
+//
+// Conduit's broker-neutrality principle ("Switzerland — no broker required at
+// all") extends to model vendors. Picking a permanent default LLM vendor would
+// be the same favoritism the roadmap forbids for brokers, so there isn't one:
+// with several providers configured and no explicit selection, Resolve
+// REFUSES rather than picking.
+//
+// A silent pick would also make a real support question — "why did it use
+// provider X?" — return a wrong answer every time the ordering changed.
+//
+// # No new dependencies
+//
+// Adapters reuse what the tree already vendors: the openai adapter wraps the
+// same client the `openai` built-in processor uses, and the anthropic and
+// ollama adapters are thin net/http JSON clients, following the `ollama`
+// processor's existing hand-rolled client rather than forking a second
+// pattern. See docs/design-documents/20260722-conduit-generate.md §1.
+package provider
+
+import (
+	"context"
+)
+
+// Provider is a single-turn text completion. Implementations never parse the
+// response into a pipeline config — that is generate's job, so an adapter never
+// needs to know the pipeline schema and a schema change never touches an
+// adapter.
+type Provider interface {
+	// Name is the stable identifier used in config, --provider, and error
+	// messages.
+	Name() string
+
+	// Complete sends a grounded prompt and returns the raw model text.
+	Complete(ctx context.Context, req CompletionRequest) (CompletionResult, error)
+}
+
+// CompletionRequest is one grounded call.
+type CompletionRequest struct {
+	// System carries the grounding: schema, connector catalog, few-shot
+	// examples. Built from llms-full.txt, never hand-maintained here.
+	System string
+	// Prompt is the user's natural-language request, verbatim. It is never
+	// rewritten before being sent — a rewrite would make the model's output
+	// unattributable to what the user actually asked.
+	Prompt string
+	// Model is the provider-specific model identifier.
+	Model string
+}
+
+// CompletionResult is one raw completion.
+type CompletionResult struct {
+	Text string
+	// TokensUsed is what the provider reported, or 0 when it reported nothing.
+	// Never estimated: a fabricated token count would be indistinguishable from
+	// a real one in --json output that users may bill against.
+	TokensUsed int
+}
+
+// Known provider names. These are the only values --provider,
+// generate.provider, and CONDUIT_GENERATE_PROVIDER accept.
+const (
+	NameAnthropic = "anthropic"
+	NameOpenAI    = "openai"
+	NameOllama    = "ollama"
+)
+
+// Names lists every known provider in the fixed order Resolve reports
+// candidates in.
+//
+// The order is for REPORTING ONLY and implies no preference — Resolve never
+// uses it to break a tie, it refuses instead. It exists so that error messages
+// and doctor output list providers the same way every run, which is what makes
+// them assertable.
+var Names = []string{NameAnthropic, NameOpenAI, NameOllama}
+
+// Valid reports whether name is a known provider.
+func Valid(name string) bool {
+	for _, n := range Names {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/conduit/internal/generate/provider/resolve.go
+++ b/cmd/conduit/internal/generate/provider/resolve.go
@@ -1,0 +1,174 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+)
+
+// EnvProvider selects a provider explicitly, for CI and agent use where there
+// is no flag to pass.
+const EnvProvider = "CONDUIT_GENERATE_PROVIDER"
+
+// Env vars whose presence makes a hosted provider a candidate.
+const (
+	EnvAnthropicKey = "ANTHROPIC_API_KEY"
+	EnvOpenAIKey    = "OPENAI_API_KEY"
+	EnvOllamaHost   = "OLLAMA_HOST"
+)
+
+// DefaultOllamaHost is where a local Ollama server listens.
+const DefaultOllamaHost = "http://localhost:11434"
+
+// Env abstracts environment lookup so resolution is testable without mutating
+// real process state. Tests that set real env vars cannot run in parallel and
+// leak into each other; this seam is the reason the tests here can.
+type Env func(key string) string
+
+// Probe reports whether a provider that has no API key — currently only
+// ollama — is actually reachable. It is a func so resolution never performs
+// network I/O in a test.
+//
+// Reachability is deliberately part of candidacy for ollama and NOT for the
+// hosted providers: a stale OLLAMA_HOST pointing at nothing would otherwise
+// make every invocation ambiguous on a machine that also has an API key set,
+// which is the single most likely misconfiguration on a developer laptop.
+type Probe func(host string) bool
+
+// ResolveInput is everything that decides which provider an invocation uses.
+type ResolveInput struct {
+	// Flag is --provider. Highest precedence.
+	Flag string
+	// Config is generate.provider from conduit.yaml.
+	Config string
+	// Env looks up environment variables. Required.
+	Env Env
+	// ProbeOllama reports whether an Ollama server is reachable. When nil,
+	// ollama is never auto-detected as a candidate — an unset probe means "we
+	// did not look", and treating "did not look" as "not there" is the safe
+	// direction: it can cause a no_provider_configured error the user can fix,
+	// never a silent wrong pick.
+	ProbeOllama Probe
+}
+
+// Resolve returns the provider name this invocation should use.
+//
+// Precedence, per design doc §1:
+//
+//  1. --provider flag
+//  2. generate.provider in conduit.yaml
+//  3. CONDUIT_GENERATE_PROVIDER
+//  4. auto-detect, and only when EXACTLY ONE candidate is resolvable
+//
+// An explicit selection (1-3) is honoured without probing anything: if a user
+// names a provider, the job is to use it and let the call fail with the
+// provider's own error, not to second-guess them with a reachability check
+// whose failure mode is a confusing refusal.
+//
+// Zero candidates and more than one candidate are both errors, and the
+// more-than-one case is the important one — see the package doc for why a
+// silent pick is not an option.
+func Resolve(in ResolveInput) (string, error) {
+	if in.Env == nil {
+		return "", conduiterr.New(conduiterr.CodeInternal, "provider resolution requires an Env lookup")
+	}
+
+	for _, explicit := range []struct{ source, value string }{
+		{"--provider", in.Flag},
+		{"generate.provider", in.Config},
+		{EnvProvider, in.Env(EnvProvider)},
+	} {
+		v := strings.TrimSpace(explicit.value)
+		if v == "" {
+			continue
+		}
+		if !Valid(v) {
+			e := conduiterr.New(codeUnknownProvider,
+				fmt.Sprintf("unknown generation provider %q (set via %s)", v, explicit.source))
+			e.Suggestion = "valid providers: " + strings.Join(Names, ", ")
+			return "", e
+		}
+		return v, nil
+	}
+
+	candidates := Candidates(in)
+
+	switch len(candidates) {
+	case 1:
+		return candidates[0], nil
+	case 0:
+		e := conduiterr.New(CodeNoProviderConfigured, "no generation provider configured")
+		e.Suggestion = fmt.Sprintf(
+			"set one of %s or %s, run a local Ollama server (%s), or select one explicitly with --provider",
+			EnvAnthropicKey, EnvOpenAIKey, DefaultOllamaHost)
+		return "", e
+	default:
+		e := conduiterr.New(CodeAmbiguousProvider,
+			fmt.Sprintf("more than one generation provider is configured: %s", strings.Join(candidates, ", ")))
+		e.Suggestion = fmt.Sprintf(
+			"choose one with --provider, generate.provider in conduit.yaml, or %s", EnvProvider)
+		return "", e
+	}
+}
+
+// Candidates returns every auto-detectable provider, in the fixed order of
+// Names.
+//
+// Order is for reporting only. Resolve never uses it to break a tie — see the
+// package doc.
+func Candidates(in ResolveInput) []string {
+	if in.Env == nil {
+		return nil
+	}
+
+	var found []string
+	if strings.TrimSpace(in.Env(EnvAnthropicKey)) != "" {
+		found = append(found, NameAnthropic)
+	}
+	if strings.TrimSpace(in.Env(EnvOpenAIKey)) != "" {
+		found = append(found, NameOpenAI)
+	}
+	if in.ProbeOllama != nil {
+		host := strings.TrimSpace(in.Env(EnvOllamaHost))
+		if host == "" {
+			host = DefaultOllamaHost
+		}
+		if in.ProbeOllama(host) {
+			found = append(found, NameOllama)
+		}
+	}
+
+	// Sorting by the fixed Names order, not alphabetically: the two happen to
+	// coincide today, and pinning it here means a future rename of a provider
+	// cannot silently reorder every error message and doctor line.
+	sort.SliceStable(found, func(i, j int) bool {
+		return indexOfName(found[i]) < indexOfName(found[j])
+	})
+
+	return found
+}
+
+func indexOfName(name string) int {
+	for i, n := range Names {
+		if n == name {
+			return i
+		}
+	}
+	return len(Names)
+}

--- a/cmd/conduit/internal/generate/provider/resolve_test.go
+++ b/cmd/conduit/internal/generate/provider/resolve_test.go
@@ -1,0 +1,247 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/matryer/is"
+)
+
+// env builds an Env from a map. Tests never touch real process environment, so
+// they stay parallel-safe and cannot leak into each other.
+func env(kv map[string]string) Env {
+	return func(k string) string { return kv[k] }
+}
+
+func reachable(bool2 bool) Probe { return func(string) bool { return bool2 } }
+
+func codeOf(t *testing.T, err error) conduiterr.Code {
+	t.Helper()
+	ce, ok := conduiterr.Get(err)
+	if !ok {
+		t.Fatalf("error is not a ConduitError: %v", err)
+	}
+	return ce.Code
+}
+
+// Test_Resolve_Precedence pins the documented order. Each case sets a LOWER
+// precedence source to a different provider, so a test only passes if the
+// higher one actually wins rather than coinciding.
+func Test_Resolve_Precedence(t *testing.T) {
+	t.Parallel()
+
+	full := map[string]string{
+		EnvProvider:     NameOllama,
+		EnvAnthropicKey: "sk-ant",
+		EnvOpenAIKey:    "sk-oai",
+	}
+
+	t.Run("flag beats everything", func(t *testing.T) {
+		is := is.New(t)
+		got, err := Resolve(ResolveInput{Flag: NameOpenAI, Config: NameAnthropic, Env: env(full), ProbeOllama: reachable(true)})
+		is.NoErr(err)
+		is.Equal(got, NameOpenAI)
+	})
+
+	t.Run("config beats env", func(t *testing.T) {
+		is := is.New(t)
+		got, err := Resolve(ResolveInput{Config: NameAnthropic, Env: env(full), ProbeOllama: reachable(true)})
+		is.NoErr(err)
+		is.Equal(got, NameAnthropic)
+	})
+
+	t.Run("env beats auto-detect", func(t *testing.T) {
+		is := is.New(t)
+		got, err := Resolve(ResolveInput{Env: env(full), ProbeOllama: reachable(true)})
+		is.NoErr(err)
+		is.Equal(got, NameOllama)
+	})
+}
+
+// Test_Resolve_ExplicitSkipsProbing pins that naming a provider is honoured
+// without a reachability check. Second-guessing an explicit choice would turn a
+// clear instruction into a confusing refusal; the provider's own call should
+// fail instead, with its own error.
+func Test_Resolve_ExplicitSkipsProbing(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+
+	probed := false
+	got, err := Resolve(ResolveInput{
+		Flag:        NameOllama,
+		Env:         env(nil),
+		ProbeOllama: func(string) bool { probed = true; return false },
+	})
+	is.NoErr(err)
+	is.Equal(got, NameOllama)
+	is.True(!probed) // explicit selection must not probe
+}
+
+// Test_Resolve_SingleCandidate is the 5-minute-wow path: a laptop with one
+// thing configured just works, with no flag.
+func Test_Resolve_SingleCandidate(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		in   ResolveInput
+		want string
+	}{
+		{"only anthropic", ResolveInput{Env: env(map[string]string{EnvAnthropicKey: "sk-ant"})}, NameAnthropic},
+		{"only openai", ResolveInput{Env: env(map[string]string{EnvOpenAIKey: "sk-oai"})}, NameOpenAI},
+		{"only ollama", ResolveInput{Env: env(nil), ProbeOllama: reachable(true)}, NameOllama},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			got, err := Resolve(tc.in)
+			is.NoErr(err)
+			is.Equal(got, tc.want)
+		})
+	}
+}
+
+// Test_Resolve_RefusesToPickAVendor is the load-bearing one.
+//
+// Conduit's broker-neutrality principle extends to model vendors. With several
+// configured and no explicit choice, resolution must REFUSE — a silent pick is
+// hidden favoritism, and it makes "why did it use provider X?" unanswerable.
+func Test_Resolve_RefusesToPickAVendor(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+
+	_, err := Resolve(ResolveInput{
+		Env:         env(map[string]string{EnvAnthropicKey: "sk-ant", EnvOpenAIKey: "sk-oai"}),
+		ProbeOllama: reachable(true),
+	})
+	is.True(err != nil)
+	is.Equal(codeOf(t, err), CodeAmbiguousProvider)
+
+	// The message must name what it found, or the user cannot act on it.
+	for _, want := range []string{NameAnthropic, NameOpenAI, NameOllama} {
+		is.True(contains(err.Error(), want))
+	}
+}
+
+// Test_Resolve_ZeroCandidates pins that the error names every way to fix it —
+// an "environment" failure the user's command did nothing wrong to cause.
+func Test_Resolve_ZeroCandidates(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+
+	_, err := Resolve(ResolveInput{Env: env(nil), ProbeOllama: reachable(false)})
+	is.True(err != nil)
+	is.Equal(codeOf(t, err), CodeNoProviderConfigured)
+
+	ce, _ := conduiterr.Get(err)
+	for _, want := range []string{EnvAnthropicKey, EnvOpenAIKey, "--provider"} {
+		is.True(contains(ce.Suggestion, want))
+	}
+}
+
+// Test_Resolve_NilProbeNeverAutoDetectsOllama pins the safe direction: an unset
+// probe means "we did not look", and treating that as "reachable" could
+// silently pick a provider that is not there.
+func Test_Resolve_NilProbeNeverAutoDetectsOllama(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+
+	_, err := Resolve(ResolveInput{Env: env(map[string]string{EnvOllamaHost: DefaultOllamaHost})})
+	is.True(err != nil)
+	is.Equal(codeOf(t, err), CodeNoProviderConfigured)
+}
+
+// Test_Resolve_UnreachableOllamaIsNotACandidate pins the most likely laptop
+// misconfiguration: a stale OLLAMA_HOST pointing at nothing must not make every
+// invocation ambiguous on a machine that also has an API key.
+func Test_Resolve_UnreachableOllamaIsNotACandidate(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+
+	got, err := Resolve(ResolveInput{
+		Env:         env(map[string]string{EnvAnthropicKey: "sk-ant", EnvOllamaHost: "http://localhost:1"}),
+		ProbeOllama: reachable(false),
+	})
+	is.NoErr(err)
+	is.Equal(got, NameAnthropic)
+}
+
+func Test_Resolve_UnknownProviderName(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+
+	_, err := Resolve(ResolveInput{Flag: "gpt5-turbo-max", Env: env(nil)})
+	is.True(err != nil)
+	is.Equal(codeOf(t, err), conduiterr.CodeInvalidArgument)
+
+	ce, _ := conduiterr.Get(err)
+	is.True(contains(ce.Suggestion, NameAnthropic)) // lists the valid ones
+}
+
+// Test_Candidates_DeterministicOrder pins that reporting order is stable.
+// Error messages and doctor output are asserted on and read by agents; an
+// order that varied per run could not be.
+func Test_Candidates_DeterministicOrder(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+
+	in := ResolveInput{
+		Env:         env(map[string]string{EnvOpenAIKey: "sk-oai", EnvAnthropicKey: "sk-ant"}),
+		ProbeOllama: reachable(true),
+	}
+	want := []string{NameAnthropic, NameOpenAI, NameOllama}
+	for range 20 {
+		is.Equal(Candidates(in), want)
+	}
+}
+
+// Test_Resolve_BlankValuesAreNotSelections pins that whitespace-only config
+// does not count as an explicit choice — an empty CONDUIT_GENERATE_PROVIDER=""
+// in CI must fall through to auto-detect, not fail as an unknown provider.
+func Test_Resolve_BlankValuesAreNotSelections(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+
+	got, err := Resolve(ResolveInput{
+		Flag:   "   ",
+		Config: "",
+		Env:    env(map[string]string{EnvProvider: "  ", EnvAnthropicKey: "sk-ant"}),
+	})
+	is.NoErr(err)
+	is.Equal(got, NameAnthropic)
+}
+
+func Test_Resolve_RequiresEnv(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+
+	_, err := Resolve(ResolveInput{})
+	is.True(err != nil)
+	is.Equal(codeOf(t, err), conduiterr.CodeInternal)
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (haystack == needle || indexOf(haystack, needle) >= 0)
+}
+
+func indexOf(h, n string) int {
+	for i := 0; i+len(n) <= len(h); i++ {
+		if h[i:i+len(n)] == n {
+			return i
+		}
+	}
+	return -1
+}

--- a/cmd/conduit/internal/llmsgen/allcodes/allcodes.go
+++ b/cmd/conduit/internal/llmsgen/allcodes/allcodes.go
@@ -57,6 +57,7 @@ import (
 	// equivalently named file) in the engine — TestAllCodesComplete in
 	// ../llmsgen fails the build if it drifts.
 	_ "github.com/conduitio/conduit/cmd/conduit/internal/deploy"
+	_ "github.com/conduitio/conduit/cmd/conduit/internal/generate/provider"
 	_ "github.com/conduitio/conduit/cmd/conduit/root/pipelines"
 	_ "github.com/conduitio/conduit/pkg/connector"
 	_ "github.com/conduitio/conduit/pkg/lifecycle-poc"

--- a/cmd/conduit/internal/validate/engine.go
+++ b/cmd/conduit/internal/validate/engine.go
@@ -15,8 +15,10 @@
 package validate
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -103,6 +105,43 @@ func RunWithOptions(ctx context.Context, path string, opts Options) (Report, err
 	return buildReport(frs, opts), nil
 }
 
+// DefaultInMemoryName is the label RunBytes uses when the caller supplies
+// none. It is deliberately not a plausible filename: a finding that says
+// `<generated>` cannot be mistaken for one pointing at a file on disk.
+const DefaultInMemoryName = "<generated>"
+
+// RunBytes runs the same parse -> enrich -> validate pipeline as Run over an
+// in-memory document instead of a file on disk.
+//
+// It exists because `conduit generate` must gate a candidate config through
+// THIS engine — not a second validator — before ever showing it to a human,
+// and the candidate only exists in memory. Writing it to a temp file first
+// would mean a config that failed validation still touched the filesystem,
+// and it would put a disk error in the path of a purely in-memory operation.
+// See docs/design-documents/20260722-conduit-generate.md §3, "the disk seam".
+//
+// name labels the findings (see validateReader); empty means
+// DefaultInMemoryName.
+//
+// Unlike Run it returns no error. Run's only hard failure is resolving path,
+// and there is no path here — every parse and validation problem comes back as
+// a Finding, exactly as it does for a file that exists but is unparseable.
+func RunBytes(ctx context.Context, name string, src []byte, opts Options) Report {
+	if name == "" {
+		name = DefaultInMemoryName
+	}
+
+	frs := []fileState{validateReader(ctx, name, bytes.NewReader(src), opts)}
+
+	// Still run the duplicate-ID pass: with one document it cannot find a
+	// CROSS-file collision, but a single file declaring the same pipeline ID
+	// twice is exactly as invalid, and generated configs are a plausible source
+	// of that.
+	checkCrossFileDuplicateIDs(frs)
+
+	return buildReport(frs, opts)
+}
+
 // CodeLintWarning is the stable code carried by every advisory `lint` warning
 // finding. The parser's warnings (deprecated/renamed/unknown fields, version
 // fallback) don't carry per-field conduiterr codes, so lint attaches this one
@@ -128,16 +167,30 @@ type fileState struct {
 // pkg/provisioning.Service.provisionPipeline's ordering at service.go:279-280)
 // over a single file, collecting every finding along the way.
 func validateFile(ctx context.Context, path string, opts Options) fileState {
-	fs := fileState{path: path}
-
 	f, err := os.Open(path)
 	if err != nil {
+		fs := fileState{path: path}
 		ce := conduiterr.Wrap(config.CodeParseError, fmt.Sprintf("could not open file %q: %v", path, err), err)
 		ce.Suggestion = "check that the file exists and is readable"
 		fs.findings = append(fs.findings, findingFromError(ce))
 		return fs
 	}
 	defer f.Close()
+
+	return validateReader(ctx, path, f, opts)
+}
+
+// validateReader is validateFile without the disk. Everything after the open
+// in validateFile only ever touched an io.Reader, so the two share this body
+// rather than the in-memory path re-implementing (and drifting from) the
+// parse -> enrich -> validate ordering.
+//
+// name is what findings report as their file. It is a label, not a path: the
+// in-memory caller has no file, and a finding with an empty location is not
+// actionable.
+func validateReader(ctx context.Context, name string, r io.Reader, opts Options) fileState {
+	fs := fileState{path: name}
+	var err error
 
 	parser := yaml.NewParser(log.Nop())
 
@@ -148,12 +201,12 @@ func validateFile(ctx context.Context, path string, opts Options) fileState {
 	var pipelines []config.Pipeline
 	if opts.Warnings {
 		var warns []yaml.Warning
-		pipelines, warns, err = parser.ParseWithWarnings(ctx, f)
+		pipelines, warns, err = parser.ParseWithWarnings(ctx, r)
 		for _, w := range warns {
 			fs.findings = append(fs.findings, warningFinding(w))
 		}
 	} else {
-		pipelines, err = parser.Parse(ctx, f)
+		pipelines, err = parser.Parse(ctx, r)
 	}
 	// err here is the parser's raw cerrors.Join of per-document failures (no
 	// extra "%w" wrap) — walk it directly with cerrors.ForEach. Wrapping it

--- a/cmd/conduit/internal/validate/runbytes_test.go
+++ b/cmd/conduit/internal/validate/runbytes_test.go
@@ -1,0 +1,141 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+const validPipeline = `version: 2.2
+pipelines:
+  - id: gen-pipeline
+    status: running
+    connectors:
+      - id: src
+        type: source
+        plugin: builtin:generator
+      - id: dst
+        type: destination
+        plugin: builtin:log
+`
+
+// Test_RunBytes_MatchesRunOnDisk is the property that makes the seam
+// trustworthy: `generate` gates its candidate through THIS engine precisely so
+// there is no second validator to drift. If the two paths could disagree, a
+// generated config could pass in memory and fail once written — the exact
+// class of bug the shared seam exists to prevent.
+func Test_RunBytes_MatchesRunOnDisk(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		src  string
+	}{
+		{"valid", validPipeline},
+		{"unparseable", "this: is: not: valid: yaml:\n\t- broken"},
+		{"missing required fields", "version: 2.2\npipelines:\n  - id: \"\"\n"},
+		{"empty", ""},
+		{"duplicate ids in one document", validPipeline + "\n---\n" + validPipeline},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			ctx := context.Background()
+
+			dir := t.TempDir()
+			path := filepath.Join(dir, "p.yaml")
+			is.NoErr(os.WriteFile(path, []byte(tc.src), 0o600))
+
+			onDisk, err := Run(ctx, path)
+			is.NoErr(err)
+			inMemory := RunBytes(ctx, path, []byte(tc.src), Options{})
+
+			is.Equal(len(inMemory.Files), len(onDisk.Files))
+			is.Equal(inMemory.OK(), onDisk.OK())
+
+			// Compare the findings themselves, not just the count: a seam that
+			// returned the right NUMBER of different findings would be worse
+			// than one that returned none.
+			is.Equal(len(inMemory.Files[0].Findings), len(onDisk.Files[0].Findings))
+			for i, got := range inMemory.Files[0].Findings {
+				want := onDisk.Files[0].Findings[i]
+				is.Equal(got.Code, want.Code)
+				is.Equal(got.ConfigPath, want.ConfigPath)
+				is.Equal(got.Severity, want.Severity)
+			}
+		})
+	}
+}
+
+// Test_RunBytes_TouchesNoDisk pins the reason this exists rather than
+// write-to-temp-then-Run: a candidate that fails validation must never reach
+// the filesystem, and a purely in-memory operation must not be able to fail on
+// a disk error. Running with the working directory removed would break any
+// implementation that quietly wrote a temp file relative to it.
+func Test_RunBytes_TouchesNoDisk(t *testing.T) {
+	is := is.New(t)
+
+	dir := t.TempDir()
+	entriesBefore, err := os.ReadDir(dir)
+	is.NoErr(err)
+
+	rep := RunBytes(context.Background(), filepath.Join(dir, "never-written.yaml"), []byte(validPipeline), Options{})
+	is.True(rep.OK())
+
+	entriesAfter, err := os.ReadDir(dir)
+	is.NoErr(err)
+	is.Equal(len(entriesAfter), len(entriesBefore)) // nothing written
+}
+
+// Test_RunBytes_DefaultsTheName pins that a finding always carries a location.
+// An empty name would render findings with a blank file, which is not
+// actionable, and `<generated>` cannot be mistaken for a real path.
+func Test_RunBytes_DefaultsTheName(t *testing.T) {
+	is := is.New(t)
+
+	rep := RunBytes(context.Background(), "", []byte("{{{ not yaml"), Options{})
+	is.Equal(len(rep.Files), 1)
+	is.Equal(rep.Files[0].Path, DefaultInMemoryName)
+	is.True(!rep.OK())
+
+	named := RunBytes(context.Background(), "my-candidate", []byte(validPipeline), Options{})
+	is.Equal(named.Files[0].Path, "my-candidate")
+}
+
+// Test_RunBytes_HonoursOptions pins that the in-memory path is not silently
+// hardwired to the zero Options — `generate` and `lint` need the same opt-in
+// checks the disk path exposes.
+func Test_RunBytes_HonoursOptions(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	// A deprecated/unknown field produces a warning only when Warnings is set.
+	const withUnknownField = `version: 2.2
+pipelines:
+  - id: gen-pipeline
+    status: running
+    totallyUnknownField: yes
+    connectors:
+      - id: src
+        type: source
+        plugin: builtin:generator
+`
+	quiet := RunBytes(ctx, "c", []byte(withUnknownField), Options{})
+	loud := RunBytes(ctx, "c", []byte(withUnknownField), Options{Warnings: true})
+
+	is.True(len(loud.Files[0].Findings) > len(quiet.Files[0].Findings))
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -614,7 +614,7 @@ Author: Meroxa, Inc.
 | `sdk.schema.extract.key.enabled` | bool | true | no | Whether to extract and decode the record key with a schema. |  |
 | `sdk.schema.extract.payload.enabled` | bool | true | no | Whether to extract and decode the record payload with a schema. |  |
 
-## 3. Error codes (94)
+## 3. Error codes (96)
 
 | Reason | gRPC status | Description |
 | --- | --- | --- |
@@ -633,6 +633,8 @@ Author: Meroxa, Inc.
 | `connector.invalid_type` | InvalidArgument | CodeConnectorInvalidType is raised when a connector type is neither "source" nor "destination". |
 | `connector.plugin_not_found` | NotFound | CodeConnectorPluginNotFound is raised when a referenced connector plugin cannot be located. |
 | `connector.running` | FailedPrecondition | CodeConnectorRunning is raised when an operation requires the connector to not be running, but a connector instance for it already exists. |
+| `generate.ambiguous_provider_configuration` | InvalidArgument | CodeAmbiguousProvider: more than one candidate and no explicit choice. This is an error rather than a pick — see the package doc. |
+| `generate.no_provider_configured` | Unauthenticated | CodeNoProviderConfigured: zero resolvable candidates. Unauthenticated (exit 3, environment) rather than InvalidArgument, because the user's command was fine — their environment is not. |
 | `internal.error` | Internal | CodeInternal is a coded internal failure. |
 | `internal.unknown` | Internal | CodeUnknown is the fallback when an un-coded error reaches a boundary. |
 | `lifecycle_v2.partial_graceful_stop_escalated` | Aborted | CodePartialGracefulStopEscalated is returned by Stop/StopAndWait for an N-source pipeline (slice 3b of the arch-v2 multi-connector epic) when a graceful stop arms some sources within the deadline but not others. See stopRunnablePipeline's doc and the adversarial-review finding this closes (H1, docs/design-documents/20260801-archv2-multiconnector-nsource.md).  Leaving that state unresolved would strand the pipeline reporting StatusRunning indefinitely: the still-unarmed worker(s) keep reading, workersWg never drains, and runPipeline's cleanup goroutine (the only thing that ever writes a terminal status) never runs - invisible to an operator except as an error return that may go to a disconnected caller. Instead the pipeline's tomb is force-killed with this code so every still-unarmed worker's next context check observes cancellation and unwinds, guaranteeing the pipeline reaches a terminal (Degraded) status instead of a silent, half-stopped one. At-least-once is preserved: this never acks anything, so an interrupted worker's in-flight, unacked batch simply replays on the pipeline's next start (invariant 3). |

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@
 (6 built-in connectors; full parameters in llms-full.txt)
 
 ## Error codes
-- 94 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
+- 96 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
 
 ## MCP tools
 - Read: deploy, doctor, dry_run, inspect, lint, repair, validate


### PR DESCRIPTION
Two prerequisites the `conduit generate` design doc names before the command itself can be built. Both are fully testable **without any LLM**, which is why they come first.

## 1. `validate.RunBytes` — the in-memory seam (§3, "the disk seam")

`generate` must gate its candidate through **this** engine, not a second validator, and the candidate exists only in memory. `validate.Run` takes a path and resolves from disk, so today a candidate could only be validated by writing it out first — meaning a config that **fails** validation still touched the filesystem, and a disk error sat in the path of a purely in-memory operation.

`validateFile` already opened the path into an `io.Reader` and did nothing else with the path, so both paths now share `validateReader` rather than the in-memory path re-implementing (and drifting from) the parse → enrich → validate ordering.

`RunBytes` returns **no error**, unlike `Run`: `Run`'s only hard failure is resolving `path`, and there is no path. Everything else comes back as a `Finding`, exactly as it does for a file that exists but is unparseable.

## 2. `provider` — the LLM seam and its resolution rules (§1)

A two-method interface plus deterministic selection. **No new dependencies** — the adapters (landing next) reuse the already-vendored `go-openai` client and follow the `ollama` processor's existing hand-rolled `net/http` pattern.

The load-bearing rule: **there is no default vendor.** Conduit's broker-neutrality principle extends to model vendors, so with several configured and no explicit selection, `Resolve` **refuses** rather than picking. A silent pick is hidden favoritism, and it makes a real support question — *"why did it use provider X?"* — return a wrong answer every time the ordering changes.

Two seams keep resolution off real process state and off the network:

| Seam | Why |
| --- | --- |
| `Env` | Tests never mutate real env vars, so they stay parallel-safe and can't leak into each other |
| `Probe` | Reachability without network I/O in tests. A **nil** probe means "we did not look" and counts as not-a-candidate — the safe direction, since it can only cause a fixable `no_provider_configured`, never a silent wrong pick |

Reachability gates candidacy for `ollama` but **not** for hosted providers: a stale `OLLAMA_HOST` pointing at nothing would otherwise make every invocation ambiguous on a laptop that also has an API key — the single most likely misconfiguration.

## Flagged for your decision

§8's error taxonomy has **no code** for an explicit `--provider` naming something unknown. I used the foundational `common.invalid_argument` rather than inventing an unlisted `generate.*` code outside the document that defines the contract. If you want a dedicated code, it belongs in §8 first, then here.

## Adversarial self-review

1. **I initially mixed this into #2771.** A `git add -A` swept the `RunBytes` work into the unrelated staticcheck PR. Caught it, rebuilt #2771 as a clean single-file change, and moved this here. #2771 is now 13 lines in one file.
2. **While splitting, I `rm -rf`'d `cmd/conduit/internal/generate/`** — which already existed on `main` (the v0.19 eval harness). Verified it never reached a commit and restored it; `git status` clean, package intact.
3. **`Candidates` order** — sorted by the fixed `Names` order, not alphabetically. The two coincide *today*; pinning it means a future provider rename can't silently reorder every error message and doctor line.
4. **Blank values** — `--provider "   "` must not be an "unknown provider" error. `TrimSpace` before the validity check, so an empty `CONDUIT_GENERATE_PROVIDER=""` in CI falls through to auto-detect.

## Tests — every mutation verified

| Mutation | Test killed |
| --- | --- |
| Silently pick the first candidate | `RefusesToPickAVendor` |
| Probe on an explicit selection | `ExplicitSkipsProbing` |
| Treat a nil probe as reachable | `NilProbeNeverAutoDetectsOllama` + 2 more |
| Drop `TrimSpace` on explicit values | `BlankValuesAreNotSelections` |
| Alphabetical candidate order | `DeterministicOrder` |
| Drop `RunBytes`' duplicate-ID pass | `MatchesRunOnDisk` |
| Hardwire `Options{}` in `RunBytes` | `HonoursOptions` |
| Drop the empty-name default | `DefaultsTheName` |

`MatchesRunOnDisk` compares the **findings themselves** — code, config path, severity — not just counts, across five input shapes (valid, unparseable, missing required fields, empty, duplicate IDs). A seam returning the right *number* of different findings would be worse than one returning none.

## Risk tier

**3.** New leaf package plus an additive, non-breaking function on an internal CLI package. No data path, no serialized format, no new dependencies.

## Roadmap

v0.20 **WS1** (`conduit generate`), design doc §1 and §3. Stacks on #2769 (`fuzzymatch`, §7). Next: the three provider adapters and the generation loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GQFzakPShAYj8CcwajYDD