### PR TITLE
feat(generate): judge a candidate against what the prompt asked for (WS1)

### DIFF
--- a/cmd/conduit/internal/generate/capability.go
+++ b/cmd/conduit/internal/generate/capability.go
@@ -32,26 +32,59 @@ import "github.com/conduitio/conduit/pkg/provisioning/config"
 // everything or nothing gracefully — an eval fixture typo'ing a capability
 // name should show up as a permanent semantic-match failure, not silently
 // pass.
+// Capability tags are a shared vocabulary: the eval corpus names them in
+// requiredCapabilities, intent.go extracts them from a prompt, and this file
+// maps them to the builtin processors that satisfy them. They are declared
+// once here so those three uses cannot drift into three spellings.
+// procFilter is the builtin PROCESSOR PLUGIN named "filter". It shares its
+// spelling with capFilter (the capability tag) and nothing else: one names a
+// plugin the engine can load, the other names an intent the corpus can ask
+// for. They are separate constants so a rename of either cannot silently
+// rewrite the other.
+const procFilter = "filter"
+
+const (
+	capFilter             = "filter"
+	capMask               = "mask"
+	capRename             = "rename"
+	capSet                = "set"
+	capConvert            = "convert"
+	capJSONEncode         = "json-encode"
+	capJSONDecode         = "json-decode"
+	capAvroEncode         = "avro-encode"
+	capAvroDecode         = "avro-decode"
+	capBase64Encode       = "base64-encode"
+	capBase64Decode       = "base64-decode"
+	capUnwrapDebezium     = "unwrap-debezium"
+	capUnwrapKafkaconnect = "unwrap-kafkaconnect"
+	capUnwrapOpencdc      = "unwrap-opencdc"
+	capSplit              = "split"
+	capClone              = "clone"
+	capWebhook            = "webhook"
+	capEmbed              = "embed"
+	capTextgen            = "textgen"
+)
+
 var capabilityProcessors = map[string]map[string]bool{
-	"filter":              {"filter": true},
-	"mask":                {"field.exclude": true},
-	"rename":              {"field.rename": true},
-	"set":                 {"field.set": true},
-	"convert":             {"field.convert": true},
-	"json-encode":         {"json.encode": true},
-	"json-decode":         {"json.decode": true},
-	"avro-encode":         {"avro.encode": true},
-	"avro-decode":         {"avro.decode": true},
-	"base64-encode":       {"base64.encode": true},
-	"base64-decode":       {"base64.decode": true},
-	"unwrap-debezium":     {"unwrap.debezium": true},
-	"unwrap-kafkaconnect": {"unwrap.kafkaconnect": true},
-	"unwrap-opencdc":      {"unwrap.opencdc": true},
-	"split":               {"split": true},
-	"clone":               {"clone": true},
-	"webhook":             {"webhook.http": true},
-	"embed":               {"openai.embed": true, "cohere.embed": true},
-	"textgen":             {"openai.textgen": true, "cohere.command": true, "ollama.request": true},
+	capFilter:             {procFilter: true},
+	capMask:               {"field.exclude": true},
+	capRename:             {"field.rename": true},
+	capSet:                {"field.set": true},
+	capConvert:            {"field.convert": true},
+	capJSONEncode:         {"json.encode": true},
+	capJSONDecode:         {"json.decode": true},
+	capAvroEncode:         {"avro.encode": true},
+	capAvroDecode:         {"avro.decode": true},
+	capBase64Encode:       {"base64.encode": true},
+	capBase64Decode:       {"base64.decode": true},
+	capUnwrapDebezium:     {"unwrap.debezium": true},
+	capUnwrapKafkaconnect: {"unwrap.kafkaconnect": true},
+	capUnwrapOpencdc:      {"unwrap.opencdc": true},
+	capSplit:              {"split": true},
+	capClone:              {"clone": true},
+	capWebhook:            {"webhook.http": true},
+	capEmbed:              {"openai.embed": true, "cohere.embed": true},
+	capTextgen:            {"openai.textgen": true, "cohere.command": true, "ollama.request": true},
 }
 
 // hasCapability reports whether any processor in procs (pipeline-level or

--- a/cmd/conduit/internal/generate/codes.go
+++ b/cmd/conduit/internal/generate/codes.go
@@ -43,4 +43,22 @@ var (
 	// never discarded, because the findings are the only thing that tells the
 	// user (or an agent) what to change.
 	CodeValidateFailed = conduiterr.Register("generate.validate_failed", codes.FailedPrecondition)
+
+	// CodeSemanticMismatch: the candidate passed validate but did not do what
+	// was asked — wrong connector, swapped direction, a requested filter
+	// missing. A schema-valid pipeline that confidently does the wrong thing
+	// is the failure mode the semantic checker exists for, so it gets its own
+	// code rather than hiding inside validate_failed.
+	CodeSemanticMismatch = conduiterr.Register("generate.semantic_mismatch", codes.FailedPrecondition)
+
+	// CodeAmbiguousPrompt: the request could not be pinned to a pipeline.
+	//
+	// Raised in two places, deliberately conservative pre-call (design §9):
+	// before any provider call ONLY when the prompt is empty or names one role
+	// for two different connectors; otherwise post-hoc, when a candidate's
+	// connectors cannot be traced to anything the request actually said. A
+	// merely terse request is never refused pre-call — it goes to the model,
+	// which reads intent far better than a keyword table, and the result is
+	// judged the normal way.
+	CodeAmbiguousPrompt = conduiterr.Register("generate.ambiguous_prompt", codes.InvalidArgument)
 )

--- a/cmd/conduit/internal/generate/generate.go
+++ b/cmd/conduit/internal/generate/generate.go
@@ -61,6 +61,9 @@ type Attempt struct {
 	Report validate.Report
 	// ParseErr is set when the reply held no usable pipeline YAML.
 	ParseErr error
+	// Semantic is the intent check's verdict for a candidate that passed
+	// validate. Zero when the attempt never got that far.
+	Semantic SemanticResult
 	// Feedback is what was handed to the NEXT attempt, empty on the last one
 	// and on success.
 	Feedback RetryFeedback
@@ -111,6 +114,23 @@ func Generate(ctx context.Context, in Input) (Generation, error) {
 	names := CatalogNames(cat)
 	system := BuildSystemPrompt(cat)
 
+	// Pre-call refusal is deliberately narrow (design §9): only a prompt with
+	// no content, or one that assigns a single role to two different
+	// connectors, is refused before spending a call. A terse or informal
+	// request goes to the model — which reads intent far better than a keyword
+	// table — and is judged on what comes back.
+	intent := ExtractIntent(in.Prompt, names)
+	if strings.TrimSpace(in.Prompt) == "" {
+		e := conduiterr.New(CodeAmbiguousPrompt, "the request is empty")
+		e.Suggestion = `describe the pipeline you want, e.g. "read from postgres and write new rows to s3 as json"`
+		return Generation{}, e
+	}
+	if intent.Contradiction != "" {
+		e := conduiterr.New(CodeAmbiguousPrompt, intent.Contradiction)
+		e.Suggestion = "name one connector as the source and a different one as the destination"
+		return Generation{}, e
+	}
+
 	attempts := in.MaxAttempts
 	switch {
 	case attempts == 0:
@@ -155,8 +175,22 @@ func Generate(ctx context.Context, in Input) (Generation, error) {
 		res.Report = report
 
 		if report.OK() {
+			sem := semanticVerdict(ctx, in.Prompt, intent, candidate)
+			att.Semantic = sem
+			if sem.Match {
+				res.Attempts = append(res.Attempts, att)
+				return res, nil
+			}
+
+			// A candidate that validates but does the wrong thing gets the
+			// same corrective treatment a schema failure does: the mismatch is
+			// named in Conduit's own vocabulary and fed back inside the
+			// budget, rather than surfaced as a failure the user has to
+			// diagnose from a config that looks fine.
+			feedback = FeedbackFromSemantic(sem)
+			att.Feedback = feedback
 			res.Attempts = append(res.Attempts, att)
-			return res, nil
+			continue
 		}
 
 		feedback = FeedbackFromReport(report).
@@ -166,6 +200,53 @@ func Generate(ctx context.Context, in Input) (Generation, error) {
 	}
 
 	return res, exhaustedError(res)
+}
+
+// semanticVerdict judges a validated candidate against what the prompt asked
+// for.
+//
+// Two cases, matching design §9:
+//
+//   - Extraction learned something: the candidate is checked against it
+//     (scoreSemantic), and anything extraction left empty is not judged.
+//   - Extraction learned nothing: the candidate is accepted as long as at
+//     least one of its connectors is traceable to the user's own words. A
+//     pipeline whose source and destination appear NOWHERE in the request is
+//     the post-hoc ambiguous case — the model chose for the user rather than
+//     from what they said.
+//
+// The second case is deliberately generous. A prompt can legitimately name
+// only one side ("get my postgres data somewhere useful"), and failing that
+// candidate would punish exactly the informal phrasing the pre-call rule went
+// out of its way not to refuse.
+func semanticVerdict(ctx context.Context, prompt string, intent Intent, candidate string) SemanticResult {
+	if !intent.IsEmpty() {
+		return scoreSemantic(ctx, intent.Expect(), candidate)
+	}
+
+	source, destination := candidateCategories(ctx, candidate)
+	if promptMentionsConnector(prompt, source) || promptMentionsConnector(prompt, destination) {
+		return SemanticResult{Match: true}
+	}
+
+	return SemanticResult{
+		Match: false,
+		Issues: []string{
+			"the request does not name a connector, and the candidate's connectors (" +
+				orNone(source) + " -> " + orNone(destination) + ") do not appear in it",
+		},
+	}
+}
+
+// candidateCategories returns the builtin source and destination names of a
+// candidate, or empty strings when it does not parse into exactly one
+// judgeable pipeline.
+func candidateCategories(ctx context.Context, candidate string) (source, destination string) {
+	pipelines, err := yamlparser.NewParser(log.Nop()).Parse(ctx, strings.NewReader(candidate))
+	if err != nil || len(pipelines) == 0 {
+		return "", ""
+	}
+	return connectorCategories(pipelines[0])
 }
 
 // candidateValidateOptions is the gate every candidate passes through.
@@ -222,10 +303,32 @@ func exhaustedError(res Generation) error {
 		return e
 	}
 
+	// A candidate that cleared validate but not the intent check is a
+	// different failure with a different fix: the config is usable, it just
+	// isn't what was asked for, so the user's next move is to say what they
+	// meant more precisely — not to debug findings.
+	if last := lastAttempt(res); last != nil && last.Report.OK() && !last.Semantic.Match {
+		msg := "the generated pipeline did not match the request"
+		if len(last.Semantic.Issues) > 0 {
+			msg += ": " + strings.Join(last.Semantic.Issues, "; ")
+		}
+		e := conduiterr.New(CodeSemanticMismatch, msg)
+		e.Suggestion = "name the source and destination explicitly, e.g. \"from postgres into kafka\""
+		return e
+	}
+
 	e := conduiterr.New(CodeValidateFailed,
 		"the generated pipeline did not pass validation within the attempt budget")
 	e.Suggestion = "see the validation findings, adjust the request, or edit the generated configuration directly"
 	return e
+}
+
+// lastAttempt returns the final attempt, or nil when there were none.
+func lastAttempt(res Generation) *Attempt {
+	if len(res.Attempts) == 0 {
+		return nil
+	}
+	return &res.Attempts[len(res.Attempts)-1]
 }
 
 // unknownPlugins returns every builtin plugin reference in candidate whose

--- a/cmd/conduit/internal/generate/generate_test.go
+++ b/cmd/conduit/internal/generate/generate_test.go
@@ -118,7 +118,7 @@ func TestGenerate_HappyPath_ValidatesAndReturnsOnFirstAttempt(t *testing.T) {
 // the output unattributable to what the user asked for.
 func TestGenerate_SendsThePromptVerbatim(t *testing.T) {
 	is := is.New(t)
-	prompt := "stream new orders from postgres into a kafka topic, only orders over $100"
+	prompt := "read from the generator and write every record to the log"
 	p := &fakeProvider{replies: []string{validCandidate}}
 
 	_, err := Generate(context.Background(), Input{Prompt: prompt, Provider: p})
@@ -133,7 +133,7 @@ func TestGenerate_GroundsWithTheCatalog(t *testing.T) {
 	is := is.New(t)
 	p := &fakeProvider{replies: []string{validCandidate}}
 
-	_, err := Generate(context.Background(), Input{Prompt: "anything", Provider: p})
+	_, err := Generate(context.Background(), Input{Prompt: "generator to log", Provider: p})
 
 	is.NoErr(err)
 	is.True(strings.Contains(p.requests[0].System, "builtin:"))
@@ -268,7 +268,7 @@ func TestGenerate_SuccessAlwaysCarriesAPassingReport(t *testing.T) {
 		"Here you go:\n\n" + validCandidate,
 	} {
 		p := &fakeProvider{replies: []string{reply}}
-		res, err := Generate(context.Background(), Input{Prompt: "x", Provider: p})
+		res, err := Generate(context.Background(), Input{Prompt: "generator to log", Provider: p})
 		is.NoErr(err)
 		is.True(res.Report.OK())
 	}

--- a/cmd/conduit/internal/generate/grounding.go
+++ b/cmd/conduit/internal/generate/grounding.go
@@ -240,6 +240,14 @@ func BuildSystemPrompt(cat []ConnectorInfo) string {
 // connector does not implement the role — an absence the model must know
 // about, since "postgres as a destination" and "log as a source" are exactly
 // the kind of plausible-but-wrong pipeline this grounding exists to prevent.
+//
+// "Not supported" is an INFERENCE from an empty parameter map, not a declared
+// fact: pconnector.Specification carries no capability flag, so emptiness is
+// the only signal available. It is the same inference the eval corpus header
+// documents ("generator is source-only", "log is destination-only"), and it
+// holds for all six built-ins today. A connector with a supported but
+// parameter-less role would be described wrongly here — if one ever ships, the
+// specification needs the flag, not this function a heuristic.
 func writeRole(b *strings.Builder, role string, params []ParamInfo) {
 	if len(params) == 0 {
 		fmt.Fprintf(b, "  %s: not supported\n", role)

--- a/cmd/conduit/internal/generate/intent.go
+++ b/cmd/conduit/internal/generate/intent.go
@@ -1,0 +1,267 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"sort"
+	"strings"
+)
+
+// Intent is what a deterministic read of the natural-language prompt can tell
+// about the pipeline the user asked for (design §9).
+//
+// It is a HEURISTIC read, and its emptiness is meaningful: an empty Source or
+// Destination means "the prompt did not clearly say", never "the user wants
+// nothing there". That distinction is what keeps a terse-but-legitimate
+// request from being refused before the model — materially better at reading
+// intent than a keyword table — ever sees it.
+type Intent struct {
+	// Source/Destination are catalog connector names, or empty when the
+	// prompt did not clearly assign one.
+	Source      string
+	Destination string
+	// Capabilities are capability.go tags the prompt clearly asked for.
+	Capabilities []string
+	// Contradiction is non-empty when the prompt assigns one role to two
+	// different connectors, which no candidate could satisfy. This is the
+	// only extraction outcome that refuses BEFORE a provider call.
+	Contradiction string
+}
+
+// Expect converts the extracted intent into the ground-truth shape
+// scoreSemantic judges against. Empty fields are no constraint, so a partial
+// read checks what it knows and stays silent about the rest.
+func (i Intent) Expect() Expect {
+	return Expect{
+		SourceCategory:       i.Source,
+		DestinationCategory:  i.Destination,
+		RequiredCapabilities: i.Capabilities,
+	}
+}
+
+// IsEmpty reports whether extraction learned nothing at all.
+func (i Intent) IsEmpty() bool {
+	return i.Source == "" && i.Destination == "" && len(i.Capabilities) == 0
+}
+
+// Catalog connector names this file reasons about. Declared once so an alias
+// target and a mention check cannot drift into two spellings of the same
+// connector. They are asserted against the real catalog by
+// TestConnectorAliases_ResolveToRealConnectors, which is what keeps this list
+// honest rather than a second source of truth.
+const (
+	connPostgres  = "postgres"
+	connKafka     = "kafka"
+	connS3        = "s3"
+	connFile      = "file"
+	connLog       = "log"
+	connGenerator = "generator"
+)
+
+// Roles a mention can be assigned to.
+const (
+	roleSource      = "source"
+	roleDestination = "destination"
+)
+
+// connectorAliases maps the words people actually use to catalog connector
+// names. The canonical NAMES come from the catalog (never a second list); this
+// is the thin alias layer over them, because no catalog knows that "pg" means
+// postgres or that "bucket" means s3.
+//
+// Every value here must be a real catalog name — TestConnectorAliases_
+// ResolveToRealConnectors fails otherwise, so an alias can never introduce a
+// connector the binary does not have.
+var connectorAliases = map[string]string{
+	connPostgres:  connPostgres,
+	"postgresql":  connPostgres,
+	"pg":          connPostgres,
+	connKafka:     connKafka,
+	"redpanda":    connKafka,
+	connS3:        connS3,
+	"bucket":      connS3,
+	connFile:      connFile,
+	connLog:       connLog,
+	"stdout":      connLog,
+	"console":     connLog,
+	connGenerator: connGenerator,
+}
+
+// capabilityPhrases maps prompt wording to a capability.go tag. Only phrases
+// that unambiguously name a transform are listed: "only orders over $100"
+// clearly asks for a filter, while "clean up the data" asks for nothing this
+// table can name, and inventing a requirement from it would fail candidates
+// that were perfectly correct.
+//
+// Every tag must exist in capabilityProcessors — TestCapabilityPhrases_
+// ResolveToRealTags fails otherwise, since an unknown tag is permanently
+// unsatisfiable (capability.go) and would make every candidate fail.
+var capabilityPhrases = map[string]string{
+	"only":         capFilter,
+	capFilter:      capFilter, // the word people use IS the tag
+	"where":        capFilter,
+	"exclude rows": capFilter,
+	"as json":      capJSONEncode,
+	"to json":      capJSONEncode,
+	"json encoded": capJSONEncode,
+	"parse json":   capJSONDecode,
+	"decode json":  capJSONDecode,
+	"as avro":      capAvroEncode,
+	"avro encoded": capAvroEncode,
+	"decode avro":  capAvroDecode,
+	capMask:        capMask,
+	"redact":       capMask,
+	capRename:      capRename,
+	"base64":       capBase64Encode,
+	"debezium":     capUnwrapDebezium,
+	"embedding":    capEmbed,
+	"embeddings":   capEmbed,
+	"summarize":    capTextgen,
+	capWebhook:     capWebhook,
+}
+
+// sourceCues and destinationCues are the directional words that assign a
+// mentioned connector to a role.
+var (
+	sourceCues      = []string{"from", roleSource, "out of", "read", "read from"}
+	destinationCues = []string{"to", "into", roleDestination, "sink", "onto", "write", "write to"}
+)
+
+// cueWindow is how many words before a connector mention are searched for a
+// directional cue. Four covers "from the postgres database" and "into an s3
+// bucket" without reaching back into the previous clause and stealing its cue.
+const cueWindow = 4
+
+// ExtractIntent reads prompt against the catalog names.
+//
+// It is deliberately conservative: a mention with no nearby directional cue
+// assigns no role, and a role claimed by two different connectors produces a
+// Contradiction rather than a guess. Everything it is unsure about it leaves
+// empty, which downstream means "do not judge this" — the checker's job is to
+// catch clear mistakes (wrong connector, swapped direction, dropped filter),
+// not to grade every pipeline it cannot fully parse.
+func ExtractIntent(prompt string, names []string) Intent {
+	known := make(map[string]bool, len(names))
+	for _, n := range names {
+		known[n] = true
+	}
+
+	lower := strings.ToLower(prompt)
+	words := strings.Fields(lower)
+
+	var intent Intent
+	roles := map[string]string{} // role -> connector name
+
+	for i, w := range words {
+		name, ok := connectorAliases[cueWord(w)]
+		if !ok || !known[name] {
+			continue
+		}
+		role := roleFromCues(words, i)
+		if role == "" {
+			continue
+		}
+		if prev, seen := roles[role]; seen && prev != name {
+			intent.Contradiction = "the request names both " + prev + " and " + name + " as the " + role
+			continue
+		}
+		roles[role] = name
+	}
+
+	intent.Source = roles[roleSource]
+	intent.Destination = roles[roleDestination]
+	intent.Capabilities = extractCapabilities(lower)
+	return intent
+}
+
+// roleFromCues classifies the mention at words[i] by the nearest directional
+// cue in the preceding cueWindow words. Nearest wins: in "from postgres to
+// kafka", kafka's nearest cue is "to" even though "from" is also in range.
+//
+// Both single-word cues ("from", "into") and two-word ones ("out of", "read
+// from") are matched, because the two-word forms are how people actually
+// phrase a source: "get everything out of postgres" has no single word that
+// says source.
+func roleFromCues(words []string, i int) string {
+	for back := 1; back <= cueWindow && i-back >= 0; back++ {
+		w := cueWord(words[i-back])
+		if matchesCue(w, sourceCues) {
+			return roleSource
+		}
+		if matchesCue(w, destinationCues) {
+			return roleDestination
+		}
+		if i-back-1 >= 0 {
+			bigram := cueWord(words[i-back-1]) + " " + w
+			if matchesCue(bigram, sourceCues) {
+				return roleSource
+			}
+			if matchesCue(bigram, destinationCues) {
+				return roleDestination
+			}
+		}
+	}
+	return ""
+}
+
+// cueWord strips the punctuation a word can carry in a sentence.
+func cueWord(w string) string { return strings.Trim(w, ".,;:!?\"'`()[]") }
+
+func matchesCue(word string, cues []string) bool {
+	for _, c := range cues {
+		if word == c {
+			return true
+		}
+	}
+	return false
+}
+
+// extractCapabilities returns every capability tag the prompt clearly asks
+// for, sorted and deduplicated so the same prompt always yields the same
+// expectation.
+func extractCapabilities(lowerPrompt string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for phrase, tag := range capabilityPhrases {
+		if seen[tag] || !strings.Contains(lowerPrompt, phrase) {
+			continue
+		}
+		seen[tag] = true
+		out = append(out, tag)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// promptMentionsConnector reports whether prompt names the given catalog
+// connector, under any alias.
+//
+// This is the post-hoc ambiguity check (design §9): when extraction learned
+// nothing, a candidate is still acceptable if the connectors it chose are
+// traceable to the user's words. A candidate whose source and destination
+// appear nowhere in the request is the case the design calls ambiguous — the
+// model picked something the prompt never asked for.
+func promptMentionsConnector(prompt, name string) bool {
+	lower := strings.ToLower(prompt)
+	for alias, canonical := range connectorAliases {
+		if canonical != name {
+			continue
+		}
+		if strings.Contains(lower, alias) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/conduit/internal/generate/intent_test.go
+++ b/cmd/conduit/internal/generate/intent_test.go
@@ -1,0 +1,243 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/matryer/is"
+)
+
+func TestExtractIntent_DirectionAndCapabilities(t *testing.T) {
+	is := is.New(t)
+	names := CatalogNames(BuiltinCatalog())
+
+	for _, tc := range []struct {
+		name         string
+		prompt       string
+		source       string
+		destination  string
+		capabilities []string
+	}{{
+		name:         "the canonical case from the design doc",
+		prompt:       "stream new orders from postgres into a kafka topic, only orders over $100",
+		source:       "postgres",
+		destination:  "kafka",
+		capabilities: []string{"filter"},
+	}, {
+		name:         "export phrasing with an encoding",
+		prompt:       "export all customer records from postgres to an s3 bucket as json",
+		source:       "postgres",
+		destination:  "s3",
+		capabilities: []string{"json-encode"},
+	}, {
+		name:        "aliases resolve to catalog names",
+		prompt:      "read from pg and write to stdout",
+		source:      "postgres",
+		destination: "log",
+	}, {
+		name:        "reversed direction is read as reversed",
+		prompt:      "move data from kafka into postgres",
+		source:      "kafka",
+		destination: "postgres",
+	}, {
+		name:        "only one side named leaves the other empty",
+		prompt:      "get everything out of postgres somewhere useful",
+		source:      "postgres",
+		destination: "",
+	}, {
+		name:   "no connector named extracts nothing",
+		prompt: "keep my search index fresh",
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExtractIntent(tc.prompt, names)
+			is.Equal(got.Source, tc.source)
+			is.Equal(got.Destination, tc.destination)
+			for _, want := range tc.capabilities {
+				is.True(slices.Contains(got.Capabilities, want))
+			}
+			is.Equal(got.Contradiction, "")
+		})
+	}
+}
+
+// A mention with no directional cue nearby assigns no role. Guessing would
+// turn "compare postgres and kafka throughput" into a pipeline request.
+func TestExtractIntent_NoCueMeansNoRole(t *testing.T) {
+	is := is.New(t)
+
+	got := ExtractIntent("compare postgres and kafka", CatalogNames(BuiltinCatalog()))
+
+	is.Equal(got.Source, "")
+	is.Equal(got.Destination, "")
+}
+
+// One role claimed by two different connectors is unsatisfiable by any
+// candidate, so it is the one extraction outcome that refuses up front.
+func TestExtractIntent_ContradictionIsDetected(t *testing.T) {
+	is := is.New(t)
+
+	got := ExtractIntent("read from kafka, source is postgres, write to the log", CatalogNames(BuiltinCatalog()))
+
+	is.True(got.Contradiction != "")
+}
+
+// Every alias must name a connector this binary actually has, or the checker
+// would demand a connector the model cannot legally produce.
+func TestConnectorAliases_ResolveToRealConnectors(t *testing.T) {
+	is := is.New(t)
+	names := CatalogNames(BuiltinCatalog())
+
+	for alias, canonical := range connectorAliases {
+		is.True(slices.Contains(names, canonical)) // alias -> real connector
+		is.True(alias != "")
+	}
+}
+
+// Every capability phrase must map to a tag capability.go can satisfy: an
+// unknown tag is permanently unsatisfiable, so a typo here would fail every
+// candidate forever.
+func TestCapabilityPhrases_ResolveToRealTags(t *testing.T) {
+	is := is.New(t)
+
+	for phrase, tag := range capabilityPhrases {
+		_, ok := capabilityProcessors[tag]
+		is.True(ok)
+		is.True(phrase != "")
+	}
+}
+
+// Pre-call refusal is narrow by design: an empty prompt and a contradictory
+// one are refused before a provider call; a terse one is not.
+func TestGenerate_PreCallRefusalIsNarrow(t *testing.T) {
+	is := is.New(t)
+
+	t.Run("empty prompt never calls the provider", func(t *testing.T) {
+		p := &fakeProvider{replies: []string{validCandidate}}
+		_, err := Generate(context.Background(), Input{Prompt: "   ", Provider: p})
+		ce, ok := conduiterr.Get(err)
+		is.True(ok)
+		is.Equal(ce.Code, CodeAmbiguousPrompt)
+		is.Equal(len(p.requests), 0)
+	})
+
+	t.Run("contradictory prompt never calls the provider", func(t *testing.T) {
+		p := &fakeProvider{replies: []string{validCandidate}}
+		_, err := Generate(context.Background(), Input{
+			Prompt:   "read from kafka, source is postgres, write to the log",
+			Provider: p,
+		})
+		ce, ok := conduiterr.Get(err)
+		is.True(ok)
+		is.Equal(ce.Code, CodeAmbiguousPrompt)
+		is.Equal(len(p.requests), 0)
+	})
+
+	t.Run("terse prompt is sent to the provider, not refused", func(t *testing.T) {
+		p := &fakeProvider{replies: []string{validCandidate}}
+		_, err := Generate(context.Background(), Input{Prompt: "generator to log", Provider: p})
+		is.NoErr(err)
+		is.Equal(len(p.requests), 1)
+	})
+}
+
+// A schema-valid pipeline that does the wrong thing is corrected inside the
+// budget, then succeeds — the failure mode the whole checker exists for.
+func TestGenerate_SemanticMismatchIsCorrectedInsideTheBudget(t *testing.T) {
+	is := is.New(t)
+	// Asked for postgres -> log; the first candidate reads from the generator.
+	p := &fakeProvider{replies: []string{validCandidate, postgresToLogCandidate}}
+
+	res, err := Generate(context.Background(), Input{
+		Prompt:   "read from postgres and write to the log",
+		Provider: p,
+	})
+
+	is.NoErr(err)
+	is.Equal(len(p.requests), 2)
+	is.True(!res.Attempts[0].Semantic.Match)
+	is.True(res.Attempts[0].Report.OK()) // it validated — that is the point
+	retry := p.requests[1].Prompt
+	is.True(len(res.Attempts[0].Feedback.Items) > 0)
+	is.True(retry != p.requests[0].Prompt) // the correction was attached
+}
+
+// Exhausting the budget on intent mismatches is its own code: the config is
+// usable, it just isn't what was asked for, so the fix is different.
+func TestGenerate_ExhaustedSemantic_IsSemanticMismatch(t *testing.T) {
+	is := is.New(t)
+	p := &fakeProvider{replies: []string{validCandidate}}
+
+	res, err := Generate(context.Background(), Input{
+		Prompt:      "read from postgres and write to kafka",
+		Provider:    p,
+		MaxAttempts: 2,
+	})
+
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.Equal(ce.Code, CodeSemanticMismatch)
+	is.True(res.Report.OK())     // the artifact is valid
+	is.True(res.Candidate != "") // and is not discarded
+}
+
+// When the prompt names no connector, a candidate is accepted if its
+// connectors are traceable to the user's words, and rejected when they are
+// not — the post-hoc half of ambiguity (design §9).
+func TestGenerate_PostHocAmbiguity(t *testing.T) {
+	is := is.New(t)
+
+	t.Run("untraceable connectors are a mismatch", func(t *testing.T) {
+		p := &fakeProvider{replies: []string{validCandidate}}
+		_, err := Generate(context.Background(), Input{
+			Prompt:      "keep my search index fresh",
+			Provider:    p,
+			MaxAttempts: 1,
+		})
+		is.True(err != nil)
+	})
+
+	t.Run("a connector named without a direction still traces", func(t *testing.T) {
+		p := &fakeProvider{replies: []string{validCandidate}}
+		_, err := Generate(context.Background(), Input{
+			Prompt:   "something involving the generator and the log",
+			Provider: p,
+		})
+		is.NoErr(err)
+	})
+}
+
+// postgresToLogCandidate reads from postgres, so it matches a "from postgres
+// to the log" request where validCandidate does not.
+const postgresToLogCandidate = `version: "2.2"
+pipelines:
+  - id: pg-to-log
+    status: running
+    connectors:
+      - id: source
+        type: source
+        plugin: "builtin:postgres"
+        settings:
+          url: postgres://user:pass@localhost:5432/db?sslmode=disable
+          tables: orders
+      - id: destination
+        type: destination
+        plugin: "builtin:log"
+        settings:
+          level: info
+`

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -614,7 +614,7 @@ Author: Meroxa, Inc.
 | `sdk.schema.extract.key.enabled` | bool | true | no | Whether to extract and decode the record key with a schema. |  |
 | `sdk.schema.extract.payload.enabled` | bool | true | no | Whether to extract and decode the record payload with a schema. |  |
 
-## 3. Error codes (99)
+## 3. Error codes (101)
 
 | Reason | gRPC status | Description |
 | --- | --- | --- |
@@ -633,10 +633,12 @@ Author: Meroxa, Inc.
 | `connector.invalid_type` | InvalidArgument | CodeConnectorInvalidType is raised when a connector type is neither "source" nor "destination". |
 | `connector.plugin_not_found` | NotFound | CodeConnectorPluginNotFound is raised when a referenced connector plugin cannot be located. |
 | `connector.running` | FailedPrecondition | CodeConnectorRunning is raised when an operation requires the connector to not be running, but a connector instance for it already exists. |
+| `generate.ambiguous_prompt` | InvalidArgument | CodeAmbiguousPrompt: the request could not be pinned to a pipeline.  Raised in two places, deliberately conservative pre-call (design §9): before any provider call ONLY when the prompt is empty or names one role for two different connectors; otherwise post-hoc, when a candidate's connectors cannot be traced to anything the request actually said. A merely terse request is never refused pre-call — it goes to the model, which reads intent far better than a keyword table, and the result is judged the normal way. |
 | `generate.ambiguous_provider_configuration` | InvalidArgument | CodeAmbiguousProvider: more than one candidate and no explicit choice. This is an error rather than a pick — see the package doc. |
 | `generate.no_provider_configured` | Unauthenticated | CodeNoProviderConfigured: zero resolvable candidates. Unauthenticated (exit 3, environment) rather than InvalidArgument, because the user's command was fine — their environment is not. |
 | `generate.parse_failed` | Internal | CodeParseFailed: the provider replied, but nothing in the reply could be read as a pipeline config within the retry budget. Internal (exit 1, runtime) rather than InvalidArgument, because the user's request was well-formed — the boundary failed, not their input. |
 | `generate.provider_error` | Unavailable | CodeProviderError covers every way the provider call itself failed: network, timeout, rate limit, or an auth rejection from the provider. Unavailable (exit 3, environment) because the user's command was fine. |
+| `generate.semantic_mismatch` | FailedPrecondition | CodeSemanticMismatch: the candidate passed validate but did not do what was asked — wrong connector, swapped direction, a requested filter missing. A schema-valid pipeline that confidently does the wrong thing is the failure mode the semantic checker exists for, so it gets its own code rather than hiding inside validate_failed. |
 | `generate.validate_failed` | FailedPrecondition | CodeValidateFailed: a candidate parsed but never passed validate within the retry budget. FailedPrecondition (exit 2, validation): the request was understood, the artifact it produced is not usable as-is, and the findings say exactly why.  The last attempt's validate.Report travels back on Result.Report — it is never discarded, because the findings are the only thing that tells the user (or an agent) what to change. |
 | `internal.error` | Internal | CodeInternal is a coded internal failure. |
 | `internal.unknown` | Internal | CodeUnknown is the fallback when an un-coded error reaches a boundary. |

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@
 (6 built-in connectors; full parameters in llms-full.txt)
 
 ## Error codes
-- 99 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
+- 101 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
 
 ## MCP tools
 - Read: deploy, doctor, dry_run, inspect, lint, repair, validate


### PR DESCRIPTION
Third slice of WS1 (`conduit generate`), on top of #2775. Still no user-facing surface — the command is the next slice.

## The problem this closes

A generated pipeline can pass `validate` and still be wrong: right schema, wrong connector, swapped direction, the requested filter dropped. Design doc §9 names that as the reason a validate-pass rate alone is not a sufficient bar. Nothing in the loop checked for it until now.

## What lands

- **`intent.go`** — a deterministic read of the prompt: connector aliases over catalog-derived canonical names (`pg` → postgres, `bucket` → s3, `stdout` → log), directional cues including the two-word forms people actually use (`get everything out of postgres`), and capability phrases mapped to real `capability.go` tags.
- **The loop judges every validated candidate.** A mismatch is corrected *inside* the retry budget, in Conduit's own vocabulary, instead of surfacing as a failure the user has to diagnose from a config that looks fine.
- **`generate.semantic_mismatch`** for an exhausted budget, distinct from `validate_failed`: the config is usable, it just isn't what was asked for, so the fix is different.

## Decisions worth stating

**Refusal stays narrow, on purpose.** Only an empty prompt, or one naming a single role for two different connectors, is refused before a provider call. A terse or informal request goes to the model — materially better at reading intent than a keyword table — and is judged on what comes back. `generate.ambiguous_prompt` covers the post-hoc half: a candidate whose connectors appear nowhere in the request means the model chose *for* the user rather than *from* what they said.

**Extraction is conservative by construction.** A mention with no nearby directional cue assigns no role; anything left empty is not judged. `scoreSemantic` already treats empty expectations as "no constraint", so a partial read checks what it knows and stays silent about the rest.

**Two guardrail tests, because both tables could rot silently.** Every alias must resolve to a connector this binary actually has, and every capability phrase must map to a tag `capability.go` can satisfy — an unknown tag is permanently unsatisfiable, so a typo would fail every candidate forever with no obvious cause.

**Capability tags became shared constants.** The eval corpus, the extractor, and `capability.go` all name the same vocabulary; three spellings of `json-encode` would have been a silent, permanent mismatch. `procFilter` is deliberately a separate constant from `capFilter` — same spelling, but one names a processor plugin the engine loads and the other an intent the corpus asks for, and a rename of either must not silently rewrite the other.

## Adversarial self-review

1. **The new gate caught three of my own tests from the previous slice.** They used prompts that did not describe the candidate the fake provider returned (`"anything"` → a generator→log pipeline). Correct behavior; the fixtures were sloppy and now match.
2. **The first cue matcher only handled single words**, so `"get everything out of postgres"` extracted no source at all — the two-word cue forms are how a source usually gets phrased. Bigram matching added, with a test for exactly that prompt.
3. **`grounding.go` stated an inference as a fact.** "role: not supported" is derived from an empty parameter map; `pconnector.Specification` carries no capability flag. It is right for all six built-ins and it is the same inference the eval corpus header documents — but the comment now says so, and says that a parameter-less-but-supported role would need the flag rather than a smarter heuristic here.
4. **Considered and rejected: refusing terse prompts up front.** It would have been simpler and it is what a keyword table "wants" to do, but it fails exactly the informal phrasing the design doc argues hardest to protect. The post-hoc traceability check gets the same safety without the false refusals.

## Tests

`go test ./cmd/...` green, `golangci-lint` (CI-exact v2.12.2) clean. No network in any test — the provider is a fake that replays scripted replies and records what was sent.

## Risk tier

**Tier 2.** No data-path code: this reads text and compares strings. No acks, positions, state, or protocol touched.

Roadmap: v0.20 WS1 (`conduit generate`), slice A2b.
