### PR TITLE
feat(generate): wire the `conduit generate` command (WS1)

### DIFF
--- a/cmd/conduit/internal/generate/summary.go
+++ b/cmd/conduit/internal/generate/summary.go
@@ -1,0 +1,57 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"context"
+	"strings"
+
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	yamlparser "github.com/conduitio/conduit/pkg/provisioning/config/yaml"
+)
+
+// CandidateSummary is what a caller can say about a generated candidate
+// without re-parsing it: the pipeline's own id (which is where a default
+// output filename comes from) and how much is in it.
+type CandidateSummary struct {
+	PipelineID string
+	Connectors int
+	Processors int
+}
+
+// Summarize reads a candidate with the same parser validate uses.
+//
+// It is only ever called on a candidate that already passed the validate
+// gate, so a parse failure here is not a user-facing error — it returns a
+// zero summary and lets the caller fall back (to a generic filename, or to
+// omitting counts). Re-reporting a parse problem at this point would
+// contradict the report that just said the config is fine.
+func Summarize(ctx context.Context, candidate string) CandidateSummary {
+	pipelines, err := yamlparser.NewParser(log.Nop()).Parse(ctx, strings.NewReader(candidate))
+	if err != nil || len(pipelines) == 0 {
+		return CandidateSummary{}
+	}
+
+	p := pipelines[0]
+	s := CandidateSummary{
+		PipelineID: p.ID,
+		Connectors: len(p.Connectors),
+		Processors: len(p.Processors),
+	}
+	for _, c := range p.Connectors {
+		s.Processors += len(c.Processors)
+	}
+	return s
+}

--- a/cmd/conduit/root/generate/generate.go
+++ b/cmd/conduit/root/generate/generate.go
@@ -1,0 +1,342 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package generate implements `conduit generate "<natural language>"`: it
+// turns a description of a pipeline into a validated pipeline configuration
+// file.
+//
+// # The boundary that defines this command
+//
+// Generation never deploys, applies, or mutates anything. Its only side
+// effects are one provider call and one file write, and the file write is
+// confined to the working directory whenever the filename came from the model
+// (outpath.go). There is deliberately no --yes, --deploy, or --apply flag: the
+// boundary is enforced by the ABSENCE of a way to cross it, not by a
+// confirmation prompt a script could answer. Deploying a generated pipeline is
+// the same explicit `conduit pipelines deploy` step a hand-written one needs.
+//
+// Every configuration this command shows or writes has passed the same
+// validate engine `conduit pipelines validate` runs — see
+// cmd/conduit/internal/generate, which owns the grounded generation loop this
+// package is a CLI shell over.
+package generate
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	gen "github.com/conduitio/conduit/cmd/conduit/internal/generate"
+	"github.com/conduitio/conduit/cmd/conduit/internal/generate/provider"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/conduitio/ecdysis"
+)
+
+var (
+	_ cecdysis.CommandWithResult = (*Command)(nil)
+	_ ecdysis.CommandWithDocs    = (*Command)(nil)
+	_ ecdysis.CommandWithFlags   = (*Command)(nil)
+	_ ecdysis.CommandWithArgs    = (*Command)(nil)
+)
+
+// Args holds the natural-language request.
+type Args struct {
+	Prompt string
+}
+
+// Flags holds the command's flags.
+//
+// There is no --yes/--deploy/--apply here, and that absence is load-bearing
+// (see the package doc). A flag-set golden test asserts it, because a boundary
+// enforced by an absence needs a test that notices when the absence ends.
+type Flags struct {
+	Provider   string `long:"provider" usage:"generation provider to use (anthropic, openai, ollama); auto-detected when exactly one is configured"`
+	Model      string `long:"model" usage:"provider-specific model identifier; the provider's default when unset"`
+	Out        string `long:"out" usage:"path to write the generated pipeline to; defaults to a filename derived from the pipeline id, in the working directory"`
+	MaxRetries int    `long:"max-retries" usage:"how many provider calls a single generate may make, including the first" default:"3"`
+	Force      bool   `long:"force" usage:"overwrite the output file if it already exists"`
+	NoColor    bool   `long:"no-color" usage:"disable colored/glyph output even on a color-capable terminal"`
+}
+
+// Command implements `conduit generate`.
+type Command struct {
+	args  Args
+	flags Flags
+
+	// env and newProvider are seams so a test can exercise the whole command
+	// — resolve, generate, write, render — without touching process
+	// environment or making a network call. Nil means the real thing.
+	env         func(string) string
+	newProvider func(name, model string, env func(string) string) (provider.Provider, error)
+	// probe reports whether a local Ollama server is reachable. It is a seam
+	// for the same reason provider.Probe is one: auto-detection would
+	// otherwise make a network call from every test that constructs this
+	// command, and whether the developer happens to be running Ollama would
+	// decide whether those tests pass.
+	probe provider.Probe
+}
+
+func (c *Command) Usage() string { return "generate <request>" }
+
+func (c *Command) Docs() ecdysis.Docs {
+	return ecdysis.Docs{
+		Short: "Generate a pipeline configuration from a natural-language description",
+		Long: `Turns a description of a pipeline into a pipeline configuration file.
+
+Every generated configuration is checked with the same offline validate engine
+'conduit pipelines validate' uses, including that every connector it references actually
+exists, before it is shown or written. A configuration that does not pass is never
+emitted; the command retries with the specific findings and, if it still cannot produce a
+valid pipeline, reports what was wrong.
+
+This command never deploys anything. It writes a file; deploying it is the same explicit
+'conduit pipelines deploy' step a hand-written pipeline needs.
+
+A generation provider must be configured: set ANTHROPIC_API_KEY or OPENAI_API_KEY, or run a
+local Ollama server. When more than one is available, choose with --provider rather than
+letting the command pick for you.`,
+		Example: `conduit generate "read from postgres and write new rows to s3 as json"
+conduit generate "stream orders from postgres into kafka, only orders over 100" --out orders.yaml
+conduit generate "sync kafka into postgres" --provider anthropic --json`,
+	}
+}
+
+func (c *Command) Flags() []ecdysis.Flag { return ecdysis.BuildFlags(&c.flags) }
+
+func (c *Command) Args(args []string) error {
+	if len(args) == 0 {
+		return cerrors.Errorf("requires a description of the pipeline to generate")
+	}
+	if len(args) > 1 {
+		return cerrors.Errorf("too many arguments: quote the description as a single argument")
+	}
+	c.args.Prompt = args[0]
+	return nil
+}
+
+func (c *Command) ResultCommand() string { return "generate" }
+
+// Result is the --json payload (design §6).
+type Result struct {
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+	// Path is where the configuration was written.
+	Path string `json:"path"`
+	// Pipeline is the configuration itself, so a consumer never has to read
+	// the file back to see what was produced.
+	Pipeline string `json:"pipeline"`
+}
+
+// Summary is the --json summary block.
+type Summary struct {
+	Attempts   int `json:"attempts"`
+	MaxRetries int `json:"maxRetries"`
+	Connectors int `json:"connectors"`
+	Processors int `json:"processors"`
+	// TokensUsed is what the provider reported, summed across attempts, or 0
+	// when it reported nothing. Never estimated — this is a number users may
+	// bill against.
+	TokensUsed int `json:"tokensUsed"`
+}
+
+// ExecuteWithResult resolves a provider, generates a validated pipeline, and
+// writes it.
+//
+// Errors are returned rather than folded into the envelope as OK:false: unlike
+// `validate`, which reports findings about files that exist, every failure
+// here means no artifact was produced, and each carries a registered code from
+// design §8 whose gRPC class maps to the process exit code through
+// pkg/conduit/exitcode.
+func (c *Command) ExecuteWithResult(ctx context.Context) (cecdysis.Outcome, error) {
+	env := c.env
+	if env == nil {
+		env = os.Getenv
+	}
+
+	probe := c.probe
+	if probe == nil {
+		probe = probeOllama
+	}
+
+	name, err := provider.Resolve(provider.ResolveInput{
+		Flag:        c.flags.Provider,
+		Env:         env,
+		ProbeOllama: probe,
+	})
+	if err != nil {
+		return cecdysis.Outcome{}, err
+	}
+
+	build := c.newProvider
+	if build == nil {
+		build = newProvider
+	}
+	p, err := build(name, c.flags.Model, env)
+	if err != nil {
+		return cecdysis.Outcome{}, err
+	}
+
+	generated, err := gen.Generate(ctx, gen.Input{
+		Prompt:      c.args.Prompt,
+		Provider:    p,
+		Model:       c.flags.Model,
+		MaxAttempts: c.flags.MaxRetries,
+	})
+	if err != nil {
+		return cecdysis.Outcome{}, err
+	}
+
+	summary := gen.Summarize(ctx, generated.Candidate)
+	path := resolveOutPath(c.flags.Out, summary.PipelineID)
+	if err := writeCandidate(path, generated.Candidate, c.flags.Force); err != nil {
+		return cecdysis.Outcome{}, err
+	}
+
+	return cecdysis.Outcome{
+		OK: true,
+		Summary: Summary{
+			Attempts:   len(generated.Attempts),
+			MaxRetries: c.flags.MaxRetries,
+			Connectors: summary.Connectors,
+			Processors: summary.Processors,
+			TokensUsed: generated.TokensUsed,
+		},
+		Result: Result{
+			Provider: name,
+			Model:    c.flags.Model,
+			Path:     path,
+			Pipeline: generated.Candidate,
+		},
+	}, nil
+}
+
+// Render is the human output: the configuration, what is in it, and the
+// commands that take it further.
+//
+// The footer always lists validate, dry-run, repair, and deploy in that order
+// — the same path a hand-written configuration takes, including `repair` for a
+// finding that has a fix.
+func (c *Command) Render(outcome cecdysis.Outcome) string {
+	result, _ := outcome.Result.(Result)
+	summary, _ := outcome.Summary.(Summary)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Generated with %s", result.Provider)
+	if result.Model != "" {
+		fmt.Fprintf(&b, " (%s)", result.Model)
+	}
+	fmt.Fprintf(&b, ", attempt %d of %d. Validation passed.\n\n", summary.Attempts, summary.MaxRetries)
+
+	b.WriteString(result.Pipeline)
+	if !strings.HasSuffix(result.Pipeline, "\n") {
+		b.WriteString("\n")
+	}
+
+	fmt.Fprintf(&b, "\n%d connector(s), %d processor(s)", summary.Connectors, summary.Processors)
+	if summary.TokensUsed > 0 {
+		fmt.Fprintf(&b, " · %d tokens", summary.TokensUsed)
+	}
+	fmt.Fprintf(&b, "\nWrote %s (not deployed).\n", result.Path)
+
+	b.WriteString("\nNext steps:\n")
+	for _, step := range nextSteps {
+		fmt.Fprintf(&b, "  conduit pipelines %s %s\n", step, result.Path)
+	}
+	return b.String()
+}
+
+// writeCandidate writes the configuration, refusing to clobber an existing
+// file unless --force was given.
+//
+// 0600 matches `pipelines init`: a generated configuration commonly carries
+// connection strings the user is about to fill in, and a file that starts
+// private can always be relaxed.
+func writeCandidate(path, candidate string, force bool) error {
+	flags := os.O_WRONLY | os.O_CREATE | os.O_EXCL
+	if force {
+		flags = os.O_WRONLY | os.O_CREATE | os.O_TRUNC
+	}
+
+	f, err := os.OpenFile(path, flags, 0o600)
+	if err != nil {
+		if os.IsExist(err) {
+			// Deliberately a FOUNDATIONAL code rather than a new
+			// generate.destination_exists: design §8's taxonomy is a frozen
+			// contract that does not list one for this case, and the provider
+			// package took the same decision for its unknown-provider case
+			// (codeUnknownProvider). If a dedicated code is wanted it belongs
+			// in §8 first, then here.
+			e := conduiterr.Wrap(conduiterr.CodeInvalidArgument,
+				fmt.Sprintf("%s already exists", path), err)
+			e.Suggestion = "pass --force to overwrite it, or --out to write somewhere else"
+			return e
+		}
+		return conduiterr.Wrap(conduiterr.CodeInternal,
+			fmt.Sprintf("could not write %s: %v", path, err), err)
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(candidate); err != nil {
+		return conduiterr.Wrap(conduiterr.CodeInternal,
+			fmt.Sprintf("could not write %s: %v", path, err), err)
+	}
+	return nil
+}
+
+// newProvider builds the adapter for a resolved provider name.
+//
+// Credentials are read here and never logged, never echoed into the prompt,
+// and never put in --json output.
+func newProvider(name, model string, env func(string) string) (provider.Provider, error) {
+	switch name {
+	case provider.NameAnthropic:
+		return &provider.Anthropic{APIKey: env(provider.EnvAnthropicKey), Model: model}, nil
+	case provider.NameOpenAI:
+		return &provider.OpenAI{APIKey: env(provider.EnvOpenAIKey), Model: model}, nil
+	case provider.NameOllama:
+		host := env(provider.EnvOllamaHost)
+		if strings.TrimSpace(host) == "" {
+			host = provider.DefaultOllamaHost
+		}
+		return &provider.Ollama{Host: host, Model: model}, nil
+	default:
+		// Unreachable: Resolve only ever returns a name it validated. Coded
+		// rather than panicking, because an unreachable branch that becomes
+		// reachable should tell the user something actionable.
+		e := conduiterr.New(conduiterr.CodeInternal,
+			fmt.Sprintf("resolved unknown generation provider %q", name))
+		e.Suggestion = "select one explicitly with --provider: " + strings.Join(provider.Names, ", ")
+		return nil, e
+	}
+}
+
+// probeOllama reports whether a local Ollama server is reachable, with a short
+// timeout: this runs on every invocation that has no explicit provider, so it
+// must never be what makes the command feel slow.
+func probeOllama(host string) bool {
+	return provider.Reachable(host, &http.Client{Timeout: probeTimeout}, probeTimeout)
+}
+
+const probeTimeout = 500 * time.Millisecond
+
+// nextSteps is the footer, in the order a user actually walks it: check it,
+// see what it would do, fix anything fixable, then run it. `repair` is in the
+// list because a generated file with a fixable finding routes to the same
+// repair path a hand-written one does.
+var nextSteps = []string{"validate", "dry-run", "repair", "deploy"}

--- a/cmd/conduit/root/generate/generate_test.go
+++ b/cmd/conduit/root/generate/generate_test.go
@@ -1,0 +1,274 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	"github.com/conduitio/conduit/cmd/conduit/internal/generate/provider"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
+	"github.com/matryer/is"
+)
+
+const validPipeline = `version: "2.2"
+pipelines:
+  - id: orders-to-log
+    status: running
+    connectors:
+      - id: source
+        type: source
+        plugin: "builtin:generator"
+        settings:
+          format.type: structured
+      - id: destination
+        type: destination
+        plugin: "builtin:log"
+        settings:
+          level: info
+`
+
+// fakeProvider returns a scripted reply without touching the network.
+type fakeProvider struct {
+	reply string
+	seen  []provider.CompletionRequest
+}
+
+func (f *fakeProvider) Name() string { return "fake" }
+
+func (f *fakeProvider) Complete(_ context.Context, req provider.CompletionRequest) (provider.CompletionResult, error) {
+	f.seen = append(f.seen, req)
+	return provider.CompletionResult{Text: f.reply, TokensUsed: 11}, nil
+}
+
+// newTestCommand builds a Command wired to a fake provider and a fixed
+// environment, so nothing in these tests reads real env or dials anything.
+func newTestCommand(t *testing.T, prompt string, flags Flags, reply string) (*Command, *fakeProvider) {
+	t.Helper()
+	fake := &fakeProvider{reply: reply}
+	cmd := &Command{
+		args:  Args{Prompt: prompt},
+		flags: flags,
+		env: func(key string) string {
+			if key == provider.EnvAnthropicKey {
+				return "test-key"
+			}
+			return ""
+		},
+		newProvider: func(string, string, func(string) string) (provider.Provider, error) {
+			return fake, nil
+		},
+		// No Ollama probing: a developer who happens to be running Ollama
+		// locally would otherwise make these tests ambiguous-provider errors.
+		probe: func(string) bool { return false },
+	}
+	return cmd, fake
+}
+
+// The security boundary is the ABSENCE of a way to apply, so it is asserted
+// directly: a future flag that crosses it fails this test rather than quietly
+// shipping.
+func TestFlags_NoApplyPathExists(t *testing.T) {
+	is := is.New(t)
+	cmd := &Command{}
+
+	var names []string
+	for _, f := range cmd.Flags() {
+		names = append(names, f.Long)
+	}
+
+	for _, forbidden := range []string{"yes", "deploy", "apply", "force-deploy", "run"} {
+		is.True(!slices.Contains(names, forbidden))
+	}
+	slices.Sort(names)
+	is.Equal(names, []string{"force", "max-retries", "model", "no-color", "out", "provider"})
+}
+
+func TestArgs(t *testing.T) {
+	is := is.New(t)
+
+	is.True((&Command{}).Args(nil) != nil)                                 // none
+	is.True((&Command{}).Args([]string{"a", "b"}) != nil)                  // too many
+	is.NoErr((&Command{}).Args([]string{"read from postgres into kafka"})) // exactly one
+}
+
+func TestExecuteWithResult_WritesAValidatedPipeline(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	out := filepath.Join(dir, "orders.yaml")
+
+	cmd, fake := newTestCommand(t, "generator to log", Flags{Out: out, MaxRetries: 3}, validPipeline)
+
+	outcome, err := cmd.ExecuteWithResult(context.Background())
+	is.NoErr(err)
+	is.True(outcome.OK)
+
+	result := outcome.Result.(Result)
+	summary := outcome.Summary.(Summary)
+	is.Equal(result.Path, out)
+	is.Equal(summary.Attempts, 1)
+	is.Equal(summary.Connectors, 2)
+	is.Equal(summary.TokensUsed, 11)
+	is.Equal(len(fake.seen), 1)
+
+	written, err := os.ReadFile(out)
+	is.NoErr(err)
+	is.Equal(string(written), result.Pipeline)
+
+	info, err := os.Stat(out)
+	is.NoErr(err)
+	is.Equal(info.Mode().Perm(), os.FileMode(0o600))
+}
+
+// A model-chosen filename is confined to the working directory; a
+// user-supplied --out is taken as given. That asymmetry is the point.
+func TestModelDerivedName_CannotEscapeTheWorkingDirectory(t *testing.T) {
+	is := is.New(t)
+
+	for _, tc := range []struct {
+		id   string
+		want string
+	}{
+		{"orders", "orders.yaml"},
+		{"orders.yaml", "orders.yaml"},
+		{"orders.yml", "orders.yml"},
+		{"../../etc/passwd", "passwd.yaml"},
+		{"/etc/passwd", "passwd.yaml"},
+		{`..\..\windows\system32\config`, "config.yaml"},
+		{"..", DefaultOutName},
+		{"", DefaultOutName},
+		{"   ", DefaultOutName},
+		{"/", DefaultOutName},
+	} {
+		got := modelDerivedName(tc.id)
+		is.Equal(got, tc.want)
+		is.True(!strings.ContainsAny(got, `/\`)) // never a path, always a name
+	}
+}
+
+func TestResolveOutPath_UserFlagIsTakenAsGiven(t *testing.T) {
+	is := is.New(t)
+
+	is.Equal(resolveOutPath("/tmp/mine.yaml", "orders"), "/tmp/mine.yaml")
+	is.Equal(resolveOutPath("", "orders"), "orders.yaml")
+}
+
+// Overwriting is opt-in: a generated file landing on top of a hand-edited one
+// would destroy work the user cannot recover.
+func TestWriteCandidate_RefusesToClobberWithoutForce(t *testing.T) {
+	is := is.New(t)
+	path := filepath.Join(t.TempDir(), "p.yaml")
+	is.NoErr(os.WriteFile(path, []byte("original\n"), 0o600))
+
+	err := writeCandidate(path, "generated\n", false)
+	is.True(err != nil)
+	ce, ok := conduiterr.Get(err)
+	is.True(ok)
+	is.True(ce.Suggestion != "") // says how to proceed
+
+	kept, err := os.ReadFile(path)
+	is.NoErr(err)
+	is.Equal(string(kept), "original\n")
+
+	is.NoErr(writeCandidate(path, "generated\n", true))
+	replaced, err := os.ReadFile(path)
+	is.NoErr(err)
+	is.Equal(string(replaced), "generated\n")
+}
+
+// A candidate that never validates surfaces the generation loop's coded
+// error, and writes nothing.
+func TestExecuteWithResult_InvalidCandidate_WritesNothing(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	out := filepath.Join(dir, "orders.yaml")
+
+	const noPlugin = `version: "2.2"
+pipelines:
+  - id: broken
+    status: running
+    connectors:
+      - id: source
+        type: source
+`
+	cmd, _ := newTestCommand(t, "generator to log", Flags{Out: out, MaxRetries: 2}, noPlugin)
+
+	_, err := cmd.ExecuteWithResult(context.Background())
+	is.True(err != nil)
+	_, statErr := os.Stat(out)
+	is.True(os.IsNotExist(statErr))
+}
+
+func TestNewProvider_BuildsEachAdapterFromItsOwnEnvVar(t *testing.T) {
+	is := is.New(t)
+	env := func(key string) string {
+		switch key {
+		case provider.EnvAnthropicKey:
+			return "anthropic-key"
+		case provider.EnvOpenAIKey:
+			return "openai-key"
+		default:
+			return ""
+		}
+	}
+
+	a, err := newProvider(provider.NameAnthropic, "m", env)
+	is.NoErr(err)
+	is.Equal(a.(*provider.Anthropic).APIKey, "anthropic-key")
+
+	o, err := newProvider(provider.NameOpenAI, "m", env)
+	is.NoErr(err)
+	is.Equal(o.(*provider.OpenAI).APIKey, "openai-key")
+
+	// Ollama has no key and falls back to the documented default host.
+	l, err := newProvider(provider.NameOllama, "m", env)
+	is.NoErr(err)
+	is.Equal(l.(*provider.Ollama).Host, provider.DefaultOllamaHost)
+
+	_, err = newProvider("nope", "m", env)
+	is.True(err != nil)
+}
+
+// The rendered output shows the configuration, what is in it, and the same
+// next steps a hand-written pipeline takes — including repair.
+func TestRender_ShowsTheConfigurationAndTheNextSteps(t *testing.T) {
+	is := is.New(t)
+	cmd := &Command{}
+
+	out := cmd.Render(cecdysis.Outcome{
+		OK: true,
+		Summary: Summary{
+			Attempts: 1, MaxRetries: 3, Connectors: 2, Processors: 0, TokensUsed: 11,
+		},
+		Result: Result{
+			Provider: "anthropic", Model: "claude-sonnet-5",
+			Path: "orders.yaml", Pipeline: validPipeline,
+		},
+	})
+
+	is.True(strings.Contains(out, "builtin:generator"))
+	is.True(strings.Contains(out, "not deployed"))
+	// Asserted against the real list, not a copy of it: a step quietly
+	// dropped from nextSteps should fail this test, not pass a duplicate.
+	is.Equal(strings.Join(nextSteps, " -> "), "validate -> dry-run -> repair -> deploy")
+	for _, step := range nextSteps {
+		is.True(strings.Contains(out, "conduit pipelines "+step+" orders.yaml"))
+	}
+}

--- a/cmd/conduit/root/generate/outpath.go
+++ b/cmd/conduit/root/generate/outpath.go
@@ -1,0 +1,79 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// DefaultOutName is used when the candidate carries no usable pipeline id.
+const DefaultOutName = "pipeline.yaml"
+
+// modelDerivedName turns a model-chosen pipeline id into a filename that
+// cannot escape the working directory.
+//
+// This is a security boundary, not a formatting nicety, and it is independent
+// of the TTY/confirmation boundary: writing the candidate to disk needs no
+// confirmation at all, so a model-influenced string must never be
+// interpretable as a path. Design §5 states the rule; this is where it is
+// enforced.
+//
+// Everything up to the last separator is discarded (filepath.Base), and the
+// result is rejected if it is still relative-traversal or empty — belt and
+// braces, since Base already strips "..\..\etc" down to "etc" on the
+// platform's own separator but a caller reading this should not have to
+// reason about that to be sure.
+func modelDerivedName(pipelineID string) string {
+	name := strings.TrimSpace(pipelineID)
+	if name == "" {
+		return DefaultOutName
+	}
+
+	// Normalize both separators before taking the base: a model can emit a
+	// Windows-style path on Linux, where filepath.Base would keep the
+	// backslashes as part of the "name".
+	name = strings.ReplaceAll(name, "\\", "/")
+	name = path.Base(name)
+
+	switch name {
+	case "", ".", "..", string(filepath.Separator):
+		return DefaultOutName
+	}
+	if strings.Contains(name, "..") {
+		return DefaultOutName
+	}
+
+	if !strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml") {
+		name += ".yaml"
+	}
+	return name
+}
+
+// resolveOutPath decides where a generated pipeline is written.
+//
+// An explicit --out is taken as given: the USER chose it, not the model, so it
+// is treated like any other CLI file argument (resolved relative to the
+// working directory, allowed to point wherever the user can write). A path
+// derived from the model's pipeline id is confined to a bare basename in the
+// working directory. That asymmetry is deliberate and is the whole point of
+// the split.
+func resolveOutPath(outFlag, pipelineID string) string {
+	if strings.TrimSpace(outFlag) != "" {
+		return outFlag
+	}
+	return modelDerivedName(pipelineID)
+}

--- a/cmd/conduit/root/root.go
+++ b/cmd/conduit/root/root.go
@@ -23,6 +23,7 @@ import (
 	"github.com/conduitio/conduit/cmd/conduit/root/connectors"
 	"github.com/conduitio/conduit/cmd/conduit/root/docs"
 	"github.com/conduitio/conduit/cmd/conduit/root/doctor"
+	"github.com/conduitio/conduit/cmd/conduit/root/generate"
 	"github.com/conduitio/conduit/cmd/conduit/root/initialize"
 	"github.com/conduitio/conduit/cmd/conduit/root/mcp"
 	"github.com/conduitio/conduit/cmd/conduit/root/open"
@@ -98,6 +99,7 @@ func (c *RootCommand) SubCommands() []ecdysis.Command {
 		&doctor.DoctorCommand{},
 		&doctor.PluginSpecCheckCommand{},
 		&docs.DocsCommand{},
+		&generate.Command{},
 		&initialize.InitCommand{Cfg: &runCmd.Cfg},
 		&mcp.MCPCommand{},
 		&open.OpenCommand{},


### PR DESCRIPTION
The command itself. Fourth and last slice of the `conduit generate` core (after #2772 seams, #2775 adapters + loop, #2790 semantic gate).

```
conduit generate "read from postgres and write new rows to s3 as json"
```

## The boundary is an absence

There is no `--yes`, no `--deploy`, no `--apply`. Generation cannot cross into deployment because **no flag exists that would let it** — not because a prompt asks first, which is something a script answers. Deploying a generated pipeline is the same explicit `conduit pipelines deploy` step a hand-written one needs, and the footer says so, listing `validate → dry-run → repair → deploy` in the order a user walks them.

`TestFlags_NoApplyPathExists` asserts the exact flag set, because a boundary enforced by an absence needs a test that notices when the absence ends.

## Path safety

A model-derived filename is confined to a bare basename in the working directory: separators normalized (a model can emit `..\..\windows\...` on Linux, where `filepath.Base` keeps the backslashes), base taken, traversal and empties rejected. An explicit `--out` is taken as given — the *user* chose it.

That asymmetry is deliberate, and it is independent of any confirmation flow: writing a file needs no TTY, so the path rule cannot lean on one. Output is `0600`, matching `pipelines init`, since a generated config usually carries a connection string the user is about to fill in. Nothing is overwritten without `--force`.

## `--json`

Rides the shared `cecdysis` envelope, so `cmd/conduit/cli`'s schema-golden test classified this as Family A the moment it registered — no new schema, no new marshalling path, no edit to that test.

## Not in this slice — named, not implied

- **`rationale` / `assumptions[]` in `--json`** (design §6). They need the model to return structured output alongside the config: a prompt-contract change, not a rendering one.
- **The interactive dry-run + confirm-deploy step** of design §4's TTY flow. What ships here is strictly *more* conservative: it never deploys at all.
- **`generate.provider` from conduit.yaml.** Resolution honors `--provider` and the environment; the config source is plumbing this command doesn't have yet.

## Adversarial self-review

1. **A test failed because the command made a real network call.** Auto-detection probes for a local Ollama server, and I'd hardcoded the real probe — so on a machine running Ollama (mine), `TestExecuteWithResult` got `ambiguous provider: anthropic, ollama`. Whether a developer happens to have Ollama running would have decided whether the suite passed. The probe is now a seam, the same reason `provider.Probe` is one. The failure was the test doing its job.
2. **`goconst` pushed the render assertion somewhere better.** The test now asserts against the real `nextSteps` list rather than a copy, so a step quietly dropped from the footer fails the test instead of passing a duplicate.
3. **The file-exists case uses foundational `CodeInvalidArgument`, not a new `generate.destination_exists`.** Design §8's taxonomy is a frozen contract that lists no code for it, and the provider package took exactly this decision for its unknown-provider case. Inventing an unlisted `generate.*` code would extend a public contract outside the document that defines it. Flagged for your call if you'd rather add it to §8.
4. **Considered: running the full dry-run engine in the preview.** Skipped — `Enriched` output would show worker counts and injected DLQ defaults, which is real value, but it belongs with the confirm-deploy flow in the next slice rather than half-shipped here.

## Tests

`go test ./cmd/...` green, `golangci-lint` (CI-exact v2.12.2) clean, `make generate` produces no diff. No test touches the network, real environment variables, or a real provider.

## Risk tier

**Tier 2.** Emits a file behind an explicit gate; no data-path code, no acks, positions, or state.

Roadmap: v0.20 WS1 (`conduit generate`), slice A2c.
