### PR TITLE
docs(design): amend generate §8 with generate.destination_exists

### DIFF
--- a/docs/design-documents/20260722-conduit-generate.md
+++ b/docs/design-documents/20260722-conduit-generate.md
@@ -612,11 +612,41 @@ New codes, registered the existing way (`conduiterr.Register`, one `codes.go` in
 | `generate.parse_failed` | `Internal` | 1 (runtime) | The provider replied, but the response could not be parsed into a pipeline config after retries — an unclassified failure of the boundary, not a bad user request. |
 | `generate.validate_failed` | `FailedPrecondition` | 2 | The parsed candidate never passed `validate` within `--max-retries` attempts. The **last** attempt's `validate.Report` is attached in full (never discarded). |
 | `generate.semantic_mismatch` | `FailedPrecondition` | 2 | The candidate passed `validate` but failed the semantic-intent checker (§4 of the generation pipeline, e.g. wrong direction, a clearly-requested connector/filter missing) within the retry budget. |
+| `generate.destination_exists` | `AlreadyExists` | 2 | The resolved output path already exists and `--force` was not passed. Added by amendment (see below); the `Suggestion` names `--force` and `--out`. |
 
 Exit codes fall out of the existing classifier (`fromGRPCCode`, `pkg/conduit/exitcode/exitcode.go`)
 verbatim — no new bucket, no new mapping logic, matching CLAUDE.md's "errors are API" and the
 existing convention that every code carries a stable reason, a gRPC category, and (via
 `Suggestion`) an actionable fix.
+
+#### Amendment 2026-08-21: `generate.destination_exists`
+
+The taxonomy above was written before the command existed and did not cover its one filesystem
+failure: the output path already exists and `--force` was not passed. The implementation
+(#2791) shipped it as the foundational `common.invalid_argument`, deliberately, because this
+document is a frozen contract and inventing an unlisted `generate.*` code inside an
+implementation PR would extend a public contract outside the document that defines it. This
+amendment adds the code so that decision can be reversed the right way round.
+
+**Why a dedicated code rather than keeping `common.invalid_argument`.** Errors are API, and the
+consumer here is frequently an agent. `common.invalid_argument` on "that file already exists" is
+indistinguishable from "you passed a bad `--provider`" — one is fixed by re-running with
+`--force` or a different `--out`, the other by changing the request. A caller that cannot tell
+those apart from the code alone has to parse the message, which is exactly what stable codes
+exist to prevent.
+
+**Why not a shared `common.destination_exists`.** The tree already carries two domain-scoped
+versions of this idea — `pipelines.init_destination_exists` and `pkg/scaffold`'s
+`CodeDestinationExists` for connector/processor scaffolding. Unifying all three would deprecate
+two shipped codes (announce → warn → remove, minimum two minor versions) for no consumer
+benefit, since a caller already branches per command. A third domain-scoped code is consistent
+with a pattern this repo set twice.
+
+**Compatibility.** `codes.AlreadyExists` lands in the same `Validation` bucket as
+`InvalidArgument` (`pkg/conduit/exitcode/exitcode.go`, `fromGRPCCode`), so the process exit code
+for this case stays **2**. Nothing that branches on the exit code changes; only the reason string
+a machine reads becomes more specific. That makes this an additive change to the error contract,
+not a breaking one.
 
 ### 9. Semantic-intent checking — deterministic heuristics, not an LLM judge
 


### PR DESCRIPTION
Doc half of the fix you approved. Code follows in its own PR; this lands first because §8 is a frozen contract and the whole point is not to extend a public contract from inside an implementation PR.

## What was wrong

`conduit generate` (#2791) has one filesystem failure the taxonomy never covered: the output path exists and `--force` wasn't passed. It shipped as foundational `common.invalid_argument` — defensible, and deliberately flagged at the time, but weak on the principle that matters.

**Errors are API, and the consumer here is frequently an agent.** `common.invalid_argument` on *"that file already exists"* is indistinguishable from *"you passed a bad `--provider`"*. One is fixed by re-running with `--force` or a different `--out`; the other by changing the request. A caller that can't tell them apart from the code has to parse the message — exactly what stable codes exist to prevent.

## Why a dedicated code, not a shared one

The tree already carries two domain-scoped versions of this idea: `pipelines.init_destination_exists` and `pkg/scaffold`'s `CodeDestinationExists`. Unifying all three into a `common.destination_exists` would deprecate two shipped public codes (announce → warn → remove, two minor versions minimum) for no consumer benefit, since callers already branch per command. A third domain-scoped code follows a pattern this repo set twice.

## Compatibility

`codes.AlreadyExists` lands in the same `Validation` bucket as `InvalidArgument` (`exitcode.go`, `fromGRPCCode`), so this case still exits **2**. Nothing branching on exit codes changes; only the reason string gets more specific. Additive, not breaking.

## Risk tier

**Tier 3** — design-document amendment, no code. The implementation PR that consumes it is Tier 2.

Roadmap: v0.20 WS1 (`conduit generate`).
