### PR TITLE
feat(generate): give the file-exists case its own error code

### DIFF
--- a/cmd/conduit/internal/generate/codes.go
+++ b/cmd/conduit/internal/generate/codes.go
@@ -61,4 +61,20 @@ var (
 	// which reads intent far better than a keyword table, and the result is
 	// judged the normal way.
 	CodeAmbiguousPrompt = conduiterr.Register("generate.ambiguous_prompt", codes.InvalidArgument)
+
+	// CodeDestinationExists: the resolved output path already exists and
+	// --force was not passed (design §8, amended 2026-08-21).
+	//
+	// It is a code of its own rather than the foundational
+	// common.invalid_argument because the consumer is frequently an agent, and
+	// "that file already exists" is fixed by re-running with --force or a
+	// different --out, while a generic invalid-argument is fixed by changing
+	// the request. A caller that cannot tell those apart from the code has to
+	// parse the message.
+	//
+	// AlreadyExists shares the Validation exit bucket with InvalidArgument
+	// (pkg/conduit/exitcode, fromGRPCCode), so this is additive: the process
+	// still exits 2, only the reason string a machine reads gets more
+	// specific.
+	CodeDestinationExists = conduiterr.Register("generate.destination_exists", codes.AlreadyExists)
 )

--- a/cmd/conduit/root/generate/generate.go
+++ b/cmd/conduit/root/generate/generate.go
@@ -276,13 +276,12 @@ func writeCandidate(path, candidate string, force bool) error {
 	f, err := os.OpenFile(path, flags, 0o600)
 	if err != nil {
 		if os.IsExist(err) {
-			// Deliberately a FOUNDATIONAL code rather than a new
-			// generate.destination_exists: design §8's taxonomy is a frozen
-			// contract that does not list one for this case, and the provider
-			// package took the same decision for its unknown-provider case
-			// (codeUnknownProvider). If a dedicated code is wanted it belongs
-			// in §8 first, then here.
-			e := conduiterr.Wrap(conduiterr.CodeInvalidArgument,
+			// gen.CodeDestinationExists, not the foundational
+			// common.invalid_argument: an agent can act on "the file is in the
+			// way" (retry with --force or --out) but not on a generic invalid
+			// argument. Added to design §8 by amendment BEFORE this code — the
+			// taxonomy is a public contract, so it moves first.
+			e := conduiterr.Wrap(gen.CodeDestinationExists,
 				fmt.Sprintf("%s already exists", path), err)
 			e.Suggestion = "pass --force to overwrite it, or --out to write somewhere else"
 			return e

--- a/cmd/conduit/root/generate/generate_test.go
+++ b/cmd/conduit/root/generate/generate_test.go
@@ -23,7 +23,9 @@ import (
 	"testing"
 
 	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
+	gen "github.com/conduitio/conduit/cmd/conduit/internal/generate"
 	"github.com/conduitio/conduit/cmd/conduit/internal/generate/provider"
+	"github.com/conduitio/conduit/pkg/conduit/exitcode"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/matryer/is"
 )
@@ -182,6 +184,16 @@ func TestWriteCandidate_RefusesToClobberWithoutForce(t *testing.T) {
 	ce, ok := conduiterr.Get(err)
 	is.True(ok)
 	is.True(ce.Suggestion != "") // says how to proceed
+
+	// The code is specific enough for a caller to act on WITHOUT reading the
+	// message: "the file is in the way" (retry with --force or --out) is a
+	// different fix from a generic invalid argument, which is why this is its
+	// own code (design §8, amended).
+	is.Equal(ce.Code, gen.CodeDestinationExists)
+	// Additive, not breaking: AlreadyExists shares the Validation bucket with
+	// InvalidArgument, so this case still exits 2 exactly as it did before the
+	// code became specific.
+	is.Equal(exitcode.ExitCode(err), exitcode.Validation)
 
 	kept, err := os.ReadFile(path)
 	is.NoErr(err)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -614,7 +614,7 @@ Author: Meroxa, Inc.
 | `sdk.schema.extract.key.enabled` | bool | true | no | Whether to extract and decode the record key with a schema. |  |
 | `sdk.schema.extract.payload.enabled` | bool | true | no | Whether to extract and decode the record payload with a schema. |  |
 
-## 3. Error codes (101)
+## 3. Error codes (102)
 
 | Reason | gRPC status | Description |
 | --- | --- | --- |
@@ -635,6 +635,7 @@ Author: Meroxa, Inc.
 | `connector.running` | FailedPrecondition | CodeConnectorRunning is raised when an operation requires the connector to not be running, but a connector instance for it already exists. |
 | `generate.ambiguous_prompt` | InvalidArgument | CodeAmbiguousPrompt: the request could not be pinned to a pipeline.  Raised in two places, deliberately conservative pre-call (design §9): before any provider call ONLY when the prompt is empty or names one role for two different connectors; otherwise post-hoc, when a candidate's connectors cannot be traced to anything the request actually said. A merely terse request is never refused pre-call — it goes to the model, which reads intent far better than a keyword table, and the result is judged the normal way. |
 | `generate.ambiguous_provider_configuration` | InvalidArgument | CodeAmbiguousProvider: more than one candidate and no explicit choice. This is an error rather than a pick — see the package doc. |
+| `generate.destination_exists` | AlreadyExists | CodeDestinationExists: the resolved output path already exists and --force was not passed (design §8, amended 2026-08-21).  It is a code of its own rather than the foundational common.invalid_argument because the consumer is frequently an agent, and "that file already exists" is fixed by re-running with --force or a different --out, while a generic invalid-argument is fixed by changing the request. A caller that cannot tell those apart from the code has to parse the message.  AlreadyExists shares the Validation exit bucket with InvalidArgument (pkg/conduit/exitcode, fromGRPCCode), so this is additive: the process still exits 2, only the reason string a machine reads gets more specific. |
 | `generate.no_provider_configured` | Unauthenticated | CodeNoProviderConfigured: zero resolvable candidates. Unauthenticated (exit 3, environment) rather than InvalidArgument, because the user's command was fine — their environment is not. |
 | `generate.parse_failed` | Internal | CodeParseFailed: the provider replied, but nothing in the reply could be read as a pipeline config within the retry budget. Internal (exit 1, runtime) rather than InvalidArgument, because the user's request was well-formed — the boundary failed, not their input. |
 | `generate.provider_error` | Unavailable | CodeProviderError covers every way the provider call itself failed: network, timeout, rate limit, or an auth rejection from the provider. Unavailable (exit 3, environment) because the user's command was fine. |

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@
 (6 built-in connectors; full parameters in llms-full.txt)
 
 ## Error codes
-- 101 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
+- 102 stable error codes, dotted `domain.name` reasons, each with a gRPC status class. Full list with descriptions in llms-full.txt.
 
 ## MCP tools
 - Read: deploy, doctor, dry_run, inspect, lint, repair, validate


### PR DESCRIPTION
Code half of #2798, which amends design §8 with this code. The doc moves first because §8 is a public contract; this PR is the mechanical consequence.

`conduit generate` refusing to overwrite an existing file now raises `generate.destination_exists` instead of foundational `common.invalid_argument`.

## Why

The consumer is frequently an agent. *"That file already exists"* needs a different next action — retry with `--force`, or pick another `--out` — than a generic invalid argument, which means "change the request". With one code covering both, a caller has to parse the message to tell them apart. That's precisely what stable codes exist to prevent.

## Additive, not breaking

`codes.AlreadyExists` shares the `Validation` bucket with `InvalidArgument`, so the process still exits **2**. The test asserts **both** the code and the exit bucket, so a future re-classification that changed the exit code fails the test rather than silently altering a documented contract.

## Tests

`go test ./cmd/...` green, `golangci-lint` (CI-exact v2.12.2) clean. `llms.txt`/`llms-full.txt` regenerated — the new code appears in the shipped error reference with its real description, and `TestAllCodesComplete` confirms the barrel already covers this package.

## Risk tier

**Tier 2.** Error-code change on a non-data-path CLI surface; no acks, positions, or state touched.

Roadmap: v0.20 WS1 (`conduit generate`).
