### PR TITLE
docs(roadmap): state what the template gallery ships, and the registry freshness gap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -133,14 +133,23 @@ and for their agents._
 ### Connector registry
 
 - [x] Public registry (signed): `conduit connectors install`/`uninstall`/`audit`/`bundle` — shipped
-      in v0.18 with a signed registry and seed connectors; issue #2625 should close
+      in v0.18 with a signed registry and seed connectors; issue #2625 should close.
+      **Operational note (2026-08-21):** the published index must be re-signed inside the client's
+      7-day freshness window or every `install` fails with `registry.index_stale`. Nothing re-signed
+      it unattended, so installs are refusing today — the heartbeat and a 72-hour staleness alarm are
+      in `conduit-connector-registry#28`
 - [ ] Community publishing via GitHub Action + signing
 - [ ] Registry web UI with search, verified badges, download stats
 
 ### Templates
 
-- [ ] Template gallery shipped with the registry: `postgres-iceberg`, `mysql-snowflake`,
-      `postgres-pgvector-rag`, `shopify-warehouse`, `kafka-clickhouse`, and more
+- [ ] Template gallery shipped with the registry — _partial_: `conduit pipelines init --template`
+      ships five templates (`generator-log`, `generator-file`, `postgres-s3`, `postgres-cdc-kafka`,
+      `postgres-pgvector-rag`). Of the templates named when this line was written, only
+      `postgres-pgvector-rag` exists; `postgres-iceberg`, `mysql-snowflake`, `shopify-warehouse` and
+      `kafka-clickhouse` are still outstanding, and Iceberg is itself a Phase-2 item below.
+      `postgres-pgvector-rag` also depends on `conduit connectors install pgvector`, which needs a
+      registry index inside its freshness window — see the note under _Public registry_
 - [ ] Community-contributed templates with the same publishing flow as connectors
 
 ### Deployment fundamentals (12-factor citizenship — the universal answer)


### PR DESCRIPTION
Two ROADMAP lines were misleading in opposite directions. Both verified against the tree and the real binary before changing.

## The template gallery line understated

It named five templates and left the box unchecked, which reads as "none of this exists". Five templates **do** ship — `generator-log`, `generator-file`, `postgres-s3`, `postgres-cdc-kafka`, `postgres-pgvector-rag` — but only one of them is among the five the line names. The box stays unchecked, because four named templates genuinely are outstanding; the line now says which ones, instead of hiding a shipped gallery behind an empty checkbox.

## The registry line overstated

It's checked off as shipped in v0.18 and says nothing about the operational requirement that makes it work: the published index must be re-signed inside the client's 7-day freshness window, or every install fails.

Nothing re-signs it unattended, so **installs are refusing right now**:

```
$ conduit connectors install pgvector
[FAIL] registry.index_stale
    index timestamp 2026-08-03T19:39:58Z is older than the max staleness window of 168h0m0s
```

That's the real binary against the live index, not an inference. It also means the RAG template's own documented prerequisite (`conduit connectors install pgvector`) cannot currently be run — so the v0.20 AI story has a broken first step until the index is re-signed.

The fix is open as `conduit-connector-registry#28` (daily freshness heartbeat + a 72-hour staleness alarm, so this stops being invisible). Clearing the *current* staleness needs a maintainer to dispatch `index-sign.yml` with `role: freshness`, because the signing key sits behind a required-reviewers environment gate.

## Why bother

This is the document a release gets planned against. Both lines would have led someone to the wrong conclusion about what's done — one pessimistically, one optimistically, and the optimistic one is currently hiding a broken user-facing command.

## Risk tier

**Tier 3.** Documentation only.
