### PR TITLE
fix(generate): make the eval harness measure the gate the command actually ships (WS1 A5a-1)

### DIFF
--- a/cmd/conduit/internal/generate/doc.go
+++ b/cmd/conduit/internal/generate/doc.go
@@ -36,14 +36,14 @@
 //     package's own tests today), ScoreRun/ScoreMedian report TWO separate
 //     numbers, never collapsed into one:
 //
-//     1. Validate-pass rate — does the candidate pass the exact
-//     cmd/conduit/internal/validate engine `conduit pipelines validate`
-//     uses. Because that engine only exposes a path-based Run (there is no
-//     RunBytes/RunReader in-memory seam yet — the design doc's Decision §3
-//     names this exact gap and its two resolutions), this package uses the
-//     documented fallback: a private (0600) temp file, validated, then
-//     removed (validateCandidate in validate_score.go). The day RunBytes
-//     lands, this is the only function that needs to change.
+//     1. Validate-pass rate — does the candidate pass validate.RunBytes with
+//     the SAME Options `conduit generate` itself gates a candidate through
+//     (ResolvePlugins on, the builtin connector/processor sets —
+//     candidateValidateOptions in generate.go), entirely in memory
+//     (validateCandidate in validate_score.go). This is the in-memory seam
+//     the design doc's Decision §3 names as preferred over a temp-file
+//     shim (cmd/conduit/internal/validate/engine.go:129); the package now
+//     touches no disk anywhere.
 //
 //     2. Semantic-intent-match rate — does the candidate's actual source/
 //     destination connector category and processor set match the

--- a/cmd/conduit/internal/generate/grounding.go
+++ b/cmd/conduit/internal/generate/grounding.go
@@ -15,6 +15,8 @@
 package generate
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"path"
 	"sort"
@@ -93,6 +95,74 @@ func BuiltinCatalog() []ConnectorInfo {
 
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out
+}
+
+// CatalogFingerprint returns a stable hash over BuiltinCatalog()'s SEMANTIC
+// grounding identity: the sorted (connector, role, paramKey, required)
+// tuples only — deliberately blind to descriptions and defaults, which can
+// be reworded or retuned without changing what a candidate must satisfy to
+// be grounded correctly.
+//
+// It hashes BuiltinCatalog()'s own output rather than re-reading
+// builtin.DefaultBuiltinConnectors a second time, so it can never drift from
+// the prompt it fingerprints: whatever catalog BuildSystemPrompt actually
+// grounded the model on (including MaxOptionalParamsPerRole's cap — an
+// optional parameter beyond the cap was never in the prompt, so it has no
+// business moving this fingerprint) is exactly the catalog fingerprinted
+// here.
+//
+// Purpose: a committed provider transcript records this fingerprint
+// alongside its prompt and output. A later build recomputes
+// CatalogFingerprint() and compares: unequal means a connector's
+// required/optional PARAMETER SET has actually moved and the transcript's
+// grounding is semantically stale against this binary — distinct from a
+// changed description or default, which leaves the fingerprint (and the
+// transcript's validity) untouched.
+func CatalogFingerprint() string {
+	return fingerprintCatalog(BuiltinCatalog())
+}
+
+// fingerprintCatalog is CatalogFingerprint's pure core, taking a catalog
+// directly rather than reading BuiltinCatalog() itself, so it can be
+// exercised in tests against a synthetic catalog without depending on (or
+// being broken by changes to) the real builtin connector registry.
+func fingerprintCatalog(cat []ConnectorInfo) string {
+	type tuple struct {
+		connector string
+		role      string
+		paramKey  string
+		required  bool
+	}
+
+	var tuples []tuple
+	for _, c := range cat {
+		for _, p := range c.SourceParams {
+			tuples = append(tuples, tuple{c.Name, "source", p.Key, p.Required})
+		}
+		for _, p := range c.DestinationParams {
+			tuples = append(tuples, tuple{c.Name, "destination", p.Key, p.Required})
+		}
+	}
+
+	// Deterministic order independent of the catalog's own (already-sorted,
+	// but not a contract this function should rely on) input ordering — the
+	// fingerprint must be stable no matter what order the caller's slice
+	// happens to be in.
+	sort.Slice(tuples, func(i, j int) bool {
+		if tuples[i].connector != tuples[j].connector {
+			return tuples[i].connector < tuples[j].connector
+		}
+		if tuples[i].role != tuples[j].role {
+			return tuples[i].role < tuples[j].role
+		}
+		return tuples[i].paramKey < tuples[j].paramKey
+	})
+
+	h := sha256.New()
+	for _, t := range tuples {
+		fmt.Fprintf(h, "%s|%s|%s|%t\n", t.connector, t.role, t.paramKey, t.required)
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // BuiltinConnectorRefs returns every resolvable builtin connector reference —

--- a/cmd/conduit/internal/generate/grounding_test.go
+++ b/cmd/conduit/internal/generate/grounding_test.go
@@ -109,3 +109,63 @@ func TestBuiltinProcessorRefs_NonEmpty(t *testing.T) {
 
 	is.True(len(BuiltinProcessorRefs()) > 0)
 }
+
+// --- CatalogFingerprint ---
+
+func TestCatalogFingerprint_StableAcrossRepeatedCalls(t *testing.T) {
+	is := is.New(t)
+
+	first := CatalogFingerprint()
+	is.True(first != "")
+	for range 5 {
+		is.Equal(CatalogFingerprint(), first)
+	}
+}
+
+// A synthetic catalog exercises fingerprintCatalog directly — a committed
+// transcript's fingerprint must move when a connector's REQUIRED parameter
+// set actually changes, since that's exactly the case where a previously
+// generated candidate could stop being groundable the same way.
+func TestFingerprintCatalog_ChangesWhenARequiredParamIsAdded(t *testing.T) {
+	is := is.New(t)
+
+	before := []ConnectorInfo{{
+		Name:         "synthetic",
+		Summary:      "a synthetic connector for this test",
+		SourceParams: []ParamInfo{{Key: "host", Type: "string", Required: true}},
+	}}
+	after := []ConnectorInfo{{
+		Name:    "synthetic",
+		Summary: "a synthetic connector for this test",
+		SourceParams: []ParamInfo{
+			{Key: "host", Type: "string", Required: true},
+			{Key: "port", Type: "int", Required: true},
+		},
+	}}
+
+	is.True(fingerprintCatalog(before) != fingerprintCatalog(after))
+}
+
+// Rewording a description, or changing a default, must NOT move the
+// fingerprint — those are exactly the changes CatalogFingerprint is
+// deliberately blind to, so a transcript isn't flagged stale over prose.
+func TestFingerprintCatalog_UnchangedWhenOnlyDescriptionOrDefaultChanges(t *testing.T) {
+	is := is.New(t)
+
+	before := []ConnectorInfo{{
+		Name:    "synthetic",
+		Summary: "original summary",
+		SourceParams: []ParamInfo{
+			{Key: "host", Type: "string", Required: true, Description: "original description", Default: ""},
+		},
+	}}
+	after := []ConnectorInfo{{
+		Name:    "synthetic",
+		Summary: "a completely reworded summary that says something else",
+		SourceParams: []ParamInfo{
+			{Key: "host", Type: "string", Required: true, Description: "a totally different description", Default: "localhost"},
+		},
+	}}
+
+	is.Equal(fingerprintCatalog(before), fingerprintCatalog(after))
+}

--- a/cmd/conduit/internal/generate/provider/adapters_test.go
+++ b/cmd/conduit/internal/generate/provider/adapters_test.go
@@ -282,6 +282,63 @@ func Test_Adapters_RequestModelOverridesAdapterDefault(t *testing.T) {
 	is.Equal(sent.Model, "from-request")
 }
 
+// Test_DefaultMaxTokens_AbsorbsThinkingNotJustOutput pins the actual value,
+// not just that SOME constant is wired through (Test_Adapters_
+// MaxTokensPassedThrough below covers wiring). A generated pipeline config
+// is small — around 350 tokens for a typical candidate in this package's own
+// corpus — so 4096 looks generous for the OUTPUT alone; it is not generous
+// for output PLUS an adaptive/extended think a model can run by default when
+// the request sets no explicit thinking budget (Anthropic's Sonnet 5,
+// DefaultAnthropicModel, shares one max_tokens budget across both). This
+// test fails if the ceiling regresses back toward a value sized for the
+// config text alone.
+func Test_DefaultMaxTokens_AbsorbsThinkingNotJustOutput(t *testing.T) {
+	is := is.New(t)
+	is.Equal(DefaultMaxTokens, 16384)
+}
+
+// Test_Adapters_MaxTokensPassedThrough pins that DefaultMaxTokens actually
+// reaches the request body, for every adapter that has a max-tokens field to
+// set. On a model that runs adaptive/extended thinking by default when the
+// request doesn't set an explicit thinking budget (e.g. Anthropic's Sonnet 5,
+// DefaultAnthropicModel — see DefaultMaxTokens' doc comment), max_tokens caps
+// thinking AND response text together: a ceiling too small for that silently
+// truncates the generated YAML mid-document rather than failing loudly, which
+// is exactly the invisible-truncation bug this constant's value guards
+// against. A regression that drops the field, hardcodes a smaller value, or
+// forgets to wire DefaultMaxTokens into a new adapter's request must fail
+// this test.
+func Test_Adapters_MaxTokensPassedThrough(t *testing.T) {
+	t.Parallel()
+
+	t.Run("anthropic", func(t *testing.T) {
+		is := is.New(t)
+		srv := newCapturing(t, 200, anthropicOK)
+		_, err := (&Anthropic{BaseURL: srv.URL}).Complete(context.Background(), CompletionRequest{Prompt: "x"})
+		is.NoErr(err)
+
+		var sent anthropicRequest
+		is.NoErr(json.Unmarshal(srv.body, &sent))
+		is.Equal(sent.MaxTokens, DefaultMaxTokens)
+	})
+
+	t.Run("openai", func(t *testing.T) {
+		is := is.New(t)
+		srv := newCapturing(t, 200, openAIOK)
+		_, err := (&OpenAI{BaseURL: srv.URL}).Complete(context.Background(), CompletionRequest{Prompt: "x"})
+		is.NoErr(err)
+
+		// Decode just the field this test cares about rather than importing
+		// go-openai's own request struct here — this test asserts what's on
+		// the wire, not the SDK's shape.
+		var sent struct {
+			MaxTokens int `json:"max_tokens"`
+		}
+		is.NoErr(json.Unmarshal(srv.body, &sent))
+		is.Equal(sent.MaxTokens, DefaultMaxTokens)
+	})
+}
+
 // Test_Reachable pins the auto-detection probe, including that it does NOT
 // require a loaded model: a reachable server with no model is still a
 // candidate, and the completion call reports the missing model with a message

--- a/cmd/conduit/internal/generate/provider/http.go
+++ b/cmd/conduit/internal/generate/provider/http.go
@@ -37,10 +37,22 @@ var CodeProviderError = conduiterr.Register("generate.provider_error", codes.Una
 // retry loop applies this per ATTEMPT, not to the whole budget.
 const DefaultTimeout = 60 * time.Second
 
-// DefaultMaxTokens bounds the response. A pipeline config is small; the only
-// thing a larger ceiling buys is a bigger bill when a model decides to
-// narrate.
-const DefaultMaxTokens = 4096
+// DefaultMaxTokens bounds the response.
+//
+// A generated pipeline config is small — around 350 tokens for a typical
+// candidate in this package's own corpus — so the ceiling is not sized for
+// the OUTPUT. It exists to absorb THINKING: on a model that runs extended or
+// adaptive reasoning by default when the request omits an explicit thinking
+// budget (e.g. Anthropic's Sonnet 5, DefaultAnthropicModel), max_tokens caps
+// thinking output and response text TOGETHER, sharing one budget. A ceiling
+// sized only for the ~350-token config truncates the model mid-think,
+// mid-YAML — and extractCandidate deliberately tolerates an unterminated
+// fence and hands the partial config to the validator, so the truncation
+// never surfaces as "the model ran out of budget": it looks like an ordinary
+// validation failure, burns a retry, and (in an eval transcript) reads as
+// model error. 16384 is sized to comfortably absorb a normal think for a
+// request this small while still bounding a genuinely wedged/looping model.
+const DefaultMaxTokens = 16384
 
 // Doer is the HTTP seam, matching the two-method shape the `ollama` built-in
 // processor already uses (pkg/plugin/processor/builtin/impl/ollama). Copying

--- a/cmd/conduit/internal/generate/score.go
+++ b/cmd/conduit/internal/generate/score.go
@@ -38,12 +38,6 @@ type Result struct {
 
 	ValidatePass   bool
 	ValidateReport validate.Report
-	// ValidateErr is non-nil only when validateCandidate itself could not
-	// run (e.g. a temp-file I/O failure) — distinct from the candidate
-	// simply failing validation, which shows up as findings inside
-	// ValidateReport with ValidatePass false and ValidateErr nil.
-	ValidateErr error
-
 	SemanticMatch  bool
 	SemanticIssues []string
 }
@@ -75,10 +69,9 @@ func ScoreRun(ctx context.Context, requests []Request, candidates Candidates) Ru
 			res.Missing = true
 			res.SemanticIssues = []string{"no candidate provided for this request"}
 		} else {
-			report, err := validateCandidate(ctx, candidate)
+			report := validateCandidate(ctx, candidate)
 			res.ValidateReport = report
-			res.ValidateErr = err
-			res.ValidatePass = err == nil && report.OK()
+			res.ValidatePass = report.OK()
 
 			sem := scoreSemantic(ctx, req.Expect, candidate)
 			res.SemanticMatch = sem.Match

--- a/cmd/conduit/internal/generate/score_test.go
+++ b/cmd/conduit/internal/generate/score_test.go
@@ -126,17 +126,23 @@ func TestValidateCandidate_GoodCandidate_Passes(t *testing.T) {
 	is := is.New(t)
 
 	candidate := mustReadCandidate(t, "postgres-cdc-to-kafka-filtered-good.yaml")
-	report, err := validateCandidate(context.Background(), candidate)
-	is.NoErr(err)
+	report := validateCandidate(context.Background(), candidate)
 	is.True(report.OK())
+
+	// F2 regression: findings label with the stable InMemoryCandidateName,
+	// never a filesystem path. The prior temp-file shim labeled every
+	// finding with a randomized scratch-file path, which made PR-CI eval
+	// output non-deterministic byte-for-byte across runs — this package
+	// must never touch disk again (see doc.go).
+	is.Equal(len(report.Files), 1)
+	is.Equal(report.Files[0].Path, InMemoryCandidateName)
 }
 
 func TestValidateCandidate_BadSchema_Fails(t *testing.T) {
 	is := is.New(t)
 
 	candidate := mustReadCandidate(t, "postgres-cdc-to-kafka-filtered-bad-schema.yaml")
-	report, err := validateCandidate(context.Background(), candidate)
-	is.NoErr(err) // validateCandidate itself succeeds; the CANDIDATE fails validation
+	report := validateCandidate(context.Background(), candidate)
 	is.True(!report.OK())
 	is.True(report.Summary.Errors > 0)
 }
@@ -149,9 +155,28 @@ func TestValidateCandidate_WrongConnectorButValid_Passes(t *testing.T) {
 	is := is.New(t)
 
 	candidate := mustReadCandidate(t, "kafka-to-postgres-sync-bad-wrong-connector.yaml")
-	report, err := validateCandidate(context.Background(), candidate)
-	is.NoErr(err)
+	report := validateCandidate(context.Background(), candidate)
 	is.True(report.OK())
+}
+
+// F1 regression: this harness must measure the SAME gate `conduit generate`
+// ships with, never a weaker one. The candidate's source plugin
+// ("builtin:postgre", a plausible typo of "builtin:postgres") is
+// schema-valid on its own — nothing about its shape is wrong — so it only
+// fails when ResolvePlugins is on and checked against the real builtin
+// connector set, exactly as candidateValidateOptions() (generate.go, the
+// options the shipped command uses) configures it. Before this fix,
+// validateCandidate ran validate.Run with the zero Options
+// (ResolvePlugins off), under which this exact candidate scored
+// validate-PASS — the fabricated-plugin class this feature exists to catch,
+// invisible to the eval harness that is supposed to gate it.
+func TestValidateCandidate_FabricatedBuiltinPlugin_Fails(t *testing.T) {
+	is := is.New(t)
+
+	candidate := mustReadCandidate(t, "postgres-cdc-to-kafka-filtered-bad-fabricated-builtin-plugin.yaml")
+	report := validateCandidate(context.Background(), candidate)
+	is.True(!report.OK())
+	is.True(report.Summary.Errors > 0)
 }
 
 // --- semantic-intent axis ---
@@ -191,8 +216,7 @@ func TestScoreSemantic_WrongConnector_FailsEvenThoughValid(t *testing.T) {
 	candidate := mustReadCandidate(t, "kafka-to-postgres-sync-bad-wrong-connector.yaml")
 
 	// Confirm the premise: this candidate DOES pass validate.
-	report, verr := validateCandidate(context.Background(), candidate)
-	is.NoErr(verr)
+	report := validateCandidate(context.Background(), candidate)
 	is.True(report.OK())
 
 	// But it must fail the semantic check: wrong source AND destination.
@@ -237,8 +261,7 @@ func TestScoreSemantic_DroppedFilter_Fails(t *testing.T) {
 
 	candidate := mustReadCandidate(t, "postgres-cdc-to-kafka-filtered-bad-dropped-filter.yaml")
 
-	report, verr := validateCandidate(context.Background(), candidate)
-	is.NoErr(verr)
+	report := validateCandidate(context.Background(), candidate)
 	is.True(report.OK()) // still schema-valid
 
 	res := scoreSemantic(context.Background(), req.Expect, candidate)
@@ -255,8 +278,7 @@ func TestScoreSemantic_SwappedDirection_Fails(t *testing.T) {
 
 	candidate := mustReadCandidate(t, "postgres-cdc-to-kafka-filtered-bad-swapped-direction.yaml")
 
-	report, verr := validateCandidate(context.Background(), candidate)
-	is.NoErr(verr)
+	report := validateCandidate(context.Background(), candidate)
 	is.True(report.OK())
 
 	res := scoreSemantic(context.Background(), req.Expect, candidate)
@@ -274,8 +296,7 @@ func TestScoreSemantic_UnknownPlugin_NeverFabricatesAMatch(t *testing.T) {
 
 	// A non-builtin plugin reference is schema-valid (validate doesn't
 	// resolve plugin registries without ResolvePlugins).
-	report, verr := validateCandidate(context.Background(), candidate)
-	is.NoErr(verr)
+	report := validateCandidate(context.Background(), candidate)
 	is.True(report.OK())
 
 	res := scoreSemantic(context.Background(), req.Expect, candidate)

--- a/cmd/conduit/internal/generate/testdata/candidates/postgres-cdc-to-kafka-filtered-bad-fabricated-builtin-plugin.yaml
+++ b/cmd/conduit/internal/generate/testdata/candidates/postgres-cdc-to-kafka-filtered-bad-fabricated-builtin-plugin.yaml
@@ -1,0 +1,23 @@
+version: "2.2"
+pipelines:
+  - id: orders-to-kafka-fabricated
+    status: running
+    name: orders-to-kafka-fabricated
+    connectors:
+      - id: pg-source
+        type: source
+        # A plausible-but-nonexistent builtin plugin name (typo'd "postgres").
+        # Schema-valid on its own; only ResolvePlugins catches it.
+        plugin: builtin:postgre
+        settings:
+          table: orders
+      - id: kafka-dest
+        type: destination
+        plugin: builtin:kafka
+        settings:
+          topic: orders
+        processors:
+          - id: amount-filter
+            plugin: filter
+            settings:
+              expression: "amount > 100"

--- a/cmd/conduit/internal/generate/validate_score.go
+++ b/cmd/conduit/internal/generate/validate_score.go
@@ -16,51 +16,31 @@ package generate
 
 import (
 	"context"
-	"os"
 
 	"github.com/conduitio/conduit/cmd/conduit/internal/validate"
-	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 )
 
-// validateCandidate runs the exact engine `conduit pipelines validate` uses
-// (validate.Run) against a candidate pipeline-config YAML document held only
-// in memory.
+// validateCandidate runs the exact gate `conduit generate` itself runs
+// against a candidate pipeline-config YAML document held only in memory:
+// validate.RunBytes with candidateValidateOptions() (ResolvePlugins on, the
+// builtin connector/processor sets — see generate.go's doc comment on
+// candidateValidateOptions for why that option is not the zero value).
 //
-// validate.Run/RunWithOptions take a file path and read the config from
-// disk — there is no in-memory (RunBytes/RunReader) entry point today (see
-// docs/design-documents/20260722-conduit-generate.md, Decision §3, "the
-// disk seam"). That design doc names the in-memory seam as the PREFERRED
-// resolution and a temp-file+cleanup shim as the fallback if the seam
-// proves infeasible at generate's build time. This eval harness needs an
-// answer now, before that command is built, so it takes the fallback:
-// write the candidate to a private (0600) temp file, run validate.Run
-// against it, and remove the file before returning — win or lose, on every
-// return path (defer, not a final explicit call, so a panic mid-Run still
-// cleans up).
+// This used to differ from the shipped command: it called validate.Run
+// (Options{}, ResolvePlugins off) against a private temp file, because
+// RunBytes did not exist yet (see docs/design-documents/20260722-conduit-
+// generate.md, Decision §3, "the disk seam", and this function's own prior
+// doc comment naming RunBytes as the trigger to change). That gap meant a
+// candidate referencing a fabricated builtin plugin (e.g.
+// `builtin:postgre`) scored validate-PASS in this harness while the real
+// command would have scored it validate-FAIL — the harness was measuring a
+// strictly weaker gate than the one it exists to benchmark, in exactly the
+// failure class (a plausible-looking fabricated plugin name) this feature
+// must never ship to a user.
 //
-// This is deliberately the ONLY place in this package that touches disk.
-// If/when validate gains RunBytes, this function's body is the only thing
-// that needs to change — every caller (ScoreRun) is unaffected.
-func validateCandidate(ctx context.Context, candidate string) (validate.Report, error) {
-	f, err := os.CreateTemp("", "conduit-generate-eval-*.yaml")
-	if err != nil {
-		return validate.Report{}, cerrors.Errorf("creating temp file for candidate validation: %w", err)
-	}
-	path := f.Name()
-	// Best-effort cleanup of a private scratch file; nothing downstream
-	// depends on the removal succeeding (a leaked temp file in the OS temp
-	// dir is a cleanup nuisance, never a correctness or security issue,
-	// since it was never a user-visible candidate — see doc.go's "the ONLY
-	// place in this package that touches disk").
-	defer func() { _ = os.Remove(path) }()
-
-	if _, err := f.WriteString(candidate); err != nil {
-		_ = f.Close()
-		return validate.Report{}, cerrors.Errorf("writing candidate to temp file %q: %w", path, err)
-	}
-	if err := f.Close(); err != nil {
-		return validate.Report{}, cerrors.Errorf("closing temp file %q: %w", path, err)
-	}
-
-	return validate.Run(ctx, path)
+// Now that RunBytes exists (cmd/conduit/internal/validate/engine.go:129),
+// this function is the ONLY thing that needed to change, exactly as
+// promised — no disk write, no temp file, no caller (ScoreRun) touched.
+func validateCandidate(ctx context.Context, candidate string) validate.Report {
+	return validate.RunBytes(ctx, InMemoryCandidateName, []byte(candidate), candidateValidateOptions())
 }

--- a/docs/generate-benchmark.md
+++ b/docs/generate-benchmark.md
@@ -27,8 +27,11 @@ is correct — it's what `generate.LoadRequests` and the future CI/scheduled eva
 Per the design doc's §10, a schema-valid pipeline is not the same thing as a _correct_ one, so the
 harness reports two independent numbers, never collapsed into one:
 
-1. **Validate-pass rate** — does the candidate pass `cmd/conduit/internal/validate`'s `Run`, the
-   exact engine `conduit pipelines validate` uses. Committed floor: **>= 90%** of the corpus.
+1. **Validate-pass rate** — does the candidate pass `cmd/conduit/internal/validate`'s engine with
+   the exact `Options` `conduit generate` itself gates a candidate through before ever showing it
+   to a human (`ResolvePlugins` on, so a fabricated builtin plugin name fails here too — not the
+   weaker `Options{}` `conduit pipelines validate` defaults to). Committed floor: **>= 90%** of
+   the corpus.
 2. **Semantic-intent-match rate** — does the candidate's actual source/destination connector
    category and processor set match the request's stated intent (`Expect`), even when it
    validates cleanly. A pipeline can be schema-valid and still point at the wrong connector, swap
@@ -68,9 +71,11 @@ harness checks a candidate against, **not** re-derived from the prompt text by t
 
 Given a candidate pipeline YAML for this request, the scorer:
 
-- Runs `validate.Run` against it (via a private temp-file shim — `validate.Run` has no in-memory
-  entry point yet; see `validate_score.go`'s doc comment and the design doc's "disk seam"
-  discussion, Decision §3).
+- Runs `validate.RunBytes` against it, entirely in memory, with the SAME `Options` `conduit
+  generate` itself gates a candidate through (`ResolvePlugins` on, the builtin connector/processor
+  sets — `candidateValidateOptions` in `generate.go`) — never a weaker check than the shipped
+  command's. See `validate_score.go`'s doc comment and the design doc's "disk seam" discussion,
+  Decision §3, which names this in-memory seam as the preferred resolution.
 - Parses it with the same YAML parser `validate` uses, and checks: does the source connector's
   plugin resolve to the `postgres` builtin category? The destination to `kafka`? Is there a
   processor (anywhere in the pipeline) matching each tag in `requiredCapabilities` — here,
@@ -138,7 +143,7 @@ the six real built-in connectors.
 ## Related
 
 - `docs/design-documents/20260722-conduit-generate.md` — the full design (provider model, the
-  never-auto-apply boundary, the disk-seam decision this harness's temp-file shim implements the
-  fallback for).
+  never-auto-apply boundary, the disk-seam decision this harness implements via the preferred
+  `validate.RunBytes` in-memory seam rather than the temp-file fallback).
 - ROADMAP.md, Agent-native section — the v0.19 Workstream 1 item this PR advances (eval-harness
   path only; the command implementation is v0.20+).


### PR DESCRIPTION
Slice A5a-1 of WS1 — the prerequisite for the `conduit generate` eval CI job. Three defects found by the adversarial review of the eval plan, each verified against the code before being fixed.

## F1 — the eval harness measured a *weaker* gate than the shipped command

`validateCandidate` called `validate.Run(ctx, path)` — zero `Options`, so `ResolvePlugins: false`. The shipped loop calls `RunBytes` with `candidateValidateOptions()`, which turns plugin resolution **on**.

Consequence: a candidate containing `plugin: "builtin:postgre"` scored **validate-PASS** in the eval and **validate-FAIL** in the real command. A published "validate-pass rate ≥90%" would have been optimistic in exactly the fabricated-plugin class this feature exists to prevent — and that number is the input to the v0.20 ship/slip decision.

Now uses `RunBytes` with the same options, backed by a new committed fixture (`…-bad-fabricated-builtin-plugin.yaml`) and a regression test.

## F2 — the temp file made a deterministic golden impossible

Same function wrote candidates through `os.CreateTemp`, so a random path landed in every finding's location. The PR-CI eval job needs byte-identical output across runs; it can't have a random string in it. Fixing F1 removed the disk write entirely — `grep -rn 'CreateTemp' cmd/conduit/internal/generate/` now returns nothing.

`Result.ValidateErr` and the `(Report, error)` return went with it. `RunBytes` has nothing to fail at, so keeping the field would have left a permanently-nil error in the API — the exact dead-code smell a reviewer flags.

## F3 — `max_tokens` was sized for the output, not the think

`DefaultMaxTokens` was 4096 against `claude-sonnet-5`, which runs adaptive thinking when the request omits a thinking budget — and `max_tokens` caps thinking *and* response text together.

A long think truncates the YAML mid-document. `extractCandidate` deliberately tolerates an unterminated fence and hands the partial to the validator, so the truncation never surfaces as "ran out of budget": it looks like an ordinary validation failure, burns a retry, and in a transcript reads as model error. **It would have depressed the eval score by an amount measuring our own constant.**

Raised to 16384 — a config is ~350 tokens, so the ceiling exists to absorb thinking while still bounding a wedged model. No `thinking` field and no `CompletionResult` change; surfacing `stop_reason` is a shipped-adapter change deferred to v0.21.

## Also

`CatalogFingerprint()` — a stable hash over the sorted `(connector, role, paramKey, required)` tuples, deliberately ignoring descriptions and defaults. A committed transcript records it, so a later build can tell "a connector's parameter set changed, this transcript is semantically stale" from "a description was reworded, it's fine". Built from the same map `BuiltinCatalog()` reads, so it can't drift from the prompt it fingerprints.

`doc.go` and `docs/generate-benchmark.md` both described `validate.Run` and the temp-file shim; both became false with F1 and are updated in the same PR.

## Verified independently

Beyond the agent's own perturbation set, I re-ran it myself: reverting `candidateValidateOptions()` to `validate.Options{}` fails `TestValidateCandidate_FabricatedBuiltinPlugin_Fails`. `go test ./cmd/... -count=1` green, `golangci-lint` 0 issues, `make generate-llms` produces no diff.

## Risk tier

**Tier 2.** The eval harness is not on the data path. `DefaultMaxTokens` does affect the shipped command's provider requests — it raises a *ceiling*, not a spend, and the failure it removes is silent truncation.

Roadmap: v0.20 WS1 (`conduit generate`), slice A5a-1.
