### PR TITLE
feat(generate): transcript format, strict loader, and redaction scanner (WS1 A5a-2)

### DIFF
--- a/cmd/conduit/internal/generate/provider/replay.go
+++ b/cmd/conduit/internal/generate/provider/replay.go
@@ -1,0 +1,107 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import "context"
+
+// ReplayTurn is one pre-recorded completion, in the shape Replay hands back
+// verbatim. It carries no knowledge of the transcript file format that
+// produced it (schemaVersion, hashes, staleness — package generate's job);
+// this package only knows how to answer Complete calls without a network
+// call, which is the one thing a golden-file eval-CI job actually needs from
+// a Provider.
+type ReplayTurn struct {
+	// Text is handed back as CompletionResult.Text unmodified — including any
+	// narration a real model reply carried, since extractCandidate's lenient
+	// reader is itself part of what a replay run exercises.
+	Text string
+	// TokensUsed is handed back as CompletionResult.TokensUsed unmodified.
+	TokensUsed int
+}
+
+// Replay is a Provider that answers every Complete call from a fixed,
+// pre-recorded sequence of turns instead of a live model — no network call,
+// ever, and no dependency on outbound connectivity even existing.
+//
+// It exists for the eval harness's PR-CI replay job (design doc
+// docs/design-documents/20260722-conduit-generate.md §10): every attempt's
+// completion was decided once, at capture time, so replaying it can never
+// make a network call and produces a byte-identical result run to run —
+// the property a golden-file regression check depends on.
+//
+// Turns are consumed strictly in order, one per Complete call — "keyed by
+// attempt index": the first call gets Turns[0] (Generate's attempt 1), a
+// retry gets Turns[1] (attempt 2), and so on. This mirrors exactly how a live
+// provider was called during capture: attempt N's completion is whatever the
+// model said in response to attempt N's (feedback-augmented) prompt, and
+// replay must reproduce that sequence rather than, say, always returning
+// Turns[0].
+//
+// Replay is not safe for concurrent use: Complete mutates the call count that
+// selects the next turn. Nothing in the eval harness calls it concurrently
+// (one Generate run at a time per Replay value); a caller that needs
+// concurrent replay of the same transcript should construct one Replay per
+// goroutine.
+type Replay struct {
+	// ProviderName is returned by Name(). Empty means "replay" — see Name.
+	ProviderName string
+	// Model is informational only; Replay never inspects
+	// CompletionRequest.Model to decide what to return (the recorded turn
+	// sequence is fixed at construction, not chosen per call).
+	Model string
+	// Turns is the fixed sequence Complete works through, in order.
+	Turns []ReplayTurn
+
+	calls int
+}
+
+// Name returns ProviderName, or the literal "replay" when it is empty — a
+// nonexistent Provider.Name() the plan/exhausted-error/report paths must
+// still be able to name something.
+func (r *Replay) Name() string {
+	if r.ProviderName == "" {
+		return "replay"
+	}
+	return r.ProviderName
+}
+
+// Complete returns the next recorded ReplayTurn in sequence, ignoring req
+// entirely — Replay's whole point is that the prompt sent no longer decides
+// what comes back, only the fixed transcript does. req is accepted only to
+// satisfy the Provider interface.
+//
+// A cancelled or expired ctx is honored before consuming a turn: Generate's
+// retry loop always passes a real context, and a Replay that ignored
+// cancellation would make a hung caller's test look like a Replay bug
+// instead of a caller bug.
+//
+// Calling Complete more times than len(Turns) is a caller error — the retry
+// budget and the recorded transcript are supposed to agree — and returns a
+// CodeProviderError naming how many turns were recorded and which attempt
+// was requested, rather than panicking or silently repeating the last turn.
+func (r *Replay) Complete(ctx context.Context, _ CompletionRequest) (CompletionResult, error) {
+	if err := ctx.Err(); err != nil {
+		return CompletionResult{}, err
+	}
+
+	if r.calls >= len(r.Turns) {
+		return CompletionResult{}, providerErrorf(r.Name(),
+			"replay exhausted: %d turn(s) recorded, attempt %d requested", len(r.Turns), r.calls+1)
+	}
+
+	t := r.Turns[r.calls]
+	r.calls++
+	return CompletionResult(t), nil
+}

--- a/cmd/conduit/internal/generate/provider/replay_test.go
+++ b/cmd/conduit/internal/generate/provider/replay_test.go
@@ -1,0 +1,125 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+// Test_Replay_ReturnsTurnsInOrderByAttempt pins the "keyed by attempt index"
+// contract: the Nth Complete call gets Turns[N-1], not always Turns[0] and
+// not any request-dependent lookup. A live capture calls the provider once
+// per attempt and records whatever came back at each point in the retry
+// sequence; replay must reproduce that exact sequence for a byte-identical
+// golden to be possible.
+func Test_Replay_ReturnsTurnsInOrderByAttempt(t *testing.T) {
+	is := is.New(t)
+
+	r := &Replay{
+		ProviderName: "anthropic",
+		Model:        "claude-sonnet-5",
+		Turns: []ReplayTurn{
+			{Text: "attempt one text", TokensUsed: 111},
+			{Text: "attempt two text", TokensUsed: 222},
+		},
+	}
+
+	got1, err := r.Complete(context.Background(), CompletionRequest{Prompt: "irrelevant"})
+	is.NoErr(err)
+	is.Equal(got1.Text, "attempt one text")
+	is.Equal(got1.TokensUsed, 111)
+
+	got2, err := r.Complete(context.Background(), CompletionRequest{Prompt: "also irrelevant"})
+	is.NoErr(err)
+	is.Equal(got2.Text, "attempt two text")
+	is.Equal(got2.TokensUsed, 222)
+}
+
+// Test_Replay_IgnoresRequestContent pins that Complete's return value never
+// depends on req — a different prompt on the second call (as Generate's
+// retry-feedback loop always sends) must not change which turn comes back.
+func Test_Replay_IgnoresRequestContent(t *testing.T) {
+	is := is.New(t)
+
+	r := &Replay{Turns: []ReplayTurn{{Text: "fixed", TokensUsed: 1}}}
+
+	got, err := r.Complete(context.Background(), CompletionRequest{
+		System: "wildly different system prompt",
+		Prompt: "wildly different user prompt",
+		Model:  "some-other-model",
+	})
+	is.NoErr(err)
+	is.Equal(got.Text, "fixed")
+}
+
+// Test_Replay_ExhaustionIsAProviderError pins that calling Complete more
+// times than there are recorded turns fails loudly, naming the counts,
+// rather than panicking (index out of range) or silently repeating the last
+// turn — either of which would hide a retry-budget/transcript mismatch
+// instead of surfacing it.
+func Test_Replay_ExhaustionIsAProviderError(t *testing.T) {
+	is := is.New(t)
+
+	r := &Replay{ProviderName: "openai", Turns: []ReplayTurn{{Text: "only turn"}}}
+
+	_, err := r.Complete(context.Background(), CompletionRequest{})
+	is.NoErr(err)
+
+	_, err = r.Complete(context.Background(), CompletionRequest{})
+	is.True(err != nil)
+	codeIs(t, err, CodeProviderError)
+	is.True(contains(err.Error(), "openai"))
+	is.True(contains(err.Error(), "1 turn"))
+}
+
+// Test_Replay_RespectsContextCancellation pins that a cancelled context is
+// honored before a turn is consumed — a cancelled caller must not still
+// silently get data back, and the call must not count against the sequence
+// (a subsequent call with a live context still gets Turns[0]).
+func Test_Replay_RespectsContextCancellation(t *testing.T) {
+	is := is.New(t)
+
+	r := &Replay{Turns: []ReplayTurn{{Text: "never reached"}}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := r.Complete(ctx, CompletionRequest{})
+	is.True(err != nil)
+
+	got, err := r.Complete(context.Background(), CompletionRequest{})
+	is.NoErr(err)
+	is.Equal(got.Text, "never reached") // the cancelled call did not consume a turn
+}
+
+// Test_Replay_Name pins the ProviderName passthrough and its "replay"
+// fallback when unset — a Replay constructed without an explicit name must
+// still identify itself as something in an error message.
+func Test_Replay_Name(t *testing.T) {
+	is := is.New(t)
+
+	is.Equal((&Replay{ProviderName: "anthropic"}).Name(), "anthropic")
+	is.Equal((&Replay{}).Name(), "replay")
+}
+
+// Test_Replay_ImplementsProvider is a compile-time-flavored check that Replay
+// satisfies the Provider interface Generate depends on — the whole point of
+// this type.
+func Test_Replay_ImplementsProvider(t *testing.T) {
+	var _ Provider = (*Replay)(nil)
+}

--- a/cmd/conduit/internal/generate/redact.go
+++ b/cmd/conduit/internal/generate/redact.go
@@ -1,0 +1,194 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/conduitio/conduit/pkg/foundation/log"
+	yamlparser "github.com/conduitio/conduit/pkg/provisioning/config/yaml"
+)
+
+// MaxTurnCompletionBytes is the hard per-turn cap on a Turn.CompletionText's
+// length (plan §5). A generated pipeline config is under 1.5 KiB in this
+// package's own corpus, so anything past this cap is truncation or narration
+// bloat — and either way is a bigger public-repo surface than a
+// maintenance-only eval fixture needs. The future capture tool (A5a-3) must
+// refuse to write a turn over this cap; ScanTranscriptForSecrets enforces it
+// again here so a hand-edit (or a future capture-path regression) can't slip
+// an oversized blob past review.
+const MaxTurnCompletionBytes = 8 * 1024
+
+// credentialShapedKey matches a connector settings key whose NAME suggests it
+// might hold a real credential, independent of whether its value happens to
+// match a known secret format. This is the structural half of §5's
+// redaction: secretPatterns below catches a value that LOOKS like a known
+// credential shape; this catches one that doesn't — e.g. a DSN with a
+// plaintext password embedded ("postgres://user:hunter2@host/db") — by
+// checking the key a model would plausibly have used to name it, per §5's
+// "a config is under 1.5 KiB, so a plausible DSN is exactly the kind of
+// thing that needs a structural check, not just a format-shaped one."
+var credentialShapedKey = regexp.MustCompile(`(?i)(password|secret|token|api[_-]?key|credential|dsn|conn)`)
+
+// secretPatterns is §5's deny-list: value SHAPES a real credential could
+// take. A finding never echoes the matched substring — the fact that
+// something matched secretPatterns[i] is what a reviewer needs, and printing
+// the match into a CI log would turn the scan's own output into the leak it
+// exists to catch.
+var secretPatterns = []struct {
+	name string
+	re   *regexp.Regexp
+}{
+	{"Anthropic API key (sk-ant-…)", regexp.MustCompile(`sk-ant-[A-Za-z0-9_-]{10,}`)},
+	{"generic secret-key-shaped token (sk-…)", regexp.MustCompile(`\bsk-[A-Za-z0-9]{20,}\b`)},
+	{"GitHub token (ghp_/github_pat_/gho_…)", regexp.MustCompile(`\b(?:ghp_|github_pat_|gho_)[A-Za-z0-9_]{20,}\b`)},
+	{"AWS access key id (AKIA…)", regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`)},
+	{"PEM private key block", regexp.MustCompile(`-----BEGIN [A-Z ]*PRIVATE KEY-----`)},
+	{"JWT", regexp.MustCompile(`\bey[A-Za-z0-9_-]{10,}\.ey[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b`)},
+	{"long base64 run (>=80 chars)", regexp.MustCompile(`\b[A-Za-z0-9+/]{80,}={0,2}\b`)},
+}
+
+// scanTextForSecrets returns the name of every secretPatterns entry that
+// matches text, in table order, or nil when text is clean.
+func scanTextForSecrets(text string) []string {
+	var found []string
+	for _, p := range secretPatterns {
+		if p.re.MatchString(text) {
+			found = append(found, p.name)
+		}
+	}
+	return found
+}
+
+// isPlaceholderValue reports whether v is an obvious placeholder rather than
+// real credential material. BuildSystemPrompt instructs the model to emit
+// the literal "TODO" for any secret (grounding.go's rule "emit the literal
+// placeholder TODO"), so that is the expected shape; a handful of other
+// common placeholder spellings are accepted too, since a model narrating
+// around the rule ("TODO_REPLACE_WITH_YOUR_KEY", "<your-api-key>") is still
+// refusing to fabricate a credential — which is what this check exists to
+// confirm, not to enforce one exact literal string.
+func isPlaceholderValue(v string) bool {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return true
+	}
+	upper := strings.ToUpper(v)
+	for _, marker := range []string{"TODO", "CHANGEME", "REDACTED", "PLACEHOLDER", "EXAMPLE", "XXXX"} {
+		if strings.Contains(upper, marker) {
+			return true
+		}
+	}
+	return strings.HasPrefix(v, "<") && strings.HasSuffix(v, ">")
+}
+
+// scanCandidateSettingsForCredentials best-effort extracts and parses the
+// pipeline YAML out of rawCompletion (the same extractCandidate +
+// yamlparser pipeline generate.go and semantic_score.go use) and flags every
+// settings key — connector OR processor, pipeline-level or attached to a
+// connector (allProcessors, semantic_score.go, flattens both) — that looks
+// credential-shaped (credentialShapedKey) but whose value is not an obvious
+// placeholder (isPlaceholderValue). Plan §5 says "any settings key", not
+// "any connector settings key": a processor plugin (e.g. one calling an
+// external enrichment API) has its own Settings map and can carry a
+// credential-shaped key exactly the same way a connector can.
+//
+// A turn that fails to extract or parse yields no findings from THIS check —
+// the deny-list scan (scanTextForSecrets) already covers the raw text
+// regardless of whether it parses as a pipeline, and guessing at settings
+// keys inside unparseable text would be inventing findings rather than
+// reporting real ones.
+func scanCandidateSettingsForCredentials(ctx context.Context, rawCompletion string) []string {
+	candidate, err := extractCandidate(rawCompletion)
+	if err != nil {
+		return nil
+	}
+	pipelines, err := yamlparser.NewParser(log.Nop()).Parse(ctx, strings.NewReader(candidate))
+	if err != nil || len(pipelines) == 0 {
+		return nil
+	}
+
+	var findings []string
+	for _, p := range pipelines {
+		for _, c := range p.Connectors {
+			findings = append(findings, credentialFindings("connector "+strconv.Quote(c.ID), c.Settings)...)
+		}
+		for _, proc := range allProcessors(p) {
+			findings = append(findings, credentialFindings("processor "+strconv.Quote(proc.ID), proc.Settings)...)
+		}
+	}
+	sort.Strings(findings) // map iteration order is random; findings must be deterministic
+	return findings
+}
+
+// credentialFindings flags every entry in settings whose key looks
+// credential-shaped but whose value is not an obvious placeholder, labeling
+// each finding with subject (e.g. `connector "src"`).
+func credentialFindings(subject string, settings map[string]string) []string {
+	var findings []string
+	for key, val := range settings {
+		if credentialShapedKey.MatchString(key) && !isPlaceholderValue(val) {
+			findings = append(findings, fmt.Sprintf(
+				"%s settings key %q does not hold an obvious placeholder", subject, key,
+			))
+		}
+	}
+	return findings
+}
+
+// ScanTranscriptForSecrets is plan §5's redaction scanner, run over one
+// committed Transcript. It never mutates, truncates, or redacts anything
+// in place — a violation is only ever reported, so the fix is always a
+// re-capture or a reviewed hand-edit, never a scanner side effect that could
+// itself hide what was found.
+//
+// Three independent checks, findings from all three combined into one slice
+// (nil when clean):
+//
+//  1. Every Turn.CompletionText is within MaxTurnCompletionBytes.
+//  2. No Turn.CompletionText matches a secretPatterns entry.
+//  3. No connector settings key that looks credential-shaped holds a
+//     non-placeholder value, in the pipeline extracted from each turn's
+//     completion text (scanCandidateSettingsForCredentials; best-effort,
+//     independent of check 2 — an unparseable turn still gets checks 1 and 2).
+//
+// This is the ONLY secret-scanning mechanism in the repo today (the repo has
+// no general secret-scanning workflow) — never call it defence-in-depth.
+func ScanTranscriptForSecrets(ctx context.Context, t Transcript) []string {
+	var findings []string
+	for _, turn := range t.Turns {
+		if n := len(turn.CompletionText); n > MaxTurnCompletionBytes {
+			findings = append(findings, fmt.Sprintf(
+				"transcript %q turn %d: completion text is %d bytes, exceeds the %d byte cap",
+				t.RequestID, turn.N, n, MaxTurnCompletionBytes,
+			))
+		}
+		for _, pattern := range scanTextForSecrets(turn.CompletionText) {
+			findings = append(findings, fmt.Sprintf(
+				"transcript %q turn %d: completion text matches deny-list pattern %q",
+				t.RequestID, turn.N, pattern,
+			))
+		}
+		for _, f := range scanCandidateSettingsForCredentials(ctx, turn.CompletionText) {
+			findings = append(findings, fmt.Sprintf("transcript %q turn %d: %s", t.RequestID, turn.N, f))
+		}
+	}
+	return findings
+}

--- a/cmd/conduit/internal/generate/redact_test.go
+++ b/cmd/conduit/internal/generate/redact_test.go
@@ -1,0 +1,225 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+// Test_ScanTextForSecrets_DetectsEveryDenyListPattern is the scanner's own
+// perturbation proof, one synthetic string per pattern: each must be
+// flagged, and a clean control string must not be.
+func Test_ScanTextForSecrets_DetectsEveryDenyListPattern(t *testing.T) {
+	is := is.New(t)
+
+	cases := map[string]string{
+		"anthropic key":   "here is my key: sk-ant-api03-FAKEFAKEFAKEFAKEFAKEFAKE123456789",
+		"generic sk key":  "token=sk-ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef",
+		"github token":    "auth: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+		"aws access key":  "AKIAABCDEFGHIJKLMNOP is the access key",
+		"pem block":       "-----BEGIN RSA PRIVATE KEY-----\nMIIB...\n-----END RSA PRIVATE KEY-----",
+		"jwt":             "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U",
+		"long base64 run": strings.Repeat("QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVowMTIzNDU2Nzg5", 3),
+	}
+	for name, text := range cases {
+		t.Run(name, func(t *testing.T) {
+			found := scanTextForSecrets(text)
+			if len(found) == 0 {
+				t.Fatalf("scanTextForSecrets found nothing in a %s fixture", name)
+			}
+		})
+	}
+
+	is.Equal(len(scanTextForSecrets("version: \"2.2\"\npipelines:\n  - id: p\n")), 0)
+}
+
+func Test_IsPlaceholderValue(t *testing.T) {
+	is := is.New(t)
+
+	for _, v := range []string{"TODO", "todo", "TODO_REPLACE_ME", "CHANGEME", "<your-api-key>", "", "  "} {
+		is.True(isPlaceholderValue(v))
+	}
+	for _, v := range []string{"hunter2", "AKIAABCDEFGHIJKLMNOP", "sk-ant-api03-realkeylookingvalue"} {
+		is.True(!isPlaceholderValue(v))
+	}
+}
+
+// Test_ScanCandidateSettingsForCredentials_FlagsNonPlaceholderCredentialKey
+// pins the structural check independent of the deny-list scan: a value that
+// matches NO known secret format (a plausible DSN with a plaintext password)
+// still gets flagged because of the KEY it's assigned to.
+func Test_ScanCandidateSettingsForCredentials_FlagsNonPlaceholderCredentialKey(t *testing.T) {
+	is := is.New(t)
+
+	candidate := "version: \"2.2\"\n" +
+		"pipelines:\n" +
+		"  - id: p\n" +
+		"    connectors:\n" +
+		"      - id: src\n" +
+		"        type: source\n" +
+		"        plugin: \"builtin:postgres\"\n" +
+		"        settings:\n" +
+		"          url: \"postgres://user:hunter2@host/db\"\n"
+
+	found := scanCandidateSettingsForCredentials(context.Background(), candidate)
+	is.True(len(found) == 0) // "url" is not a credential-shaped key
+
+	credentialShaped := strings.Replace(candidate, "url:", "conn.password:", 1)
+	found = scanCandidateSettingsForCredentials(context.Background(), credentialShaped)
+	is.True(len(found) == 1)
+	is.True(strings.Contains(found[0], "conn.password"))
+}
+
+// Test_ScanCandidateSettingsForCredentials_ChecksProcessorSettingsToo pins
+// that a PROCESSOR's settings (pipeline-level or connector-attached) are
+// checked the same way a connector's are — plan §5 says "any settings key",
+// and config.Processor has its own Settings map a processor plugin (e.g. one
+// calling an external enrichment API) could put a real credential in.
+func Test_ScanCandidateSettingsForCredentials_ChecksProcessorSettingsToo(t *testing.T) {
+	is := is.New(t)
+
+	candidate := "version: \"2.2\"\n" +
+		"pipelines:\n" +
+		"  - id: p\n" +
+		"    processors:\n" +
+		"      - id: enrich\n" +
+		"        plugin: \"custom.enrich\"\n" +
+		"        settings:\n" +
+		"          api_key: \"hunter2-actual-value-9f8e7d\"\n"
+
+	found := scanCandidateSettingsForCredentials(context.Background(), candidate)
+	is.True(len(found) == 1)
+	is.True(strings.Contains(found[0], "processor"))
+	is.True(strings.Contains(found[0], "api_key"))
+}
+
+// Test_ScanCandidateSettingsForCredentials_AcceptsPlaceholder pins that a
+// credential-shaped key holding the literal TODO grounding.go instructs the
+// model to emit is NOT flagged — a false positive here would make every
+// clean, correctly-generated transcript fail the scan.
+func Test_ScanCandidateSettingsForCredentials_AcceptsPlaceholder(t *testing.T) {
+	is := is.New(t)
+
+	candidate := "version: \"2.2\"\n" +
+		"pipelines:\n" +
+		"  - id: p\n" +
+		"    connectors:\n" +
+		"      - id: src\n" +
+		"        type: source\n" +
+		"        plugin: \"builtin:postgres\"\n" +
+		"        settings:\n" +
+		"          password: TODO\n"
+
+	found := scanCandidateSettingsForCredentials(context.Background(), candidate)
+	is.Equal(len(found), 0)
+}
+
+// Test_ScanCandidateSettingsForCredentials_UnparseableTextYieldsNoFindings
+// pins that narration-only or malformed text is skipped by this check rather
+// than erroring — the deny-list scan (checked separately) is what still
+// covers raw, unparseable text.
+func Test_ScanCandidateSettingsForCredentials_UnparseableTextYieldsNoFindings(t *testing.T) {
+	is := is.New(t)
+	found := scanCandidateSettingsForCredentials(context.Background(), "I'm sorry, I cannot help with that request.")
+	is.Equal(len(found), 0)
+}
+
+// harmlessFiller returns n bytes of filler text that trips none of
+// secretPatterns — in particular the "long base64 run" pattern, which a bare
+// strings.Repeat("a", n) would itself match (lowercase letters are valid
+// base64 alphabet). A newline every other byte breaks up any run before it
+// reaches the pattern's 80-character floor.
+func harmlessFiller(n int) string {
+	var b strings.Builder
+	b.Grow(n)
+	for b.Len() < n {
+		b.WriteString("a\n")
+	}
+	return b.String()[:n]
+}
+
+// Test_ScanTranscriptForSecrets_EnforcesTheSizeCap pins MaxTurnCompletionBytes
+// as a hard cap: a turn one byte over it is flagged, one byte under is not.
+func Test_ScanTranscriptForSecrets_EnforcesTheSizeCap(t *testing.T) {
+	is := is.New(t)
+
+	within := Transcript{
+		RequestID: "req",
+		Turns:     []Turn{{N: 1, CompletionText: harmlessFiller(MaxTurnCompletionBytes)}},
+	}
+	is.Equal(len(ScanTranscriptForSecrets(context.Background(), within)), 0)
+
+	over := Transcript{
+		RequestID: "req",
+		Turns:     []Turn{{N: 1, CompletionText: harmlessFiller(MaxTurnCompletionBytes + 1)}},
+	}
+	found := ScanTranscriptForSecrets(context.Background(), over)
+	is.True(len(found) == 1)
+	is.True(strings.Contains(found[0], "exceeds"))
+}
+
+// Test_ScanTranscriptForSecrets_CleanTranscriptHasNoFindings is the negative
+// control every perturbation test in this file is contrasted against: a
+// realistic, well-formed transcript scans clean.
+func Test_ScanTranscriptForSecrets_CleanTranscriptHasNoFindings(t *testing.T) {
+	is := is.New(t)
+
+	tr := Transcript{
+		RequestID: "postgres-cdc-to-kafka-filtered",
+		Turns: []Turn{{
+			N: 1,
+			CompletionText: "version: \"2.2\"\n" +
+				"pipelines:\n" +
+				"  - id: p\n" +
+				"    connectors:\n" +
+				"      - id: src\n" +
+				"        type: source\n" +
+				"        plugin: \"builtin:postgres\"\n" +
+				"        settings:\n" +
+				"          url: TODO\n",
+		}},
+	}
+	is.Equal(len(ScanTranscriptForSecrets(context.Background(), tr)), 0)
+}
+
+// Test_ScanTranscriptForSecrets_PlantedSecretIsCaught is the scanner-level
+// perturbation proof (as opposed to the pattern-level one above): a
+// synthetic Anthropic key planted in a turn's completion text — the exact
+// shape a captured transcript could carry if capture forgot to redact
+// narration — must be caught, naming which turn.
+func Test_ScanTranscriptForSecrets_PlantedSecretIsCaught(t *testing.T) {
+	is := is.New(t)
+
+	tr := Transcript{
+		RequestID: "req",
+		Turns: []Turn{{
+			N: 2,
+			CompletionText: "Sure, here is the config. By the way my key is " +
+				"sk-ant-api03-FAKEFAKEFAKEFAKEFAKEFAKE123456789 in case that helps.\n" +
+				"```yaml\nversion: \"2.2\"\n```\n",
+		}},
+	}
+
+	found := ScanTranscriptForSecrets(context.Background(), tr)
+	is.True(len(found) == 1)
+	is.True(strings.Contains(found[0], "req"))
+	is.True(strings.Contains(found[0], "turn 2"))
+	is.True(strings.Contains(found[0], "Anthropic API key"))
+	is.True(!strings.Contains(found[0], "sk-ant-api03")) // the finding never echoes the matched secret itself
+}

--- a/cmd/conduit/internal/generate/secrets_scan_test.go
+++ b/cmd/conduit/internal/generate/secrets_scan_test.go
@@ -1,0 +1,78 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/conduitio/yaml/v3"
+)
+
+// TestTranscripts_CarryNoSecretMaterial is AC 1.21: every transcript
+// committed anywhere under testdata/transcripts is scanned
+// (ScanTranscriptForSecrets, redact.go) and must carry no secret material.
+//
+// Deliberately UNTAGGED — no `//go:build` line — so it runs in the normal
+// `test` job on every PR, over WHATEVER transcripts exist today. That is
+// none: A5a-3 (a later PR) is what captures the first 28 real transcripts,
+// so this test's job right now is to pass cleanly on an empty corpus and
+// keep failing loudly the day a captured transcript ever carries something
+// it shouldn't — never to gate on the capture pipeline having run yet. A
+// transcripts directory that does not exist at all is treated exactly like
+// an empty one: this test proves an invariant about content, not about
+// whether A5a-3 has landed.
+func TestTranscripts_CarryNoSecretMaterial(t *testing.T) {
+	root := "testdata/transcripts"
+
+	if _, err := os.Stat(root); os.IsNotExist(err) {
+		t.Skip("no transcripts directory yet (testdata/transcripts) — nothing to scan")
+	}
+
+	var checked int
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".yaml") || d.Name() == manifestFileName {
+			return nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading %q: %w", path, err)
+		}
+		var tr Transcript
+		if err := yaml.Unmarshal(data, &tr); err != nil {
+			return fmt.Errorf("parsing %q: %w", path, err)
+		}
+
+		checked++
+		if findings := ScanTranscriptForSecrets(context.Background(), tr); len(findings) > 0 {
+			t.Errorf("%s carries secret-scan findings:\n  %s", path, strings.Join(findings, "\n  "))
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walking %q: %v", root, walkErr)
+	}
+
+	t.Logf("scanned %d committed transcript(s) under %s", checked, root)
+}

--- a/cmd/conduit/internal/generate/testdata/transcripts/README.md
+++ b/cmd/conduit/internal/generate/testdata/transcripts/README.md
@@ -1,0 +1,41 @@
+# Committed provider transcripts
+
+Empty today. This directory is where the eval harness's replay corpus lives once A5a-3 (the
+capture slice — WS1 A5a/A5b plan §4) runs against a live provider and commits its output; this
+slice (A5a-2) defines the format and the loader, not the capture tool, and ships no transcripts.
+
+## Layout
+
+```text
+testdata/transcripts/<provider>/<model>/
+  manifest.yaml         # one capture run's summary — schema: generate.Manifest (transcript.go)
+  <requestID>.yaml       # one per testdata/eval_requests.yaml entry — schema: generate.Transcript
+```
+
+`<provider>` and `<model>` match `provider.Provider.Name()` and the model identifier used for
+that capture run (e.g. `anthropic/claude-sonnet-5`).
+
+## Loading
+
+`generate.LoadTranscripts(dir, requests)` reads every `<requestID>.yaml` in one
+`<provider>/<model>/` directory, validates it against the corpus (`testdata/eval_requests.yaml`)
+**before** anything is scored, and hard-errors — never skips — on:
+
+- **bijection**: every corpus id has exactly one transcript file and every transcript file's id
+  has a corpus entry; a mismatch in either direction names the offending id.
+- **`corpusPromptSHA256` mismatch**: a transcript's recorded hash of the corpus prompt it was
+  captured against must still match that id's prompt today — catches a prompt edited under an
+  unchanged id, which bijection alone would miss.
+
+Grounding staleness (the system prompt or the compiled-in connector catalog moving since capture)
+is classified (`generate.Staleness`) and returned as data, never as a load error — see
+`transcript.go`'s doc comments and
+`docs/design-documents/20260722-conduit-generate.md` §10.
+
+## Redaction
+
+Every transcript under this directory is scanned by `generate.ScanTranscriptForSecrets`
+(`redact.go`) in the untagged `TestTranscripts_CarryNoSecretMaterial` test
+(`secrets_scan_test.go`), which runs in the normal `test` job on every PR. See `redact.go` for the
+deny-list patterns, the 8 KiB per-turn cap, and the credential-shaped-settings-key structural
+check.

--- a/cmd/conduit/internal/generate/transcript.go
+++ b/cmd/conduit/internal/generate/transcript.go
@@ -1,0 +1,445 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/conduitio/conduit/cmd/conduit/internal/generate/provider"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
+	"github.com/conduitio/yaml/v3"
+)
+
+// TranscriptSchemaVersion is the only schemaVersion LoadTranscripts accepts
+// today. Bumping it is a format change: add a migration in LoadTranscripts
+// (or a version-dispatch shim) in the same PR that bumps it, per CLAUDE.md's
+// "serialized state ... must be readable by N+1 versions" — the future
+// capture tool (A5a-3) always writes the current constant, never a caller-
+// chosen value.
+const TranscriptSchemaVersion = 1
+
+// manifestFileName is the one file in a transcripts/<provider>/<model>/
+// directory that is NOT a per-request transcript — LoadTranscripts and the
+// redaction scanner both skip it by name when listing a directory.
+const manifestFileName = "manifest.yaml"
+
+// Transcript is one committed provider transcript: everything replay needs
+// to answer Generate's calls for exactly one corpus Request, plus the
+// metadata needed to decide whether it is still meaningful (design doc §10;
+// plan doc "WS1 A5a/A5b" §3.1/§3.3).
+//
+// One Transcript is committed per corpus request, per provider, per model,
+// as its own file at
+// testdata/transcripts/<provider>/<model>/<requestID>.yaml — never a single
+// file for the whole corpus, so that a diff reviewing one re-captured
+// request never touches the other 27.
+//
+// Not captured, structurally: raw HTTP response bodies, headers, or any
+// provider-side identifier (request-id, rate-limit counters, org id).
+// CompletionResult (provider.CompletionResult) is the only thing an adapter
+// ever hands back to Conduit's own code, and it carries none of those — see
+// provider/provider.go's doc comment. A committed transcript can only ever
+// carry what CompletionResult carries.
+type Transcript struct {
+	SchemaVersion int `yaml:"schemaVersion"`
+	// RequestID must equal the corpus Request.ID this transcript was
+	// captured against, AND the file's own basename (minus ".yaml") —
+	// LoadTranscripts hard-errors if either disagrees with the other.
+	RequestID string `yaml:"requestID"`
+	// Provider is the adapter name that produced this transcript
+	// (provider.NameAnthropic etc.), informational plus the value
+	// ReplayProviderFor reports from Replay.Name().
+	Provider string `yaml:"provider"`
+	// Model is the provider-specific model identifier the capture run used.
+	Model string `yaml:"model"`
+	// CapturedAt is when the capture tool made the LAST call recorded in
+	// Turns — never re-derived from a file's mtime, which a `git checkout`
+	// or CI clone would silently reset.
+	CapturedAt time.Time `yaml:"capturedAt"`
+	// CorpusPromptSHA256 is sha256Hex(Request.Prompt) for RequestID, AT
+	// CAPTURE TIME. LoadTranscripts recomputes it from the corpus passed in
+	// and hard-errors on a mismatch — the check that catches a request
+	// edited under an unchanged id (§3.3, AC 1.20).
+	CorpusPromptSHA256 string `yaml:"corpusPromptSHA256"`
+	// SystemPromptSHA256 is sha256Hex(BuildSystemPrompt(BuiltinCatalog()))
+	// at capture time — the grounding prompt's own identity, distinct from
+	// CorpusPromptSHA256 (the user request). LoadTranscripts compares this
+	// against the CURRENT binary's system prompt hash to classify staleness
+	// (classifyStaleness); a mismatch here is never an error, only data.
+	SystemPromptSHA256 string `yaml:"systemPromptSHA256"`
+	// CatalogFingerprint is CatalogFingerprint() at capture time — the
+	// catalog's SEMANTIC identity (grounding.go), blind to descriptions and
+	// defaults. Distinguishes cosmetic grounding drift (system prompt text
+	// moved, e.g. a reworded description) from semantic drift (a
+	// connector's actual parameter set moved) in classifyStaleness.
+	CatalogFingerprint string `yaml:"catalogFingerprint"`
+	// Turns is every provider call made for this request, in the order
+	// Generate's retry loop made them — Turns[0] is attempt 1, Turns[1] the
+	// first retry, and so on. ReplayProviderFor hands these back in this
+	// same order, one per Complete call.
+	Turns []Turn `yaml:"turns"`
+	// Outcome is this transcript's own scored result at capture time — the
+	// corpus verdict a re-capture is expected to keep clearing.
+	Outcome Outcome `yaml:"outcome"`
+}
+
+// Turn is one provider call recorded within a Transcript.
+type Turn struct {
+	// N is the 1-based attempt number, matching Attempt.N (generate.go) —
+	// carried for human readability in a diff; LoadTranscripts does not
+	// require it to be contiguous or sorted, since a turn's POSITION in the
+	// YAML list (not this field) is what ReplayProviderFor uses as replay
+	// order.
+	N int `yaml:"n"`
+	// UserPromptSHA256 is sha256Hex of the exact prompt text sent for THIS
+	// turn (the original request plus any prior turn's retry feedback,
+	// promptWithFeedback in generate.go) — distinct from
+	// Transcript.CorpusPromptSHA256, which hashes only the corpus's own
+	// Request.Prompt and never the feedback-augmented text.
+	UserPromptSHA256 string `yaml:"userPromptSHA256"`
+	// TokensUsed is what the provider reported for this call, never
+	// estimated — provider.CompletionResult's own invariant, carried
+	// through unchanged.
+	TokensUsed int `yaml:"tokensUsed"`
+	// CompletionText is the model's reply, VERBATIM — narration, fences, and
+	// all. extractCandidate's lenient reader is part of what replay
+	// exercises (plan §3.1), so trimming or pre-extracting here would remove
+	// exactly the thing a replay run is supposed to prove still works.
+	CompletionText string `yaml:"completionText"`
+}
+
+// Outcome is a transcript's own scored result, recorded at capture time —
+// what ScoreRun found for this request against Turns' LAST candidate, the
+// day the transcript was captured.
+type Outcome struct {
+	ValidatePass  bool `yaml:"validatePass"`
+	SemanticMatch bool `yaml:"semanticMatch"`
+	// SemanticIssues carries scoreSemantic's Issues when SemanticMatch is
+	// false — never populated when true, since a passing outcome has nothing
+	// to explain.
+	SemanticIssues []string `yaml:"semanticIssues,omitempty"`
+}
+
+// Manifest is the per-<provider>/<model> capture-run summary committed
+// alongside its transcripts (plan §3.1, AC 1.23's "manifest records measured
+// tokens and cost"). Its schema is defined here because it is part of the
+// committed layout; WRITING one is the capture tool's job (A5a-3, not this
+// slice) — LoadTranscripts never reads or requires it, so a missing or
+// malformed manifest.yaml can never block replay.
+type Manifest struct {
+	SchemaVersion int    `yaml:"schemaVersion"`
+	Provider      string `yaml:"provider"`
+	Model         string `yaml:"model"`
+	// CapturedAt is the capture run's own start time, distinct from any one
+	// Transcript.CapturedAt.
+	CapturedAt   time.Time `yaml:"capturedAt"`
+	RequestCount int       `yaml:"requestCount"`
+	// TotalTokensUsed sums every Turn.TokensUsed across every transcript this
+	// run produced — MEASURED, from providers' own reported usage, per
+	// provider.CompletionResult's "never estimated" invariant.
+	TotalTokensUsed int `yaml:"totalTokensUsed"`
+	// EstimatedCostUSD is TotalTokensUsed priced at the provider's list rate
+	// at capture time — an estimate (the field name says so), because actual
+	// billed cost depends on rate-card details (cached-prefix discounts,
+	// promotional pricing) this package has no way to observe.
+	EstimatedCostUSD float64 `yaml:"estimatedCostUSD"`
+}
+
+// LoadManifest reads the manifest.yaml committed alongside one capture run's
+// transcripts. It is independent of LoadTranscripts — nothing in bijection or
+// prompt-hash validation depends on a manifest existing or parsing.
+func LoadManifest(path string) (Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Manifest{}, cerrors.Errorf("reading manifest %q: %w", path, err)
+	}
+	var m Manifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return Manifest{}, cerrors.Errorf("parsing manifest %q: %w", path, err)
+	}
+	return m, nil
+}
+
+// Staleness classifies a loaded Transcript against the CURRENT binary's
+// grounding, per plan §3.3. It is data, never an error: LoadTranscripts
+// returns it on every LoadedTranscript, and it is the CALLER's decision what
+// a non-fresh transcript means (a PR-CI warning, a scheduled re-capture, or
+// nothing at all). Making drift an error here would be the "red on every
+// connector bump" flaky-gate failure CLAUDE.md's process-maturity history
+// already names — this package refuses to repeat it.
+type Staleness int
+
+const (
+	// StalenessFresh: the current binary's system prompt hashes the same as
+	// it did at capture time. The transcript is answering exactly the
+	// question the binary asks today.
+	StalenessFresh Staleness = iota
+	// StalenessCosmeticDrift: the system prompt text has changed (a
+	// dependabot bump reworded a connector description, say) but
+	// CatalogFingerprint — the SEMANTIC grounding identity — has not. The
+	// transcript's answer is still valid; only its literal prompt text is
+	// out of date.
+	StalenessCosmeticDrift
+	// StalenessSemanticDrift: CatalogFingerprint itself has changed — a
+	// connector's required/optional parameter set moved since capture. The
+	// transcript may be answering a question the binary no longer asks the
+	// same way.
+	StalenessSemanticDrift
+)
+
+// String renders s for a report line or a warning annotation.
+func (s Staleness) String() string {
+	switch s {
+	case StalenessFresh:
+		return "fresh"
+	case StalenessCosmeticDrift:
+		return "cosmetic"
+	case StalenessSemanticDrift:
+		return "semantic"
+	default:
+		return "unknown"
+	}
+}
+
+// classifyStaleness is Staleness's pure core, taking the current binary's
+// system-prompt hash and catalog fingerprint directly rather than computing
+// them itself — exercised in tests against synthetic values, the same
+// grounding.go pattern fingerprintCatalog uses for testability without
+// depending on the real builtin connector registry.
+func classifyStaleness(t Transcript, currentSystemPromptSHA256, currentCatalogFingerprint string) Staleness {
+	if t.SystemPromptSHA256 == currentSystemPromptSHA256 {
+		return StalenessFresh
+	}
+	if t.CatalogFingerprint == currentCatalogFingerprint {
+		return StalenessCosmeticDrift
+	}
+	return StalenessSemanticDrift
+}
+
+// LoadedTranscript pairs a validated Transcript with its Staleness against
+// the CURRENT binary, as computed at LoadTranscripts time.
+type LoadedTranscript struct {
+	Transcript Transcript
+	Staleness  Staleness
+}
+
+// LoadResult is LoadTranscripts' return value: every transcript found, keyed
+// by request id, already validated against requests.
+type LoadResult struct {
+	ByID map[string]LoadedTranscript
+}
+
+// LoadTranscripts reads every committed transcript in dir (one file per
+// corpus request, "<requestID>.yaml"; manifestFileName is skipped, never
+// treated as a malformed transcript) and validates it against requests
+// BEFORE returning anything a caller could score.
+//
+// ScoreRun counts a request with no candidate as a fail on BOTH metrics —
+// correct for a live run, where "no candidate" really does mean the model
+// never produced anything usable. For replay that same rule is silently
+// wrong: a corpus id renamed out from under its transcript would be absorbed
+// as one more "missing candidate", quietly turning a 28-request corpus into
+// a 27/28 = 96% pass rate — still above both floors, still green, measuring
+// a smaller and differently-shaped corpus than the one actually committed.
+// So LoadTranscripts hard-errors, never skips, on:
+//
+//  1. Bijection — every requests[i].ID has exactly one transcript file in
+//     dir, and every transcript file's id has a matching entry in requests.
+//     Both directions are checked and the error names every offending id, not
+//     just the first (AC 1.19).
+//  2. corpusPromptSHA256 equality — a transcript's recorded hash of the
+//     corpus prompt it was captured against must equal
+//     sha256Hex(requests[i].Prompt) for that SAME id today. This is what
+//     catches a request's prompt text edited under an id nobody renamed (AC
+//     1.20) — bijection alone would pass that case, since the id itself
+//     never moved.
+//
+// Grounding staleness (Staleness) is computed and returned on every result
+// but is never a reason to fail this call — see Staleness's doc comment.
+//
+// Malformed transcripts (missing required fields, a requestID that disagrees
+// with its own filename, an unrecognized schemaVersion) are also hard
+// errors, matching LoadRequests' "never silently drops a malformed entry"
+// discipline (fixture.go).
+func LoadTranscripts(dir string, requests []Request) (LoadResult, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return LoadResult{}, cerrors.Errorf("reading transcripts directory %q: %w", dir, err)
+	}
+
+	byID := make(map[string]Transcript, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") || e.Name() == manifestFileName {
+			continue
+		}
+
+		id := strings.TrimSuffix(e.Name(), ".yaml")
+		path := filepath.Join(dir, e.Name())
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return LoadResult{}, cerrors.Errorf("reading transcript %q: %w", path, err)
+		}
+		var t Transcript
+		if err := yaml.Unmarshal(data, &t); err != nil {
+			return LoadResult{}, cerrors.Errorf("parsing transcript %q: %w", path, err)
+		}
+		if err := validateTranscriptShape(t, path, id); err != nil {
+			return LoadResult{}, err
+		}
+		byID[id] = t
+	}
+
+	corpusIDs := make(map[string]bool, len(requests))
+	promptByID := make(map[string]string, len(requests))
+	for _, r := range requests {
+		corpusIDs[r.ID] = true
+		promptByID[r.ID] = r.Prompt
+	}
+
+	if err := checkBijection(dir, corpusIDs, byID); err != nil {
+		return LoadResult{}, err
+	}
+
+	currentSystemPromptSHA256 := sha256Hex(BuildSystemPrompt(BuiltinCatalog()))
+	currentCatalogFingerprint := CatalogFingerprint()
+
+	out := make(map[string]LoadedTranscript, len(byID))
+	for id, t := range byID {
+		wantPromptSHA256 := sha256Hex(promptByID[id])
+		if t.CorpusPromptSHA256 != wantPromptSHA256 {
+			return LoadResult{}, cerrors.Errorf(
+				"transcript %q: corpusPromptSHA256 %q does not match the corpus prompt for id %q today (%q) — "+
+					"the request was edited under an unchanged id; re-capture this transcript",
+				id, t.CorpusPromptSHA256, id, wantPromptSHA256,
+			)
+		}
+
+		out[id] = LoadedTranscript{
+			Transcript: t,
+			Staleness:  classifyStaleness(t, currentSystemPromptSHA256, currentCatalogFingerprint),
+		}
+	}
+
+	return LoadResult{ByID: out}, nil
+}
+
+// checkBijection reports every corpus id with no transcript AND every
+// transcript id with no corpus entry, in one error naming all of them — AC
+// 1.19 requires each direction to name the offending id, not just detect that
+// SOME mismatch exists.
+func checkBijection(dir string, corpusIDs map[string]bool, byID map[string]Transcript) error {
+	var missing, extra []string
+	for id := range corpusIDs {
+		if _, ok := byID[id]; !ok {
+			missing = append(missing, id)
+		}
+	}
+	for id := range byID {
+		if !corpusIDs[id] {
+			extra = append(extra, id)
+		}
+	}
+	if len(missing) == 0 && len(extra) == 0 {
+		return nil
+	}
+
+	sort.Strings(missing)
+	sort.Strings(extra)
+
+	var msg strings.Builder
+	fmt.Fprintf(&msg, "transcripts directory %q is not a bijection with the corpus", dir)
+	if len(missing) > 0 {
+		fmt.Fprintf(&msg, "; corpus id(s) with no transcript: %s", strings.Join(missing, ", "))
+	}
+	if len(extra) > 0 {
+		fmt.Fprintf(&msg, "; transcript id(s) with no corpus entry: %s", strings.Join(extra, ", "))
+	}
+	return cerrors.New(msg.String())
+}
+
+// validateTranscriptShape hard-errors on a malformed transcript before it
+// ever reaches the bijection or prompt-hash checks — an empty or
+// wrong-schema file must never be silently treated as "no transcript for
+// this id" (which would misreport as a missing-id bijection failure instead
+// of the actual malformed-file problem).
+func validateTranscriptShape(t Transcript, path, expectedID string) error {
+	if t.SchemaVersion != TranscriptSchemaVersion {
+		return cerrors.Errorf("transcript %q: schemaVersion %d, want %d", path, t.SchemaVersion, TranscriptSchemaVersion)
+	}
+	if t.RequestID == "" {
+		return cerrors.Errorf("transcript %q: no requestID", path)
+	}
+	if t.RequestID != expectedID {
+		return cerrors.Errorf("transcript %q: requestID %q does not match its filename id %q", path, t.RequestID, expectedID)
+	}
+	if t.Provider == "" {
+		return cerrors.Errorf("transcript %q: no provider", path)
+	}
+	if t.Model == "" {
+		return cerrors.Errorf("transcript %q: no model", path)
+	}
+	if t.CorpusPromptSHA256 == "" {
+		return cerrors.Errorf("transcript %q: no corpusPromptSHA256", path)
+	}
+	if t.SystemPromptSHA256 == "" {
+		return cerrors.Errorf("transcript %q: no systemPromptSHA256", path)
+	}
+	if t.CatalogFingerprint == "" {
+		return cerrors.Errorf("transcript %q: no catalogFingerprint", path)
+	}
+	if len(t.Turns) == 0 {
+		return cerrors.Errorf("transcript %q: no turns", path)
+	}
+	for _, turn := range t.Turns {
+		if turn.CompletionText == "" {
+			return cerrors.Errorf("transcript %q: turn %d has no completion text", path, turn.N)
+		}
+	}
+	return nil
+}
+
+// sha256Hex hashes s and returns the lowercase hex digest — the same
+// crypto/sha256 + encoding/hex pairing fingerprintCatalog (grounding.go)
+// already uses, applied here to a single string instead of a stream of
+// tuples.
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// ReplayProviderFor builds a provider.Replay that answers Generate's calls
+// with t's recorded Turns, in file order — turn 0 for attempt 1, turn 1 for
+// the first retry, and so on (provider.Replay's own "keyed by attempt index"
+// contract). No network call is ever made; this is what a PR-CI replay job
+// drives Generate with instead of a live provider.Provider.
+func ReplayProviderFor(t Transcript) *provider.Replay {
+	turns := make([]provider.ReplayTurn, len(t.Turns))
+	for i, turn := range t.Turns {
+		turns[i] = provider.ReplayTurn{Text: turn.CompletionText, TokensUsed: turn.TokensUsed}
+	}
+	return &provider.Replay{
+		ProviderName: t.Provider,
+		Model:        t.Model,
+		Turns:        turns,
+	}
+}

--- a/cmd/conduit/internal/generate/transcript_test.go
+++ b/cmd/conduit/internal/generate/transcript_test.go
@@ -1,0 +1,335 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/conduitio/yaml/v3"
+	"github.com/matryer/is"
+)
+
+// writeTranscript marshals t to dir/<id>.yaml, for tests that build a
+// synthetic transcripts directory without depending on any real committed
+// corpus (today's real testdata/transcripts is empty — A5a-3's job).
+func writeTranscript(t *testing.T, dir, id string, tr Transcript) {
+	t.Helper()
+	data, err := yaml.Marshal(tr)
+	if err != nil {
+		t.Fatalf("marshaling transcript %q: %v", id, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, id+".yaml"), data, 0o600); err != nil {
+		t.Fatalf("writing transcript %q: %v", id, err)
+	}
+}
+
+// validTranscript returns a well-formed Transcript for request r, hashed
+// against r.Prompt and the CURRENT binary's grounding — a fixture that
+// LoadTranscripts accepts as-is, before any test perturbs it.
+func validTranscript(r Request) Transcript {
+	return Transcript{
+		SchemaVersion:      TranscriptSchemaVersion,
+		RequestID:          r.ID,
+		Provider:           "anthropic",
+		Model:              "claude-sonnet-5",
+		CapturedAt:         time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		CorpusPromptSHA256: sha256Hex(r.Prompt),
+		SystemPromptSHA256: sha256Hex(BuildSystemPrompt(BuiltinCatalog())),
+		CatalogFingerprint: CatalogFingerprint(),
+		Turns: []Turn{{
+			N:                1,
+			UserPromptSHA256: sha256Hex(r.Prompt),
+			TokensUsed:       123,
+			CompletionText:   "version: \"2.2\"\npipelines:\n  - id: p\n",
+		}},
+		Outcome: Outcome{ValidatePass: true, SemanticMatch: true},
+	}
+}
+
+func twoRequestCorpus() []Request {
+	return []Request{
+		{ID: "req-a", Prompt: "prompt for request a"},
+		{ID: "req-b", Prompt: "prompt for request b"},
+	}
+}
+
+// Test_LoadTranscripts_HappyPath pins that a well-formed, complete transcript
+// directory loads cleanly and every entry classifies StalenessFresh — the
+// baseline every perturbation test below is a deviation from.
+func Test_LoadTranscripts_HappyPath(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	reqs := twoRequestCorpus()
+	for _, r := range reqs {
+		writeTranscript(t, dir, r.ID, validTranscript(r))
+	}
+
+	got, err := LoadTranscripts(dir, reqs)
+	is.NoErr(err)
+	is.Equal(len(got.ByID), 2)
+	for _, r := range reqs {
+		lt, ok := got.ByID[r.ID]
+		is.True(ok)
+		is.Equal(lt.Staleness, StalenessFresh)
+		is.Equal(lt.Transcript.RequestID, r.ID)
+	}
+}
+
+// Test_LoadTranscripts_ManifestFileIsSkipped pins that manifest.yaml sitting
+// alongside per-request transcripts is never treated as a malformed
+// transcript (it has none of Transcript's required fields) or as an "extra"
+// bijection violation.
+func Test_LoadTranscripts_ManifestFileIsSkipped(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	reqs := twoRequestCorpus()
+	for _, r := range reqs {
+		writeTranscript(t, dir, r.ID, validTranscript(r))
+	}
+	is.NoErr(os.WriteFile(filepath.Join(dir, manifestFileName), []byte("schemaVersion: 1\n"), 0o600))
+
+	got, err := LoadTranscripts(dir, reqs)
+	is.NoErr(err)
+	is.Equal(len(got.ByID), 2)
+}
+
+// --- Bijection (AC 1.19): a file added or removed on either side must
+// hard-error naming the offending id. ---
+
+// Test_LoadTranscripts_MissingTranscript_ErrorsNamingTheID is the "removed
+// file" half of AC 1.19: a corpus request with no transcript must hard-error,
+// naming that request's id, rather than silently scoring it as a
+// Result.Missing fail the way a live ScoreRun would (§3.3's whole point).
+func Test_LoadTranscripts_MissingTranscript_ErrorsNamingTheID(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	reqs := twoRequestCorpus()
+	// Only req-a gets a transcript; req-b's is "removed".
+	writeTranscript(t, dir, "req-a", validTranscript(reqs[0]))
+
+	_, err := LoadTranscripts(dir, reqs)
+	is.True(err != nil)
+	is.True(strings.Contains(err.Error(), "req-b"))
+	is.True(!strings.Contains(err.Error(), "req-a")) // req-a is fine; only the offending id is named as missing
+}
+
+// Test_LoadTranscripts_ExtraTranscript_ErrorsNamingTheID is the "added file"
+// half of AC 1.19: a transcript for an id the corpus doesn't have (e.g. a
+// corpus entry renamed and the old transcript file left behind, or simply
+// never removed) must hard-error naming that id.
+func Test_LoadTranscripts_ExtraTranscript_ErrorsNamingTheID(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	reqs := twoRequestCorpus()
+	for _, r := range reqs {
+		writeTranscript(t, dir, r.ID, validTranscript(r))
+	}
+	// An extra transcript with no corpus entry — as if req-a were renamed to
+	// req-a-renamed in the corpus but its old transcript file was left in
+	// place under the stale id.
+	stray := validTranscript(Request{ID: "req-a-renamed", Prompt: "prompt for request a"})
+	writeTranscript(t, dir, "req-a-renamed", stray)
+
+	_, err := LoadTranscripts(dir, reqs)
+	is.True(err != nil)
+	is.True(strings.Contains(err.Error(), "req-a-renamed"))
+}
+
+// Test_LoadTranscripts_RenamedCorpusID_ErrorsOnBothSides is the literal
+// "corpus id renamed" scenario the plan calls out (§3.3): renaming req-a to
+// req-a-v2 in the corpus, with the transcript directory untouched, must
+// error naming req-a-v2 as missing AND req-a as extra — never absorbed as a
+// passing 1/2 = 50% (the harness's analogue of "27/28 = 96%, still above the
+// floor").
+func Test_LoadTranscripts_RenamedCorpusID_ErrorsOnBothSides(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	reqs := twoRequestCorpus()
+	for _, r := range reqs {
+		writeTranscript(t, dir, r.ID, validTranscript(r))
+	}
+
+	renamed := []Request{
+		{ID: "req-a-v2", Prompt: reqs[0].Prompt}, // req-a renamed, transcript left behind under "req-a"
+		reqs[1],
+	}
+
+	_, err := LoadTranscripts(dir, renamed)
+	is.True(err != nil)
+	is.True(strings.Contains(err.Error(), "no transcript: req-a-v2"))    // corpus id with no transcript
+	is.True(strings.Contains(err.Error(), "no corpus entry: req-a"))     // transcript id with no corpus entry (not the "req-a-v2" substring)
+	is.True(!strings.Contains(err.Error(), "no corpus entry: req-a-v2")) // the extra id is req-a, never req-a-v2
+}
+
+// --- corpusPromptSHA256 (AC 1.20): a prompt edited under an unchanged id. ---
+
+// Test_LoadTranscripts_PromptEditedUnderSameID_Errors is AC 1.20: bijection
+// alone passes here (the id didn't move), so this is a DIFFERENT check —
+// corpusPromptSHA256 must equal sha256Hex of the CURRENT corpus prompt for
+// that id, and a hand-edited prompt with no re-capture must hard-error.
+func Test_LoadTranscripts_PromptEditedUnderSameID_Errors(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	reqs := twoRequestCorpus()
+	for _, r := range reqs {
+		writeTranscript(t, dir, r.ID, validTranscript(r))
+	}
+
+	edited := []Request{
+		{ID: "req-a", Prompt: "a completely different prompt text, edited without a re-capture"},
+		reqs[1],
+	}
+
+	_, err := LoadTranscripts(dir, edited)
+	is.True(err != nil)
+	is.True(strings.Contains(err.Error(), "req-a"))
+	is.True(strings.Contains(err.Error(), "corpusPromptSHA256"))
+}
+
+// --- Malformed transcripts: never silently absorbed as "missing". ---
+
+func Test_LoadTranscripts_WrongSchemaVersion_Errors(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	reqs := twoRequestCorpus()
+	for _, r := range reqs {
+		writeTranscript(t, dir, r.ID, validTranscript(r))
+	}
+	bad := validTranscript(reqs[0])
+	bad.SchemaVersion = 999
+	writeTranscript(t, dir, "req-a", bad)
+
+	_, err := LoadTranscripts(dir, reqs)
+	is.True(err != nil)
+	is.True(strings.Contains(err.Error(), "schemaVersion"))
+}
+
+func Test_LoadTranscripts_RequestIDDisagreesWithFilename_Errors(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	reqs := twoRequestCorpus()
+	writeTranscript(t, dir, "req-a", validTranscript(reqs[1])) // wrong content under req-a's filename
+	writeTranscript(t, dir, "req-b", validTranscript(reqs[1]))
+
+	_, err := LoadTranscripts(dir, reqs)
+	is.True(err != nil)
+	is.True(strings.Contains(err.Error(), "does not match its filename"))
+}
+
+func Test_LoadTranscripts_NoTurns_Errors(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	reqs := twoRequestCorpus()
+	for _, r := range reqs {
+		writeTranscript(t, dir, r.ID, validTranscript(r))
+	}
+	empty := validTranscript(reqs[0])
+	empty.Turns = nil
+	writeTranscript(t, dir, "req-a", empty)
+
+	_, err := LoadTranscripts(dir, reqs)
+	is.True(err != nil)
+	is.True(strings.Contains(err.Error(), "no turns"))
+}
+
+// --- Staleness classification (§3.3): data, never an error. ---
+
+func Test_ClassifyStaleness(t *testing.T) {
+	is := is.New(t)
+
+	fresh := Transcript{SystemPromptSHA256: "sys-a", CatalogFingerprint: "cat-a"}
+	is.Equal(classifyStaleness(fresh, "sys-a", "cat-a"), StalenessFresh)
+
+	cosmetic := Transcript{SystemPromptSHA256: "sys-old", CatalogFingerprint: "cat-a"}
+	is.Equal(classifyStaleness(cosmetic, "sys-new", "cat-a"), StalenessCosmeticDrift)
+
+	semantic := Transcript{SystemPromptSHA256: "sys-old", CatalogFingerprint: "cat-old"}
+	is.Equal(classifyStaleness(semantic, "sys-new", "cat-new"), StalenessSemanticDrift)
+}
+
+// Test_LoadTranscripts_StaleTranscript_LoadsWithoutError pins that a
+// transcript whose recorded grounding no longer matches the current binary
+// is NOT a load error — only its Staleness field reflects the drift. A
+// red-on-every-connector-bump loader would be exactly the flaky-gate failure
+// §3.3 refuses to reintroduce.
+func Test_LoadTranscripts_StaleTranscript_LoadsWithoutError(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	reqs := twoRequestCorpus()
+	stale := validTranscript(reqs[0])
+	stale.SystemPromptSHA256 = "no-longer-the-current-system-prompt-hash"
+	stale.CatalogFingerprint = "no-longer-the-current-catalog-fingerprint"
+	writeTranscript(t, dir, "req-a", stale)
+	writeTranscript(t, dir, "req-b", validTranscript(reqs[1]))
+
+	got, err := LoadTranscripts(dir, reqs)
+	is.NoErr(err)
+	is.Equal(got.ByID["req-a"].Staleness, StalenessSemanticDrift)
+	is.Equal(got.ByID["req-b"].Staleness, StalenessFresh)
+}
+
+// --- ReplayProviderFor ---
+
+func Test_ReplayProviderFor_CarriesTurnsAndIdentity(t *testing.T) {
+	is := is.New(t)
+	tr := Transcript{
+		Provider: "anthropic",
+		Model:    "claude-sonnet-5",
+		Turns: []Turn{
+			{CompletionText: "first", TokensUsed: 10},
+			{CompletionText: "second", TokensUsed: 20},
+		},
+	}
+
+	p := ReplayProviderFor(tr)
+	is.Equal(p.Name(), "anthropic")
+	is.Equal(len(p.Turns), 2)
+	is.Equal(p.Turns[0].Text, "first")
+	is.Equal(p.Turns[0].TokensUsed, 10)
+	is.Equal(p.Turns[1].Text, "second")
+}
+
+// --- Manifest ---
+
+func Test_LoadManifest_ReadsCommittedShape(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, manifestFileName)
+	is.NoErr(os.WriteFile(path, []byte(`
+schemaVersion: 1
+provider: anthropic
+model: claude-sonnet-5
+capturedAt: 2026-08-01T00:00:00Z
+requestCount: 28
+totalTokensUsed: 94000
+estimatedCostUSD: 2.9
+`), 0o600))
+
+	m, err := LoadManifest(path)
+	is.NoErr(err)
+	is.Equal(m.Provider, "anthropic")
+	is.Equal(m.RequestCount, 28)
+	is.Equal(m.TotalTokensUsed, 94000)
+}
+
+func Test_LoadManifest_MissingFile_Errors(t *testing.T) {
+	is := is.New(t)
+	_, err := LoadManifest(filepath.Join(t.TempDir(), "does-not-exist.yaml"))
+	is.True(err != nil)
+}


### PR DESCRIPTION
Slice A5a-2 of WS1: the committed transcript format, its loader, the redaction scanner, and the replay provider. **No capture and no network** — A5a-3 does that, and it needs this schema to exist first.

The plan is `conduit-v020-plans/ws1-a5-eval-plan.md` §3 and §5; the design doc is `20260722-conduit-generate.md` §10.

## Why the loader is strict

`ScoreRun` counts a missing request id as a fail on both metrics. That's right for a live run and **silently wrong for replay**, where a renamed corpus id quietly becomes `27/28 = 96%` — still above the floor, green CI, measuring a corpus one request smaller than the committed one.

So `LoadTranscripts` validates *before* anything is scored and hard-errors on:

- **bijection**, both directions, naming every offending id;
- **`corpusPromptSHA256` mismatch**, which catches a prompt edited under an unchanged id — the case a name check alone cannot see.

Malformed transcripts (wrong `schemaVersion`, `requestID` ≠ filename, zero turns) are errors too. Never skips, matching `LoadRequests`'s existing "never silently drops a malformed entry" discipline.

## Why staleness is data, not an error

`BuildSystemPrompt` derives from the compiled-in connector catalog, so any dependabot bump of a `conduit-connector-*` module can change the prompt and leave a frozen transcript answering a question the binary no longer asks.

`classifyStaleness` returns **fresh / cosmetic / semantic** on the load result and lets the consumer decide. A check that goes red on every connector bump is the flaky-gate failure this project has documented history with; the eval job warns, and the scheduled job (A5b-2) is what re-captures.

## Redaction

Deny-list patterns, an 8 KiB per-turn cap, and a structural check that credential-shaped `settings` keys hold only `TODO`-style placeholders. `TestTranscripts_CarryNoSecretMaterial` is **untagged**, so it runs in the normal `test` job over whatever transcripts exist — no new required check to negotiate.

Two corrections the agent made against the plan, both worth keeping visible:

1. **Processor settings were initially missed.** The plan says "any settings key"; the first pass only scanned `Connector.Settings`. `config.Processor` has its own `Settings` map, pipeline-level and connector-attached. Fixed via the existing `allProcessors` helper, with a regression test.
2. **The long-base64 pattern has a real false-positive risk** — a run of any single repeated character matches it, which it hit against its own test filler. No false positives against the six builtin connectors' actual parameter names today, but this is a literal reading of the plan's deny-list rather than a tuned heuristic. It fails *closed* (capture aborts), so the failure mode is a wasted capture run, not a leak. Worth knowing before A5a-3's real capture.

## Verified independently

Beyond the agent's own perturbations, I planted a synthetic `sk-ant-api03-…` key in a transcript under the real testdata tree and ran the scanner: it failed, naming the transcript, the turn, and the pattern — **without echoing the key**. Removing it passed again.

`go test ./cmd/... -count=1` green across 28 packages, `golangci-lint` 0 issues, `make generate-llms` no diff. Rebased cleanly onto `main` after A5a-1 merged.

## Risk tier

**Tier 2.** Test infrastructure and a committed data format; no data-path code, no runtime behavior change.

Roadmap: v0.20 WS1 (`conduit generate`), slice A5a-2.
