### PR TITLE
fix: two production bugs and one async assertion behind three flaky tests

### DIFF
--- a/cmd/conduit/root/mcp/mcp.go
+++ b/cmd/conduit/root/mcp/mcp.go
@@ -178,7 +178,7 @@ func (c *MCPCommand) Execute(ctx context.Context) error {
 	if c.flags.HTTP == "" {
 		// stdio only — the common case: the agent owns this process, so no
 		// separate auth is needed (design doc §5).
-		return srv.Run(ctx, &sdkmcp.StdioTransport{})
+		return stdioResult(ctx, srv.Run(ctx, &sdkmcp.StdioTransport{}))
 	}
 
 	httpSrv, err := c.newHTTPServer(srv, c.httpLogger())
@@ -208,6 +208,40 @@ func (c *MCPCommand) Execute(ctx context.Context) error {
 	})
 
 	return grp.Wait()
+}
+
+// stdioResult reports what the stdio transport should surface to the CLI
+// entrypoint once srv.Run has returned, making a cancelled shutdown report
+// cancellation deterministically.
+//
+// sdkmcp.Server.Run ends in a select between ctx.Done() and an internal
+// session-closed channel. On a cancelled context BOTH cases become ready:
+// Run's own ss.Close() closes the connection, and StdioTransport hands the
+// SDK os.Stdin/os.Stdout directly (mcp/transport.go: `newIOConn(rwc{os.Stdin,
+// ...})`), so closing it makes the read loop fail and the session end within
+// tens of microseconds of the cancellation. Go picks uniformly at random
+// among ready select cases, so the exact same graceful SIGINT/SIGTERM
+// shutdown could return any of three values:
+//
+//   - context.Canceled      -> exitcode.OK (0), the intended outcome
+//   - nil                   -> exit 0, but silently (the session-closed case
+//     winning on a stdin that was already at EOF)
+//   - *fs.PathError "read /dev/stdin: file already closed" -> classified as
+//     exitcode.Runtime (1)
+//
+// That last one is the bug: a clean, operator-initiated shutdown of `conduit
+// mcp` would intermittently exit 1 and print a spurious error, which a
+// supervisor (systemd/Kubernetes) reads as a crash. Cancellation is the
+// reason we are returning, so report ctx.Err() and let pkg/conduit/exitcode
+// map it to 0 — the same graceful-shutdown convention `conduit run` uses.
+//
+// A transport error that is NOT concurrent with cancellation still
+// propagates unchanged; only the shutdown window is normalized.
+func stdioResult(ctx context.Context, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	return err
 }
 
 // httpLogger builds the log.CtxLogger the --http path uses for its startup/

--- a/cmd/conduit/root/mcp/mcp_test.go
+++ b/cmd/conduit/root/mcp/mcp_test.go
@@ -16,10 +16,13 @@ package mcp
 
 import (
 	"context"
+	"io/fs"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/conduitio/conduit/pkg/conduit/exitcode"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/matryer/is"
 )
@@ -76,6 +79,22 @@ func TestExecute_NoHTTPFlag_UsesStdioTransport(t *testing.T) {
 
 	c := &MCPCommand{flags: MCPFlags{}}
 
+	// Hold stdin open for the duration of the test (#2774). Two reasons,
+	// both load-bearing:
+	//
+	//  1. Determinism. Under `go test` the real os.Stdin is /dev/null, which
+	//     is at EOF immediately, so the SDK session ends on its own the
+	//     instant Run starts it — making BOTH cases of Run's internal select
+	//     ready and the outcome random (see stdioResult's doc). An open pipe
+	//     never EOFs, so the session stays alive and cancellation is the only
+	//     ready case: Run takes the ctx.Done() branch every time.
+	//  2. Isolation. StdioTransport hands the SDK the process's real
+	//     os.Stdin and the SDK closes it on shutdown. Without this swap the
+	//     test permanently closes stdin for every other test in the binary,
+	//     which is what turned `-count`/`-shuffle` runs into "read
+	//     /dev/stdin: file already closed" failures.
+	stdinPipe(t)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // already cancelled: the stdio path must return promptly
 
@@ -89,4 +108,67 @@ func TestExecute_NoHTTPFlag_UsesStdioTransport(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("Execute did not return promptly on the no-HTTP path; it may not be taking the stdio branch")
 	}
+}
+
+// stdinPipe replaces os.Stdin with the read end of a fresh pipe that is never
+// written to (so it blocks rather than reaching EOF) and restores the
+// original at test end. The write end is deliberately kept open until
+// cleanup: closing it would put the read end at EOF and reintroduce exactly
+// the race this guards against.
+func stdinPipe(t *testing.T) {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = orig
+		_ = w.Close()
+		_ = r.Close()
+	})
+}
+
+// TestStdioResult_CancellationIsDeterministic is the #2774 regression test.
+//
+// It pins the property the flaky Execute test was only usually observing:
+// whatever sdkmcp.Server.Run's internal select happens to pick, a cancelled
+// stdio run reports cancellation — and therefore exits 0. Without
+// stdioResult, the "session closed" cases below return nil and the PathError
+// respectively, and the PathError case exits 1 on a clean operator-initiated
+// shutdown.
+func TestStdioResult_CancellationIsDeterministic(t *testing.T) {
+	// The three values sdkmcp.Server.Run can return for the same cancelled
+	// shutdown, depending only on which ready select case Go picks.
+	stdinClosed := &fs.PathError{Op: "read", Path: "/dev/stdin", Err: os.ErrClosed}
+	runOutcomes := []error{
+		context.Canceled, // ctx.Done() branch won
+		nil,              // session-closed branch won, stdin was at EOF
+		stdinClosed,      // session-closed branch won, after Run closed stdin
+	}
+
+	t.Run("cancelled ctx always reports cancellation", func(t *testing.T) {
+		is := is.New(t)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		for _, runErr := range runOutcomes {
+			got := stdioResult(ctx, runErr)
+			is.True(cerrors.Is(got, context.Canceled))
+			// The property an operator/supervisor actually observes.
+			is.Equal(exitcode.ExitCode(got), exitcode.OK)
+		}
+	})
+
+	t.Run("live ctx propagates Run's result unchanged", func(t *testing.T) {
+		is := is.New(t)
+
+		ctx := context.Background()
+
+		is.NoErr(stdioResult(ctx, nil))
+		is.Equal(stdioResult(ctx, stdinClosed), error(stdinClosed))
+	})
 }

--- a/pkg/lifecycle-poc/service.go
+++ b/pkg/lifecycle-poc/service.go
@@ -270,12 +270,14 @@ func (s *Service) Start(
 
 	s.logger.Trace(ctx).Str(log.PipelineIDField, pl.ID).Msg("running pipeline")
 
+	// runPipeline publishes rp into runningPipelines itself, at the exact
+	// point the run goes live — see the Set call there for why that ordering
+	// is load-bearing (#2746) and why this function must not do it after the
+	// fact.
 	if err := s.runPipeline(rp); err != nil {
 		return cerrors.Errorf("failed to run pipeline %s: %w", pl.ID, err)
 	}
 	s.logger.Info(ctx).Str(log.PipelineIDField, pl.ID).Msg("pipeline started")
-
-	s.runningPipelines.Set(pl.ID, rp)
 
 	return nil
 }
@@ -1656,6 +1658,37 @@ func (s *Service) runPipeline(rp *runnablePipeline) error {
 	// write (the cleanup goroutine is the one that waits for that, via
 	// startupDone).
 	close(registered)
+
+	// Publish this run as THE live run for its pipeline ID, here and not in
+	// Start (#2746).
+	//
+	// Invariant: whenever a caller can observe the pipeline as running,
+	// runningPipelines[id] is the run that is actually running. Every public
+	// entry point resolves a pipeline through this map — Stop, StopAll,
+	// WaitPipeline, StopAndWait (and thus provisioning.ApplyPlanLive) — and
+	// StartWithBackoff's "am I still the live pipeline" guard is a pointer
+	// comparison against it. A stale entry does not fail loudly; it makes all
+	// of them operate on the previous, already-dead run.
+	//
+	// Start used to Set this AFTER runPipeline returned, i.e. after the
+	// UpdateStatus below had already announced StatusRunning. On a recovery
+	// restart the old entry is deliberately left in place until the swap (see
+	// runPipeline's recovery arm), so in that window the map still pointed at
+	// the FAILED run: WaitPipeline joined the dead tomb and returned the
+	// pre-recovery error for a pipeline that had just recovered, and Stop
+	// stopped the dead run while the recovered one kept going — leaving a
+	// pipeline nobody could stop and a persister that never quiesced.
+	//
+	// This is the correct publish point, and it needs no rollback on error:
+	//   - every earlier return in this function (sink Open, worker Open)
+	//     fails before any goroutine is on the tomb, so nothing is published;
+	//   - from here on the tomb owns termination, and its cleanup goroutine
+	//     performs the matching runningPipelines.Delete — including when the
+	//     UpdateStatus below fails;
+	//   - that cleanup goroutine blocks on startupDone (closed below), so it
+	//     can never Delete before this Set, which would strand a live run
+	//     outside the map.
+	s.runningPipelines.Set(rp.pipeline.ID, rp)
 
 	// It's now safe to make the potentially slow UpdateStatus call and then
 	// release the cleanup goroutine to make its own. close(startupDone)

--- a/pkg/lifecycle-poc/service_test.go
+++ b/pkg/lifecycle-poc/service_test.go
@@ -791,6 +791,134 @@ func TestServiceLifecycle_Recovery_TransientErrorRecovers(t *testing.T) {
 	})
 }
 
+// TestServiceLifecycle_Recovery_LiveEntryPublishedBeforeRunningStatus is the
+// #2746 regression test.
+//
+// The invariant: whenever a caller can observe the pipeline as running,
+// runningPipelines[id] is the run that is ACTUALLY running. Everything
+// public resolves a pipeline through that map — Stop, StopAll, WaitPipeline,
+// StopAndWait (and so provisioning.ApplyPlanLive) — and StartWithBackoff's
+// "am I still the live pipeline" guard is a pointer comparison against it.
+//
+// Start used to publish the new run only AFTER runPipeline returned, i.e.
+// after runPipeline had already announced StatusRunning. On a recovery
+// restart the previous entry is deliberately left in place until that swap,
+// so in the gap the map pointed at the FAILED run: WaitPipeline joined the
+// dead tomb and returned the pre-recovery error for a pipeline that had just
+// recovered, and Stop stopped the dead run while the recovered one kept
+// running — a pipeline nobody could stop, and a persister that never
+// quiesced (which is the 10-minute hang in #2746, not just its fast
+// assertion failure).
+//
+// This does not try to catch that gap by racing it, which is what made the
+// original symptom intermittent. It HOLDS the lifecycle inside the gap:
+// statusRecorder.onUpdate blocks in the middle of the post-recovery
+// StatusRunning write — the exact instant an observer first learns the
+// pipeline is running again — and the assertions run there. Pre-fix that is
+// a deterministic failure, not a probabilistic one.
+func TestServiceLifecycle_Recovery_LiveEntryPublishedBeforeRunningStatus(t *testing.T) {
+	is := is.New(t)
+	ctx, killAll := context.WithCancel(context.Background())
+	defer killAll()
+	logger := log.New(zerolog.Nop())
+	db := &inmemory.DB{}
+	persister := connector.NewPersister(logger, db, time.Second, 3)
+	defer stopAndWaitPersister(t, killAll, persister)
+
+	ps := pipeline.NewService(logger, db)
+	pl, err := ps.Create(ctx, uuid.NewString(), pipeline.Config{Name: "test pipeline"}, pipeline.ProvisionTypeAPI)
+	is.NoErr(err)
+
+	transientErr := cerrors.New("lost connection to source")
+	healthyRecords := generateRecords(3)
+
+	ctrl := gomock.NewController(t)
+	source, srcDispenser := sourceRecoversAfterTransientError(ctrl, persister, healthyRecords, transientErr)
+	destination, destDispenser := destinationRecovers(ctrl, persister, healthyRecords)
+	dlq, dlqDispenser := dlqDispenserTimes(ctrl, persister, 2)
+	pl.DLQ.Plugin = dlq.Plugin
+
+	pl, err = ps.AddConnector(ctx, pl.ID, source.ID)
+	is.NoErr(err)
+	pl, err = ps.AddConnector(ctx, pl.ID, destination.ID)
+	is.NoErr(err)
+
+	// inWindow closes when the recovered run is mid-announcement; release
+	// unblocks it once the assertions below have run.
+	inWindow := make(chan struct{})
+	release := make(chan struct{})
+	rec := newStatusRecorder(ps)
+	rec.onUpdate = func(status pipeline.Status, nth int) {
+		// The 2nd StatusRunning is the recovery restart (the 1st is the
+		// initial run). Fire once: a later run must not re-block.
+		if status == pipeline.StatusRunning && nth == 2 {
+			close(inWindow)
+			<-release
+		}
+	}
+
+	ls := NewService(
+		logger,
+		testErrRecoveryCfg(),
+		testConnectorService{
+			source.ID:      source,
+			destination.ID: destination,
+			testDLQID:      dlq,
+		},
+		testProcessorService{},
+		testConnectorPluginService{
+			source.Plugin:      srcDispenser,
+			destination.Plugin: destDispenser,
+			dlq.Plugin:         dlqDispenser,
+		},
+		rec,
+		false,
+	)
+
+	is.NoErr(ls.Start(ctx, pl.ID))
+
+	<-inWindow
+
+	// The assertion, taken while the lifecycle is frozen in the window: the
+	// entry a caller would resolve right now must be the live run, not the
+	// one that just failed. Reading rp.t directly (rather than going through
+	// Stop/WaitPipeline, both of which legitimately BLOCK on a live tomb and
+	// so cannot distinguish "correct" from "hung" here) is what keeps this
+	// deterministic. Pre-fix, ok is true but the entry is the pre-recovery
+	// runnablePipeline, whose tomb was killed by transientErr.
+	rp, ok := ls.runningPipelines.Get(pl.ID)
+	is.True(ok) // no live entry at all while the pipeline reports Running
+	is.True(rp.t != nil)
+	if !rp.t.Alive() {
+		t.Fatalf(
+			"runningPipelines[%s] is a DEAD run at the moment the pipeline announces StatusRunning "+
+				"(tomb err: %v) - Stop/WaitPipeline/StopAndWait would all operate on the failed "+
+				"pre-recovery run instead of the recovered one (#2746)",
+			pl.ID, rp.t.Err(),
+		)
+	}
+
+	close(release)
+
+	// Behavioural half: with the live entry published in time, the recovered
+	// run is the one a caller can actually drive to a clean stop - no
+	// pre-recovery error resurfacing from a dead tomb, and no orphaned run
+	// left behind (which is what stopAndWaitPersister above would hang on).
+	waitForRecordsAcked(t, source, healthyRecords)
+	is.Equal(pipeline.StatusRunning, pl.GetStatus())
+
+	is.NoErr(ls.Stop(ctx, pl.ID, false))
+	is.NoErr(ls.WaitPipeline(pl.ID))
+	is.Equal(pipeline.StatusUserStopped, pl.GetStatus())
+
+	is.Equal(rec.snapshot(), []pipeline.Status{
+		pipeline.StatusRunning,
+		pipeline.StatusRecovering,
+		pipeline.StatusRunning,
+		pipeline.StatusUserStopped,
+	})
+}
+
 // TestServiceLifecycle_Recovery_MaxRetriesExhausted proves the bounded-retry
 // path (design-doc path: running → recovering → degraded). With a finite
 // MaxRetries and a source that fails on every run, the pipeline attempts exactly
@@ -1755,6 +1883,16 @@ type statusRecorder struct {
 	PipelineService
 	mu       sync.Mutex
 	statuses []pipeline.Status
+
+	// onUpdate, if set, is called from inside UpdateStatus — after the status
+	// has been recorded (so a concurrent snapshot/waitForRecovered already
+	// sees it) but before the wrapped service applies it. It is the seam that
+	// lets a test hold the lifecycle inside the "run is going live" window
+	// and inspect it, instead of trying to catch that window by racing it.
+	// The argument is the status being written and its 1-based occurrence
+	// count for that status, so a hook can distinguish e.g. the initial
+	// StatusRunning from the post-recovery one.
+	onUpdate func(status pipeline.Status, nth int)
 }
 
 func newStatusRecorder(inner PipelineService) *statusRecorder {
@@ -1764,7 +1902,18 @@ func newStatusRecorder(inner PipelineService) *statusRecorder {
 func (r *statusRecorder) UpdateStatus(ctx context.Context, id string, status pipeline.Status, errMsg string) error {
 	r.mu.Lock()
 	r.statuses = append(r.statuses, status)
+	nth := 0
+	for _, s := range r.statuses {
+		if s == status {
+			nth++
+		}
+	}
+	hook := r.onUpdate
 	r.mu.Unlock()
+
+	if hook != nil {
+		hook(status, nth)
+	}
 	return r.PipelineService.UpdateStatus(ctx, id, status, errMsg)
 }
 

--- a/tests/chaos/sigterm_test.go
+++ b/tests/chaos/sigterm_test.go
@@ -34,11 +34,59 @@ import (
 //
 // Timing mirrors property2_test.go's mid-position-write case exactly
 // (paceMS=15, killAfterReads=95): by read #95 (~1.4s in) one automatic
-// debounce flush has already happened (~1s, around read ~66) and a second
-// debounce window has already started (on the next ack after that flush) but
-// not yet fired - so there is a genuine deferred ack in flight when SIGTERM
-// lands, which is exactly the window invariant 7 protects.
+// debounce flush has normally already happened (~1s, around read ~66) and a
+// second debounce window has already started (on the next ack after that
+// flush) but not yet fired - so there is a genuine deferred ack in flight
+// when SIGTERM lands, which is exactly the window invariant 7 protects.
+//
+// "Normally" is load-bearing, and used to be the flake (#2773): the read
+// count and the flush chain are ordered only by wall clock, with a measured
+// ~460ms of margin between them. The read count is still what puts this case
+// in the mid-position-write window, but the flush is now WAITED FOR
+// (waitForFirstUpstreamCommit) rather than assumed, and every assertion
+// below is anchored on state this test actually observed at signal time.
 func TestSIGTERM_GracefulTeardown_DrainsDeferredAck(t *testing.T) {
+	cases := []struct {
+		name string
+		// persistDelayMS overrides the persister debounce; 0 = production
+		// default (1s). See childConfig.persistDelayMS.
+		persistDelayMS int
+	}{{
+		// The original case: production's own 1s debounce, so the deferred
+		// window this exercises is the one real deployments have.
+		name:           "default_debounce",
+		persistDelayMS: 0,
+	}, {
+		// #2773 regression case, and a stronger invariant-7 scenario in its
+		// own right.
+		//
+		// A debounce longer than the run's read phase means NO flush can
+		// have landed by read #95 - deterministically, on any machine, with
+		// no contention needed. Pre-fix that made this case fail 100% of the
+		// time ("test setup assumption violated: expected 0 <
+		// committedBefore(0)"), which is precisely the failure #2773 saw
+		// intermittently in CI: a slow enough box is indistinguishable from
+		// a slow enough debounce. Post-fix the run simply waits for the
+		// flush and asserts the same invariant against it.
+		//
+		// It is also the worst case for invariant 7 on its own merits: the
+		// entire run's worth of acks is still deferred when SIGTERM lands,
+		// so Teardown has the largest possible backlog to drain. Same knob,
+		// same reasoning as sigkillCases' mid-snapshot precondition (see
+		// childConfig.persistDelayMS) - make the precondition deterministic
+		// instead of wall-clock-inferred.
+		name:           "debounce_slower_than_read_phase",
+		persistDelayMS: 2000,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runSigtermDrainCase(t, tc.persistDelayMS)
+		})
+	}
+}
+
+func runSigtermDrainCase(t *testing.T, persistDelayMS int) {
 	is := is.New(t)
 	dir := t.TempDir()
 
@@ -51,12 +99,13 @@ func TestSIGTERM_GracefulTeardown_DrainsDeferredAck(t *testing.T) {
 	)
 
 	cfg := childConfig{
-		dbDir:       dir + "/db",
-		upstreamDir: dir + "/upstream",
-		prune:       false, // graceful path; prune-vs-durable is irrelevant here (Property 2 already covers that axis)
-		paceMS:      paceMS,
-		total:       total,
-		sigtermMode: true,
+		dbDir:          dir + "/db",
+		upstreamDir:    dir + "/upstream",
+		prune:          false, // graceful path; prune-vs-durable is irrelevant here (Property 2 already covers that axis)
+		paceMS:         paceMS,
+		total:          total,
+		sigtermMode:    true,
+		persistDelayMS: persistDelayMS,
 	}
 
 	cp := spawnChild(t, cfg)
@@ -67,19 +116,49 @@ func TestSIGTERM_GracefulTeardown_DrainsDeferredAck(t *testing.T) {
 	// still-pending flush.
 	upstreamBefore, err := openUpstreamStore(cfg.upstreamDir, cfg.prune)
 	is.NoErr(err)
-	committedBefore, err := upstreamBefore.Committed()
-	is.NoErr(err)
-	// The timing (see doc comment) is chosen so a flush has already
-	// happened, but nowhere near killAfterReads worth of positions -
-	// confirming there's genuinely a "deferred and not yet visible upstream"
-	// gap for Teardown to close, not something that had already caught up
-	// on its own.
-	if committedBefore == 0 || committedBefore >= uint64(killAfterReads) {
+
+	// #2773: POLL for the first flush to become visible upstream instead of
+	// sampling the watermark once and asserting it is already non-zero.
+	//
+	// "One debounce flush has happened by read #95" is an asynchronous
+	// watermark, not a fact the read count establishes. The two are only
+	// ordered by wall clock, and the budget is small and fixed: measured
+	// over 15 -race runs on an idle machine, the first upstream commit lands
+	// at 1.10-1.19s (the 1s persister debounce, plus the durable write, plus
+	// the deferred-ack send, plus the plugin's own commit) while read #95
+	// lands at 1.56-1.64s - a margin of 448-473ms, ~460ms every time. Any CI
+	// stall longer than that anywhere in that chain used to turn this into a
+	// "test setup assumption violated" failure on a required check, with
+	// nothing wrong with the code under test (that is exactly the 1.98s
+	// failure in #2773).
+	//
+	// Waiting for the watermark itself removes the wall-clock dependency
+	// without weakening anything: the property this case exists to pin is
+	// about what SIGTERM does to a deferred ack, and it is asserted below
+	// against the state actually observed here, not against an assumed one.
+	committedBefore := waitForFirstUpstreamCommit(t, cp, upstreamBefore, 30*time.Second)
+
+	// Sample the read count AFTER the watermark (never before: polling may
+	// have taken time, and a stale-low read count would make the gap check
+	// below fire spuriously). readsAtSignal is a lower bound on how many
+	// records the source had read when the signal landed - reads keep coming
+	// until then - which is what makes it a safe anchor for the drain
+	// assertion further down.
+	readsAtSignal := uint64(cp.readCount())
+
+	// The premise this case needs, now checked against observed state rather
+	// than assumed from timing: a flush has landed upstream, but it is
+	// behind the reads - i.e. there genuinely IS a "deferred and not yet
+	// visible upstream" gap for Teardown to close, not something that had
+	// already caught up on its own. The persister's debounce makes acks lag
+	// reads structurally, so this holds however slow the run was.
+	if committedBefore >= readsAtSignal {
 		t.Fatalf(
-			"test setup assumption violated: expected 0 < committedBefore(%d) < killAfterReads(%d) - "+
-				"either the persister debounce timing changed, or this case's pacing no longer lands "+
-				"in the intended mid-position-write window\n%s",
-			committedBefore, killAfterReads, cp.diagnostics(),
+			"test setup assumption violated: expected committedBefore(%d) < readsAtSignal(%d) - "+
+				"the upstream watermark has caught up with the reads, so there is no deferred ack "+
+				"in flight for SIGTERM to land on; either the persister debounce was disabled or "+
+				"this case's pacing no longer lands in the intended mid-position-write window\n%s",
+			committedBefore, readsAtSignal, cp.diagnostics(),
 		)
 	}
 
@@ -113,19 +192,27 @@ func TestSIGTERM_GracefulTeardown_DrainsDeferredAck(t *testing.T) {
 			committedBefore, committedAfter, killAfterReads, cp.diagnostics(),
 		)
 	}
-	// Allow a small margin below killAfterReads: the producer's own pacing
+	// Allow a small margin below readsAtSignal: the producer's own pacing
 	// means the very last read(s) before the signal may not have been acked
 	// yet (an Ack call happens strictly after its Read), so the drained
-	// position can be a few short of killAfterReads without indicating any
-	// drop - what matters is that it advanced well past committedBefore,
-	// not that it hit the read count exactly.
+	// position can be a few short without indicating any drop - what matters
+	// is that it advanced well past committedBefore, not that it hit the
+	// read count exactly.
+	//
+	// Anchored on readsAtSignal rather than the killAfterReads constant
+	// (#2773): once the watermark is polled for above, a slow run can go on
+	// reading past killAfterReads before the signal lands, and every one of
+	// those extra reads must be drained too. Using the observed read count
+	// keeps this assertion as strong as the run was long, instead of
+	// silently loosening to a fixed 95 on exactly the slow runs where a
+	// drain bug is most likely to show.
 	const slack = 5
-	if committedAfter+slack < uint64(killAfterReads) {
+	if committedAfter+slack < readsAtSignal {
 		t.Fatalf(
 			"graceful SIGTERM teardown drained fewer acks than expected - committed only reached %d, "+
-				"expected within %d of killAfterReads (%d) - the deferred ack pending at signal-time "+
-				"looks like it was NOT fully flushed before the process exited\n%s",
-			committedAfter, slack, killAfterReads, cp.diagnostics(),
+				"expected within %d of the read count at signal time (%d) - the deferred ack pending "+
+				"at signal-time looks like it was NOT fully flushed before the process exited\n%s",
+			committedAfter, slack, readsAtSignal, cp.diagnostics(),
 		)
 	}
 
@@ -164,4 +251,47 @@ func TestSIGTERM_GracefulTeardown_DrainsDeferredAck(t *testing.T) {
 
 	_, done := third.line(markerDone)
 	is.True(done)
+}
+
+// waitForFirstUpstreamCommit blocks (polling, exactly like
+// childProcess.waitForReadCount - never a fixed sleep) until the upstream
+// store reports a non-zero committed watermark, and returns it.
+//
+// This exists because "the persister has flushed at least once, and that
+// flush's deferred ack has made it all the way to the plugin's own durable
+// commit" is an ASYNCHRONOUS event with no ordering relationship to the
+// child's read count. Read progress is paced (waitForReadCount's doc
+// explains why that makes it a sound clock); the flush chain is not paced by
+// anything this test controls, so the only correct way to depend on it is to
+// wait for it. Reading it once and asserting it already happened is the
+// #2773 flake.
+//
+// The timeout is a stuck-forever guard, not a tuning knob: on the happy path
+// this returns after ~0ms (the flush has normally already landed by the time
+// killAfterReads reads have been paced out) and it must never be raised to
+// "fix" a failure - a run that genuinely never commits upstream is a real
+// invariant-1 finding, and the diagnostics dump below is how to read it.
+func waitForFirstUpstreamCommit(t *testing.T, cp *childProcess, upstream *upstreamStore, timeout time.Duration) uint64 {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for {
+		committed, err := upstream.Committed()
+		if err != nil {
+			t.Fatalf("read upstream committed watermark: %v\n%s", err, cp.diagnostics())
+		}
+		if committed > 0 {
+			return committed
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf(
+				"upstream watermark never advanced past 0 within %s - the persister's debounce flush, "+
+					"its durable write, the resulting deferred ack, or the plugin's commit of it never "+
+					"completed while the source kept reading; that is an invariant-1 finding, not a "+
+					"timing artifact\n%s",
+				timeout, cp.diagnostics(),
+			)
+		}
+		time.Sleep(time.Millisecond)
+	}
 }


### PR DESCRIPTION
**Tier 1 — the #2746 fix is data-path. Needs your sign-off; not merging on green.**

Three issues that all presented as flaky tests. **Two were production bugs.** Three independent commits, revertable separately, each with a test verified to fail without its fix.

## #2746 — `WaitPipeline` returns the pre-recovery error — **production bug**

`runPipeline` announces `StatusRunning` at its tail, but `Start` publishes the new `runnablePipeline` into `runningPipelines` only *after* `runPipeline` returns. On a recovery restart the previous entry is deliberately left in place until that swap (the recovery arm returns nil early so the pointer guard can see a concurrent restart). **So between the announcement and the swap, the map still points at the failed run.**

Every public entry point resolves through that map. `WaitPipeline` joined the dead tomb and returned the stale error. Worse: `Stop` stopped the dead run and reported success while the recovered run kept going — connectors never torn down, persister never quiesced. That orphaned-run stall *is* the 10-minute timeout in the issue.

Fixed by publishing inside `runPipeline`, immediately after `close(registered)` and before the `StatusRunning` write. No rollback needed: earlier returns fail before any goroutine is on the tomb, and after that point the tomb's cleanup goroutine owns the matching `Delete` and blocks on `startupDone`, so it cannot `Delete` before the `Set`.

The test doesn't race the window — it **holds the lifecycle inside it** via a status-update hook that blocks mid-`StatusRunning`. Pre-fix it fails 5/5 in 12s (the orphaned-run stall showing up directly); post-fix it passes 5/5 in 0.00s. Note that a pre-fix `-count=60` sweep of the whole package passed, which is exactly why the deterministic hold matters more than repeat runs.

## #2774 — MCP stdio returns nil instead of `context.Canceled` — **production bug**

`sdkmcp.Server.Run` ends in a `select` between `ctx.Done()` and its session-closed channel. On cancellation **both** become ready — `Run`'s own `ss.Close()` closes the connection, and `StdioTransport` hands the SDK the process's real `os.Stdin`, so closing it fails the read loop and ends the session. Measured latency between them: **21–49 µs**.

Go picks uniformly at random among ready cases, so the same graceful shutdown returned `context.Canceled` (exit 0), `nil` (exit 0, silent), or `*fs.PathError "file already closed"` — which classifies as `exitcode.Runtime` and **exits 1 on a clean SIGTERM**. A supervisor reads that as a crash.

Reproduced pre-fix with 24 concurrent race-enabled processes at `GOMAXPROCS=2`, ×200 each: **4/24 failed**. Post-fix: **0/24**.

## #2773 — chaos SIGTERM deferred-ack — **test bug (async assertion)**

The test asserted its own precondition — "one debounce flush has already landed" — by sampling the watermark once after 95 paced reads, with nothing ordering the two events but wall clock. Measured margin: **448–473 ms**, consistently. Any CI stall longer than that fails a healthy pipeline. That's the 1.98 s CI failure.

Fixed per the #2698 precedent — poll the watermark, widen nothing, no retry, no skip. The drain assertion is now anchored on the *observed* read count rather than the `killAfterReads` constant, because a slow run reads past 95 and those extra reads must drain too; the constant would have silently **loosened** the assertion on exactly the slow runs where a drain bug is likeliest.

The regression test is a second case rather than a repeat run: with `persistDelayMS=2000`, no flush *can* have landed by read #95 on any machine. Pre-fix it fails 100% deterministically.

## What was deliberately left alone

Under CPU oversubscription far beyond CI's (32 concurrent race-enabled binaries at `GOMAXPROCS=1` on 16 cores), a *different* failure dominates: the child's post-Teardown `waitForUpstreamAtLeast` bounded wait in `tests/chaos/child.go:586`, which polls for the plugin `ackLoop`'s commits instead of having a real handoff. It doesn't reproduce at 16 or 24 copies, CI runs the chaos suite as its only workload, and the reported failure was unambiguously the other one. Making it deterministic means adding a completion signal to shared harness code every chaos test uses — worth its own issue, not worth guessing at with no CI-level evidence.

## And one thing that needs its own PR: #2806

**The same #2746 ordering bug exists in `pkg/lifecycle` — the default engine.** I verified it against `main` rather than assuming it from the v2 fix: `UpdateStatus(StatusRunning)` at `service.go:860`, `runningPipelines.Set` at `:230` after `runPipeline` returns, same early-return recovery arm at `:905-914`.

There it reaches `StopAndWait` → `ApplyPlanLive`, so **a drain can be reported complete when it never happened** — invariant 7 failing silently in the engine that ships. Filed as #2806. Deliberately not folded into a flaky-test branch: it's Tier 1 on the default engine, and v1's `runPipeline` registers its cleanup goroutine *after* `UpdateStatus`, so the fix is not a copy-paste.

## Verification

| Check | Result |
|---|---|
| `go build ./...` | clean |
| `golangci-lint` on all three touched packages | 0 issues |
| `./cmd/conduit/root/mcp/... -race -count=20 -shuffle=on` | ok |
| `./pkg/lifecycle-poc/ -race -count=20 -shuffle=on` | ok (290s) |
| `./tests/chaos/... -race -count=3 -shuffle=on` | ok, run twice |
| `./tests/chaos/ -run TestSIGTERM -race -count=20 -shuffle=on` | ok (221s) |

Fixes #2746, #2773, #2774.
