### PR TITLE
fix(generate): stop a cue from reaching past an intervening connector mention

### DIFF
--- a/cmd/conduit/internal/generate/intent.go
+++ b/cmd/conduit/internal/generate/intent.go
@@ -140,9 +140,36 @@ var (
 )
 
 // cueWindow is how many words before a connector mention are searched for a
-// directional cue. Four covers "from the postgres database" and "into an s3
-// bucket" without reaching back into the previous clause and stealing its cue.
-const cueWindow = 4
+// directional cue. Two is the smallest value that still covers "from the
+// postgres database" and "into an s3 bucket" (both need exactly two words of
+// reach) — and it is deliberately NOT larger than that.
+//
+// A wider window (this was 4 until it produced a false Contradiction, see
+// the regression test for "kafka-connect-unwrap-to-postgres") can walk
+// backward past an intervening connector mention that already consumed the
+// cue lexically meant for it, and reassign that same cue to a second,
+// unrelated mention later in the sentence — e.g. in "...into postgres,
+// unwrapping the kafka connect envelope first", a window of 4 reaches from
+// the second "kafka" mention all the way back to "into", stepping over
+// "postgres" (which is what "into" actually assigns), and manufactures a
+// postgres-vs-kafka destination contradiction that was never in the prompt.
+//
+// Shrinking the window is the conservative fix in the direction this package
+// requires (design §9): a cue just out of reach leaves a role unextracted,
+// which the semantic checker judges later, while a cue reached in error
+// produces a Contradiction that refuses the request before the model ever
+// sees it. An under-reaching window costs accuracy on long noun phrases; an
+// over-reaching one costs correctness. Prefer the former.
+//
+// 2, not 3: a window of 3 still crosses this same class of boundary — e.g.
+// "...write them to kafka, since postgres emits them as a WAL stream" lets a
+// window of 3 reach from the second "postgres" back through "kafka," to the
+// "to" that assigned kafka as the destination, manufacturing the identical
+// kind of false contradiction one word later (see
+// TestExtractIntent_ConnectorMentionedTwiceIsNotAContradiction). 2 is the
+// largest value that does not reach past an intervening connector mention in
+// either regression case, not a number tuned to one prompt.
+const cueWindow = 2
 
 // ExtractIntent reads prompt against the catalog names.
 //

--- a/cmd/conduit/internal/generate/intent_test.go
+++ b/cmd/conduit/internal/generate/intent_test.go
@@ -97,6 +97,84 @@ func TestExtractIntent_ContradictionIsDetected(t *testing.T) {
 	is.True(got.Contradiction != "")
 }
 
+// A prompt that names the same connector twice — once as part of a format
+// description, once as the actual endpoint — must not be read as two
+// different connectors claiming the same role. This is the regression for
+// the "kafka-connect-unwrap-to-postgres" corpus row (testdata/
+// eval_requests.yaml), which ExtractIntent refused before ever calling a
+// provider: cueWindow was wide enough to walk backward from the second
+// "kafka" mention (in "unwrapping the kafka connect envelope") past the
+// intervening "postgres" and steal the "into" cue that actually belonged to
+// postgres, manufacturing a postgres-vs-kafka destination contradiction.
+//
+// Sibling phrasings that name a connector as part of a *format* rather than
+// an endpoint are included here because they are the same class of bug, not
+// because "kafka connect" is special-cased: the fix (narrowing cueWindow)
+// must generalize to any wording, not just the literal corpus string.
+func TestExtractIntent_ConnectorMentionedTwiceIsNotAContradiction(t *testing.T) {
+	is := is.New(t)
+	names := CatalogNames(BuiltinCatalog())
+
+	for _, tc := range []struct {
+		name        string
+		prompt      string
+		source      string
+		destination string
+	}{{
+		name:        "the exact corpus prompt (kafka-connect-unwrap-to-postgres)",
+		prompt:      "consume kafka connect formatted messages from a topic and upsert them into postgres, unwrapping the kafka connect envelope first",
+		destination: "postgres",
+	}, {
+		name:        "same prompt without the comma before the participial clause",
+		prompt:      "consume kafka connect formatted messages from a topic and upsert them into postgres unwrapping the kafka connect envelope first",
+		destination: "postgres",
+	}, {
+		// "postgres" opens the sentence with nothing before it, so this
+		// heuristic cannot reach a source cue for it either way — that is
+		// an existing, acceptable under-extraction (the semantic checker
+		// judges it later), not a regression. What matters here is that
+		// naming "debezium" as the envelope format doesn't collide with
+		// anything: it is not a catalog connector alias at all, so it can
+		// never contend for a role.
+		name:        "debezium envelope named as a format, not an endpoint",
+		prompt:      "capture postgres change data and publish it to kafka, unwrapping the debezium envelope so the topic only has the actual row data",
+		destination: "kafka",
+	}, {
+		name:        "connector name repeated in a trailing clause describing the source format",
+		prompt:      "read change events from postgres and write them to kafka, since postgres emits them as a WAL stream",
+		source:      "postgres",
+		destination: "kafka",
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExtractIntent(tc.prompt, names)
+			is.Equal(got.Contradiction, "")
+			is.Equal(got.Source, tc.source)
+			is.Equal(got.Destination, tc.destination)
+		})
+	}
+}
+
+// The corpus (testdata/eval_requests.yaml) is the spec for what `generate`
+// is for (design §9); a corpus row that ExtractIntent refuses before a
+// provider is ever called is our own heuristic being wrong, not the
+// fixture. This must fail the build the moment it regresses, rather than
+// being discovered by spending money on a live transcript capture run.
+func TestExtractIntent_CorpusNeverProducesAContradiction(t *testing.T) {
+	is := is.New(t)
+	names := CatalogNames(BuiltinCatalog())
+
+	requests, err := LoadRequests("testdata/eval_requests.yaml")
+	is.NoErr(err)
+	is.True(len(requests) > 0)
+
+	for _, r := range requests {
+		got := ExtractIntent(r.Prompt, names)
+		if got.Contradiction != "" {
+			t.Errorf("id=%q: ExtractIntent found a false contradiction: %s\n  prompt=%q", r.ID, got.Contradiction, r.Prompt)
+		}
+	}
+}
+
 // Every alias must name a connector this binary actually has, or the checker
 // would demand a connector the model cannot legally produce.
 func TestConnectorAliases_ResolveToRealConnectors(t *testing.T) {


### PR DESCRIPTION
A legitimate request in our own eval corpus was refused **before the provider was ever called**, costing a request on all three passes of the first live transcript capture:

```
pass 1: no completion recorded for "kafka-connect-unwrap-to-postgres":
        the request names both postgres and kafka as the destination
```

The prompt: *"consume kafka connect formatted messages from a topic and upsert them into postgres, unwrapping the kafka connect envelope first"* — unambiguous to any reader.

## Root cause

`roleFromCues` scans backward up to `cueWindow` words from each connector mention. Tokenized:

```
... 11 into  12 postgres,  13 unwrapping  14 the  15 kafka  16 connect  17 envelope
```

`postgres` (12) correctly takes `destination` from `into` (11). Then `kafka` at 15 — part of *"kafka connect envelope"*, a **format** description, not an endpoint — runs its own scan and at `back=4` reaches the same `into`, **stepping straight over the intervening `postgres` mention that cue actually belonged to**. Two connectors claim `destination`, so the contradiction detector fires and `Generate` refuses.

## Fix: `cueWindow` 4 → 2

Not a special case for the literal string "kafka connect" — that would leave the bug class in place.

The agent first tried 3, which preserves identical extraction on the current corpus, and then rejected it by constructing a sibling that breaks at 3 as well (*"...write them to kafka, since postgres emits them as a WAL stream"* — the second `postgres` reaches back through `kafka,` to its `to`). **2 is the largest window that cannot cross an intervening connector mention**, and it still covers both cases the original comment cited (`"from the postgres database"`, `"into an s3 bucket"` each need exactly 2).

## The cost, measured rather than asserted

I ran extraction over the whole corpus at both settings:

| `cueWindow` | both roles | one role | neither | contradictions |
| --- | --- | --- | --- | --- |
| 4 (before) | 12 | 16 | 0 | **1 — this bug** |
| 2 (after) | 9 | 19 | 0 | 0 |

Three rows drop from two extracted roles to one. **None drops to zero.** `scoreSemantic` treats an empty field as no constraint, so the effect is *less* pre-call checking, never *wrong* checking — which is the direction design §9 requires: "a legitimate-but-terse prompt is sent to the provider, not refused on a heuristic's inability to parse it."

A false contradiction kills a request before the model sees it. An unextracted role is judged afterwards by the semantic checker. Those costs are not symmetric.

## The test that makes this permanent

`TestExtractIntent_CorpusNeverProducesAContradiction` loads the committed corpus and asserts no row trips the detector. The corpus **is** the spec of what `generate` is for, so a row our own pre-call refusal rejects should fail the build — not get discovered by spending money on a capture run, which is how this one surfaced.

Plus the failing prompt itself, a comma-less variant (proving the fix isn't punctuation-dependent), the WAL-stream sibling that breaks at window=3, and the "debezium envelope" row — which the agent checked and found was never at risk, since `debezium` isn't a connector alias and can't contend for a role.

`go test ./cmd/... -count=1` green, `golangci-lint` 0 issues.

Roadmap: v0.20 WS1 (`conduit generate`).
