### PR TITLE
fix(generate): preserve partial capture results instead of discarding them

### DIFF
--- a/.github/workflows/generate-capture.yml
+++ b/.github/workflows/generate-capture.yml
@@ -46,13 +46,25 @@ name: generate-capture
 # job's own steps below ("Check whether any transcript changed", "Upload
 # captured transcripts") run even after that failure (`if: ${{ !cancelled()
 # }}`, see the "Partial results" section further down) rather than being
-# skipped outright - but since nothing was ever promoted into
-# testdata/transcripts/, `git status --porcelain` sees no change, "changed"
-# resolves to `false`, the upload step's own `if` condition on `changed ==
-# 'true'` is false so no artifact is uploaded, and `publish`'s `if` (which
-# requires `needs.capture.outputs.changed == 'true'`) never runs either. The
-# conclusion - a redaction violation never reaches a published PR - still
-# holds; it is reached via `changed=false`, not via the job stopping outright.
+# skipped outright - and, given a PRISTINE checkout (the common case: a
+# fresh `actions/checkout@v7` at the top of this job, nothing else in the
+# job writes under testdata/transcripts/), nothing was ever promoted into
+# testdata/transcripts/ means `git status --porcelain -uall` sees no
+# change either, so "changed" resolves to `false`, the upload step's own
+# `if` condition on `changed == 'true'` is false so no artifact is
+# uploaded, and `publish`'s `if` (which requires
+# `needs.capture.outputs.changed == 'true'`) never runs either. (N2, round-3
+# review of #2814: this is conditional on that pristine-checkout premise,
+# not an unconditional guarantee - `-uall`, unlike the `-unormal` default,
+# also surfaces any UNRELATED stray untracked file already sitting under
+# testdata/transcripts/ before this run, which would make `changed=true`
+# even though this run's own redaction gate aborted and promoted nothing;
+# that is not a redaction violation escaping, just a normal git-status
+# artifact of a non-pristine starting tree, and worth knowing about before
+# assuming "changed" always means "runCapture promoted something".) The
+# conclusion - a redaction violation never reaches a published PR on a
+# pristine checkout - still holds; it is reached via `changed=false`, not
+# via the job stopping outright.
 #
 # # Partial results are preserved, not discarded (WS1 A5a-3 follow-up)
 #
@@ -119,11 +131,15 @@ jobs:
     timeout-minutes: 35 # go test's own -timeout 30m below, plus setup/checkout headroom
     outputs:
       changed: ${{ steps.check-changes.outputs.changed }}
-      # manifest_path is the manifest.yaml THIS RUN wrote, if any - never
-      # re-derived by `publish` searching the checked-out tree, which may
-      # already carry a manifest.yaml committed by an EARLIER run (see the
-      # "Summarize the manifest" step below for why that distinction
-      # matters). Empty for a scoped --request_id run, which writes none.
+      # manifest_path is the manifest.yaml THIS RUN wrote OR PATCHED, if
+      # any - never re-derived by `publish` searching the checked-out
+      # tree, which may already carry a manifest.yaml committed by an
+      # EARLIER run (see the "Summarize the manifest" step below for why
+      # that distinction matters). Empty for a scoped --request_id run
+      # ONLY when there was no prior manifest.yaml to patch
+      # (runCapture's patchManifestForScopedRun, M1 fix - round-3 review
+      # of #2814); otherwise a scoped run patches the existing one in
+      # place, which sets this exactly like a fresh write does.
       manifest_path: ${{ steps.check-changes.outputs.manifest_path }}
     steps:
       - uses: actions/checkout@v7
@@ -138,10 +154,16 @@ jobs:
           REQUEST_ID: ${{ inputs.request_id }}
         run: |
           set -euo pipefail
+          # N7 (round-3 review of #2814): `-run` is an UNANCHORED regexp
+          # per path segment, so `-run TestCaptureTranscripts/req-a` also
+          # matches subtest "req-abc" - anchoring each segment with ^...$
+          # makes this scope to EXACTLY the named test/id, never a prefix
+          # match on real corpus request ids (e.g. a future
+          # "kafka-to-postgres-sync" vs "kafka-to-postgres-sync-v2").
           if [ -n "$REQUEST_ID" ]; then
-            echo "pattern=TestCaptureTranscripts/${REQUEST_ID}" >> "$GITHUB_OUTPUT"
+            echo "pattern=^TestCaptureTranscripts\$/^${REQUEST_ID}\$" >> "$GITHUB_OUTPUT"
           else
-            echo "pattern=TestCaptureTranscripts" >> "$GITHUB_OUTPUT"
+            echo "pattern=^TestCaptureTranscripts\$" >> "$GITHUB_OUTPUT"
           fi
 
       # The ONE narrowly-scoped invocation plan §4/§7.2 requires: this exact
@@ -196,16 +218,33 @@ jobs:
           fi
 
           # The manifest.yaml path THIS RUN itself wrote or modified, if
-          # any - a scoped --request_id run writes none (runCapture returns
-          # wrote=false), and `git status --porcelain -uall` over a clean
-          # checkout only ever shows files this run's own `go test`
-          # invocation touched, so an empty result here is unambiguous
-          # (never confused with a manifest.yaml already committed by an
-          # earlier run sitting untouched in the checkout). Tracked,
-          # unmodified files never appear in `git status` regardless of the
-          # `-u` mode, so that guarantee does not depend on `-uall` - only
-          # the untracked-directory collapse above does.
-          manifest_path=$(printf '%s\n' "$changes" | awk '{print $2}' | grep -E '/manifest\.yaml$' | head -1 || true)
+          # any - `git status --porcelain -uall` over a clean checkout only
+          # ever shows files this run's own `go test` invocation touched,
+          # so an empty result here is unambiguous (never confused with a
+          # manifest.yaml already committed by an earlier run sitting
+          # untouched in the checkout). Tracked, unmodified files never
+          # appear in `git status` regardless of the `-u` mode, so that
+          # guarantee does not depend on `-uall` - only the
+          # untracked-directory collapse above does. A scoped --request_id
+          # run writes none of its own ONLY when there was no prior
+          # manifest.yaml to patch (runCapture's patchManifestForScopedRun,
+          # M1 fix - round-3 review of #2814); otherwise it patches the
+          # EXISTING one in place, which shows up here exactly like a fresh
+          # write does.
+          manifest_lines=$(printf '%s\n' "$changes" | awk '{print $2}' | grep -E '/manifest\.yaml$' || true)
+          manifest_count=$(printf '%s\n' "$manifest_lines" | grep -c . || true)
+          if [ "${manifest_count:-0}" -gt 1 ]; then
+            # N1 (round-3 review of #2814): this run's own `go test`
+            # invocation should only ever touch ONE provider/model's
+            # manifest.yaml. More than one match is unexpected (and the
+            # naive `awk '{print $2}'` split below is not quote-aware, so a
+            # path porcelain quotes would also land here) - surface it
+            # loudly rather than silently picking the first and hiding the
+            # ambiguity from a reviewer.
+            echo "::warning::found ${manifest_count} modified manifest.yaml paths in this run, expected at most 1 - using the first; review the diff:"
+            printf '%s\n' "$manifest_lines"
+          fi
+          manifest_path=$(printf '%s\n' "$manifest_lines" | head -1)
           echo "manifest_path=${manifest_path}" >> "$GITHUB_OUTPUT"
 
       - name: Upload captured transcripts
@@ -251,14 +290,34 @@ jobs:
           # own checkout would happily match a manifest.yaml already
           # committed by an EARLIER run and render ITS numbers under a
           # heading that calls them "the headline numbers" for THIS run -
-          # exactly what happens on a scoped --request_id run, which writes
-          # no manifest.yaml of its own (runCapture returns wrote=false).
+          # exactly what happens on a scoped --request_id run with no
+          # PRIOR manifest.yaml to patch (runCapture's own
+          # patchManifestForScopedRun, M1 fix - round-3 review of #2814 -
+          # writes none in that one case; otherwise it patches the
+          # existing one, and this DOES get set).
           MANIFEST_PATH: ${{ needs.capture.outputs.manifest_path }}
+          REQUEST_ID: ${{ inputs.request_id }}
+          # Also-fix "end state 5" (round-3 review of #2814): distinguishes
+          # "no manifest.yaml because this was a scoped run with nothing to
+          # patch" (routine) from "no manifest.yaml even though the tree
+          # changed" (a `go test` crash - panic, or a -timeout kill -
+          # between promoting transcripts and writing/patching the
+          # manifest; see the file header's "Partial results" section).
+          # Both leave MANIFEST_PATH empty; CAPTURE_RESULT is what tells
+          # them apart.
+          CAPTURE_RESULT: ${{ needs.capture.result }}
         run: |
           set -euo pipefail
           if [ -z "$MANIFEST_PATH" ] || [ ! -f "$MANIFEST_PATH" ]; then
+            if [ "$CAPTURE_RESULT" != "success" ]; then
+              summary_msg="capture did not finish cleanly and left no manifest.yaml in this run's artifact - likely a crash (panic, or a -timeout kill) between promoting transcripts and writing/patching the manifest, not a routine scoped re-capture; review the raw job log. Whatever WAS promoted above is still safe to use."
+            elif [ -n "$REQUEST_ID" ]; then
+              summary_msg="no manifest.yaml in this run's artifact (a scoped --request_id run patches an EXISTING manifest.yaml when one is there to patch, and writes none when there isn't - see runCapture's patchManifestForScopedRun)"
+            else
+              summary_msg="no manifest.yaml in this run's artifact even though capture reported success and the tree changed - unexpected for a full (non-scoped) run; review the raw job log"
+            fi
             {
-              echo "summary=no manifest.yaml in this run's artifact (a scoped --request_id run does not write one)"
+              echo "summary=${summary_msg}"
               echo "missing=0"
               echo "degraded=0"
             } >> "$GITHUB_OUTPUT"
@@ -266,7 +325,23 @@ jobs:
           fi
           {
             echo "summary<<EOF"
-            grep -E '^(provider|model|requestCount|capturedCount|missingCount|passes|medianValidatePassRate|medianSemanticMatchRate|degradedPasses|totalTokensUsed|estimatedCostUSD|corpusCommitSha):' "$MANIFEST_PATH" || true
+            # M2 (round-3 review of #2814): a plain line-anchored grep on
+            # `degradedPasses:` only ever prints the (empty) key line -
+            # conduitio/yaml/v3 emits a YAML list's items on FOLLOWING
+            # indented lines, which the anchor (correctly) does not match,
+            # so the banner told readers to check a field this rendered
+            # nothing of. The awk state machine below keeps every other
+            # field's line-anchored, top-level-only matching EXACTLY as it
+            # was (in particular, passScores[].missingCount stays excluded -
+            # only the top-level `missingCount:` matches) and additionally
+            # follows `degradedPasses:` through its own indented list
+            # items, stopping at the next top-level (unindented) key.
+            awk '
+              /^(provider|model|requestCount|capturedCount|missingCount|passes|medianValidatePassRate|medianSemanticMatchRate|medianSampleSize|mediansUnreliable|totalTokensUsed|estimatedCostUSD|corpusCommitSha):/ { print; in_degraded=0; next }
+              /^degradedPasses:/ { print; in_degraded=1; next }
+              in_degraded && /^[[:space:]]/ { print; next }
+              { in_degraded=0 }
+            ' "$MANIFEST_PATH" || true
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
@@ -292,6 +367,14 @@ jobs:
           # LIST field with `omitempty` - entirely absent from the file
           # when no pass was degraded, so its presence as a top-level key
           # (not the count of items under it) is the boolean signal here.
+          #
+          # A run where EVERY pass was degraded (Manifest.MediansUnreliable
+          # - B1 fix, round-3 review of #2814) never reaches this line with
+          # CAPTURE_RESULT == success in the first place: runCapture fails
+          # that `go test` run outright (t.Errorf), so "Open the PR"'s
+          # CAPTURE_RESULT != "success" branch handles it with the
+          # [!WARNING] PARTIAL-capture title before this DEGRADED signal is
+          # ever consulted.
           degraded=$(grep -c '^degradedPasses:' "$MANIFEST_PATH" || true)
           echo "degraded=${degraded:-0}" >> "$GITHUB_OUTPUT"
 
@@ -361,7 +444,21 @@ jobs:
             tombstone="$id_dir/$id.missing.yaml"
             if [ -f "$tombstone" ]; then
               echo "removing stale tombstone for promoted id: $tombstone"
-              git rm -q "$tombstone"
+              # M3 (round-3 review of #2814): --ignore-unmatch, not a bare
+              # `git rm`. `capture` and `publish` each run their OWN
+              # checkout, and publish's can land on a newer `main` than
+              # capture's - if some other, unrelated merge already removed
+              # this same tombstone from git's tree in the meantime,
+              # download-artifact's overlay still re-creates the FILE on
+              # disk (from capture's uploaded snapshot) but it is untracked
+              # in publish's own checkout, so a bare `git rm` fails
+              # ("did not match any files") and, under `set -euo pipefail`,
+              # aborts this whole step at exit 128 - after `git checkout -b`
+              # but before `git push` - so NOTHING publishes, even though
+              # everything captured is still safe on disk. --ignore-unmatch
+              # makes this a no-op instead: there is nothing left to stage
+              # a removal for, which is exactly correct.
+              git rm -q --ignore-unmatch "$tombstone"
             fi
           done < <(find "$transcripts_dir" -type f -name '*.yaml' ! -name 'manifest.yaml' ! -name '*.missing.yaml' -print0)
 
@@ -384,10 +481,20 @@ jobs:
             else
               title="chore(generate): capture provider transcripts, degraded pass(es) (run ${RUN_ID})"
             fi
-            banner="> [!NOTE]
-          > "
+            # M2 nit (round-3 review of #2814): the banner used to open
+            # with "> [!NOTE]\n> " unconditionally, then glue the MISSING
+            # text onto that trailing "> " - fine when MISSING fires, but
+            # when only DEGRADED fires the next block below prepends its
+            # OWN leading blank line, landing "> [!NOTE]\n> \n> At least
+            # one..." - an empty quoted paragraph GitHub renders as a
+            # visible blank line before the real content. Each block below
+            # now prepends its own "\n> " only when IT actually fires, so
+            # there is never an empty quoted line regardless of which
+            # combination of MISSING/DEGRADED is set.
+            banner="> [!NOTE]"
             if [ "${MISSING:-0}" -gt 0 ]; then
-              banner="${banner}${MISSING} request(s) are missing from this capture, below captureCompletenessVerdict's
+              banner="${banner}
+          > ${MISSING} request(s) are missing from this capture, below captureCompletenessVerdict's
           > run-failing threshold - \`capture\` reported success, and this IS a routine partial result (ordinary
           > live-provider noise: a 429, a timeout), not an incident. Review each \`requestOutcomes\` reason in the
           > diff before relying on this batch for eval; re-capture the missing id(s) cheaply with

--- a/.github/workflows/generate-capture.yml
+++ b/.github/workflows/generate-capture.yml
@@ -176,7 +176,19 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
-          changes=$(git status --porcelain -- cmd/conduit/internal/generate/testdata/transcripts || true)
+          # `-uall`, not the `-unormal` default: plain `git status --porcelain`
+          # collapses a WHOLLY UNTRACKED directory into a single `?? dir/`
+          # entry instead of listing the files inside it. The very first
+          # capture run (or any run that captures a brand-new
+          # provider/model dir via CONDUIT_GENERATE_CAPTURE_MODEL) writes
+          # into testdata/transcripts/<provider>/<model>/, which does not
+          # exist on main yet - so without `-uall` this collapses to one
+          # `?? testdata/transcripts/anthropic/` line, the manifest.yaml
+          # grep below matches nothing, and manifest_path silently comes
+          # back empty even though a manifest WAS written. Reproduced in a
+          # scratch repo: default `-unormal` yields the single collapsed
+          # line, `-uall` lists every file including manifest.yaml.
+          changes=$(git status --porcelain -uall -- cmd/conduit/internal/generate/testdata/transcripts || true)
           if [ -n "$changes" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
@@ -185,11 +197,14 @@ jobs:
 
           # The manifest.yaml path THIS RUN itself wrote or modified, if
           # any - a scoped --request_id run writes none (runCapture returns
-          # wrote=false), and `git status --porcelain` over a clean
+          # wrote=false), and `git status --porcelain -uall` over a clean
           # checkout only ever shows files this run's own `go test`
           # invocation touched, so an empty result here is unambiguous
           # (never confused with a manifest.yaml already committed by an
-          # earlier run sitting untouched in the checkout).
+          # earlier run sitting untouched in the checkout). Tracked,
+          # unmodified files never appear in `git status` regardless of the
+          # `-u` mode, so that guarantee does not depend on `-uall` - only
+          # the untracked-directory collapse above does.
           manifest_path=$(printf '%s\n' "$changes" | awk '{print $2}' | grep -E '/manifest\.yaml$' | head -1 || true)
           echo "manifest_path=${manifest_path}" >> "$GITHUB_OUTPUT"
 
@@ -242,13 +257,16 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "$MANIFEST_PATH" ] || [ ! -f "$MANIFEST_PATH" ]; then
-            echo "summary=no manifest.yaml in this run's artifact (a scoped --request_id run does not write one)" >> "$GITHUB_OUTPUT"
-            echo "missing=0" >> "$GITHUB_OUTPUT"
+            {
+              echo "summary=no manifest.yaml in this run's artifact (a scoped --request_id run does not write one)"
+              echo "missing=0"
+              echo "degraded=0"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
           {
             echo "summary<<EOF"
-            grep -E '^(provider|model|requestCount|capturedCount|missingCount|passes|medianValidatePassRate|medianSemanticMatchRate|totalTokensUsed|estimatedCostUSD|corpusCommitSha):' "$MANIFEST_PATH" || true
+            grep -E '^(provider|model|requestCount|capturedCount|missingCount|passes|medianValidatePassRate|medianSemanticMatchRate|degradedPasses|totalTokensUsed|estimatedCostUSD|corpusCommitSha):' "$MANIFEST_PATH" || true
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
@@ -261,12 +279,29 @@ jobs:
           missing=$(grep -E '^missingCount:' "$MANIFEST_PATH" | awk '{print $2}' || true)
           echo "missing=${missing:-0}" >> "$GITHUB_OUTPUT"
 
+          # degraded is a SEPARATE signal from missing (H2, round-2 review
+          # of #2814): a request captured on an early pass but absent from
+          # a later one (a rate-limit storm or captureWallClockBudget
+          # expiring partway through) does not raise missingCount at all -
+          # runCapture's CapturedCount/MissingCount only require ONE pass
+          # to have produced a request - but DOES drag
+          # medianValidatePassRate/medianSemanticMatchRate down (that
+          # degraded pass scores the request as a hard fail on both axes -
+          # score.go's ScoreRun), which the routine-title/no-banner path
+          # would otherwise publish silently. `degradedPasses` is a YAML
+          # LIST field with `omitempty` - entirely absent from the file
+          # when no pass was degraded, so its presence as a top-level key
+          # (not the count of items under it) is the boolean signal here.
+          degraded=$(grep -c '^degradedPasses:' "$MANIFEST_PATH" || true)
+          echo "degraded=${degraded:-0}" >> "$GITHUB_OUTPUT"
+
       - name: Open the PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           SUMMARY: ${{ steps.summary.outputs.summary }}
           MISSING: ${{ steps.summary.outputs.missing }}
+          DEGRADED: ${{ steps.summary.outputs.degraded }}
           REQUEST_ID: ${{ inputs.request_id }}
           # Set by `!cancelled()` above even when `capture` FAILED (see the
           # file header's "Partial results" section) - 'failure' here means
@@ -283,7 +318,18 @@ jobs:
           # routinely-titled PR with a green check, with the only trace
           # being a `missingCount: 13` line inside a fenced code block. The
           # banner and title below are gated on CAPTURE_RESULT != success
-          # OR MISSING > 0, not on CAPTURE_RESULT alone.
+          # OR MISSING > 0 OR DEGRADED > 0, not on CAPTURE_RESULT alone.
+          #
+          # DEGRADED (H2, round-2 review of #2814) catches a run MISSING
+          # alone cannot: a request captured on an early pass but absent
+          # from a later one leaves MissingCount at 0 (some pass produced
+          # it) while still dragging medianValidatePassRate/
+          # medianSemanticMatchRate toward zero (a degraded pass scores
+          # that request as a hard fail on both axes). Without this, a
+          # capture that lost its tail passes to rate limiting or
+          # captureWallClockBudget expiring would show MISSING=0 and a
+          # routine title while publishing a 0.00-adjacent median as the
+          # new baseline the next run gets compared against.
           CAPTURE_RESULT: ${{ needs.capture.result }}
         run: |
           set -euo pipefail
@@ -291,7 +337,35 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$branch"
-          git add cmd/conduit/internal/generate/testdata/transcripts
+
+          # H3 fix (round-2 review of #2814): a promoted "<id>.yaml" makes
+          # any "<id>.missing.yaml" tombstone for the SAME id stale.
+          # runCapture (transcript_capture_test.go) already `os.Remove`s
+          # that tombstone the moment it promotes real data for an id - but
+          # only in the `capture` job's OWN checkout. The artifact
+          # `capture` uploads is a copy of the directory, which cannot
+          # represent a deletion; `download-artifact` above only overlays
+          # files onto this job's checkout of `main` (which may still carry
+          # the tombstone from an earlier run), so a blind `git add` would
+          # stage the new transcript but never stage the tombstone's
+          # removal - landing a tree with BOTH files, which LoadTranscripts
+          # (transcript.go) hard-errors on for every consumer until a human
+          # manually deletes the stale file. Explicitly `git rm` every
+          # tombstone whose id now also has a real transcript, so the
+          # deletion this job's checkout never saw gets staged here
+          # instead.
+          transcripts_dir="cmd/conduit/internal/generate/testdata/transcripts"
+          while IFS= read -r -d '' transcript; do
+            id_dir=$(dirname "$transcript")
+            id=$(basename "$transcript" .yaml)
+            tombstone="$id_dir/$id.missing.yaml"
+            if [ -f "$tombstone" ]; then
+              echo "removing stale tombstone for promoted id: $tombstone"
+              git rm -q "$tombstone"
+            fi
+          done < <(find "$transcripts_dir" -type f -name '*.yaml' ! -name 'manifest.yaml' ! -name '*.missing.yaml' -print0)
+
+          git add "$transcripts_dir"
 
           banner=""
           if [ "$CAPTURE_RESULT" != "success" ]; then
@@ -304,14 +378,32 @@ jobs:
           > result.
 
           "
-          elif [ "${MISSING:-0}" -gt 0 ]; then
-            title="chore(generate): capture provider transcripts, ${MISSING} missing (run ${RUN_ID})"
+          elif [ "${MISSING:-0}" -gt 0 ] || [ "${DEGRADED:-0}" -gt 0 ]; then
+            if [ "${MISSING:-0}" -gt 0 ]; then
+              title="chore(generate): capture provider transcripts, ${MISSING} missing (run ${RUN_ID})"
+            else
+              title="chore(generate): capture provider transcripts, degraded pass(es) (run ${RUN_ID})"
+            fi
             banner="> [!NOTE]
-          > ${MISSING} request(s) are missing from this capture, below captureCompletenessVerdict's run-failing
-          > threshold - \`capture\` reported success, and this IS a routine partial result (ordinary live-provider
-          > noise: a 429, a timeout), not an incident. Review each \`requestOutcomes\` reason in the diff before
-          > relying on this batch for eval; re-capture the missing id(s) cheaply with
-          > \`-run TestCaptureTranscripts/<id>\`.
+          > "
+            if [ "${MISSING:-0}" -gt 0 ]; then
+              banner="${banner}${MISSING} request(s) are missing from this capture, below captureCompletenessVerdict's
+          > run-failing threshold - \`capture\` reported success, and this IS a routine partial result (ordinary
+          > live-provider noise: a 429, a timeout), not an incident. Review each \`requestOutcomes\` reason in the
+          > diff before relying on this batch for eval; re-capture the missing id(s) cheaply with
+          > \`-run TestCaptureTranscripts/<id>\`."
+            fi
+            if [ "${DEGRADED:-0}" -gt 0 ]; then
+              banner="${banner}
+          > At least one capture pass (manifest's \`degradedPasses\`) did not produce a completion for the whole
+          > corpus - a request captured on an earlier pass but absent from a later one (ordinary rate-limit noise,
+          > or \`captureWallClockBudget\` expiring partway through) still counts as this run's own kind of routine
+          > partial result: \`capturedCount\`/\`missingCount\` may both look clean while
+          > \`medianValidatePassRate\`/\`medianSemanticMatchRate\` were computed excluding the degraded pass(es) so
+          > they are not silently dragged toward zero. Check \`passScores[].missingCount\` in the diff before
+          > relying on this batch for eval."
+            fi
+            banner="${banner}
 
           "
           elif [ -n "$REQUEST_ID" ]; then

--- a/.github/workflows/generate-capture.yml
+++ b/.github/workflows/generate-capture.yml
@@ -372,24 +372,45 @@ jobs:
           # a later one (a rate-limit storm or captureWallClockBudget
           # expiring partway through) does not raise missingCount at all -
           # runCapture's CapturedCount/MissingCount only require ONE pass
-          # to have produced a request - but DOES drag
+          # to have produced a request - but CAN drag
           # medianValidatePassRate/medianSemanticMatchRate down (that
           # degraded pass scores the request as a hard fail on both axes -
           # score.go's ScoreRun), which the routine-title/no-banner path
-          # would otherwise publish silently. `degradedPasses` is a YAML
-          # LIST field with `omitempty` - entirely absent from the file
-          # when no pass was degraded, so its presence as a top-level key
-          # (not the count of items under it) is the boolean signal here.
+          # would otherwise publish silently.
           #
-          # A run where EVERY pass was degraded (Manifest.MediansUnreliable
-          # - B1 fix, round-3 review of #2814) never reaches this line with
-          # CAPTURE_RESULT == success in the first place: runCapture fails
-          # that `go test` run outright (t.Errorf), so "Open the PR"'s
-          # CAPTURE_RESULT != "success" branch handles it with the
-          # [!WARNING] PARTIAL-capture title before this DEGRADED signal is
-          # ever consulted.
-          degraded=$(grep -c '^degradedPasses:' "$MANIFEST_PATH" || true)
-          echo "degraded=${degraded:-0}" >> "$GITHUB_OUTPUT"
+          # M1-3 (round-5 review of #2814): degraded used to be
+          # `grep -c '^degradedPasses:'` - whether that KEY is present at
+          # all, not whether anything was actually excluded from the
+          # median. That is fail-open in the misleading direction: a run
+          # can have degradedPasses non-empty while summarizePasses'
+          # all-passes fallback folded every degraded pass in WITHOUT
+          # excluding it (every degraded pass missed the exact same,
+          # reliably-attributed request(s) - manifest.yaml's own
+          # medianSampleSize equals passes in that case, same as a run with
+          # NO degraded passes at all) - the old grep fired the DEGRADED
+          # banner and title regardless, claiming an exclusion that never
+          # happened. medianSampleSize < passes is the actual signal that
+          # real exclusion occurred (see Manifest.MedianSampleSize's own
+          # doc comment, transcript.go) - compare the two fields directly
+          # instead of checking degradedPasses' mere presence.
+          #
+          # A run where EVERY pass was degraded AND unreliable
+          # (Manifest.MediansUnreliable - B1 fix round-3, generalized H1
+          # round-4, H1 x H2 interaction and the preserveMediansIfNothing-
+          # Promoted shape-mismatch case both round-5, review of #2814)
+          # never reaches this line with CAPTURE_RESULT == success in the
+          # first place: runCapture fails that `go test` run outright
+          # (t.Errorf), so "Open the PR"'s CAPTURE_RESULT != "success"
+          # branch handles it with the [!WARNING] PARTIAL-capture title
+          # before this DEGRADED signal is ever consulted.
+          median_sample_size=$(grep -E '^medianSampleSize:' "$MANIFEST_PATH" | awk '{print $2}' || true)
+          manifest_passes=$(grep -E '^passes:' "$MANIFEST_PATH" | awk '{print $2}' || true)
+          degraded=0
+          if [ -n "${median_sample_size:-}" ] && [ -n "${manifest_passes:-}" ] \
+             && [ "${median_sample_size}" -lt "${manifest_passes}" ]; then
+            degraded=1
+          fi
+          echo "degraded=${degraded}" >> "$GITHUB_OUTPUT"
 
       - name: Open the PR
         env:

--- a/.github/workflows/generate-capture.yml
+++ b/.github/workflows/generate-capture.yml
@@ -309,17 +309,30 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "$MANIFEST_PATH" ] || [ ! -f "$MANIFEST_PATH" ]; then
+            # L2 (round-4 review of #2814): `degraded` defaults to 0 (routine)
+            # for the two EXPECTED reasons this branch is reached (a
+            # not-clean capture, already flagged via CAPTURE_RESULT below
+            # regardless of this value; or a scoped run with nothing to
+            # patch). The third arm - success, the tree changed, yet no
+            # manifest.yaml at all - is NOT expected, and "Open the PR"
+            # below only escalates past a routine [!NOTE]-or-nothing title
+            # when MISSING>0 or DEGRADED>0: without setting degraded=1 here,
+            # that anomaly would open with the plain
+            # "chore(generate): capture provider transcripts" title and no
+            # banner at all, identical to a totally unremarkable run.
+            anomaly_degraded=0
             if [ "$CAPTURE_RESULT" != "success" ]; then
               summary_msg="capture did not finish cleanly and left no manifest.yaml in this run's artifact - likely a crash (panic, or a -timeout kill) between promoting transcripts and writing/patching the manifest, not a routine scoped re-capture; review the raw job log. Whatever WAS promoted above is still safe to use."
             elif [ -n "$REQUEST_ID" ]; then
               summary_msg="no manifest.yaml in this run's artifact (a scoped --request_id run patches an EXISTING manifest.yaml when one is there to patch, and writes none when there isn't - see runCapture's patchManifestForScopedRun)"
             else
               summary_msg="no manifest.yaml in this run's artifact even though capture reported success and the tree changed - unexpected for a full (non-scoped) run; review the raw job log"
+              anomaly_degraded=1
             fi
             {
               echo "summary=${summary_msg}"
               echo "missing=0"
-              echo "degraded=0"
+              echo "degraded=${anomaly_degraded}"
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/generate-capture.yml
+++ b/.github/workflows/generate-capture.yml
@@ -44,6 +44,34 @@ name: generate-capture
 # batch, never a partial promotion. If that scan ever finds something, the
 # `capture` job fails before an artifact is even uploaded, and `publish`
 # never runs.
+#
+# # Partial results are preserved, not discarded (WS1 A5a-3 follow-up)
+#
+# The first live run made 27/28 requests, one failed on all 3 passes, and
+# `go test` exited nonzero - which, combined with `set -euo pipefail`,
+# skipped every step after "Run the live capture", so the 27 good
+# transcripts (already paid for) were never uploaded and never published.
+# That is fixed two ways, together:
+#
+#  1. runCapture (transcript_capture_test.go) now only fails the `go test`
+#     process outright when a STRICT MAJORITY of the attempted requests
+#     produced no completion at all (captureCompletenessVerdict) - a single
+#     429 or a handful of flaky requests is recorded in manifest.yaml
+#     (CapturedCount/MissingCount/RequestOutcomes) and logged, never
+#     Errorf'd. This is the common case and needs no workflow help: the job
+#     succeeds normally and every step below already runs.
+#  2. For the rarer case where the test STILL fails (majority missing, or
+#     the wrong reason - a compile error, a panic), "Check whether any
+#     transcript changed" and "Upload captured transcripts" carry
+#     `if: ${{ !cancelled() }}` so they run even after a failed previous
+#     step, and `publish`'s own `if` does not implicitly require `capture`
+#     to have succeeded either. Whatever landed on disk before the failure
+#     - which, since runCapture promotes and writes manifest.yaml BEFORE
+#     ever calling t.Errorf, is everything captureCompletenessVerdict saw -
+#     still gets uploaded and opened as a PR. The `capture` job still shows
+#     red in that case (on purpose - see captureCompletenessVerdict's own
+#     doc comment for why "most of the corpus missing" must be loud), but
+#     red no longer means "nothing was kept."
 
 on:
   workflow_dispatch:
@@ -119,8 +147,18 @@ jobs:
             -run "$RUN_PATTERN" \
             ./cmd/conduit/internal/generate/...
 
+      # `if: ${{ !cancelled() }}` (not the default implicit success()-only
+      # gate): "Run the live capture" can now fail while STILL having
+      # promoted good transcripts and written manifest.yaml to disk before
+      # captureCompletenessVerdict decided to Errorf (see the file header's
+      # "Partial results" section) - this step, and the upload step below,
+      # must still run in that case so nothing already captured is thrown
+      # away. `!cancelled()` runs after either success OR failure, but
+      # (unlike `always()`) still skips if the workflow run itself was
+      # cancelled.
       - name: Check whether any transcript changed
         id: check-changes
+        if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
           if git status --porcelain -- cmd/conduit/internal/generate/testdata/transcripts | grep -q .; then
@@ -130,7 +168,7 @@ jobs:
           fi
 
       - name: Upload captured transcripts
-        if: steps.check-changes.outputs.changed == 'true'
+        if: ${{ !cancelled() && steps.check-changes.outputs.changed == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: generate-transcripts
@@ -139,7 +177,15 @@ jobs:
           if-no-files-found: error
 
   publish:
-    if: github.repository == 'ConduitIO/conduit' && needs.capture.outputs.changed == 'true'
+    # `!cancelled()` (rather than the default implicit "needs.capture must
+    # have succeeded") deliberately lets this job run when `capture` FAILED
+    # too - the whole point of the partial-results fix (file header) is that
+    # a majority-missing capture run still uploads whatever it captured, and
+    # `publish` still opens a PR for it as long as `changed` is true. A
+    # `capture` job that was itself skipped (the `if: github.repository ==`
+    # guard on a fork) never sets `changed`, so this still correctly no-ops
+    # on a fork without an extra check.
+    if: ${{ !cancelled() && github.repository == 'ConduitIO/conduit' && needs.capture.outputs.changed == 'true' }}
     needs: capture
     name: publish (opens a PR, no key)
     runs-on: ubuntu-latest
@@ -167,7 +213,7 @@ jobs:
           fi
           {
             echo "summary<<EOF"
-            grep -E '^(provider|model|requestCount|passes|medianValidatePassRate|medianSemanticMatchRate|totalTokensUsed|estimatedCostUSD|corpusCommitSha):' "$manifest" || true
+            grep -E '^(provider|model|requestCount|capturedCount|missingCount|passes|medianValidatePassRate|medianSemanticMatchRate|totalTokensUsed|estimatedCostUSD|corpusCommitSha):' "$manifest" || true
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
@@ -177,6 +223,13 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           SUMMARY: ${{ steps.summary.outputs.summary }}
           REQUEST_ID: ${{ inputs.request_id }}
+          # Set by `!cancelled()` above even when `capture` FAILED (see the
+          # file header's "Partial results" section) - 'failure' here means
+          # captureCompletenessVerdict crossed the majority-missing floor (or
+          # something else in the job broke), never that nothing was
+          # captured: `changed == 'true'` (this job's own `if`) already
+          # proved something worth publishing landed on disk.
+          CAPTURE_RESULT: ${{ needs.capture.result }}
         run: |
           set -euo pipefail
           branch="generate-capture/$(date -u +%Y%m%d)-run${RUN_ID}"
@@ -184,7 +237,19 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$branch"
           git add cmd/conduit/internal/generate/testdata/transcripts
-          if [ -n "$REQUEST_ID" ]; then
+
+          banner=""
+          if [ "$CAPTURE_RESULT" != "success" ]; then
+            title="chore(generate): PARTIAL capture, review before merging (run ${RUN_ID})"
+            banner="> [!WARNING]
+          > \`capture\` did NOT finish cleanly (job result: \`${CAPTURE_RESULT}\`). Either a strict majority of
+          > requests never produced a completion (captureCompletenessVerdict, transcript_capture_test.go) or
+          > something else in the job failed. Everything below IS still what got captured and redaction-scanned
+          > clean - it is safe to review, but treat this as an incident to investigate, not a routine partial
+          > result.
+
+          "
+          elif [ -n "$REQUEST_ID" ]; then
             title="chore(generate): re-capture transcript for ${REQUEST_ID}"
           else
             title="chore(generate): capture provider transcripts (run ${RUN_ID})"
@@ -194,7 +259,7 @@ jobs:
           gh pr create \
             --title "$title" \
             --body "$(cat <<EOF
-          Opened by \`.github/workflows/generate-capture.yml\` (run ${RUN_ID}), never pushed to main.
+          ${banner}Opened by \`.github/workflows/generate-capture.yml\` (run ${RUN_ID}), never pushed to main.
 
           ## Manifest
 
@@ -202,11 +267,16 @@ jobs:
           ${SUMMARY}
           \`\`\`
 
+          \`capturedCount\`/\`missingCount\` above are the headline numbers; \`manifest.yaml\`'s
+          \`requestOutcomes\` (in the diff) names every missing request id and why.
+
           ## Review checklist
 
           - [ ] \`TestTranscripts_CarryNoSecretMaterial\` is green on this PR (untagged, runs on every PR already)
           - [ ] Manifest numbers look sane against the last capture (see \`docs/generate-benchmark.md\` once A5b lands)
           - [ ] Diff is scoped to \`cmd/conduit/internal/generate/testdata/transcripts/\` only
+          - [ ] If \`missingCount\` > 0, review each \`requestOutcomes\` reason; re-capture cheaply with
+                \`-run TestCaptureTranscripts/<id>\` before relying on this batch for eval
 
           🤖 Generated by the \`generate-capture\` workflow, live-capture job holds the key and cannot write to the
           repo (\`contents: read\`) - this job has no key and only opens the PR.

--- a/.github/workflows/generate-capture.yml
+++ b/.github/workflows/generate-capture.yml
@@ -39,11 +39,20 @@ name: generate-capture
 #
 # The go test itself (transcript_capture_test.go's runCapture) writes to a
 # scratch directory, redaction-scans every file (redact.go's
-# ScanTranscriptForSecrets, plan §5), and only copies the batch into
-# testdata/transcripts/ if the scan is clean - all failures abort the WHOLE
-# batch, never a partial promotion. If that scan ever finds something, the
-# `capture` job fails before an artifact is even uploaded, and `publish`
-# never runs.
+# ScanTranscriptForSecrets, plan §5) - and, separately, scans every
+# manifest-bound failure reason it computed (safeFailureReason) - and only
+# copies anything into testdata/transcripts/ if BOTH scans are clean - all
+# failures abort the WHOLE batch, never a partial promotion. The `capture`
+# job's own steps below ("Check whether any transcript changed", "Upload
+# captured transcripts") run even after that failure (`if: ${{ !cancelled()
+# }}`, see the "Partial results" section further down) rather than being
+# skipped outright - but since nothing was ever promoted into
+# testdata/transcripts/, `git status --porcelain` sees no change, "changed"
+# resolves to `false`, the upload step's own `if` condition on `changed ==
+# 'true'` is false so no artifact is uploaded, and `publish`'s `if` (which
+# requires `needs.capture.outputs.changed == 'true'`) never runs either. The
+# conclusion - a redaction violation never reaches a published PR - still
+# holds; it is reached via `changed=false`, not via the job stopping outright.
 #
 # # Partial results are preserved, not discarded (WS1 A5a-3 follow-up)
 #
@@ -110,6 +119,12 @@ jobs:
     timeout-minutes: 35 # go test's own -timeout 30m below, plus setup/checkout headroom
     outputs:
       changed: ${{ steps.check-changes.outputs.changed }}
+      # manifest_path is the manifest.yaml THIS RUN wrote, if any - never
+      # re-derived by `publish` searching the checked-out tree, which may
+      # already carry a manifest.yaml committed by an EARLIER run (see the
+      # "Summarize the manifest" step below for why that distinction
+      # matters). Empty for a scoped --request_id run, which writes none.
+      manifest_path: ${{ steps.check-changes.outputs.manifest_path }}
     steps:
       - uses: actions/checkout@v7
 
@@ -161,11 +176,22 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
-          if git status --porcelain -- cmd/conduit/internal/generate/testdata/transcripts | grep -q .; then
+          changes=$(git status --porcelain -- cmd/conduit/internal/generate/testdata/transcripts || true)
+          if [ -n "$changes" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
+
+          # The manifest.yaml path THIS RUN itself wrote or modified, if
+          # any - a scoped --request_id run writes none (runCapture returns
+          # wrote=false), and `git status --porcelain` over a clean
+          # checkout only ever shows files this run's own `go test`
+          # invocation touched, so an empty result here is unambiguous
+          # (never confused with a manifest.yaml already committed by an
+          # earlier run sitting untouched in the checkout).
+          manifest_path=$(printf '%s\n' "$changes" | awk '{print $2}' | grep -E '/manifest\.yaml$' | head -1 || true)
+          echo "manifest_path=${manifest_path}" >> "$GITHUB_OUTPUT"
 
       - name: Upload captured transcripts
         if: ${{ !cancelled() && steps.check-changes.outputs.changed == 'true' }}
@@ -204,24 +230,43 @@ jobs:
 
       - name: Summarize the manifest
         id: summary
+        env:
+          # Passed through from `capture` rather than re-derived by
+          # searching the checked-out tree here: a `find` over this job's
+          # own checkout would happily match a manifest.yaml already
+          # committed by an EARLIER run and render ITS numbers under a
+          # heading that calls them "the headline numbers" for THIS run -
+          # exactly what happens on a scoped --request_id run, which writes
+          # no manifest.yaml of its own (runCapture returns wrote=false).
+          MANIFEST_PATH: ${{ needs.capture.outputs.manifest_path }}
         run: |
           set -euo pipefail
-          manifest=$(find cmd/conduit/internal/generate/testdata/transcripts -maxdepth 2 -name manifest.yaml | head -1)
-          if [ -z "$manifest" ]; then
+          if [ -z "$MANIFEST_PATH" ] || [ ! -f "$MANIFEST_PATH" ]; then
             echo "summary=no manifest.yaml in this run's artifact (a scoped --request_id run does not write one)" >> "$GITHUB_OUTPUT"
+            echo "missing=0" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           {
             echo "summary<<EOF"
-            grep -E '^(provider|model|requestCount|capturedCount|missingCount|passes|medianValidatePassRate|medianSemanticMatchRate|totalTokensUsed|estimatedCostUSD|corpusCommitSha):' "$manifest" || true
+            grep -E '^(provider|model|requestCount|capturedCount|missingCount|passes|medianValidatePassRate|medianSemanticMatchRate|totalTokensUsed|estimatedCostUSD|corpusCommitSha):' "$MANIFEST_PATH" || true
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
+
+          # missing is its own output (not just embedded in the summary
+          # text block) so "Open the PR" can gate the banner and title on
+          # it directly, per the fix below: a missingCount > 0 run that
+          # still reports CAPTURE_RESULT == success (ordinary live-provider
+          # noise below captureCompletenessVerdict's threshold) must not
+          # look routine just because the job itself didn't fail.
+          missing=$(grep -E '^missingCount:' "$MANIFEST_PATH" | awk '{print $2}' || true)
+          echo "missing=${missing:-0}" >> "$GITHUB_OUTPUT"
 
       - name: Open the PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           SUMMARY: ${{ steps.summary.outputs.summary }}
+          MISSING: ${{ steps.summary.outputs.missing }}
           REQUEST_ID: ${{ inputs.request_id }}
           # Set by `!cancelled()` above even when `capture` FAILED (see the
           # file header's "Partial results" section) - 'failure' here means
@@ -229,6 +274,16 @@ jobs:
           # something else in the job broke), never that nothing was
           # captured: `changed == 'true'` (this job's own `if`) already
           # proved something worth publishing landed on disk.
+          #
+          # CAPTURE_RESULT alone is NOT the right signal for "does this PR
+          # need a reader's attention": captureCompletenessVerdict only
+          # fails the job past a STRICT MAJORITY missing (>50%). The likely
+          # degraded case - say 13/28 (46%) missing from ordinary rate
+          # limiting - reports CAPTURE_RESULT == success and would open a
+          # routinely-titled PR with a green check, with the only trace
+          # being a `missingCount: 13` line inside a fenced code block. The
+          # banner and title below are gated on CAPTURE_RESULT != success
+          # OR MISSING > 0, not on CAPTURE_RESULT alone.
           CAPTURE_RESULT: ${{ needs.capture.result }}
         run: |
           set -euo pipefail
@@ -247,6 +302,16 @@ jobs:
           > something else in the job failed. Everything below IS still what got captured and redaction-scanned
           > clean - it is safe to review, but treat this as an incident to investigate, not a routine partial
           > result.
+
+          "
+          elif [ "${MISSING:-0}" -gt 0 ]; then
+            title="chore(generate): capture provider transcripts, ${MISSING} missing (run ${RUN_ID})"
+            banner="> [!NOTE]
+          > ${MISSING} request(s) are missing from this capture, below captureCompletenessVerdict's run-failing
+          > threshold - \`capture\` reported success, and this IS a routine partial result (ordinary live-provider
+          > noise: a 429, a timeout), not an incident. Review each \`requestOutcomes\` reason in the diff before
+          > relying on this batch for eval; re-capture the missing id(s) cheaply with
+          > \`-run TestCaptureTranscripts/<id>\`.
 
           "
           elif [ -n "$REQUEST_ID" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,48 @@ jobs:
         # in production, on the wire, to a user or agent.
         run: go test ./pkg/http/api/status/... -run 'Codes|Registry' -v -race
 
+      - name: generate_capture build+lint gate (M2, round-4 review of #2814)
+        # cmd/conduit/internal/generate/transcript_capture_test.go
+        # (`//go:build generate_capture`) is ~3,200 lines carrying every
+        # regression test this package's capture-preservation fixes rest
+        # on (B1/B2/H1/H2/M1-M3 across rounds 2-4 of #2814's review) - but
+        # the ONLY thing in CI that ever builds with this tag is
+        # generate-capture.yml's live-capture job, and that job only runs
+        # `-run "^TestCaptureTranscripts$"` against a real Anthropic
+        # account on workflow_dispatch. Nothing untagged ever compiles this
+        # file (a normal `go build ./...`/`go vet ./...` skips it - the tag
+        # excludes it from the build entirely, not just from running), so a
+        # compile break in it is invisible until a live run - which costs
+        # real money - is already in flight, and golangci-lint (lint.yml)
+        # never lints it at all (see .golangci.yml's `run.build-tags`,
+        # added in the same PR as this step, for the other half of this
+        # fix - gosec's taint analysis only sees this file's
+        # patchManifestForScopedRun caller under this tag, so an untagged
+        # lint run cannot verify transcript.go's `#nosec G703` annotation
+        # still matches a real violation).
+        #
+        # This step runs the same non-live tests generate-capture.yml
+        # already excludes from ITS run (decideCaptureGuard refuses without
+        # CONDUIT_GENERATE_CAPTURE=1, which is never set here, so
+        # TestCaptureTranscripts itself would no-op even if named) -
+        # everything else in the tagged file that does NOT need a live
+        # provider or network access: the pure decision/scoring functions
+        # (summarizePasses, captureCompletenessVerdict,
+        # requestsMissingUsableCandidate via TestSummarizePasses*,
+        # decideCaptureGuard, capturePassCount, captureCallCeiling), the
+        # fake-provider end-to-end paths (TestRunCapture_*,
+        # TestCaptureProvider_Ceilings), the promotion/redaction gate
+        # (TestScanAndPromoteScratch*), the manifest-patch helper
+        # (TestPatchManifest*), and the failure-reason sanitizer
+        # (TestSafeFailureReason*, TestReportCaptureCompleteness). No
+        # ANTHROPIC_API_KEY is in scope for this step, by design - it must
+        # never be able to reach a live provider.
+        run: |
+          go build -tags=generate_capture ./...
+          go test -tags=generate_capture -count=1 -v \
+            -run 'TestRunCapture|TestSummarizePasses|TestScanAndPromote|TestCaptureCompleteness|TestPatchManifest|TestSafeFailureReason|TestDecideCaptureGuard|TestCaptureProvider|TestCapturePassCount|TestCaptureCallCeiling|TestReportCaptureCompleteness' \
+            ./cmd/conduit/internal/generate/...
+
   build-cross:
     # Cross-compile for the 32-bit release target. Regular CI only builds on
     # 64-bit, so a dependency that fails to compile on 32-bit (e.g. one using

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,21 +68,44 @@ jobs:
         # CONDUIT_GENERATE_CAPTURE=1, which is never set here, so
         # TestCaptureTranscripts itself would no-op even if named) -
         # everything else in the tagged file that does NOT need a live
-        # provider or network access: the pure decision/scoring functions
-        # (summarizePasses, captureCompletenessVerdict,
-        # requestsMissingUsableCandidate via TestSummarizePasses*,
-        # decideCaptureGuard, capturePassCount, captureCallCeiling), the
-        # fake-provider end-to-end paths (TestRunCapture_*,
-        # TestCaptureProvider_Ceilings), the promotion/redaction gate
-        # (TestScanAndPromoteScratch*), the manifest-patch helper
-        # (TestPatchManifest*), and the failure-reason sanitizer
-        # (TestSafeFailureReason*, TestReportCaptureCompleteness). No
-        # ANTHROPIC_API_KEY is in scope for this step, by design - it must
-        # never be able to reach a live provider.
+        # provider or network access. No ANTHROPIC_API_KEY is in scope for
+        # this step, by design - it must never be able to reach a live
+        # provider.
+        #
+        # LOW-1 (round-5 review of #2814): `go build` compiles the package
+        # but never runs its tests, so it is a no-op verification of a
+        # `_test.go` file - `go build` never compiles `_test.go` files at
+        # all, tagged or not. Verified: a planted syntax error in
+        # transcript_capture_test.go left `go build -tags=generate_capture
+        # ./...` green while `go vet`/`go test` correctly failed. `go vet`
+        # DOES compile (and type-check) `_test.go` files, so it is the
+        # right cheap pre-flight for a compile break, scoped to just this
+        # package rather than `./...` since that is the only tree this tag
+        # touches; the `go test` line below still provides the real
+        # coverage this step exists for.
+        #
+        # LOW-3 (round-5 review of #2814): a `-run` allowlist regex is
+        # fail-OPEN by construction - a future test named outside its listed
+        # prefixes runs nowhere, `go test` still exits 0, and CI stays green
+        # while silently not covering it. This PR's own new regression
+        # tests (TestPreserveMediansIfNothingPromoted_ShapeMismatch_...,
+        # TestRequestIsCaptured_RejectsContentMismatch) do not match ANY of
+        # the 11 prefixes the prior allowlist named - they would have
+        # silently never run in this gate. `-skip` naming just the one live
+        # test to exclude is fail-SAFE instead: every other test in the
+        # file, present or future, runs unless explicitly excluded.
+        #
+        # LOW-4 (round-5 review of #2814): `-race` added - green locally in
+        # under 4s, and this package's own regression tests
+        # (flakyAfterFirstCallProvider, diesAfterNCallsProvider) use
+        # goroutine-shared counters guarded by sync.Mutex specifically
+        # because runCapture drives concurrent-looking per-request work;
+        # the race detector is the check that actually verifies those
+        # guards, not just that they exist.
         run: |
-          go build -tags=generate_capture ./...
-          go test -tags=generate_capture -count=1 -v \
-            -run 'TestRunCapture|TestSummarizePasses|TestScanAndPromote|TestCaptureCompleteness|TestPatchManifest|TestSafeFailureReason|TestDecideCaptureGuard|TestCaptureProvider|TestCapturePassCount|TestCaptureCallCeiling|TestReportCaptureCompleteness' \
+          go vet -tags=generate_capture ./cmd/conduit/internal/generate/...
+          go test -tags=generate_capture -count=1 -race -v \
+            -skip '^TestCaptureTranscripts$' \
             ./cmd/conduit/internal/generate/...
 
   build-cross:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,21 @@
 version: "2"
+run:
+  # M2 (round-4 review of #2814): without this, golangci-lint never even
+  # SEES cmd/conduit/internal/generate/transcript_capture_test.go (its
+  # `//go:build generate_capture` tag excludes it from every untagged
+  # build/lint, and generate-capture.yml's live-capture job is the only
+  # place in CI that ever passes `-tags=generate_capture` - and that job
+  # runs `go test`, never `golangci-lint run`). This is not redundant with
+  # `go vet`/compilation catching a break: gosec's own taint analysis on
+  # transcript.go's LoadManifest (the `#nosec G703` on its os.ReadFile)
+  # only sees a tainted call site at all once this file's own
+  # patchManifestForScopedRun is in the build - remove that #nosec and
+  # `--build-tags=generate_capture` reports `G703: Path traversal via
+  # taint analysis` while an untagged run reports zero issues, verified
+  # empirically. Add a tag here, add the matching `go build`/`go test`
+  # step to .github/workflows/test.yml's `test` job in the same PR.
+  build-tags:
+    - generate_capture
 linters:
   default: none
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,8 +12,11 @@ run:
   # patchManifestForScopedRun is in the build - remove that #nosec and
   # `--build-tags=generate_capture` reports `G703: Path traversal via
   # taint analysis` while an untagged run reports zero issues, verified
-  # empirically. Add a tag here, add the matching `go build`/`go test`
-  # step to .github/workflows/test.yml's `test` job in the same PR.
+  # empirically. Add a tag here, add the matching `go vet`/`go test`
+  # step to .github/workflows/test.yml's `test` job in the same PR (LOW-1,
+  # round-5 review of #2814: `go vet`, not `go build` - `go build` never
+  # compiles `_test.go` files at all and so cannot catch a break in this
+  # tagged _test.go file; see that step's own comment).
   build-tags:
     - generate_capture
 linters:

--- a/cmd/conduit/internal/generate/provider/adapters_test.go
+++ b/cmd/conduit/internal/generate/provider/adapters_test.go
@@ -186,6 +186,80 @@ func Test_Adapters_EmptyResponseIsAnError(t *testing.T) {
 	}
 }
 
+// Test_Adapters_EmptyResponseIsMarkedUnusable_AndCarriesTokens is the
+// regression test for the finding that a refusal (a 2xx with an empty
+// completion) was reported identically to absence of data (a 429, a
+// timeout) and its tokens were silently dropped from cost accounting: the
+// response DID decode, so the provider-reported usage is known even though
+// the completion is unusable, and that must survive on CompletionResult
+// even though Complete returns an error — a caller that only inspects the
+// error return (as code used to) would otherwise undercount real spend.
+func Test_Adapters_EmptyResponseIsMarkedUnusable_AndCarriesTokens(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		body       string
+		build      func(url string) Provider
+		wantTokens int
+	}{
+		"anthropic": {
+			`{"content":[],"usage":{"input_tokens":7,"output_tokens":3}}`,
+			func(u string) Provider { return &Anthropic{BaseURL: u} }, 10,
+		},
+		"ollama": {
+			`{"response":"","prompt_eval_count":7,"eval_count":3}`,
+			func(u string) Provider { return &Ollama{Host: u} }, 10,
+		},
+		"openai": {
+			`{"choices":[],"usage":{"total_tokens":10}}`,
+			func(u string) Provider { return &OpenAI{BaseURL: u} }, 10,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			is := is.New(t)
+			srv := newCapturing(t, 200, tc.body)
+			got, err := tc.build(srv.URL).Complete(context.Background(), CompletionRequest{Prompt: "x"})
+			is.True(err != nil)
+			is.True(IsUnusableResponse(err)) // a refusal, not absence of data
+			is.Equal(got.TokensUsed, tc.wantTokens)
+			_, hasStatus := HTTPStatus(err)
+			is.True(!hasStatus) // a 2xx has no failing status to report
+		})
+	}
+}
+
+// Test_Adapters_HTTPErrorsCarryHTTPStatus pins the structured half of a
+// checkStatus failure: the numeric status is recoverable via HTTPStatus
+// without parsing message text, and such an error is never marked
+// IsUnusableResponse (a non-2xx means no usable response was obtained at
+// all, a different failure mode than a refusal).
+//
+// openai is deliberately excluded: it wraps the vendored goopenai SDK
+// client rather than calling checkStatus directly (see openai.go's own doc
+// comment on why), so an HTTP error from it never carries a *httpStatusError
+// today — a real gap, but a pre-existing one this fix does not widen, and
+// out of scope here since the live capture harness (transcript_capture_test.go)
+// only ever drives the anthropic adapter.
+func Test_Adapters_HTTPErrorsCarryHTTPStatus(t *testing.T) {
+	t.Parallel()
+
+	for name, build := range map[string]func(url string) Provider{
+		"anthropic": func(u string) Provider { return &Anthropic{BaseURL: u} },
+		"ollama":    func(u string) Provider { return &Ollama{Host: u} },
+	} {
+		t.Run(name, func(t *testing.T) {
+			is := is.New(t)
+			srv := newCapturing(t, 429, `{"error":"nope"}`)
+			_, err := build(srv.URL).Complete(context.Background(), CompletionRequest{Prompt: "x"})
+			is.True(err != nil)
+			status, ok := HTTPStatus(err)
+			is.True(ok)
+			is.Equal(status, 429)
+			is.True(!IsUnusableResponse(err))
+		})
+	}
+}
+
 // Test_Anthropic_ConcatenatesTextBlocks pins that a response split across
 // blocks is joined. Taking only the first block would silently truncate the
 // generated config — which would then fail validation for the wrong reason.

--- a/cmd/conduit/internal/generate/provider/adapters_test.go
+++ b/cmd/conduit/internal/generate/provider/adapters_test.go
@@ -71,10 +71,10 @@ const (
 	openAIOK    = `{"choices":[{"message":{"role":"assistant","content":"version: 2.2"}}],"usage":{"total_tokens":15}}`
 )
 
-// Test_Adapters_HappyPath pins that each adapter returns the model's text and
+// TestAdapters_HappyPath pins that each adapter returns the model's text and
 // only a provider-REPORTED token count. A fabricated count would be
 // indistinguishable from a real one in --json output users may bill against.
-func Test_Adapters_HappyPath(t *testing.T) {
+func TestAdapters_HappyPath(t *testing.T) {
 	t.Parallel()
 
 	t.Run("anthropic", func(t *testing.T) {
@@ -128,10 +128,10 @@ func Test_Adapters_HappyPath(t *testing.T) {
 	})
 }
 
-// Test_Adapters_HTTPErrorsAreProviderErrors pins the error code and that the
+// TestAdapters_HTTPErrorsAreProviderErrors pins the error code and that the
 // message names the provider and status. A user seeing this needs to know
 // which provider failed and why — not a stack trace from inside an HTTP client.
-func Test_Adapters_HTTPErrorsAreProviderErrors(t *testing.T) {
+func TestAdapters_HTTPErrorsAreProviderErrors(t *testing.T) {
 	t.Parallel()
 
 	for _, status := range []int{401, 429, 500} {
@@ -160,10 +160,10 @@ func Test_Adapters_HTTPErrorsAreProviderErrors(t *testing.T) {
 	}
 }
 
-// Test_Adapters_EmptyResponseIsAnError pins that a 200 with no text fails
+// TestAdapters_EmptyResponseIsAnError pins that a 200 with no text fails
 // loudly. Returning an empty string would send the generation loop into a
 // parse failure that blames the wrong layer.
-func Test_Adapters_EmptyResponseIsAnError(t *testing.T) {
+func TestAdapters_EmptyResponseIsAnError(t *testing.T) {
 	t.Parallel()
 
 	for name, tc := range map[string]struct {
@@ -186,7 +186,7 @@ func Test_Adapters_EmptyResponseIsAnError(t *testing.T) {
 	}
 }
 
-// Test_Adapters_EmptyResponseIsMarkedUnusable_AndCarriesTokens is the
+// TestAdapters_EmptyResponseIsMarkedUnusable_AndCarriesTokens is the
 // regression test for the finding that a refusal (a 2xx with an empty
 // completion) was reported identically to absence of data (a 429, a
 // timeout) and its tokens were silently dropped from cost accounting: the
@@ -194,7 +194,7 @@ func Test_Adapters_EmptyResponseIsAnError(t *testing.T) {
 // the completion is unusable, and that must survive on CompletionResult
 // even though Complete returns an error — a caller that only inspects the
 // error return (as code used to) would otherwise undercount real spend.
-func Test_Adapters_EmptyResponseIsMarkedUnusable_AndCarriesTokens(t *testing.T) {
+func TestAdapters_EmptyResponseIsMarkedUnusable_AndCarriesTokens(t *testing.T) {
 	t.Parallel()
 
 	for name, tc := range map[string]struct {
@@ -228,7 +228,7 @@ func Test_Adapters_EmptyResponseIsMarkedUnusable_AndCarriesTokens(t *testing.T) 
 	}
 }
 
-// Test_Adapters_HTTPErrorsCarryHTTPStatus pins the structured half of a
+// TestAdapters_HTTPErrorsCarryHTTPStatus pins the structured half of a
 // checkStatus failure: the numeric status is recoverable via HTTPStatus
 // without parsing message text, and such an error is never marked
 // IsUnusableResponse (a non-2xx means no usable response was obtained at
@@ -240,7 +240,7 @@ func Test_Adapters_EmptyResponseIsMarkedUnusable_AndCarriesTokens(t *testing.T) 
 // today — a real gap, but a pre-existing one this fix does not widen, and
 // out of scope here since the live capture harness (transcript_capture_test.go)
 // only ever drives the anthropic adapter.
-func Test_Adapters_HTTPErrorsCarryHTTPStatus(t *testing.T) {
+func TestAdapters_HTTPErrorsCarryHTTPStatus(t *testing.T) {
 	t.Parallel()
 
 	for name, build := range map[string]func(url string) Provider{
@@ -274,9 +274,9 @@ func Test_Anthropic_ConcatenatesTextBlocks(t *testing.T) {
 	is.Equal(got.Text, "version: 2.2") // joined, and non-text blocks skipped
 }
 
-// Test_Adapters_RespectContextCancellation pins that a caller's cancellation
+// TestAdapters_RespectContextCancellation pins that a caller's cancellation
 // aborts promptly rather than waiting out the per-call timeout.
-func Test_Adapters_RespectContextCancellation(t *testing.T) {
+func TestAdapters_RespectContextCancellation(t *testing.T) {
 	t.Parallel()
 
 	// The wait is BOUNDED. httptest.Server.Close waits for in-flight handlers,
@@ -317,7 +317,7 @@ func Test_Adapters_RespectContextCancellation(t *testing.T) {
 	}
 }
 
-// Test_Adapters_TimeoutIsBounded pins that a wedged provider fails rather than
+// TestAdapters_TimeoutIsBounded pins that a wedged provider fails rather than
 // hanging an interactive command forever, and (round-2 review of #2814,
 // "safeFailureReason collapses DNS failure, connection-refused, timeout...
 // to one string") that the failure is specifically identifiable via
@@ -325,7 +325,7 @@ func Test_Adapters_RespectContextCancellation(t *testing.T) {
 // transport-level miss (DNS failure, connection refused), which HTTPStatus
 // alone can't tell apart (none of those ever got a response with a status
 // to report).
-func Test_Adapters_TimeoutIsBounded(t *testing.T) {
+func TestAdapters_TimeoutIsBounded(t *testing.T) {
 	t.Parallel()
 
 	// Bounded for the same reason as in the cancellation test above.
@@ -359,24 +359,36 @@ func Test_Adapters_TimeoutIsBounded(t *testing.T) {
 	}
 }
 
-// Test_Adapters_NonTimeoutTransportErrorIsNotMarkedAsTimeout is the
+// TestAdapters_NonTimeoutTransportErrorIsNotMarkedAsTimeout is the
 // negative case for IsTimeout: a connection actively refused (not a
 // deadline expiring) must never be misreported as a timeout — the two call
 // for different remediation (retry later vs. check the endpoint/network).
-func Test_Adapters_NonTimeoutTransportErrorIsNotMarkedAsTimeout(t *testing.T) {
+func TestAdapters_NonTimeoutTransportErrorIsNotMarkedAsTimeout(t *testing.T) {
 	t.Parallel()
 
 	// A server that accepts and immediately closes the connection is a
 	// reliable, fast way to force "connection refused"/"EOF" rather than a
 	// deadline — no sleeping, no wedged handler.
+	//
+	// N5 (round-3 review of #2814): this handler runs on net/http's OWN
+	// per-request goroutine, never the test goroutine — calling
+	// t.Fatal/t.Fatalf here was an invalid use of *testing.T (its docs:
+	// "FailNow must be called from the goroutine running the test... function,
+	// not from other goroutines"). Neither branch below is expected to
+	// ever actually fire against httptest's server transport (its
+	// ResponseWriter always implements Hijacker, and Hijack on a fresh
+	// connection does not fail), so panicking is the correct "this should
+	// never happen" signal here: net/http recovers a per-connection panic
+	// and logs it (visible with `go test -v`) without the goroutine-safety
+	// hazard a *testing.T call would carry.
 	refusing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hj, ok := w.(http.Hijacker)
 		if !ok {
-			t.Fatal("test setup: ResponseWriter does not support hijacking")
+			panic("test setup: ResponseWriter does not support hijacking")
 		}
 		conn, _, err := hj.Hijack()
 		if err != nil {
-			t.Fatalf("test setup: hijack: %v", err)
+			panic(fmt.Sprintf("test setup: hijack: %v", err))
 		}
 		conn.Close()
 	}))
@@ -395,9 +407,9 @@ func Test_Adapters_NonTimeoutTransportErrorIsNotMarkedAsTimeout(t *testing.T) {
 	}
 }
 
-// Test_Adapters_RequestModelOverridesAdapterDefault pins the precedence the
+// TestAdapters_RequestModelOverridesAdapterDefault pins the precedence the
 // --model flag depends on.
-func Test_Adapters_RequestModelOverridesAdapterDefault(t *testing.T) {
+func TestAdapters_RequestModelOverridesAdapterDefault(t *testing.T) {
 	t.Parallel()
 	is := is.New(t)
 
@@ -412,7 +424,7 @@ func Test_Adapters_RequestModelOverridesAdapterDefault(t *testing.T) {
 }
 
 // Test_DefaultMaxTokens_AbsorbsThinkingNotJustOutput pins the actual value,
-// not just that SOME constant is wired through (Test_Adapters_
+// not just that SOME constant is wired through (TestAdapters_
 // MaxTokensPassedThrough below covers wiring). A generated pipeline config
 // is small — around 350 tokens for a typical candidate in this package's own
 // corpus — so 4096 looks generous for the OUTPUT alone; it is not generous
@@ -426,7 +438,7 @@ func Test_DefaultMaxTokens_AbsorbsThinkingNotJustOutput(t *testing.T) {
 	is.Equal(DefaultMaxTokens, 16384)
 }
 
-// Test_Adapters_MaxTokensPassedThrough pins that DefaultMaxTokens actually
+// TestAdapters_MaxTokensPassedThrough pins that DefaultMaxTokens actually
 // reaches the request body, for every adapter that has a max-tokens field to
 // set. On a model that runs adaptive/extended thinking by default when the
 // request doesn't set an explicit thinking budget (e.g. Anthropic's Sonnet 5,
@@ -437,7 +449,7 @@ func Test_DefaultMaxTokens_AbsorbsThinkingNotJustOutput(t *testing.T) {
 // against. A regression that drops the field, hardcodes a smaller value, or
 // forgets to wire DefaultMaxTokens into a new adapter's request must fail
 // this test.
-func Test_Adapters_MaxTokensPassedThrough(t *testing.T) {
+func TestAdapters_MaxTokensPassedThrough(t *testing.T) {
 	t.Parallel()
 
 	t.Run("anthropic", func(t *testing.T) {

--- a/cmd/conduit/internal/generate/provider/adapters_test.go
+++ b/cmd/conduit/internal/generate/provider/adapters_test.go
@@ -318,10 +318,15 @@ func Test_Adapters_RespectContextCancellation(t *testing.T) {
 }
 
 // Test_Adapters_TimeoutIsBounded pins that a wedged provider fails rather than
-// hanging an interactive command forever.
+// hanging an interactive command forever, and (round-2 review of #2814,
+// "safeFailureReason collapses DNS failure, connection-refused, timeout...
+// to one string") that the failure is specifically identifiable via
+// IsTimeout — distinguishing "our own deadline expired" from every OTHER
+// transport-level miss (DNS failure, connection refused), which HTTPStatus
+// alone can't tell apart (none of those ever got a response with a status
+// to report).
 func Test_Adapters_TimeoutIsBounded(t *testing.T) {
 	t.Parallel()
-	is := is.New(t)
 
 	// Bounded for the same reason as in the cancellation test above.
 	wedged := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -332,12 +337,62 @@ func Test_Adapters_TimeoutIsBounded(t *testing.T) {
 	}))
 	t.Cleanup(wedged.Close)
 
-	start := time.Now()
-	_, err := (&Ollama{Host: wedged.URL, Timeout: 200 * time.Millisecond}).
-		Complete(context.Background(), CompletionRequest{Prompt: "x"})
-	is.True(err != nil)
-	codeIs(t, err, CodeProviderError)
-	is.True(time.Since(start) < 5*time.Second)
+	for name, build := range map[string]func(url string) Provider{
+		"anthropic": func(u string) Provider { return &Anthropic{BaseURL: u, Timeout: 200 * time.Millisecond} },
+		"ollama":    func(u string) Provider { return &Ollama{Host: u, Timeout: 200 * time.Millisecond} },
+		"openai":    func(u string) Provider { return &OpenAI{BaseURL: u, Timeout: 200 * time.Millisecond} },
+	} {
+		t.Run(name, func(t *testing.T) {
+			is := is.New(t)
+			start := time.Now()
+			_, err := build(wedged.URL).Complete(context.Background(), CompletionRequest{Prompt: "x"})
+			is.True(err != nil)
+			codeIs(t, err, CodeProviderError)
+			is.True(time.Since(start) < 5*time.Second)
+			is.True(IsTimeout(err))
+			// Never confused with the OTHER thing HTTPStatus/IsUnusableResponse
+			// report false for: no response ever arrived, so neither applies.
+			_, hasStatus := HTTPStatus(err)
+			is.True(!hasStatus)
+			is.True(!IsUnusableResponse(err))
+		})
+	}
+}
+
+// Test_Adapters_NonTimeoutTransportErrorIsNotMarkedAsTimeout is the
+// negative case for IsTimeout: a connection actively refused (not a
+// deadline expiring) must never be misreported as a timeout — the two call
+// for different remediation (retry later vs. check the endpoint/network).
+func Test_Adapters_NonTimeoutTransportErrorIsNotMarkedAsTimeout(t *testing.T) {
+	t.Parallel()
+
+	// A server that accepts and immediately closes the connection is a
+	// reliable, fast way to force "connection refused"/"EOF" rather than a
+	// deadline — no sleeping, no wedged handler.
+	refusing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("test setup: ResponseWriter does not support hijacking")
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			t.Fatalf("test setup: hijack: %v", err)
+		}
+		conn.Close()
+	}))
+	t.Cleanup(refusing.Close)
+
+	for name, build := range map[string]func(url string) Provider{
+		"anthropic": func(u string) Provider { return &Anthropic{BaseURL: u} },
+		"ollama":    func(u string) Provider { return &Ollama{Host: u} },
+	} {
+		t.Run(name, func(t *testing.T) {
+			is := is.New(t)
+			_, err := build(refusing.URL).Complete(context.Background(), CompletionRequest{Prompt: "x"})
+			is.True(err != nil)
+			is.True(!IsTimeout(err))
+		})
+	}
 }
 
 // Test_Adapters_RequestModelOverridesAdapterDefault pins the precedence the

--- a/cmd/conduit/internal/generate/provider/anthropic.go
+++ b/cmd/conduit/internal/generate/provider/anthropic.go
@@ -107,7 +107,7 @@ func (a *Anthropic) Complete(ctx context.Context, req CompletionRequest) (Comple
 
 	var out anthropicResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		return CompletionResult{}, providerErrorf(a.Name(), "decode response: %v", err)
+		return CompletionResult{}, markUnusableResponse(providerErrorf(a.Name(), "decode response: %v", err))
 	}
 
 	// Concatenate every text block. A response split across blocks is valid,
@@ -119,12 +119,18 @@ func (a *Anthropic) Complete(ctx context.Context, req CompletionRequest) (Comple
 		}
 	}
 	text := sb.String()
+	tokensUsed := out.Usage.InputTokens + out.Usage.OutputTokens
 	if strings.TrimSpace(text) == "" {
-		return CompletionResult{}, providerErrorf(a.Name(), "empty response")
+		// A refusal is still a BILLED call: out.Usage decoded successfully
+		// above even though the content array came back empty, so the
+		// token count IS known here — carried on CompletionResult even
+		// though this returns an error, so a caller that inspects it on
+		// error (captureProvider.Complete) never undercounts real spend.
+		return CompletionResult{TokensUsed: tokensUsed}, markUnusableResponse(providerErrorf(a.Name(), "empty response"))
 	}
 
 	return CompletionResult{
 		Text:       text,
-		TokensUsed: out.Usage.InputTokens + out.Usage.OutputTokens,
+		TokensUsed: tokensUsed,
 	}, nil
 }

--- a/cmd/conduit/internal/generate/provider/anthropic.go
+++ b/cmd/conduit/internal/generate/provider/anthropic.go
@@ -95,9 +95,14 @@ func (a *Anthropic) Complete(ctx context.Context, req CompletionRequest) (Comple
 	httpReq.Header.Set("x-api-key", a.APIKey)
 	httpReq.Header.Set("anthropic-version", anthropicVersion)
 
-	resp, err := doer(a.HTTP).Do(httpReq)
-	if err != nil {
-		return CompletionResult{}, providerErrorf(a.Name(), "%v", err)
+	resp, transportErr := doer(a.HTTP).Do(httpReq)
+	if transportErr != nil {
+		// MarkIfTimeout distinguishes "ctx's deadline expired" (DefaultTimeout,
+		// or the capture harness's captureWallClockBudget) from every OTHER
+		// transport-level miss — DNS failure, connection refused, TLS error —
+		// which HTTPStatus also can't discriminate (see errTimeout's doc
+		// comment, provider/http.go).
+		return CompletionResult{}, MarkIfTimeout(providerErrorf(a.Name(), "%v", transportErr), transportErr)
 	}
 	defer resp.Body.Close()
 

--- a/cmd/conduit/internal/generate/provider/http.go
+++ b/cmd/conduit/internal/generate/provider/http.go
@@ -15,6 +15,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -183,4 +184,48 @@ func HTTPStatus(err error) (status int, ok bool) {
 		return se.statusCode, true
 	}
 	return 0, false
+}
+
+// errTimeout marks a provider error whose underlying transport failure was
+// specifically the calling context's deadline expiring (context.
+// DeadlineExceeded) — as opposed to every OTHER transport-level miss
+// HTTPStatus also returns ok=false for: DNS resolution failure, connection
+// refused, a TLS handshake failure, and so on. Nit from the round-2 review
+// of #2814: without this, safeFailureReason (transcript_capture_test.go)
+// collapses all of those to the identical string (CodeProviderError's
+// generic Reason(), no HTTP status to append — none of them ever got a
+// response), which is a real triage regression: "our own deadline expired"
+// (captureWallClockBudget, DefaultTimeout) and "the provider's DNS is
+// broken" call for different remediation and read identically in a
+// committed manifest/tombstone today.
+var errTimeout = cerrors.New("provider call timed out")
+
+// IsTimeout reports whether err was produced by a Do() call that failed
+// because ctx's deadline expired — see errTimeout. False for every other
+// provider error, including a non-timeout network failure.
+func IsTimeout(err error) bool {
+	return cerrors.Is(err, errTimeout)
+}
+
+// timeoutError wraps err to mark it via IsTimeout, transparently: Error()
+// and Unwrap() forward to cause unchanged, so marking never changes what a
+// user or a log line sees.
+type timeoutError struct {
+	cause error
+}
+
+func (e *timeoutError) Error() string        { return e.cause.Error() }
+func (e *timeoutError) Unwrap() error        { return e.cause }
+func (e *timeoutError) Is(target error) bool { return target == errTimeout }
+
+// MarkIfTimeout wraps err (nil-safe, and a no-op if err is already nil or
+// transportErr does not satisfy context.DeadlineExceeded) so IsTimeout(err)
+// reports true — call at the Do() call site, passing the ORIGINAL transport
+// error (transportErr) to test, since providerErrorf's %v-formatted result
+// no longer carries a traversable Unwrap chain back to it.
+func MarkIfTimeout(wrapped error, transportErr error) error {
+	if wrapped == nil || !cerrors.Is(transportErr, context.DeadlineExceeded) {
+		return wrapped
+	}
+	return &timeoutError{cause: wrapped}
 }

--- a/cmd/conduit/internal/generate/provider/http.go
+++ b/cmd/conduit/internal/generate/provider/http.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"google.golang.org/grpc/codes"
 )
@@ -89,13 +90,97 @@ func readErrorBody(r io.Reader) string {
 	return strings.Join(strings.Fields(string(b)), " ")
 }
 
+// errUnusableResponse marks a provider error that occurred AFTER an HTTP
+// response was already in hand — a body that doesn't decode, or a
+// well-formed but empty completion (a refusal) — as distinct from a
+// transport-level failure (network error, timeout, non-2xx status) where no
+// usable response ever arrived. The distinction matters: a refusal is a
+// BILLED, attempted call and must never be reported the same way as
+// absence of data the way an unreachable endpoint or a rate limit is (see
+// IsUnusableResponse and RequestOutcome.Unusable,
+// transcript_capture_test.go / transcript.go).
+var errUnusableResponse = cerrors.New("provider response could not be used")
+
+// IsUnusableResponse reports whether err was produced by a call that DID
+// receive an HTTP response but could not turn it into a usable completion —
+// see errUnusableResponse. False for every other provider error, including
+// one produced by checkStatus (a non-2xx status means no usable response
+// was ever obtained in the first place, which is a different failure mode
+// entirely).
+func IsUnusableResponse(err error) bool {
+	return cerrors.Is(err, errUnusableResponse)
+}
+
+// unusableResponseError wraps err to mark it via IsUnusableResponse,
+// transparently: Error() and Unwrap() forward to cause unchanged, so
+// marking never changes what a user or a log line sees.
+type unusableResponseError struct {
+	cause error
+}
+
+func (e *unusableResponseError) Error() string        { return e.cause.Error() }
+func (e *unusableResponseError) Unwrap() error        { return e.cause }
+func (e *unusableResponseError) Is(target error) bool { return target == errUnusableResponse }
+
+// markUnusableResponse wraps err (nil-safe) so IsUnusableResponse(err)
+// reports true. Use only for a failure detected strictly AFTER a 2xx
+// response was already parsed — never for a transport or status failure.
+func markUnusableResponse(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &unusableResponseError{cause: err}
+}
+
 // checkStatus converts a non-2xx response into a provider error.
+//
+// The returned error is wrapped in *httpStatusError so a caller can recover
+// the numeric status via HTTPStatus without parsing message text — see that
+// function's doc comment for why this exists.
 func checkStatus(name string, resp *http.Response) error {
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return nil
 	}
+	var err error
 	if body := readErrorBody(resp.Body); body != "" {
-		return providerErrorf(name, "HTTP %d: %s", resp.StatusCode, body)
+		err = providerErrorf(name, "HTTP %d: %s", resp.StatusCode, body)
+	} else {
+		err = providerErrorf(name, "HTTP %d", resp.StatusCode)
 	}
-	return providerErrorf(name, "HTTP %d", resp.StatusCode)
+	return &httpStatusError{cause: err, statusCode: resp.StatusCode}
+}
+
+// httpStatusError carries checkStatus's numeric HTTP status alongside the
+// provider error it wraps, transparently: Error() and Unwrap() forward to
+// cause unchanged, so wrapping never changes what a user or a log line
+// sees — only what a caller doing HTTPStatus(err) can recover.
+type httpStatusError struct {
+	cause      error
+	statusCode int
+}
+
+func (e *httpStatusError) Error() string { return e.cause.Error() }
+func (e *httpStatusError) Unwrap() error { return e.cause }
+
+// HTTPStatus extracts the response status code from err, when err (or
+// something it wraps) came from checkStatus. ok is false for every other
+// provider error — a network failure, a decode failure, an empty response —
+// because none of those had a response WITH a status code worth reporting,
+// either because no response ever arrived (network error, timeout) or
+// because it arrived with a 2xx and failed for a reason checkStatus never
+// saw.
+//
+// This is the structured half of the fix for storing a provider error's raw
+// text in a committed file (transcript_capture_test.go's
+// safeFailureReason): the status code is the load-bearing part of a
+// checkStatus failure (invariant documented on readErrorBody above) and is
+// safe to persist verbatim, unlike the response body readErrorBody embeds
+// into the human-readable message, which may echo back caller-supplied or
+// provider-controlled content (e.g. a 401 body quoting the rejected key).
+func HTTPStatus(err error) (status int, ok bool) {
+	var se *httpStatusError
+	if cerrors.As(err, &se) {
+		return se.statusCode, true
+	}
+	return 0, false
 }

--- a/cmd/conduit/internal/generate/provider/ollama.go
+++ b/cmd/conduit/internal/generate/provider/ollama.go
@@ -94,15 +94,18 @@ func (o *Ollama) Complete(ctx context.Context, req CompletionRequest) (Completio
 
 	var out ollamaResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		return CompletionResult{}, providerErrorf(o.Name(), "decode response: %v", err)
+		return CompletionResult{}, markUnusableResponse(providerErrorf(o.Name(), "decode response: %v", err))
 	}
+	tokensUsed := out.PromptEvalCount + out.EvalCount
 	if strings.TrimSpace(out.Response) == "" {
-		return CompletionResult{}, providerErrorf(o.Name(), "empty response")
+		// See anthropic.go's identical comment: out decoded successfully,
+		// so the token count is known even though the response is unusable.
+		return CompletionResult{TokensUsed: tokensUsed}, markUnusableResponse(providerErrorf(o.Name(), "empty response"))
 	}
 
 	return CompletionResult{
 		Text:       out.Response,
-		TokensUsed: out.PromptEvalCount + out.EvalCount,
+		TokensUsed: tokensUsed,
 	}, nil
 }
 

--- a/cmd/conduit/internal/generate/provider/ollama.go
+++ b/cmd/conduit/internal/generate/provider/ollama.go
@@ -82,9 +82,12 @@ func (o *Ollama) Complete(ctx context.Context, req CompletionRequest) (Completio
 	}
 	httpReq.Header.Set("content-type", "application/json")
 
-	resp, err := doer(o.HTTP).Do(httpReq)
-	if err != nil {
-		return CompletionResult{}, providerErrorf(o.Name(), "%v", err)
+	resp, transportErr := doer(o.HTTP).Do(httpReq)
+	if transportErr != nil {
+		// MarkIfTimeout distinguishes "ctx's deadline expired" from every
+		// OTHER transport-level miss — see errTimeout's doc comment,
+		// provider/http.go.
+		return CompletionResult{}, MarkIfTimeout(providerErrorf(o.Name(), "%v", transportErr), transportErr)
 	}
 	defer resp.Body.Close()
 

--- a/cmd/conduit/internal/generate/provider/openai.go
+++ b/cmd/conduit/internal/generate/provider/openai.go
@@ -65,7 +65,11 @@ func (o *OpenAI) Complete(ctx context.Context, req CompletionRequest) (Completio
 		},
 	})
 	if err != nil {
-		return CompletionResult{}, providerErrorf(o.Name(), "%v", err)
+		// MarkIfTimeout distinguishes "ctx's deadline expired" from every
+		// OTHER transport-level miss — see errTimeout's doc comment,
+		// provider/http.go. A no-op if the go-openai SDK's error doesn't
+		// unwrap to context.DeadlineExceeded.
+		return CompletionResult{}, MarkIfTimeout(providerErrorf(o.Name(), "%v", err), err)
 	}
 	if len(resp.Choices) == 0 || strings.TrimSpace(resp.Choices[0].Message.Content) == "" {
 		// resp decoded successfully (CreateChatCompletion returned no

--- a/cmd/conduit/internal/generate/provider/openai.go
+++ b/cmd/conduit/internal/generate/provider/openai.go
@@ -68,7 +68,10 @@ func (o *OpenAI) Complete(ctx context.Context, req CompletionRequest) (Completio
 		return CompletionResult{}, providerErrorf(o.Name(), "%v", err)
 	}
 	if len(resp.Choices) == 0 || strings.TrimSpace(resp.Choices[0].Message.Content) == "" {
-		return CompletionResult{}, providerErrorf(o.Name(), "empty response")
+		// resp decoded successfully (CreateChatCompletion returned no
+		// error), so resp.Usage is known even though there is no usable
+		// choice — see anthropic.go's identical comment.
+		return CompletionResult{TokensUsed: resp.Usage.TotalTokens}, markUnusableResponse(providerErrorf(o.Name(), "empty response"))
 	}
 
 	return CompletionResult{

--- a/cmd/conduit/internal/generate/score.go
+++ b/cmd/conduit/internal/generate/score.go
@@ -17,6 +17,7 @@ package generate
 import (
 	"context"
 	"sort"
+	"strings"
 
 	"github.com/conduitio/conduit/cmd/conduit/internal/validate"
 )
@@ -58,6 +59,22 @@ type RunScore struct {
 // from candidates is recorded as Result.Missing and counts as a fail on
 // BOTH metrics — never silently dropped from the denominator (see doc.go's
 // invariants). requests order is preserved in RunScore.Results.
+//
+// A candidate that IS present but empty or whitespace-only is a different,
+// narrower case than Missing (B2, round-3 review of #2814): the Candidates
+// map had an entry — Result.Missing stays false, per its own doc comment —
+// but there is nothing in it to score. This happens when a model's raw
+// completions were all recorded (so runCapture, transcript_capture_test.go,
+// treats them as real DATA, never as an absent request) yet none of them
+// ever extracted into pipeline YAML. Left to validateCandidate,
+// validate.RunBytes on zero bytes reports zero findings — nothing to find a
+// problem WITH — so Report.OK() reads true: a validate PASS for a request
+// the model never produced anything usable for, inflating
+// MedianValidatePassRate by exactly the failure the corpus exists to
+// measure. This function is the one place both axes are computed for a
+// request, so it is where that gets caught for both — not pushed down into
+// validateCandidate (which only ever sees the validate axis) or scoreSemantic
+// (which only ever sees the semantic axis).
 func ScoreRun(ctx context.Context, requests []Request, candidates Candidates) RunScore {
 	rs := RunScore{Total: len(requests), Results: make([]Result, 0, len(requests))}
 
@@ -65,10 +82,18 @@ func ScoreRun(ctx context.Context, requests []Request, candidates Candidates) Ru
 		res := Result{RequestID: req.ID}
 
 		candidate, ok := candidates[req.ID]
-		if !ok {
+		switch {
+		case !ok:
 			res.Missing = true
 			res.SemanticIssues = []string{"no candidate provided for this request"}
-		} else {
+		case strings.TrimSpace(candidate) == "":
+			// Hard fail on both axes — ValidatePass and SemanticMatch stay
+			// at their false zero values, deliberately never routed through
+			// validateCandidate/scoreSemantic (see the func doc comment).
+			res.SemanticIssues = []string{
+				"the candidate is empty or whitespace-only — no usable pipeline was ever extracted for this request",
+			}
+		default:
 			report := validateCandidate(ctx, candidate)
 			res.ValidateReport = report
 			res.ValidatePass = report.OK()

--- a/cmd/conduit/internal/generate/score_test.go
+++ b/cmd/conduit/internal/generate/score_test.go
@@ -380,6 +380,22 @@ func TestScoreRun_EmptyCandidate_FailsBothMetrics(t *testing.T) {
 		is.True(!rs.Results[0].SemanticMatch)
 		is.Equal(rs.ValidatePassRate, 0.0)
 		is.Equal(rs.SemanticMatchRate, 0.0)
+
+		// L1 (round-4 review of #2814): ValidatePass/SemanticMatch being
+		// false alone does not prove THIS branch ran — validateCandidate's
+		// own empty-candidate guard (TestValidateCandidate_EmptyCandidate_Fails)
+		// would fail ValidatePass on its own, and scoreSemantic("") happens
+		// to report no match too, so a neutered version of ScoreRun's guard
+		// (score.go, the "default" case delegating straight to
+		// validateCandidate/scoreSemantic instead of short-circuiting)
+		// would still pass every assertion above. This exact message is
+		// only ever produced by ScoreRun's own guard (score.go), never by
+		// validateCandidate or scoreSemantic — pinning it is what actually
+		// exercises this branch instead of merely being consistent with it.
+		wantIssue := "the candidate is empty or whitespace-only — no usable pipeline was ever extracted for this request"
+		if len(rs.Results[0].SemanticIssues) != 1 || rs.Results[0].SemanticIssues[0] != wantIssue {
+			t.Fatalf("SemanticIssues = %v, want exactly [%q]", rs.Results[0].SemanticIssues, wantIssue)
+		}
 	}
 }
 

--- a/cmd/conduit/internal/generate/score_test.go
+++ b/cmd/conduit/internal/generate/score_test.go
@@ -179,6 +179,26 @@ func TestValidateCandidate_FabricatedBuiltinPlugin_Fails(t *testing.T) {
 	is.True(report.Summary.Errors > 0)
 }
 
+// TestValidateCandidate_EmptyCandidate_Fails is the regression test for B2
+// (round-3 review of #2814): validate.RunBytes on zero bytes reports zero
+// findings (there is nothing in an empty document to find a problem WITH),
+// so before this fix validateCandidate("").OK() read true — a validate PASS
+// for a candidate that is empty because Generate exhausted every attempt
+// without ever extracting pipeline YAML (runCapture stores gen.Candidate
+// verbatim in its Candidates map in exactly that case — see
+// transcript_capture_test.go's inline comment on why an empty string, never
+// an omitted key). Whitespace-only is covered too (a candidate consisting
+// entirely of spaces/newlines is exactly as uninformative as "").
+func TestValidateCandidate_EmptyCandidate_Fails(t *testing.T) {
+	is := is.New(t)
+
+	for _, candidate := range []string{"", "   \n\t  "} {
+		report := validateCandidate(context.Background(), candidate)
+		is.True(!report.OK())
+		is.True(report.Summary.Errors > 0)
+	}
+}
+
 // --- semantic-intent axis ---
 
 func TestScoreSemantic_GoodCandidate_Matches(t *testing.T) {
@@ -334,6 +354,33 @@ func TestScoreRun_MissingCandidate_FailsBothMetrics(t *testing.T) {
 	is.True(rs.Results[0].Missing)
 	is.Equal(rs.ValidatePassRate, 0.0)
 	is.Equal(rs.SemanticMatchRate, 0.0)
+}
+
+// TestScoreRun_EmptyCandidate_FailsBothMetrics is the regression test for B2
+// (round-3 review of #2814): a request WITH an entry in the Candidates map
+// (Missing must stay false — the map DID have something for this id) whose
+// value is empty or whitespace-only must score a hard fail on BOTH axes,
+// never a validate PASS. Before this fix, ScoreRun delegated straight to
+// validateCandidate("") (report.OK() == true — nothing to find a problem
+// WITH) and scored this exactly like a real, passing candidate.
+func TestScoreRun_EmptyCandidate_FailsBothMetrics(t *testing.T) {
+	is := is.New(t)
+
+	requests := []Request{
+		{ID: "a", Prompt: "x", Expect: Expect{SourceCategory: "file", DestinationCategory: "log"}},
+	}
+	for _, candidate := range []string{"", "   \n\t  "} {
+		rs := ScoreRun(context.Background(), requests, Candidates{"a": candidate})
+
+		is.Equal(rs.Total, 1)
+		is.Equal(rs.ValidatePassCount, 0)
+		is.Equal(rs.SemanticMatchCount, 0)
+		is.True(!rs.Results[0].Missing) // the map DID have an entry for "a"
+		is.True(!rs.Results[0].ValidatePass)
+		is.True(!rs.Results[0].SemanticMatch)
+		is.Equal(rs.ValidatePassRate, 0.0)
+		is.Equal(rs.SemanticMatchRate, 0.0)
+	}
 }
 
 func TestScoreRun_MixedResults_ComputesRatesOverFullDenominator(t *testing.T) {

--- a/cmd/conduit/internal/generate/secrets_scan_test.go
+++ b/cmd/conduit/internal/generate/secrets_scan_test.go
@@ -30,6 +30,22 @@ import (
 // committed anywhere under testdata/transcripts is scanned
 // (ScanTranscriptForSecrets, redact.go) and must carry no secret material.
 //
+// manifest.yaml and any "<id>.missing.yaml" tombstone (transcript.go) are
+// NOT parsed into a Transcript and skipped from there on — a struct-shaped
+// scan is only as good as ScanTranscriptForSecrets' knowledge of
+// Transcript's fields, and Manifest/Tombstone carry their own free-text-
+// shaped fields (RequestOutcome.FailureReason, Tombstone.FailureCode) that
+// Transcript has no field for at all, so unmarshaling either into a
+// Transcript would silently scan zero of them (Transcript.Turns would just
+// come back empty). Both are instead scanned as RAW TEXT via
+// scanTextForSecrets directly — deliberately the one check in this package
+// with no schema-shaped blind spot: it catches a secret in a field added to
+// either type tomorrow even if nothing else here is ever updated for it.
+// This is the regression test for the incident where a provider's raw HTTP
+// error body (readErrorBody, provider/http.go) could reach
+// RequestOutcome.FailureReason and then manifest.yaml completely unscanned,
+// because this test used to skip manifest.yaml by name.
+//
 // Deliberately UNTAGGED — no `//go:build` line — so it runs in the normal
 // `test` job on every PR, over WHATEVER transcripts exist today. That is
 // none: A5a-3 (a later PR) is what captures the first 28 real transcripts,
@@ -51,7 +67,7 @@ func TestTranscripts_CarryNoSecretMaterial(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if d.IsDir() || !strings.HasSuffix(path, ".yaml") || d.Name() == manifestFileName {
+		if d.IsDir() || !strings.HasSuffix(path, ".yaml") {
 			return nil
 		}
 
@@ -59,6 +75,15 @@ func TestTranscripts_CarryNoSecretMaterial(t *testing.T) {
 		if err != nil {
 			return fmt.Errorf("reading %q: %w", path, err)
 		}
+
+		if d.Name() == manifestFileName || strings.HasSuffix(d.Name(), tombstoneFileSuffix) {
+			checked++
+			if findings := scanTextForSecrets(string(data)); len(findings) > 0 {
+				t.Errorf("%s carries secret-scan findings:\n  %s", path, strings.Join(findings, "\n  "))
+			}
+			return nil
+		}
+
 		var tr Transcript
 		if err := yaml.Unmarshal(data, &tr); err != nil {
 			return fmt.Errorf("parsing %q: %w", path, err)

--- a/cmd/conduit/internal/generate/transcript.go
+++ b/cmd/conduit/internal/generate/transcript.go
@@ -230,6 +230,56 @@ type Manifest struct {
 	// median fields above are the headline, this is the detail a regression
 	// investigation needs.
 	PassScores []PassScore `yaml:"passScores"`
+
+	// --- Partial-results follow-up (WS1 A5a-3, "make a partial capture
+	// produce a usable, honest result instead of nothing") ---
+
+	// CapturedCount and MissingCount split RequestCount into what this run
+	// actually preserved versus what it could not, after every pass —
+	// read together with RequestOutcomes for the per-request detail. A
+	// request counts as captured the moment ANY pass produced a completion
+	// for it (even one whose Transcript.Outcome later failed validate or
+	// semantic scoring — that is DATA, not a missing request; see
+	// RequestOutcome's own doc comment for the distinction this package
+	// draws between the two). MissingCount is never silently absorbed into
+	// RequestCount or the scored rates going quiet about it — see
+	// transcript_capture_test.go's captureCompletenessVerdict for the
+	// threshold that decides when a nonzero MissingCount should fail the
+	// capture run outright rather than merely be noted here.
+	CapturedCount int `yaml:"capturedCount"`
+	MissingCount  int `yaml:"missingCount"`
+	// RequestOutcomes is this run's final disposition for every request it
+	// attempted (the full corpus for a normal run, or the single id a
+	// scoped `-run TestCaptureTranscripts/<id>` re-capture names) — in
+	// corpus order. It is the field a PR reviewer reads to see "27
+	// captured, 1 failed for reason X" without inferring it from a missing
+	// file in the diff.
+	RequestOutcomes []RequestOutcome `yaml:"requestOutcomes"`
+}
+
+// RequestOutcome is one corpus request's final disposition within a capture
+// run, distinguishing the two ways a request can end up with no promoted
+// transcript from the one way it can fail and still be perfectly good data:
+//
+//   - Captured = true: at least one pass produced a completion for this
+//     request, so a transcript exists in testdata/transcripts. Whether that
+//     transcript's own Transcript.Outcome.ValidatePass/SemanticMatch is true
+//     or false is irrelevant here — a request whose generation legitimately
+//     failed (the model never produced a passing candidate) is still DATA,
+//     arguably the most interesting data the benchmark has, and is recorded
+//     as captured with its real (failing) Outcome, never as missing.
+//   - Captured = false: NO pass ever produced a single completion for this
+//     request — a transport error (429, timeout), a tripped ceiling, or a
+//     pre-call refusal reached before the provider was ever called. This is
+//     absence of data, not a disagreement about what the data says, and
+//     FailureReason carries the last such error seen across every pass so a
+//     reader knows why without re-running anything.
+type RequestOutcome struct {
+	RequestID string `yaml:"requestID"`
+	Captured  bool   `yaml:"captured"`
+	// FailureReason is set only when Captured is false — see the type doc
+	// comment. Always empty when Captured is true.
+	FailureReason string `yaml:"failureReason,omitempty"`
 }
 
 // PassScore is one capture pass's corpus-level score, mirroring RunScore

--- a/cmd/conduit/internal/generate/transcript.go
+++ b/cmd/conduit/internal/generate/transcript.go
@@ -245,12 +245,23 @@ type Manifest struct {
 	// both axes (score.go), so folding a degraded pass in here would drag
 	// these two headline numbers toward zero even though the requests it
 	// dropped are still recorded elsewhere (RequestOutcomes, and possibly
-	// captured by another pass). Falls back to the median across ALL
-	// passes only when every single pass is degraded (no clean pass
-	// exists to prefer). DegradedPasses names which passes were excluded;
-	// PassScores carries every pass's own rate, degraded or not, for the
-	// detail this field summarizes away. Never best-of (CLAUDE.md's
-	// benchmarking discipline).
+	// captured by another pass).
+	//
+	// That "median across every CLEAN pass" description holds only when
+	// MediansUnreliable is false. When every single pass is degraded (no
+	// clean pass exists), these two fields fall back to the median across
+	// ALL passes instead — every missing request still scored as a hard
+	// fail, with no clean pass left to dilute that — and MediansUnreliable
+	// is true. B1 (round-3 review of #2814): that fallback is not a
+	// defense against a misleading number, it is what PRODUCES one — do
+	// not read these fields as this run's baseline when MediansUnreliable
+	// is true; runCapture also fails the `go test` run outright in that
+	// case (t.Errorf) for the same reason. DegradedPasses names which
+	// passes were excluded (or, when MediansUnreliable is true, which
+	// passes the fallback had no alternative but to include); PassScores
+	// carries every pass's own rate, degraded or not, for the detail this
+	// field summarizes away. Never best-of (CLAUDE.md's benchmarking
+	// discipline).
 	MedianValidatePassRate  float64 `yaml:"medianValidatePassRate"`
 	MedianSemanticMatchRate float64 `yaml:"medianSemanticMatchRate"`
 	// MedianValidatePassCount and MedianSemanticMatchCount are the median of
@@ -262,6 +273,47 @@ type Manifest struct {
 	// (odd), where this is always a whole number in practice.
 	MedianValidatePassCount  float64 `yaml:"medianValidatePassCount"`
 	MedianSemanticMatchCount float64 `yaml:"medianSemanticMatchCount"`
+	// MedianSampleSize is how many of Passes actually contributed to the
+	// four median fields above — the number of CLEAN passes ordinarily, or
+	// every pass (== Passes) when MediansUnreliable's fallback is in
+	// effect. N3 (round-3 review of #2814): a median is only as meaningful
+	// as its sample size, and that size is not otherwise stated anywhere
+	// in this file — a reader would have to compute
+	// Passes - len(DegradedPasses) themselves (and get it wrong when
+	// MediansUnreliable is true, since that fallback counts every pass,
+	// not the clean ones) to know whether a given median came from 1 pass
+	// or 3.
+	MedianSampleSize int `yaml:"medianSampleSize"`
+	// MediansUnreliable is true when BOTH: every one of Passes capture
+	// passes was degraded (PassScores[i].MissingCount > 0 for all of them —
+	// see DegradedPasses), AND at least one of those passes was WIPED
+	// (PassScores[i].MissingCount == PassScores[i].Total — it captured
+	// NOTHING at all, the signature of captureWallClockBudget expiring
+	// before a pass even started, or a rate-limit storm eating the whole
+	// pass). There was no clean pass left for MedianValidatePassRate/
+	// MedianSemanticMatchRate/MedianValidatePassCount/
+	// MedianSemanticMatchCount to be computed from, so those four fields
+	// fall back to a median across ALL passes with every missing request
+	// scored as a hard fail and nothing to dilute it (see
+	// MedianValidatePassRate's own doc comment) — and because at least one
+	// pass contributed a raw, uninformative 0, that fallback is not just
+	// unlabeled, it is actively misleading (B1, round-3 review of #2814).
+	// The second condition matters: a single request that is chronically
+	// missing across every pass (never wiping a WHOLE pass) also leaves no
+	// pass "clean", but every pass's own rate is then identical and stable
+	// — the fallback equals what a clean-pass median would have shown too,
+	// and this field correctly stays false for that ordinary, sub-threshold
+	// partial result (captureCompletenessVerdict's job, not this field's).
+	//
+	// Omitted (`omitempty`, false is the common case) rather than always
+	// present, so its mere presence in a committed manifest.yaml is itself
+	// the signal something is wrong — the same convention DegradedPasses
+	// already uses. A run that sets this true also fails its own
+	// `go test` invocation (runCapture, t.Errorf), which generate-capture.yml
+	// turns into a PARTIAL-capture PR with a [!WARNING] banner rather than a
+	// routine one; this field is what keeps that fact true for a reader
+	// looking at the file alone, without the PR body.
+	MediansUnreliable bool `yaml:"mediansUnreliable,omitempty"`
 	// PassScores is every pass's own RunScore rollup (counts AND rates, plan
 	// §8.1's "three passes, median never best-of" made auditable) — the
 	// median fields above are the headline, this is the detail a regression
@@ -441,7 +493,21 @@ type Tombstone struct {
 // transcripts. It is independent of LoadTranscripts — nothing in bijection or
 // prompt-hash validation depends on a manifest existing or parsing.
 func LoadManifest(path string) (Manifest, error) {
-	data, err := os.ReadFile(path)
+	// path is caller-controlled (a repo-relative
+	// testdata/transcripts/.../manifest.yaml path or a test's own
+	// t.TempDir()), never externally-supplied/attacker-controlled input —
+	// this package never runs against untrusted paths (see doc.go's
+	// invariants); same trust boundary every other os.ReadFile call in
+	// this package already operates under. Gosec's taint analysis only
+	// flags this when the package is built with `-tags=generate_capture`
+	// (the tag that pulls in transcript_capture_test.go's own
+	// patchManifestForScopedRun caller) — real CI's golangci-lint job
+	// does not pass that tag, so `#nosec` (gosec's own native suppression
+	// syntax, which golangci's nolintlint does not police for
+	// "unused" the way it does //nolint directives) is what stays quiet
+	// in both configurations rather than flip-flopping between "needed"
+	// and "unused".
+	data, err := os.ReadFile(path) // #nosec G703
 	if err != nil {
 		return Manifest{}, cerrors.Errorf("reading manifest %q: %w", path, err)
 	}

--- a/cmd/conduit/internal/generate/transcript.go
+++ b/cmd/conduit/internal/generate/transcript.go
@@ -42,6 +42,15 @@ const TranscriptSchemaVersion = 1
 // redaction scanner both skip it by name when listing a directory.
 const manifestFileName = "manifest.yaml"
 
+// tombstoneFileSuffix marks a legitimately-missing transcript: a corpus
+// request that was attempted but never produced a single completion on any
+// pass (RequestOutcome.Captured == false, runCapture in
+// transcript_capture_test.go) gets a "<id>.missing.yaml" file committed in
+// place of "<id>.yaml". See the Tombstone type doc comment for why
+// LoadTranscripts needs this rather than tolerating a missing file
+// outright.
+const tombstoneFileSuffix = ".missing.yaml"
+
 // Transcript is one committed provider transcript: everything replay needs
 // to answer Generate's calls for exactly one corpus Request, plus the
 // metadata needed to decide whether it is still meaningful (design doc §10;
@@ -279,7 +288,32 @@ type RequestOutcome struct {
 	Captured  bool   `yaml:"captured"`
 	// FailureReason is set only when Captured is false — see the type doc
 	// comment. Always empty when Captured is true.
+	//
+	// This is manifest-safe by construction (safeFailureReason,
+	// transcript_capture_test.go): a conduiterr code plus an HTTP status
+	// when known, NEVER the provider's own error text — a provider error
+	// message may embed up to 512 bytes of raw response body
+	// (readErrorBody, provider/http.go), which can echo back
+	// caller-supplied or provider-controlled content (e.g. a 401 body
+	// quoting the rejected key, a *url.Error carrying credentials embedded
+	// in a base URL). manifest.yaml is a committed file with no
+	// content-based redaction of its own — TestTranscripts_CarryNoSecretMaterial
+	// (secrets_scan_test.go) scans it as raw text specifically because a
+	// struct-shaped scan would never look at this field — so nothing that
+	// reaches here may ever be raw, unscanned provider text.
 	FailureReason string `yaml:"failureReason,omitempty"`
+	// Unusable is true when Captured is false AND the underlying failure
+	// was a response that DID arrive from the provider but could not be
+	// turned into a completion — a decode failure, or a well-formed but
+	// empty completion (a refusal) — as opposed to a transport-level
+	// failure (network error, timeout, non-2xx status, a tripped ceiling)
+	// where no response ever arrived at all (provider.IsUnusableResponse).
+	// This is the distinction a 429 and a refusal must never share: both
+	// leave Captured false, but only a refusal was a BILLED, attempted
+	// call whose tokens are already counted in Manifest.TotalTokensUsed —
+	// see captureProvider.Complete (transcript_capture_test.go). Always
+	// false when Captured is true.
+	Unusable bool `yaml:"unusable,omitempty"`
 }
 
 // PassScore is one capture pass's corpus-level score, mirroring RunScore
@@ -293,6 +327,49 @@ type PassScore struct {
 	ValidatePassRate   float64 `yaml:"validatePassRate"`
 	SemanticMatchCount int     `yaml:"semanticMatchCount"`
 	SemanticMatchRate  float64 `yaml:"semanticMatchRate"`
+}
+
+// Tombstone is committed as "<id>.missing.yaml" in place of a Transcript for
+// a corpus request that was attempted but never produced a single
+// completion on any capture pass (RequestOutcome.Captured == false; see
+// runCapture's "Partial results" doc comment, transcript_capture_test.go).
+//
+// It exists so LoadTranscripts' bijection check (checkBijection) can tell
+// "this id was legitimately attempted and came back with nothing" apart
+// from "this id was renamed out from under its transcript" WITHOUT
+// weakening bijection into blanket tolerance for a missing file —
+// LoadTranscripts' own doc comment explains why silently tolerating an
+// absent transcript would let a renamed corpus id quietly turn a
+// 28-request corpus into a passing 27/28. A tombstone is the explicit,
+// reviewable, committed artifact that makes "this id has no data, and
+// here's why" a fact checkBijection can see, instead of an absence
+// checkBijection has to guess about.
+//
+// It also survives a lost or stale manifest.yaml (LoadTranscripts never
+// reads the manifest at all): bijection stays correct even if
+// manifest.yaml is deleted, corrupted, or never committed for some reason,
+// because the tombstone — not the manifest — is what checkBijection
+// consults.
+type Tombstone struct {
+	SchemaVersion int `yaml:"schemaVersion"`
+	// RequestID must equal the corpus Request.ID this tombstone was written
+	// for, AND the file's own basename (minus ".missing.yaml") —
+	// LoadTranscripts hard-errors if either disagrees with the other, the
+	// same discipline Transcript.RequestID follows.
+	RequestID string `yaml:"requestID"`
+	// CorpusPromptSHA256 is checked the exact same way a real Transcript's
+	// is (LoadTranscripts): a request edited under an unchanged id must
+	// still be caught even when that id has no data at all.
+	CorpusPromptSHA256 string `yaml:"corpusPromptSHA256"`
+	// FailureCode is the manifest-safe reason this id has no transcript —
+	// see RequestOutcome.FailureReason's doc comment for what "safe" means
+	// here (a conduiterr code plus an HTTP status when known, never the
+	// provider's own error text). Required: a tombstone with no reason is
+	// as useless as an absent file was.
+	FailureCode string `yaml:"failureCode"`
+	// CapturedAt is when the capture run that produced this tombstone
+	// ran — same meaning as Transcript.CapturedAt.
+	CapturedAt time.Time `yaml:"capturedAt"`
 }
 
 // LoadManifest reads the manifest.yaml committed alongside one capture run's
@@ -377,12 +454,24 @@ type LoadedTranscript struct {
 // by request id, already validated against requests.
 type LoadResult struct {
 	ByID map[string]LoadedTranscript
+	// Tombstoned holds every corpus id whose capture legitimately produced
+	// no transcript (a committed "<id>.missing.yaml", Tombstone), keyed by
+	// request id. checkBijection already proved every corpus id is
+	// accounted for by exactly one of ByID or Tombstoned — a caller (the
+	// replay/eval consumer) skips a tombstoned id rather than treating its
+	// absence from ByID as an error.
+	Tombstoned map[string]Tombstone
 }
 
 // LoadTranscripts reads every committed transcript in dir (one file per
 // corpus request, "<requestID>.yaml"; manifestFileName is skipped, never
 // treated as a malformed transcript) and validates it against requests
 // BEFORE returning anything a caller could score.
+//
+// A corpus id may also be satisfied by a committed "<requestID>.missing.yaml"
+// Tombstone instead of a transcript — see the Tombstone type doc comment for
+// why that is a distinct, explicit case, never absorbed the way a plain
+// missing file would be.
 //
 // ScoreRun counts a request with no candidate as a fail on BOTH metrics —
 // correct for a live run, where "no candidate" really does mean the model
@@ -393,51 +482,50 @@ type LoadResult struct {
 // a smaller and differently-shaped corpus than the one actually committed.
 // So LoadTranscripts hard-errors, never skips, on:
 //
-//  1. Bijection — every requests[i].ID has exactly one transcript file in
-//     dir, and every transcript file's id has a matching entry in requests.
-//     Both directions are checked and the error names every offending id, not
-//     just the first (AC 1.19).
-//  2. corpusPromptSHA256 equality — a transcript's recorded hash of the
-//     corpus prompt it was captured against must equal
+//  1. Bijection — every requests[i].ID has exactly one transcript OR
+//     tombstone file in dir, and every transcript/tombstone file's id has a
+//     matching entry in requests. Both directions are checked and the error
+//     names every offending id, not just the first (AC 1.19). A corpus id
+//     with NEITHER a transcript nor a tombstone is still a hard "missing"
+//     error — a renamed id is never silently tolerated just because
+//     tombstones exist.
+//  2. corpusPromptSHA256 equality — a transcript's (or tombstone's) recorded
+//     hash of the corpus prompt it was captured against must equal
 //     sha256Hex(requests[i].Prompt) for that SAME id today. This is what
 //     catches a request's prompt text edited under an id nobody renamed (AC
 //     1.20) — bijection alone would pass that case, since the id itself
 //     never moved.
+//  3. An id carrying BOTH a transcript and a tombstone — self-contradictory
+//     (RequestOutcome can only ever report one disposition per id per
+//     capture run) and always a hard error rather than a guess about which
+//     file to trust.
 //
-// Grounding staleness (Staleness) is computed and returned on every result
-// but is never a reason to fail this call — see Staleness's doc comment.
+// Grounding staleness (Staleness) is computed and returned on every
+// transcript result but is never a reason to fail this call — see
+// Staleness's doc comment.
 //
 // Malformed transcripts (missing required fields, a requestID that disagrees
 // with its own filename, an unrecognized schemaVersion) are also hard
 // errors, matching LoadRequests' "never silently drops a malformed entry"
-// discipline (fixture.go).
+// discipline (fixture.go). The same applies to a malformed tombstone.
 func LoadTranscripts(dir string, requests []Request) (LoadResult, error) {
-	entries, err := os.ReadDir(dir)
+	byID, tombstones, err := scanTranscriptsDir(dir)
 	if err != nil {
-		return LoadResult{}, cerrors.Errorf("reading transcripts directory %q: %w", dir, err)
+		return LoadResult{}, err
 	}
 
-	byID := make(map[string]Transcript, len(entries))
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") || e.Name() == manifestFileName {
-			continue
+	// An id can never legitimately carry both — that would mean a capture
+	// run somehow recorded two different final dispositions for the same
+	// request. Caught here, before bijection even runs, rather than
+	// silently preferring one file over the other.
+	for id := range tombstones {
+		if _, ok := byID[id]; ok {
+			return LoadResult{}, cerrors.Errorf(
+				"transcripts directory %q: %q has BOTH a transcript (%s.yaml) and a tombstone (%s%s) — "+
+					"exactly one may exist per id; delete the stale one",
+				dir, id, id, id, tombstoneFileSuffix,
+			)
 		}
-
-		id := strings.TrimSuffix(e.Name(), ".yaml")
-		path := filepath.Join(dir, e.Name())
-
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return LoadResult{}, cerrors.Errorf("reading transcript %q: %w", path, err)
-		}
-		var t Transcript
-		if err := yaml.Unmarshal(data, &t); err != nil {
-			return LoadResult{}, cerrors.Errorf("parsing transcript %q: %w", path, err)
-		}
-		if err := validateTranscriptShape(t, path, id); err != nil {
-			return LoadResult{}, err
-		}
-		byID[id] = t
 	}
 
 	corpusIDs := make(map[string]bool, len(requests))
@@ -447,10 +535,116 @@ func LoadTranscripts(dir string, requests []Request) (LoadResult, error) {
 		promptByID[r.ID] = r.Prompt
 	}
 
-	if err := checkBijection(dir, corpusIDs, byID); err != nil {
+	if err := checkBijection(dir, corpusIDs, byID, tombstones); err != nil {
+		return LoadResult{}, err
+	}
+	if err := checkTombstonePrompts(tombstones, promptByID); err != nil {
 		return LoadResult{}, err
 	}
 
+	out, err := loadedTranscriptsFor(byID, promptByID)
+	if err != nil {
+		return LoadResult{}, err
+	}
+	return LoadResult{ByID: out, Tombstoned: tombstones}, nil
+}
+
+// scanTranscriptsDir reads dir and classifies every entry: manifestFileName
+// is skipped, an "<id>.missing.yaml" file is parsed and validated as a
+// Tombstone, and every other "<id>.yaml" file is parsed and validated as a
+// Transcript. Split out from LoadTranscripts to keep that function's own
+// cyclomatic complexity down — this is the one part of loading that is pure
+// I/O and per-file shape validation, with no corpus-comparison logic at all.
+func scanTranscriptsDir(dir string) (byID map[string]Transcript, tombstones map[string]Tombstone, err error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, nil, cerrors.Errorf("reading transcripts directory %q: %w", dir, err)
+	}
+
+	byID = make(map[string]Transcript, len(entries))
+	tombstones = make(map[string]Tombstone, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || e.Name() == manifestFileName {
+			continue
+		}
+
+		switch {
+		case strings.HasSuffix(e.Name(), tombstoneFileSuffix):
+			id := strings.TrimSuffix(e.Name(), tombstoneFileSuffix)
+			ts, err := readTombstone(filepath.Join(dir, e.Name()), id)
+			if err != nil {
+				return nil, nil, err
+			}
+			tombstones[id] = ts
+
+		case strings.HasSuffix(e.Name(), ".yaml"):
+			id := strings.TrimSuffix(e.Name(), ".yaml")
+			t, err := readTranscript(filepath.Join(dir, e.Name()), id)
+			if err != nil {
+				return nil, nil, err
+			}
+			byID[id] = t
+		}
+	}
+	return byID, tombstones, nil
+}
+
+// readTranscript reads, parses, and shape-validates one "<id>.yaml" file.
+func readTranscript(path, id string) (Transcript, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Transcript{}, cerrors.Errorf("reading transcript %q: %w", path, err)
+	}
+	var t Transcript
+	if err := yaml.Unmarshal(data, &t); err != nil {
+		return Transcript{}, cerrors.Errorf("parsing transcript %q: %w", path, err)
+	}
+	if err := validateTranscriptShape(t, path, id); err != nil {
+		return Transcript{}, err
+	}
+	return t, nil
+}
+
+// readTombstone reads, parses, and shape-validates one "<id>.missing.yaml"
+// file.
+func readTombstone(path, id string) (Tombstone, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Tombstone{}, cerrors.Errorf("reading tombstone %q: %w", path, err)
+	}
+	var ts Tombstone
+	if err := yaml.Unmarshal(data, &ts); err != nil {
+		return Tombstone{}, cerrors.Errorf("parsing tombstone %q: %w", path, err)
+	}
+	if err := validateTombstoneShape(ts, path, id); err != nil {
+		return Tombstone{}, err
+	}
+	return ts, nil
+}
+
+// checkTombstonePrompts is the tombstone half of AC 1.20: a tombstone's
+// recorded corpusPromptSHA256 must match the corpus prompt for that SAME id
+// today, exactly the check loadedTranscriptsFor runs for a real Transcript —
+// a request edited under an unchanged id must still be caught even when
+// that id has no data at all.
+func checkTombstonePrompts(tombstones map[string]Tombstone, promptByID map[string]string) error {
+	for id, ts := range tombstones {
+		wantPromptSHA256 := sha256Hex(promptByID[id])
+		if ts.CorpusPromptSHA256 != wantPromptSHA256 {
+			return cerrors.Errorf(
+				"tombstone %q: corpusPromptSHA256 %q does not match the corpus prompt for id %q today (%q) — "+
+					"the request was edited under an unchanged id; re-capture this transcript",
+				id, ts.CorpusPromptSHA256, id, wantPromptSHA256,
+			)
+		}
+	}
+	return nil
+}
+
+// loadedTranscriptsFor checks AC 1.20 for every real Transcript (mirroring
+// checkTombstonePrompts for a Tombstone) and pairs each with its Staleness
+// against the CURRENT binary's grounding.
+func loadedTranscriptsFor(byID map[string]Transcript, promptByID map[string]string) (map[string]LoadedTranscript, error) {
 	currentSystemPromptSHA256 := sha256Hex(BuildSystemPrompt(BuiltinCatalog()))
 	currentCatalogFingerprint := CatalogFingerprint()
 
@@ -458,7 +652,7 @@ func LoadTranscripts(dir string, requests []Request) (LoadResult, error) {
 	for id, t := range byID {
 		wantPromptSHA256 := sha256Hex(promptByID[id])
 		if t.CorpusPromptSHA256 != wantPromptSHA256 {
-			return LoadResult{}, cerrors.Errorf(
+			return nil, cerrors.Errorf(
 				"transcript %q: corpusPromptSHA256 %q does not match the corpus prompt for id %q today (%q) — "+
 					"the request was edited under an unchanged id; re-capture this transcript",
 				id, t.CorpusPromptSHA256, id, wantPromptSHA256,
@@ -470,22 +664,31 @@ func LoadTranscripts(dir string, requests []Request) (LoadResult, error) {
 			Staleness:  classifyStaleness(t, currentSystemPromptSHA256, currentCatalogFingerprint),
 		}
 	}
-
-	return LoadResult{ByID: out}, nil
+	return out, nil
 }
 
-// checkBijection reports every corpus id with no transcript AND every
-// transcript id with no corpus entry, in one error naming all of them — AC
-// 1.19 requires each direction to name the offending id, not just detect that
-// SOME mismatch exists.
-func checkBijection(dir string, corpusIDs map[string]bool, byID map[string]Transcript) error {
+// checkBijection reports every corpus id with neither a transcript nor a
+// tombstone, AND every transcript/tombstone id with no corpus entry, in one
+// error naming all of them — AC 1.19 requires each direction to name the
+// offending id, not just detect that SOME mismatch exists. A tombstoned id
+// satisfies the corpus side exactly like a transcript does; an ORPHANED
+// tombstone (no corpus entry) is exactly as much a bijection problem as an
+// orphaned transcript.
+func checkBijection(dir string, corpusIDs map[string]bool, byID map[string]Transcript, tombstones map[string]Tombstone) error {
 	var missing, extra []string
 	for id := range corpusIDs {
-		if _, ok := byID[id]; !ok {
+		_, hasTranscript := byID[id]
+		_, hasTombstone := tombstones[id]
+		if !hasTranscript && !hasTombstone {
 			missing = append(missing, id)
 		}
 	}
 	for id := range byID {
+		if !corpusIDs[id] {
+			extra = append(extra, id)
+		}
+	}
+	for id := range tombstones {
 		if !corpusIDs[id] {
 			extra = append(extra, id)
 		}
@@ -500,10 +703,10 @@ func checkBijection(dir string, corpusIDs map[string]bool, byID map[string]Trans
 	var msg strings.Builder
 	fmt.Fprintf(&msg, "transcripts directory %q is not a bijection with the corpus", dir)
 	if len(missing) > 0 {
-		fmt.Fprintf(&msg, "; corpus id(s) with no transcript: %s", strings.Join(missing, ", "))
+		fmt.Fprintf(&msg, "; corpus id(s) with no transcript or tombstone: %s", strings.Join(missing, ", "))
 	}
 	if len(extra) > 0 {
-		fmt.Fprintf(&msg, "; transcript id(s) with no corpus entry: %s", strings.Join(extra, ", "))
+		fmt.Fprintf(&msg, "; transcript/tombstone id(s) with no corpus entry: %s", strings.Join(extra, ", "))
 	}
 	return cerrors.New(msg.String())
 }
@@ -545,6 +748,28 @@ func validateTranscriptShape(t Transcript, path, expectedID string) error {
 		if turn.CompletionText == "" {
 			return cerrors.Errorf("transcript %q: turn %d has no completion text", path, turn.N)
 		}
+	}
+	return nil
+}
+
+// validateTombstoneShape hard-errors on a malformed tombstone before it
+// ever reaches the bijection or prompt-hash checks — mirrors
+// validateTranscriptShape's discipline for Transcript.
+func validateTombstoneShape(ts Tombstone, path, expectedID string) error {
+	if ts.SchemaVersion != TranscriptSchemaVersion {
+		return cerrors.Errorf("tombstone %q: schemaVersion %d, want %d", path, ts.SchemaVersion, TranscriptSchemaVersion)
+	}
+	if ts.RequestID == "" {
+		return cerrors.Errorf("tombstone %q: no requestID", path)
+	}
+	if ts.RequestID != expectedID {
+		return cerrors.Errorf("tombstone %q: requestID %q does not match its filename id %q", path, ts.RequestID, expectedID)
+	}
+	if ts.CorpusPromptSHA256 == "" {
+		return cerrors.Errorf("tombstone %q: no corpusPromptSHA256", path)
+	}
+	if ts.FailureCode == "" {
+		return cerrors.Errorf("tombstone %q: no failureCode", path)
 	}
 	return nil
 }

--- a/cmd/conduit/internal/generate/transcript.go
+++ b/cmd/conduit/internal/generate/transcript.go
@@ -43,12 +43,20 @@ const TranscriptSchemaVersion = 1
 const manifestFileName = "manifest.yaml"
 
 // tombstoneFileSuffix marks a legitimately-missing transcript: a corpus
-// request that was attempted but never produced a single completion on any
-// pass (RequestOutcome.Captured == false, runCapture in
-// transcript_capture_test.go) gets a "<id>.missing.yaml" file committed in
-// place of "<id>.yaml". See the Tombstone type doc comment for why
-// LoadTranscripts needs this rather than tolerating a missing file
-// outright.
+// request that gets a "<id>.missing.yaml" file committed in place of
+// "<id>.yaml". Two causes, not one:
+//
+//   - the request was attempted and never produced a single completion on
+//     any pass (RequestOutcome.Captured == false), or
+//   - an "<id>.yaml" IS on disk from an earlier run but no longer matches
+//     the current corpus (requestIsCaptured rejects it on RequestID or
+//     corpusPromptSHA256, M5 of #2814's round-5 review). That case
+//     deliberately leaves BOTH files in place, because LoadTranscripts
+//     hard-errors on an id carrying both — a loud, specific failure rather
+//     than a silently wrong manifest.
+//
+// See the Tombstone type doc comment for why LoadTranscripts needs this
+// rather than tolerating a missing file outright.
 const tombstoneFileSuffix = ".missing.yaml"
 
 // Transcript is one committed provider transcript: everything replay needs

--- a/cmd/conduit/internal/generate/transcript.go
+++ b/cmd/conduit/internal/generate/transcript.go
@@ -247,21 +247,34 @@ type Manifest struct {
 	// dropped are still recorded elsewhere (RequestOutcomes, and possibly
 	// captured by another pass).
 	//
-	// That "median across every CLEAN pass" description holds only when
-	// MediansUnreliable is false. When every single pass is degraded (no
-	// clean pass exists), these two fields fall back to the median across
-	// ALL passes instead — every missing request still scored as a hard
-	// fail, with no clean pass left to dilute that — and MediansUnreliable
-	// is true. B1 (round-3 review of #2814): that fallback is not a
-	// defense against a misleading number, it is what PRODUCES one — do
-	// not read these fields as this run's baseline when MediansUnreliable
+	// That "median across every CLEAN pass" description holds whenever at
+	// least one pass was clean (MedianSampleSize is then the clean-pass
+	// count, less than Passes). When every single pass is degraded instead
+	// (no clean pass exists — MedianSampleSize == Passes here too, but
+	// because nothing was excluded, not because everything was), these two
+	// fields fall back to the median across ALL passes instead — every
+	// missing request still scored as a hard fail, with no clean pass left
+	// to dilute that. M1-3 (round-5 review of #2814): that fallback runs
+	// whenever no pass was clean, REGARDLESS of whether MediansUnreliable
+	// ends up true or false for the run — a prior version of this comment
+	// tied the two together ("holds only when MediansUnreliable is false
+	// ... and MediansUnreliable is true" for the fallback), which is wrong:
+	// a single request chronically missing on every pass also has no clean
+	// pass (the same fallback runs), yet MediansUnreliable correctly stays
+	// false there, because that fallback's number equals what a clean-pass
+	// median would have shown anyway (see MediansUnreliable's own doc
+	// comment for the full condition, including the H1 x H2 carry-forward
+	// interaction round-5 added to it). B1 (round-3 review of #2814): the
+	// fallback is not a defense against a misleading number on its OWN —
+	// whether it is misleading is exactly what MediansUnreliable decides;
+	// do not read these fields as this run's baseline when MediansUnreliable
 	// is true; runCapture also fails the `go test` run outright in that
 	// case (t.Errorf) for the same reason. DegradedPasses names which
-	// passes were excluded (or, when MediansUnreliable is true, which
-	// passes the fallback had no alternative but to include); PassScores
-	// carries every pass's own rate, degraded or not, for the detail this
-	// field summarizes away. Never best-of (CLAUDE.md's benchmarking
-	// discipline).
+	// passes were excluded (or, when the fallback ran without being
+	// misleading, which passes the fallback had no alternative but to
+	// include); PassScores carries every pass's own rate, degraded or not,
+	// for the detail this field summarizes away. Never best-of (CLAUDE.md's
+	// benchmarking discipline).
 	MedianValidatePassRate  float64 `yaml:"medianValidatePassRate"`
 	MedianSemanticMatchRate float64 `yaml:"medianSemanticMatchRate"`
 	// MedianValidatePassCount and MedianSemanticMatchCount are the median of
@@ -275,20 +288,39 @@ type Manifest struct {
 	MedianSemanticMatchCount float64 `yaml:"medianSemanticMatchCount"`
 	// MedianSampleSize is how many of Passes actually contributed to the
 	// four median fields above — the number of CLEAN passes ordinarily, or
-	// every pass (== Passes) when MediansUnreliable's fallback is in
-	// effect. N3 (round-3 review of #2814): a median is only as meaningful
-	// as its sample size, and that size is not otherwise stated anywhere
-	// in this file — a reader would have to compute
-	// Passes - len(DegradedPasses) themselves (and get it wrong when
-	// MediansUnreliable is true, since that fallback counts every pass,
-	// not the clean ones) to know whether a given median came from 1 pass
-	// or 3.
+	// every pass (== Passes) whenever NO pass was clean, i.e. the
+	// all-passes fallback ran (see MedianValidatePassRate's own doc comment
+	// — M1-3, round-5 review of #2814: that fallback, and therefore
+	// MedianSampleSize == Passes, is NOT exclusive to a run with
+	// MediansUnreliable true). MedianSampleSize < Passes is the reliable
+	// signal that real exclusion happened; generate-capture.yml's banner
+	// gates on exactly that comparison, not on DegradedPasses' mere
+	// presence, for this reason. N3 (round-3 review of #2814): a median is
+	// only as meaningful as its sample size, and that size is not otherwise
+	// stated anywhere in this file — a reader would have to compute
+	// Passes - len(DegradedPasses) themselves (and get it wrong whenever
+	// the fallback ran, since it counts every pass, not the clean ones) to
+	// know whether a given median came from 1 pass or 3.
 	MedianSampleSize int `yaml:"medianSampleSize"`
 	// MediansUnreliable is true when BOTH: every one of Passes capture
 	// passes was degraded (PassScores[i].MissingCount > 0 for all of them —
-	// see DegradedPasses), AND those degraded passes do not all miss the
-	// SAME set of request ids (allMissingSetsEqual,
-	// transcript_capture_test.go). There was no clean pass left for
+	// see DegradedPasses), AND missingSetsAreReliable
+	// (transcript_capture_test.go) is false for those degraded passes'
+	// missing sets — which requires BOTH that they all miss the SAME set of
+	// request ids (allMissingSetsEqual) AND that none of those ids is
+	// captured overall ONLY through requestIsCaptured's on-disk
+	// carry-forward (H1 x H2, round-5 review of #2814 — see
+	// missingSetsAreReliable's own doc comment for the interaction and a
+	// worked repro: a request 429ing on every pass of a re-capture run has
+	// an identical missing set every time, but if an EARLIER run already
+	// committed a real transcript for it, MissingCount stays 0 and this
+	// field would have stayed false too without that second check — with
+	// nothing else in the file recording that the median silently
+	// dropped). preserveMediansIfNothingPromoted also sets this field
+	// directly (M4, round-5 review of #2814), independent of the above,
+	// when a run that promoted nothing new finds an existing manifest whose
+	// own shape (RequestCount/Passes) does not match this run's — see that
+	// function's doc comment. There was no clean pass left for
 	// MedianValidatePassRate/MedianSemanticMatchRate/MedianValidatePassCount/
 	// MedianSemanticMatchCount to be computed from, so those four fields
 	// fall back to a median across ALL passes with every missing request
@@ -365,22 +397,29 @@ type Manifest struct {
 	// every pass" — check DegradedPasses for that.
 	CapturedCount int `yaml:"capturedCount"`
 	MissingCount  int `yaml:"missingCount"`
-	// DegradedPasses names (1-indexed) every pass excluded from
-	// MedianValidatePassRate/MedianSemanticMatchRate/
-	// MedianValidatePassCount/MedianSemanticMatchCount because it didn't
-	// contribute a usable candidate for the full corpus
-	// (PassScores[i].MissingCount > 0 — see that field's own doc comment:
-	// this covers both "no completion at all" and "a completion arrived
-	// but nothing extracted into pipeline YAML", M1 round-4 review of
-	// #2814). Empty — and therefore absent from the committed YAML,
-	// `omitempty` — when every pass captured the full corpus, which is the
-	// common case and needs no reader attention. A nonempty list here is
-	// exactly the CapturedCount/MissingCount blind spot documented above
-	// made visible and machine-checkable: generate-capture.yml's "Open the
-	// PR" step greps for this key too, not just MissingCount, so a run
-	// that captured every request overall (MissingCount == 0) but lost a
-	// tail pass to rate limiting or the wall-clock budget still gets the
-	// PR banner instead of a routine title.
+	// DegradedPasses names (1-indexed) every pass that didn't contribute a
+	// usable candidate for the full corpus (PassScores[i].MissingCount > 0
+	// — see that field's own doc comment: this covers both "no completion
+	// at all" and "a completion arrived but nothing extracted into pipeline
+	// YAML", M1 round-4 review of #2814) — NOT necessarily every pass
+	// excluded from the four median fields above (M1-3, round-5 review of
+	// #2814: a prior version of this comment claimed the two always
+	// coincide; MedianSampleSize < Passes is the field that actually says
+	// whether exclusion happened — see its own doc comment — since a
+	// degraded pass can still be folded into the all-passes fallback
+	// without being misleading). Empty — and therefore absent from the
+	// committed YAML, `omitempty` — when every pass captured the full
+	// corpus, which is the common case and needs no reader attention. A
+	// nonempty list here is exactly the CapturedCount/MissingCount blind
+	// spot documented above made visible and machine-checkable:
+	// generate-capture.yml's "Open the PR" step computes its DEGRADED
+	// banner signal from MedianSampleSize vs Passes (M1-3, round-5 review
+	// of #2814 — a prior version grepped for this key's mere presence
+	// instead, which fired even when the fallback had folded the degraded
+	// pass in WITHOUT excluding anything), so a run that captured every
+	// request overall (MissingCount == 0) but genuinely lost a tail pass to
+	// rate limiting or the wall-clock budget still gets the PR banner
+	// instead of a routine title.
 	DegradedPasses []int `yaml:"degradedPasses,omitempty"`
 	// RequestOutcomes is this run's final disposition for every request it
 	// attempted (the full corpus for a normal run, or the single id a
@@ -395,24 +434,45 @@ type Manifest struct {
 // run, distinguishing the two ways a request can end up with no promoted
 // transcript from the one way it can fail and still be perfectly good data:
 //
-//   - Captured = true: at least one pass produced a completion for this
-//     request, so a transcript exists in testdata/transcripts. Whether that
+//   - Captured = true: a VALID transcript exists in testdata/transcripts for
+//     this request — either a pass THIS run made produced a completion, or
+//     an earlier run already committed a real, still-matching transcript
+//     for it that this run's own attempt(s) failed to reproduce
+//     (requestIsCaptured's on-disk carry-forward, H2 fix round-4 review of
+//     #2814, hardened M5 round-5 to require the on-disk transcript's own
+//     requestID/corpusPromptSHA256 still match — a stale file left behind
+//     by an edited-but-unrenamed request does not count). Whether that
 //     transcript's own Transcript.Outcome.ValidatePass/SemanticMatch is true
 //     or false is irrelevant here — a request whose generation legitimately
 //     failed (the model never produced a passing candidate) is still DATA,
 //     arguably the most interesting data the benchmark has, and is recorded
 //     as captured with its real (failing) Outcome, never as missing.
-//   - Captured = false: NO pass ever produced a single completion for this
-//     request — a transport error (429, timeout), a tripped ceiling, or a
-//     pre-call refusal reached before the provider was ever called. This is
-//     absence of data, not a disagreement about what the data says, and
-//     FailureReason carries the last such error seen across every pass so a
-//     reader knows why without re-running anything.
+//     FailureReason is still set in the specific case where Captured is
+//     true ONLY through carry-forward AND this run's own attempt(s) also
+//     produced no completion for it (M2, round-5 review of #2814) — see
+//     that field's own doc comment.
+//   - Captured = false: NO pass THIS run made produced a completion, AND
+//     no valid transcript from an earlier run exists on disk for this id —
+//     a transport error (429, timeout, a tripped ceiling), a pre-call
+//     refusal reached before the provider was ever called, or (M5) an
+//     on-disk transcript whose own requestID/corpusPromptSHA256 no longer
+//     matches this id's current corpus entry. This is absence of USABLE
+//     data, not a disagreement about what the data says, and FailureReason
+//     carries the last such error seen across every pass this run made so
+//     a reader knows why without re-running anything.
 type RequestOutcome struct {
 	RequestID string `yaml:"requestID"`
 	Captured  bool   `yaml:"captured"`
-	// FailureReason is set only when Captured is false — see the type doc
-	// comment. Always empty when Captured is true.
+	// FailureReason is set when Captured is false — see the type doc
+	// comment — and also (M2, round-5 review of #2814) in the one case
+	// where Captured is true but only through requestIsCaptured's on-disk
+	// carry-forward AND this run's own attempt(s) for the id still produced
+	// no completion: H2's carry-forward fix (round-4 review of #2814)
+	// silently dropped that fact entirely, leaving manifest.yaml — the only
+	// committed record of why a run could not reproduce a request — with no
+	// trace that this run ever tried and failed. Empty in every other case,
+	// in particular whenever Captured is true because THIS run itself
+	// reproduced the request on at least one pass.
 	//
 	// This is manifest-safe by construction (safeFailureReason,
 	// transcript_capture_test.go): a conduiterr code plus an HTTP status
@@ -528,12 +588,22 @@ func LoadManifest(path string) (Manifest, error) {
 	// this package already operates under. Gosec's taint analysis only
 	// flags this when the package is built with `-tags=generate_capture`
 	// (the tag that pulls in transcript_capture_test.go's own
-	// patchManifestForScopedRun caller) — real CI's golangci-lint job
-	// does not pass that tag, so `#nosec` (gosec's own native suppression
-	// syntax, which golangci's nolintlint does not police for
-	// "unused" the way it does //nolint directives) is what stays quiet
-	// in both configurations rather than flip-flopping between "needed"
-	// and "unused".
+	// patchManifestForScopedRun caller) — and, since .golangci.yml's own
+	// `run.build-tags: [generate_capture]` (M2, round-4 review of #2814),
+	// real CI's golangci-lint job now DOES build with that tag on every
+	// PR, so this taint path is live in the actual required gate, not a
+	// hypothetical only reachable with a manual flag. LOW-2 (round-5
+	// review of #2814): a prior version of this comment justified `#nosec`
+	// by claiming the opposite ("real CI's golangci-lint job does not pass
+	// that tag") — that stopped being true the moment build-tags landed in
+	// the SAME round-4 PR that added this reasoning, so the conclusion
+	// below was right for the wrong, already-stale reason. The suppression
+	// itself is still correct (this remains a false positive under the
+	// trust boundary above); `#nosec` (gosec's own native suppression
+	// syntax, which golangci's nolintlint does not police for "unused" the
+	// way it does //nolint directives) is what stays quiet whether or not
+	// a given local invocation happens to pass the tag, which is the
+	// property that actually matters now that the real gate always does.
 	data, err := os.ReadFile(path) // #nosec G703
 	if err != nil {
 		return Manifest{}, cerrors.Errorf("reading manifest %q: %w", path, err)

--- a/cmd/conduit/internal/generate/transcript.go
+++ b/cmd/conduit/internal/generate/transcript.go
@@ -155,6 +155,21 @@ type Outcome struct {
 // transcript_capture_test.go's TestCaptureTranscripts) — LoadTranscripts
 // never reads or requires it, so a missing or malformed manifest.yaml can
 // never block replay.
+// Model, CaptureCommand, and CorpusCommitSHA below carry NO in-process
+// scanTextForSecrets call of their own — the pre-promotion redaction gate
+// (runCapture's reasonFindings check, transcript_capture_test.go) only
+// scans RequestOutcome.FailureReason/Tombstone.FailureCode, the two
+// free-text fields safeFailureReason's doc comment covers. This is
+// deliberate, not an oversight (nit from the round-2 review of #2814,
+// which asked this be made explicit rather than left implicit): all three
+// are derived from inputs the OPERATOR running this capture already
+// controls — Model and CaptureCommand from the CLI flags/env vars that
+// operator set, CorpusCommitSHA from `git log` against this repo's own
+// history — never from provider response text, which is the actual attack
+// surface every OTHER redaction gate in this package exists for. The
+// untagged TestTranscripts_CarryNoSecretMaterial (secrets_scan_test.go)
+// still scans the fully-marshalled manifest.yaml as raw text on every PR
+// as a backstop, independent of this reasoning.
 type Manifest struct {
 	SchemaVersion int    `yaml:"schemaVersion"`
 	Provider      string `yaml:"provider"`
@@ -220,9 +235,22 @@ type Manifest struct {
 	// scored (plan's cost table assumes 3; TestCaptureTranscripts defaults to
 	// 3, overridable via CONDUIT_GENERATE_CAPTURE_PASSES).
 	Passes int `yaml:"passes"`
-	// MedianValidatePassRate and MedianSemanticMatchRate are ScoreMedian's two
-	// rates (fraction 0..1) across Passes independent full-corpus scoring
-	// runs — median, never best-of (CLAUDE.md's benchmarking discipline).
+	// MedianValidatePassRate and MedianSemanticMatchRate are the median of
+	// the two rates (fraction 0..1) across every CLEAN pass — a pass whose
+	// PassScores[i].MissingCount is 0, i.e. it produced a completion for
+	// every corpus request. A DEGRADED pass (PassScores[i].MissingCount >
+	// 0 — a rate-limit storm or captureWallClockBudget expiring partway
+	// through wipes every request from that pass onward) is excluded from
+	// this median: ScoreRun scores a missing candidate as a hard fail on
+	// both axes (score.go), so folding a degraded pass in here would drag
+	// these two headline numbers toward zero even though the requests it
+	// dropped are still recorded elsewhere (RequestOutcomes, and possibly
+	// captured by another pass). Falls back to the median across ALL
+	// passes only when every single pass is degraded (no clean pass
+	// exists to prefer). DegradedPasses names which passes were excluded;
+	// PassScores carries every pass's own rate, degraded or not, for the
+	// detail this field summarizes away. Never best-of (CLAUDE.md's
+	// benchmarking discipline).
 	MedianValidatePassRate  float64 `yaml:"medianValidatePassRate"`
 	MedianSemanticMatchRate float64 `yaml:"medianSemanticMatchRate"`
 	// MedianValidatePassCount and MedianSemanticMatchCount are the median of
@@ -244,19 +272,44 @@ type Manifest struct {
 	// produce a usable, honest result instead of nothing") ---
 
 	// CapturedCount and MissingCount split RequestCount into what this run
-	// actually preserved versus what it could not, after every pass —
+	// actually preserved versus what it could not, ACROSS ALL PASSES —
 	// read together with RequestOutcomes for the per-request detail. A
 	// request counts as captured the moment ANY pass produced a completion
 	// for it (even one whose Transcript.Outcome later failed validate or
 	// semantic scoring — that is DATA, not a missing request; see
 	// RequestOutcome's own doc comment for the distinction this package
-	// draws between the two). MissingCount is never silently absorbed into
-	// RequestCount or the scored rates going quiet about it — see
-	// transcript_capture_test.go's captureCompletenessVerdict for the
-	// threshold that decides when a nonzero MissingCount should fail the
-	// capture run outright rather than merely be noted here.
+	// draws between the two). See transcript_capture_test.go's
+	// captureCompletenessVerdict for the threshold that decides when a
+	// nonzero MissingCount should fail the capture run outright rather
+	// than merely be noted here.
+	//
+	// MissingCount is run-scoped, not pass-scoped: a request captured on
+	// pass 1 but absent from passes 2-3 (a rate-limit storm or
+	// captureWallClockBudget expiring partway through a later pass) counts
+	// as captured here — CapturedCount/MissingCount say nothing about
+	// which INDIVIDUAL passes went on to score it as present. That
+	// per-pass picture, which DOES feed MedianValidatePassRate and
+	// MedianSemanticMatchRate (a pass missing a request scores it as a
+	// hard fail on both axes — score.go's ScoreRun), lives in
+	// PassScores[i].MissingCount and DegradedPasses below. Do not read
+	// MissingCount == 0 as "the scored rates saw a complete corpus on
+	// every pass" — check DegradedPasses for that.
 	CapturedCount int `yaml:"capturedCount"`
 	MissingCount  int `yaml:"missingCount"`
+	// DegradedPasses names (1-indexed) every pass excluded from
+	// MedianValidatePassRate/MedianSemanticMatchRate/
+	// MedianValidatePassCount/MedianSemanticMatchCount because it didn't
+	// produce a completion for the full corpus (PassScores[i].MissingCount
+	// > 0). Empty — and therefore absent from the committed YAML,
+	// `omitempty` — when every pass captured the full corpus, which is the
+	// common case and needs no reader attention. A nonempty list here is
+	// exactly the CapturedCount/MissingCount blind spot documented above
+	// made visible and machine-checkable: generate-capture.yml's "Open the
+	// PR" step greps for this key too, not just MissingCount, so a run
+	// that captured every request overall (MissingCount == 0) but lost a
+	// tail pass to rate limiting or the wall-clock budget still gets the
+	// PR banner instead of a routine title.
+	DegradedPasses []int `yaml:"degradedPasses,omitempty"`
 	// RequestOutcomes is this run's final disposition for every request it
 	// attempted (the full corpus for a normal run, or the single id a
 	// scoped `-run TestCaptureTranscripts/<id>` re-capture names) — in
@@ -327,6 +380,18 @@ type PassScore struct {
 	ValidatePassRate   float64 `yaml:"validatePassRate"`
 	SemanticMatchCount int     `yaml:"semanticMatchCount"`
 	SemanticMatchRate  float64 `yaml:"semanticMatchRate"`
+	// MissingCount is how many corpus requests produced NO completion on
+	// THIS pass specifically (runCapture omits a request from that pass's
+	// Candidates rather than scoring an empty-string stand-in — see
+	// runCapture's inline comment on why — so ValidatePassRate/
+	// SemanticMatchRate above already score every one of these as a fail;
+	// this field is what makes that visible instead of silently baked into
+	// the rate). A request missing here may still be Manifest.Captured (a
+	// different, later pass produced it) — this is per-pass, Manifest.
+	// MissingCount is per-run; do not conflate the two. Nonzero marks this
+	// pass as "degraded": excluded from Manifest.MedianValidatePassRate/
+	// MedianSemanticMatchRate and named in Manifest.DegradedPasses.
+	MissingCount int `yaml:"missingCount"`
 }
 
 // Tombstone is committed as "<id>.missing.yaml" in place of a Transcript for

--- a/cmd/conduit/internal/generate/transcript.go
+++ b/cmd/conduit/internal/generate/transcript.go
@@ -286,24 +286,41 @@ type Manifest struct {
 	MedianSampleSize int `yaml:"medianSampleSize"`
 	// MediansUnreliable is true when BOTH: every one of Passes capture
 	// passes was degraded (PassScores[i].MissingCount > 0 for all of them —
-	// see DegradedPasses), AND at least one of those passes was WIPED
-	// (PassScores[i].MissingCount == PassScores[i].Total — it captured
-	// NOTHING at all, the signature of captureWallClockBudget expiring
-	// before a pass even started, or a rate-limit storm eating the whole
-	// pass). There was no clean pass left for MedianValidatePassRate/
-	// MedianSemanticMatchRate/MedianValidatePassCount/
+	// see DegradedPasses), AND those degraded passes do not all miss the
+	// SAME set of request ids (allMissingSetsEqual,
+	// transcript_capture_test.go). There was no clean pass left for
+	// MedianValidatePassRate/MedianSemanticMatchRate/MedianValidatePassCount/
 	// MedianSemanticMatchCount to be computed from, so those four fields
 	// fall back to a median across ALL passes with every missing request
 	// scored as a hard fail and nothing to dilute it (see
-	// MedianValidatePassRate's own doc comment) — and because at least one
-	// pass contributed a raw, uninformative 0, that fallback is not just
+	// MedianValidatePassRate's own doc comment) — and when the passes
+	// disagree about WHICH requests they missed, that fallback is not just
 	// unlabeled, it is actively misleading (B1, round-3 review of #2814).
 	// The second condition matters: a single request that is chronically
-	// missing across every pass (never wiping a WHOLE pass) also leaves no
-	// pass "clean", but every pass's own rate is then identical and stable
-	// — the fallback equals what a clean-pass median would have shown too,
-	// and this field correctly stays false for that ordinary, sub-threshold
-	// partial result (captureCompletenessVerdict's job, not this field's).
+	// missing across every pass (the SAME request, every time — the
+	// missing-id set is then identical pass to pass, whether that set has
+	// one member or is the whole corpus) also leaves no pass "clean", but
+	// every pass's own rate is then identical and stable — the fallback
+	// equals what a clean-pass median would have shown too, and this field
+	// correctly stays false for that ordinary, sub-threshold partial result
+	// (captureCompletenessVerdict's job, not this field's).
+	//
+	// H1 (round-4 review of #2814): an earlier version of this condition
+	// checked "at least one pass was WIPED (missing every request)"
+	// instead of "the missing sets disagree" — that proxy is wrong: five
+	// passes rotating which single request they capture (pass p captures
+	// only request p, missing the other four every time) has NO wiped pass
+	// (every pass captures exactly one request) and NO stable missing set
+	// (a different request each time), yet the old condition read this as
+	// reliable and published a 0.20 median for a corpus whose true quality
+	// was 1.00. Comparing the missing-id SETS, not just whether any one of
+	// them happens to be everything, is what tells a genuinely stable
+	// partial result apart from this one. A run where every pass is wiped
+	// identically (missing the whole corpus every time) still has equal
+	// missing sets under this rule and so does NOT set MediansUnreliable —
+	// that catastrophic case is caught separately, by
+	// captureCompletenessVerdict's own majority-missing threshold on the
+	// run as a whole.
 	//
 	// Omitted (`omitempty`, false is the common case) rather than always
 	// present, so its mere presence in a committed manifest.yaml is itself
@@ -351,8 +368,11 @@ type Manifest struct {
 	// DegradedPasses names (1-indexed) every pass excluded from
 	// MedianValidatePassRate/MedianSemanticMatchRate/
 	// MedianValidatePassCount/MedianSemanticMatchCount because it didn't
-	// produce a completion for the full corpus (PassScores[i].MissingCount
-	// > 0). Empty — and therefore absent from the committed YAML,
+	// contribute a usable candidate for the full corpus
+	// (PassScores[i].MissingCount > 0 — see that field's own doc comment:
+	// this covers both "no completion at all" and "a completion arrived
+	// but nothing extracted into pipeline YAML", M1 round-4 review of
+	// #2814). Empty — and therefore absent from the committed YAML,
 	// `omitempty` — when every pass captured the full corpus, which is the
 	// common case and needs no reader attention. A nonempty list here is
 	// exactly the CapturedCount/MissingCount blind spot documented above
@@ -432,13 +452,20 @@ type PassScore struct {
 	ValidatePassRate   float64 `yaml:"validatePassRate"`
 	SemanticMatchCount int     `yaml:"semanticMatchCount"`
 	SemanticMatchRate  float64 `yaml:"semanticMatchRate"`
-	// MissingCount is how many corpus requests produced NO completion on
-	// THIS pass specifically (runCapture omits a request from that pass's
-	// Candidates rather than scoring an empty-string stand-in — see
-	// runCapture's inline comment on why — so ValidatePassRate/
-	// SemanticMatchRate above already score every one of these as a fail;
-	// this field is what makes that visible instead of silently baked into
-	// the rate). A request missing here may still be Manifest.Captured (a
+	// MissingCount is how many corpus requests contributed no USABLE
+	// candidate on THIS pass specifically — either no completion was ever
+	// recorded (runCapture omits the request from that pass's Candidates
+	// rather than scoring an empty-string stand-in — see runCapture's
+	// inline comment on why) OR a completion WAS recorded but never
+	// extracted into pipeline YAML (an explicit empty/whitespace-only
+	// entry — B2, round-3 review of #2814; this field's name and this
+	// comment previously said "produced NO completion", which stopped
+	// being accurate the moment that second case was added — M1, round-4
+	// review of #2814). Either way ValidatePassRate/SemanticMatchRate
+	// above already score every one of these as a fail (score.go's
+	// ScoreRun treats both cases identically); this field is what makes
+	// that visible instead of silently baked into the rate. A request
+	// missing here may still be Manifest.Captured (a
 	// different, later pass produced it) — this is per-pass, Manifest.
 	// MissingCount is per-run; do not conflate the two. Nonzero marks this
 	// pass as "degraded": excluded from Manifest.MedianValidatePassRate/

--- a/cmd/conduit/internal/generate/transcript_capture_test.go
+++ b/cmd/conduit/internal/generate/transcript_capture_test.go
@@ -142,6 +142,7 @@ import (
 	json "github.com/goccy/go-json"
 
 	"github.com/conduitio/conduit/cmd/conduit/internal/generate/provider"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors"
 	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/yaml/v3"
 )
@@ -432,7 +433,21 @@ func buildTranscript(req Request, gen Generation, raw []provider.CompletionResul
 	var outcome Outcome
 	if last := lastAttempt(gen); last != nil {
 		outcome = Outcome{
-			ValidatePass:   last.Report.OK(),
+			// last.Candidate == "" means extraction failed on this (the
+			// LAST) attempt — every attempt failed to produce parseable
+			// pipeline YAML, generate.go never calls validate.RunBytes, and
+			// last.Report is left at its zero value. Report.OK() on a zero
+			// Report reads true (Errors == 0: there was nothing to find a
+			// problem WITH), which would otherwise commit this transcript's
+			// own Outcome.ValidatePass as a PASS for a request that never
+			// produced anything usable (B2, round-3 review of #2814) — the
+			// same trap ScoreRun (score.go) guards against for the scoring
+			// harness's own numbers. Guard on Candidate rather than trusting
+			// Report.OK() alone; SemanticMatch needs no equivalent guard —
+			// generate.go only ever sets att.Semantic after a candidate
+			// clears validate, so its zero value (Match: false) is already
+			// correct here.
+			ValidatePass:   last.Candidate != "" && last.Report.OK(),
 			SemanticMatch:  last.Semantic.Match,
 			SemanticIssues: last.Semantic.Issues,
 		}
@@ -610,6 +625,60 @@ func safeFailureReason(err error) string {
 	return err.Error()
 }
 
+// TestSafeFailureReason_Timeout is the regression test for N4 (round-3
+// review of #2814): safeFailureReason's `(timeout)` suffix was never
+// asserted anywhere on its own — only exercised transitively by tests that
+// go through a real *testing.T end to end. provider.MarkIfTimeout is what a
+// real adapter calls at its ctx.Err() == context.DeadlineExceeded branch
+// (anthropic.go, ollama.go, openai.go), so this constructs the exact shape
+// those call sites produce rather than a hand-rolled stand-in.
+func TestSafeFailureReason_Timeout(t *testing.T) {
+	wrapped := conduiterr.New(provider.CodeProviderError, "anthropic: context deadline exceeded")
+	err := provider.MarkIfTimeout(wrapped, context.DeadlineExceeded)
+
+	got := safeFailureReason(err)
+	if !strings.HasSuffix(got, "(timeout)") {
+		t.Fatalf("safeFailureReason(timeout error) = %q, want a string ending in %q", got, "(timeout)")
+	}
+	if strings.Contains(got, "context deadline exceeded") {
+		t.Fatalf("safeFailureReason(timeout error) = %q, leaked the raw error text (must carry only the "+
+			"registered Code.Reason() plus the (timeout) suffix)", got)
+	}
+}
+
+// TestSafeFailureReason_HTTPStatus_NeverLeaksAndNil round out the axes
+// TestSafeFailureReason_Timeout covers alone: nil (the one branch with no
+// conduiterr at all), and a real HTTP-status-carrying error built the same
+// way TestRunCapture_ProviderHTTPErrorNeverLeaksResponseBodyIntoManifest's
+// httptest server produces one, asserting directly on safeFailureReason's
+// own return value rather than only on the manifest field it ends up in.
+func TestSafeFailureReason_HTTPStatus_NeverLeaksAndNil(t *testing.T) {
+	if got := safeFailureReason(nil); got != "no completion recorded" {
+		t.Fatalf("safeFailureReason(nil) = %q, want %q", got, "no completion recorded")
+	}
+
+	const leakedSecret = "sk-ant-1234567890abcdefghijklmnop"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":{"type":"authentication_error","message":"Incorrect API key provided: `+leakedSecret+`"}}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	base := &provider.Anthropic{BaseURL: srv.URL}
+	_, err := base.Complete(context.Background(), provider.CompletionRequest{Prompt: "x"})
+	if err == nil {
+		t.Fatal("expected the 401 response to produce an error")
+	}
+
+	got := safeFailureReason(err)
+	if !strings.Contains(got, "HTTP 401") {
+		t.Fatalf("safeFailureReason(401 error) = %q, want it to name HTTP 401", got)
+	}
+	if strings.Contains(got, leakedSecret) {
+		t.Fatalf("safeFailureReason(401 error) = %q, leaked the response body's secret", got)
+	}
+}
+
 // writeTombstone commits a Tombstone for a corpus request whose capture
 // never produced a transcript on any pass — see the Tombstone type doc
 // comment (transcript.go) for why LoadTranscripts' bijection check needs an
@@ -676,14 +745,20 @@ func TestCaptureTranscripts(t *testing.T) {
 // care) and the directory to promote into, it runs every pass, builds and
 // scratch-writes each request's transcript, redaction-scans and promotes the
 // batch, and — for a run that attempted the FULL corpus (never scoped by a
-// `-run` filter to a subset) — scores the run (ScoreMedian) and writes
-// manifest.yaml, INCLUDING for a run where some requests never produced a
-// completion at all (see the file's "Partial results" doc comment):
-// whatever a pass DID capture is promoted and recorded regardless, and
-// captureCompletenessVerdict decides only how loud the `go test` signal is,
-// never whether anything gets preserved. A scoped `-run` (a targeted
-// re-capture of one id) still writes no manifest.yaml, unchanged from
-// before — that file always describes the whole corpus, never a subset.
+// `-run` filter to a subset) — scores the run (ScoreMedian) and writes a
+// FRESH manifest.yaml, INCLUDING for a run where some requests never
+// produced a completion at all (see the file's "Partial results" doc
+// comment): whatever a pass DID capture is promoted and recorded
+// regardless, and captureCompletenessVerdict decides only how loud the
+// `go test` signal is, never whether anything gets preserved. A scoped
+// `-run` (a targeted re-capture of one id) never computes new
+// medians/PassScores (there is no full-corpus data to compute them from),
+// but it DOES patch the scoped id(s)' own RequestOutcomes/CapturedCount/
+// MissingCount into whatever manifest.yaml the last full run left behind
+// (patchManifestForScopedRun, M1 fix — round-3 review of #2814) — leaving
+// it untouched entirely, as this used to, meant a re-capture that turned a
+// previously-tombstoned id back into real data left the committed
+// manifest.yaml contradicting the tree it describes.
 //
 // Split out from TestCaptureTranscripts so the FULL pipeline (transcript
 // construction, the redaction-scan-then-promote gate, scoring, manifest
@@ -701,8 +776,14 @@ func TestCaptureTranscripts(t *testing.T) {
 // in particular, that a request with no completion gets NO entry at all
 // (see the "absence of data" branch below) — rather than hand-building a
 // Candidates map that only ASSERTS it mirrors that behavior. Nil for a
-// scoped run that never reaches the full-corpus scoring step (wrote ==
-// false).
+// scoped run that never reaches the full-corpus scoring step — that is
+// independent of wrote (below), which a scoped run can still report true
+// for if it patched an existing manifest.yaml (patchManifestForScopedRun).
+//
+// wrote is true whenever manifest.yaml was written OR patched on disk —
+// not only for a fresh, full-corpus write. It is false only when there was
+// truly nothing to do: a scoped run with no prior manifest.yaml to patch
+// (patchManifestForScopedRun's own ok == false).
 func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captureProvider, providerName, model string, passes int, destDir string) (manifest Manifest, passRuns []RunScore, wrote bool) {
 	t.Helper()
 
@@ -731,20 +812,27 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 	lastFailureErr := make(map[string]error)
 
 	var scoreCandidatesList []Candidates
-	// scoreMissingCounts[i] is how many of len(requests) got NO entry in
-	// scoreCandidatesList[i] — i.e. how many corpus requests produced no
-	// completion on that specific pass (see the inline comment below on
-	// why passCandidates omits, rather than empty-strings, those entries).
-	// Kept as a parallel slice, index-aligned with scoreCandidatesList
-	// (and therefore with ms.Runs below), rather than added to
-	// RunScore/ScoreRun: score.go's Result.Missing already carries this
-	// per-request, and re-deriving the per-pass count from passCandidates'
-	// size here is cheaper than plumbing a new field through ScoreRun for
-	// a number runCapture already has for free. This is what lets a
-	// degraded tail pass (a rate-limit storm, or captureWallClockBudget
-	// expiring partway through) be excluded from the median instead of
-	// silently dragging MedianValidatePassRate/MedianSemanticMatchRate
-	// toward zero — see PassScore.MissingCount and Manifest.DegradedPasses.
+	// scoreMissingCounts[i] is how many of len(requests) contributed NO
+	// USABLE candidate to scoreCandidatesList[i] — either no completion was
+	// ever recorded on that pass (no map entry — see the inline comment
+	// below on why passCandidates omits, rather than empty-strings, those
+	// entries) OR a completion WAS recorded but never extracted into
+	// pipeline YAML (an empty/whitespace-only entry: Generate exhausted
+	// every attempt without ever producing a candidate — B2, round-3 review
+	// of #2814). requestsMissingUsableCandidate treats both the same way
+	// ScoreRun (score.go) itself does — a pass full of unparseable
+	// completions is exactly as degraded as one the provider never answered
+	// at all. Kept as a parallel slice, index-aligned with
+	// scoreCandidatesList (and therefore with ms.Runs below), rather than
+	// added to RunScore/ScoreRun: score.go's Result.Missing already carries
+	// the no-completion half of this per-request, and re-deriving the
+	// per-pass count from passCandidates here is cheaper than plumbing a
+	// new field through ScoreRun for a number runCapture already has for
+	// free. This is what lets a degraded tail pass (a rate-limit storm, or
+	// captureWallClockBudget expiring partway through) be excluded from the
+	// median instead of silently dragging
+	// MedianValidatePassRate/MedianSemanticMatchRate toward zero — see
+	// PassScore.MissingCount and Manifest.DegradedPasses.
 	var scoreMissingCounts []int
 	for pass := 1; pass <= passes; pass++ {
 		passCandidates := make(Candidates, len(requests))
@@ -774,11 +862,24 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 					//
 					// passCandidates deliberately gets NO entry for req.ID
 					// here (never a key with an empty value) — ScoreRun
-					// (score.go) reports a MISSING key as Result.Missing;
-					// setting an empty-string candidate instead would score
-					// this exactly like a model that produced a candidate
-					// and failed validation, which is a different, wrong
-					// story for a request the provider never even answered.
+					// (score.go) reports a MISSING key as Result.Missing.
+					// Storing an empty-string candidate instead would flip
+					// Result.Missing to false — scoring this as DATA (a
+					// request the provider answered, however badly) rather
+					// than as absence of data, which is the wrong story for
+					// a request whose provider call never even returned a
+					// response. (B2, round-3 review of #2814, corrects this
+					// comment's prior claim that an empty-string candidate
+					// here "would score this exactly like a model that
+					// produced a candidate and failed validation" — false as
+					// written: before ScoreRun's own empty-candidate guard
+					// existed, an empty string scored a validate PASS, not a
+					// failed validation, which was the actual bug. ScoreRun
+					// now hard-fails an empty candidate on both axes either
+					// way — the choice to omit the key HERE is still right,
+					// but for this reason: it is Result.Missing, not the
+					// pass/fail verdict, that an empty string here would get
+					// wrong.)
 					lastFailureErr[req.ID] = genErr
 					t.Logf("pass %d: %q produced no completion (absence of data): %v", pass, req.ID, genErr)
 					return
@@ -813,7 +914,7 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 		// never per-pass.
 		if len(attempted) == len(requests) {
 			scoreCandidatesList = append(scoreCandidatesList, passCandidates)
-			scoreMissingCounts = append(scoreMissingCounts, len(requests)-len(passCandidates))
+			scoreMissingCounts = append(scoreMissingCounts, requestsMissingUsableCandidate(requests, passCandidates))
 		} else {
 			t.Logf("pass %d: %d/%d requests ran (a -run filter is scoping this to a subset) — "+
 				"excluded from corpus-level scoring and the manifest", pass, len(attempted), len(requests))
@@ -906,15 +1007,44 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 	reportCaptureCompleteness(t, len(attemptOrder), capturedCount, missingCount, outcomes)
 
 	if len(scoreCandidatesList) != passes {
-		t.Logf("only %d/%d pass(es) captured the full corpus — skipping manifest.yaml "+
-			"(a scoped -run leaves the existing manifest untouched)", len(scoreCandidatesList), passes)
-		return Manifest{}, nil, false
+		// A scoped `-run TestCaptureTranscripts/<id>` re-capture — split
+		// out into finishScopedRun to keep THIS function's own cyclomatic
+		// complexity under gocyclo's threshold (the same reason
+		// summarizePasses was split out for H2, round-2 review of #2814).
+		return finishScopedRun(t, destDir, outcomes, len(scoreCandidatesList), passes)
 	}
 
 	ms := ScoreMedian(ctx, requests, scoreCandidatesList)
 	passScores, degradedMedians := summarizePasses(ms.Runs, scoreMissingCounts)
 
-	if len(degradedMedians.degradedPasses) > 0 {
+	switch {
+	case degradedMedians.allDegraded:
+		// B1 fix (round-3 review of #2814): every one of `passes` passes
+		// lost the full corpus (a rate-limit storm, or
+		// captureWallClockBudget expiring partway through and wiping every
+		// pass from that point on) — summarizePasses has no clean pass
+		// left to compute a median FROM, so validateRate/semanticRate below
+		// are its all-passes fallback, which scores every missing request
+		// as a hard fail with nothing to dilute it. Treated as a hard
+		// failure of this `go test` run, the same class of thing
+		// captureCompletenessVerdict already does for attemptedCount == 0:
+		// t.Errorf (not t.Fatalf) so the manifest below still gets written
+		// with whatever WAS captured (see captureCompletenessVerdict's own
+		// doc comment on why a true verdict there does not mean nothing is
+		// preserved — the same reasoning applies here), but the `go test`
+		// exit code goes nonzero, which generate-capture.yml's `capture`
+		// job turns into CAPTURE_RESULT != "success" — the [!WARNING]
+		// PARTIAL-capture banner and title, not the routine [!NOTE] one.
+		// Manifest.MediansUnreliable (set below) carries the same fact
+		// into the committed file for a reader who never sees the PR body.
+		t.Errorf("every one of %d capture pass(es) was degraded (see passScores[].missingCount) — no pass "+
+			"produced a completion for the full corpus, so medianValidatePassRate (%.3f) and "+
+			"medianSemanticMatchRate (%.3f) below are a fallback computed across ALL passes, with every "+
+			"missing request scored as a hard fail and no clean pass to dilute that — NOT a reliable "+
+			"median, and must not be used as this run's baseline. Whatever WAS captured is still promoted "+
+			"and recorded below (capturedCount/missingCount/requestOutcomes).",
+			passes, degradedMedians.validateRate, degradedMedians.semanticRate)
+	case len(degradedMedians.degradedPasses) > 0:
 		// Deliberately a separate Logf, not folded into
 		// reportCaptureCompleteness below: that function's fail/log
 		// threshold (captureCompletenessVerdict) is scoped to REQUESTS
@@ -923,7 +1053,10 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 		// request captured (missingCount == 0, so
 		// reportCaptureCompleteness has nothing to say) while still
 		// having lost a tail pass to rate limiting, which is exactly the
-		// case this exists to surface.
+		// case this exists to surface. Only reached when at least one
+		// OTHER pass was clean (the allDegraded case above is handled
+		// separately), so "excluded... so a wiped tail pass does not
+		// silently drag those numbers toward zero" is actually true here.
 		t.Logf("pass(es) %v captured fewer than the full corpus (see passScores[].missingCount in the "+
 			"manifest) — excluded from medianValidatePassRate/medianSemanticMatchRate so a wiped tail pass "+
 			"does not silently drag those numbers toward zero; requests affected may still show as captured "+
@@ -947,6 +1080,8 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 		MedianSemanticMatchRate:  degradedMedians.semanticRate,
 		MedianValidatePassCount:  degradedMedians.validateCount,
 		MedianSemanticMatchCount: degradedMedians.semanticCount,
+		MedianSampleSize:         degradedMedians.sampleSize,
+		MediansUnreliable:        degradedMedians.allDegraded,
 		PassScores:               passScores,
 		DegradedPasses:           degradedMedians.degradedPasses,
 		CapturedCount:            capturedCount,
@@ -960,6 +1095,197 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 	return manifest, ms.Runs, true
 }
 
+// finishScopedRun is runCapture's return path for a scoped
+// `-run TestCaptureTranscripts/<id>` re-capture — one that never attempted
+// the full corpus (capturedPasses != passes), so there is no full-corpus
+// data to compute new medians/PassScores from. Split out from runCapture
+// (kept its own cyclomatic complexity under gocyclo's threshold, the same
+// reason summarizePasses was split out for H2 — round-2 review of #2814).
+//
+// The tree itself was already mutated by the caller before this runs
+// (promoted, and any stale tombstone removed, or a fresh tombstone
+// written) — this only decides what happens to manifest.yaml. M1 fix
+// (round-3 review of #2814): patch the EXISTING manifest.yaml's own
+// RequestOutcomes/CapturedCount/MissingCount for just the scoped id(s)
+// rather than leaving it untouched — before this fix, a re-capture that
+// turned a previously-tombstoned id back into real data left the tree with
+// "<id>.yaml" and no tombstone (correct) while manifest.yaml still said
+// captured: false for that id, with a stale failureReason and stale counts
+// nothing else ever caught (LoadTranscripts never reads the manifest).
+// Medians and PassScores are left exactly as the last FULL run recorded
+// them — see patchManifestForScopedRun's own doc comment for why.
+func finishScopedRun(t *testing.T, destDir string, outcomes []RequestOutcome, capturedPasses, passes int) (Manifest, []RunScore, bool) {
+	t.Helper()
+	t.Logf("only %d/%d pass(es) captured the full corpus — a scoped -run limits scoring to a subset",
+		capturedPasses, passes)
+
+	patched, ok := patchManifestForScopedRun(t, destDir, outcomes)
+	if !ok {
+		t.Logf("no existing manifest.yaml in %q to patch — a scoped run before any full run has "+
+			"nothing to patch and correctly leaves nothing behind", destDir)
+		return Manifest{}, nil, false
+	}
+	t.Logf("patched manifest.yaml's requestOutcomes/capturedCount/missingCount for %d scoped request(s); "+
+		"medians/passScores still describe the last full run", len(outcomes))
+	return patched, nil, true
+}
+
+// patchManifestForScopedRun updates an EXISTING manifest.yaml in destDir
+// with a scoped re-capture's own RequestOutcomes (M1, round-3 review of
+// #2814). Before this fix, runCapture promoted/tombstoned files for a
+// scoped `-run TestCaptureTranscripts/<id>` re-capture (mutating the tree)
+// and then returned early WITHOUT ever touching manifest.yaml — so
+// re-capturing a previously-tombstoned id back into real data left the
+// committed tree with "<id>.yaml" and no tombstone (correct — H3's own
+// fix), while manifest.yaml still said captured: false for that id, with a
+// stale failureReason and stale CapturedCount/MissingCount that nothing
+// else ever catches (LoadTranscripts never reads the manifest at all — see
+// its own doc comment). The tree loaded fine; the committed manifest.yaml
+// just quietly contradicted it.
+//
+// Only scopedOutcomes' own ids are patched into RequestOutcomes — every
+// OTHER entry, and the medians/PassScores (which this scoped run has no
+// full-corpus data to recompute — see runCapture's own check on
+// len(scoreCandidatesList) != passes), are left exactly as the last FULL
+// run recorded them: a single re-captured request says nothing new about
+// what the other requests scored. CapturedCount/MissingCount ARE
+// recomputed (from the patched RequestOutcomes list), since those two
+// fields exist specifically to summarize it.
+//
+// Returns ok == false when there is no existing manifest.yaml to patch —
+// LoadManifest's own not-exist error — which is correct, not a fallback:
+// a scoped run before any full run has ever completed has nothing to
+// patch, and correctly leaves nothing behind (unchanged from this
+// function's absence).
+func patchManifestForScopedRun(t *testing.T, destDir string, scopedOutcomes []RequestOutcome) (Manifest, bool) {
+	t.Helper()
+
+	path := filepath.Join(destDir, manifestFileName)
+	existing, err := LoadManifest(path)
+	if err != nil {
+		if cerrors.Is(err, os.ErrNotExist) {
+			return Manifest{}, false
+		}
+		t.Fatalf("loading existing manifest %q to patch: %v", path, err)
+	}
+
+	// Built append-only from a zero-length slice (never make'd with a
+	// non-zero length and appended onto afterward — golangci's makezero
+	// linter flags exactly that pattern), even though every existing
+	// entry is expected to be replaced or carried through unchanged.
+	patched := make([]RequestOutcome, 0, len(existing.RequestOutcomes)+len(scopedOutcomes))
+
+	byID := make(map[string]RequestOutcome, len(scopedOutcomes))
+	for _, o := range scopedOutcomes {
+		byID[o.RequestID] = o
+	}
+	for _, o := range existing.RequestOutcomes {
+		if updated, ok := byID[o.RequestID]; ok {
+			patched = append(patched, updated)
+			delete(byID, o.RequestID)
+			continue
+		}
+		patched = append(patched, o)
+	}
+	// Any scoped id not found in the existing manifest at all (unusual —
+	// every corpus request should already be present from the last full
+	// run) is appended rather than silently dropped, in corpus order
+	// relative to scopedOutcomes.
+	for _, o := range scopedOutcomes {
+		if _, stillPending := byID[o.RequestID]; stillPending {
+			patched = append(patched, o)
+		}
+	}
+
+	captured, missing := 0, 0
+	for _, o := range patched {
+		if o.Captured {
+			captured++
+		} else {
+			missing++
+		}
+	}
+
+	existing.RequestOutcomes = patched
+	existing.CapturedCount = captured
+	existing.MissingCount = missing
+	writeManifest(t, destDir, existing)
+	return existing, true
+}
+
+// TestPatchManifestForScopedRun_NoExistingManifest_ReturnsFalse covers the
+// one patchManifestForScopedRun branch nothing else here exercises: no
+// prior manifest.yaml at all (a scoped run before any full run ever
+// completed). ok must come back false, and nothing should be written to
+// destDir — asserted directly, since a bug that wrote an empty/partial
+// manifest.yaml here would be exactly the "manifest contradicts the tree"
+// class of defect M1 exists to prevent.
+func TestPatchManifestForScopedRun_NoExistingManifest_ReturnsFalse(t *testing.T) {
+	destDir := t.TempDir()
+
+	_, ok := patchManifestForScopedRun(t, destDir, []RequestOutcome{{RequestID: "req-a", Captured: true}})
+	if ok {
+		t.Fatal("ok = true, want false — there was no existing manifest.yaml to patch")
+	}
+	if _, err := os.Stat(filepath.Join(destDir, manifestFileName)); !os.IsNotExist(err) {
+		t.Fatalf("expected no manifest.yaml to have been written, stat err = %v", err)
+	}
+}
+
+// TestPatchManifestForScopedRun_AppendsUnknownID covers the defensive
+// "scoped id not already in the existing manifest" branch: unusual (every
+// corpus request should already be present from the last full run), but
+// must append rather than silently drop the id.
+func TestPatchManifestForScopedRun_AppendsUnknownID(t *testing.T) {
+	destDir := t.TempDir()
+	writeManifest(t, destDir, Manifest{
+		SchemaVersion: TranscriptSchemaVersion,
+		RequestCount:  1,
+		CapturedCount: 1,
+		RequestOutcomes: []RequestOutcome{
+			{RequestID: "req-a", Captured: true},
+		},
+	})
+
+	patched, ok := patchManifestForScopedRun(t, destDir, []RequestOutcome{
+		{RequestID: "req-new", Captured: false, FailureReason: "generate.provider_error (HTTP 429)"},
+	})
+	if !ok {
+		t.Fatal("ok = false, want true — an existing manifest.yaml was there to patch")
+	}
+	if len(patched.RequestOutcomes) != 2 {
+		t.Fatalf("len(patched.RequestOutcomes) = %d, want 2 (req-a carried through, req-new appended)",
+			len(patched.RequestOutcomes))
+	}
+	if patched.CapturedCount != 1 || patched.MissingCount != 1 {
+		t.Fatalf("patched CapturedCount/MissingCount = %d/%d, want 1/1", patched.CapturedCount, patched.MissingCount)
+	}
+}
+
+// requestsMissingUsableCandidate counts, for one pass's passCandidates, how
+// many corpus requests contributed no USABLE candidate — either no
+// completion was ever recorded for that request this pass (no map entry:
+// passCandidates[req.ID] then reads as Go's zero value for string, "",
+// exactly like an explicit empty entry would) or a completion WAS recorded
+// but every attempt failed to extract pipeline YAML from it (an explicit
+// empty or whitespace-only entry — B2, round-3 review of #2814: see
+// runCapture's own inline comment on why passCandidates gets that empty
+// entry rather than omitting the key in this case). Both cases are scored
+// identically by ScoreRun (score.go) — a hard fail on both axes — so they
+// are counted identically here too: a pass where the model replied with
+// nothing but unparseable garbage for every request is exactly as degraded,
+// for Manifest.DegradedPasses/MedianValidatePassRate purposes, as one the
+// provider never answered at all.
+func requestsMissingUsableCandidate(requests []Request, passCandidates Candidates) int {
+	missing := 0
+	for _, req := range requests {
+		if strings.TrimSpace(passCandidates[req.ID]) == "" {
+			missing++
+		}
+	}
+	return missing
+}
+
 // passesSummary is summarizePasses' reduction of a capture run's per-pass
 // RunScores down to the median rates/counts Manifest reports, plus which
 // passes were excluded from that median (see summarizePasses' own doc
@@ -970,6 +1296,24 @@ type passesSummary struct {
 	semanticRate   float64
 	validateCount  float64
 	semanticCount  float64
+	// sampleSize is how many passes actually contributed to
+	// validateRate/semanticRate/validateCount/semanticCount above — the
+	// number of clean passes ordinarily, or every pass (len(runs)) when
+	// allDegraded's fallback is in effect. N3 (round-3 review of #2814):
+	// exposed via Manifest.MedianSampleSize so a reader isn't left
+	// inferring "how many passes is this median actually over" from
+	// Passes minus len(DegradedPasses) — a median over 1 pass and a median
+	// over 3 both render as one number without this.
+	sampleSize int
+	// allDegraded is true when every pass in runs was degraded (no pass
+	// produced a completion for the full corpus) AND at least one of those
+	// passes was WIPED (missing every single corpus request, not just
+	// some) — see summarizePasses' doc comment for why both conditions are
+	// required, and for what the four fields above mean in that case.
+	// runCapture treats this as a hard failure (B1, round-3 review of
+	// #2814), the same class of thing captureCompletenessVerdict already
+	// does for attemptedCount == 0.
+	allDegraded bool
 }
 
 // summarizePasses builds Manifest.PassScores and reduces runs (ms.Runs from
@@ -989,11 +1333,37 @@ type passesSummary struct {
 // manifest that otherwise reports MissingCount == 0 (a request captured on
 // an earlier pass but absent from a later one is NOT run-missing — see
 // Manifest.CapturedCount's doc comment — but ScoreRun DOES score the
-// absence on every pass that lacks it). Falls back to the median across
-// ALL passes (identical to this function's pre-H2 behavior, and
-// mathematically identical to ScoreMedian's own reduction) when every
-// single pass is degraded — with no clean pass to prefer, a 0.00 median
-// would be actively misleading.
+// absence on every pass that lacks it).
+//
+// When every single pass is degraded, there is no clean pass left to
+// exclude anything FROM — the returned validateRate/semanticRate/
+// validateCount/semanticCount fall back to the median across ALL passes
+// (identical to this function's pre-H2 behavior, and mathematically
+// identical to ScoreMedian's own reduction), which is NOT "the median
+// across every clean pass" those fields otherwise mean, because
+// scoreMissingCounts still scores every missing request as a hard fail on
+// both axes (score.go's ScoreRun) with no clean pass to dilute that.
+//
+// That fallback is not automatically UNTRUSTWORTHY, though: a single
+// request that is chronically missing across every pass (the same one
+// request, every time — ordinary live-provider noise, already handled as a
+// routine partial result by captureCompletenessVerdict below its majority
+// threshold) leaves every pass's own rate identical and stable, so the
+// all-passes median equals what a "clean-pass" median would have shown
+// too. The case that IS misleading is B1 (round-3 review of #2814): one or
+// more passes WIPED entirely (missing every single corpus request, not
+// just one) — the signature of captureWallClockBudget expiring before a
+// pass even started, or a rate-limit storm eating the whole pass — which
+// contributes a raw, uninformative 0 to the median regardless of how well
+// the requests that WERE captured actually scored. Reproduced: 3 passes,
+// 2 wiped down to zero after a wall-clock budget expiry midway through
+// pass 1, computes a median of 0.00 even though every request captured on
+// pass 1 validated cleanly — the fallback IS what produces that
+// misleadingly low number, not a defense against one. allDegraded (below)
+// is true only when BOTH conditions hold (no clean pass AND at least one
+// wiped pass), so the caller can fail the run for the actual failure mode
+// without also failing on ordinary single-request flakiness — see
+// runCapture's own handling and Manifest.MediansUnreliable.
 func summarizePasses(runs []RunScore, missingCounts []int) ([]PassScore, passesSummary) {
 	passScores := make([]PassScore, len(runs))
 	allValidateRates := make([]float64, len(runs))
@@ -1004,6 +1374,7 @@ func summarizePasses(runs []RunScore, missingCounts []int) ([]PassScore, passesS
 	var degradedPasses []int
 	var cleanValidateRates, cleanSemanticRates []float64
 	var cleanValidateCounts, cleanSemanticCounts []int
+	var anyPassWiped bool
 
 	for i, rs := range runs {
 		passMissing := missingCounts[i]
@@ -1023,6 +1394,18 @@ func summarizePasses(runs []RunScore, missingCounts []int) ([]PassScore, passesS
 
 		if passMissing > 0 {
 			degradedPasses = append(degradedPasses, i+1)
+			// A WIPED pass (missing every single corpus request — Total > 0
+			// and passMissing == Total) is what makes the all-passes
+			// fallback below untrustworthy (see allDegraded): it is the
+			// signature of captureWallClockBudget expiring before the pass
+			// even started, or a rate-limit storm that ate the whole pass,
+			// not ordinary per-request noise (one chronically-flaky
+			// request, present in every OTHER pass's missingCounts too,
+			// still leaves each pass's rate a stable, meaningful number —
+			// see allDegraded's own doc comment).
+			if rs.Total > 0 && passMissing == rs.Total {
+				anyPassWiped = true
+			}
 			continue
 		}
 		cleanValidateRates = append(cleanValidateRates, rs.ValidatePassRate)
@@ -1037,13 +1420,30 @@ func summarizePasses(runs []RunScore, missingCounts []int) ([]PassScore, passesS
 		semanticRate:   median(allSemanticRates),
 		validateCount:  medianInt(allValidateCounts),
 		semanticCount:  medianInt(allSemanticCounts),
+		sampleSize:     len(runs),
 	}
-	if n := len(cleanValidateRates); n > 0 && n < len(runs) {
+	n := len(cleanValidateRates)
+	if n > 0 && n < len(runs) {
 		summary.validateRate = median(cleanValidateRates)
 		summary.semanticRate = median(cleanSemanticRates)
 		summary.validateCount = medianInt(cleanValidateCounts)
 		summary.semanticCount = medianInt(cleanSemanticCounts)
+		summary.sampleSize = n
 	}
+	// allDegraded requires BOTH no clean pass (n == 0) AND at least one
+	// WIPED pass — n == 0 alone is not enough: a single request that is
+	// chronically missing across every pass (present in no pass's
+	// candidates at all, but the SAME one request every time) also leaves
+	// n == 0, yet every pass's rate is identical and stable — reporting the
+	// all-passes median in that case is not misleading, it is the true
+	// answer, and this is exactly the "normal partial result" scenario
+	// captureCompletenessVerdict already treats as routine below its
+	// majority threshold. Requiring a wiped pass too narrows this to the
+	// actual failure mode B1 (round-3 review of #2814) found: one or more
+	// passes contributing a raw, uninformative 0 because they captured
+	// NOTHING, dragging the median toward zero in a way no individual
+	// pass's own rate would suggest.
+	summary.allDegraded = n == 0 && anyPassWiped
 	return passScores, summary
 }
 
@@ -1121,11 +1521,16 @@ func reportCaptureCompleteness(sink completenessSink, attemptedCount, capturedCo
 //
 // At or past a strict majority missing, something systemic broke — a
 // revoked key, a provider outage, a ceiling misconfigured too low (plan §10
-// failure modes #7-9) — and the artifact is no longer representative of the
-// corpus it claims to measure. fail is true. Note that a true verdict does
-// NOT mean nothing gets preserved: runCapture promotes and writes the
-// manifest for whatever WAS captured regardless of this verdict — this
-// function controls only how loud the `go test` signal is.
+// failure modes #7-9), or systematic model refusal (RequestOutcome.Unusable
+// — the provider responded on every attempt, but with a decode failure or a
+// well-formed, empty completion; N8, round-3 review of #2814: named as its
+// own cause now that Unusable exists to distinguish it from the other
+// three, which are transport-level misses where no response arrived at
+// all) — and the artifact is no longer representative of the corpus it
+// claims to measure. fail is true. Note that a true verdict does NOT mean
+// nothing gets preserved: runCapture promotes and writes the manifest for
+// whatever WAS captured regardless of this verdict — this function
+// controls only how loud the `go test` signal is.
 func captureCompletenessVerdict(attemptedCount, capturedCount, missingCount int, outcomes []RequestOutcome) (fail bool, message string) {
 	if attemptedCount == 0 {
 		return true, fmt.Sprintf(
@@ -1151,8 +1556,10 @@ func captureCompletenessVerdict(attemptedCount, capturedCount, missingCount int,
 		return true, fmt.Sprintf(
 			"most of this run failed to capture anything: %d/%d captured, %d/%d missing (%.0f%%) — "+
 				"this is not a usable partial artifact; investigate before re-running (a revoked key, a "+
-				"provider outage, or a ceiling set too low are the likely causes — plan §10 failure modes "+
-				"#7-9). Whatever WAS captured is still promoted and recorded below. missing: %s",
+				"provider outage, a ceiling set too low, or systematic model refusal are the likely causes — "+
+				"plan §10 failure modes #7-9, and check requestOutcomes[].unusable in the manifest below to "+
+				"tell a refusal apart from the other three). Whatever WAS captured is still promoted and "+
+				"recorded below. missing: %s",
 			capturedCount, attemptedCount, missingCount, attemptedCount, missingFrac*100, strings.Join(missingIDs, ", "),
 		)
 	}
@@ -1704,6 +2111,12 @@ func TestRunCapture_DegradedTailPass_ExcludedFromMedian(t *testing.T) {
 	if manifest.MedianSemanticMatchRate != 1 {
 		t.Fatalf("manifest.MedianSemanticMatchRate = %v, want 1 — same regression, semantic axis", manifest.MedianSemanticMatchRate)
 	}
+	// N3 (round-3 review of #2814): the median above is over exactly 1
+	// clean pass, not all 3 — MedianSampleSize is what lets a reader see
+	// that without computing Passes - len(DegradedPasses) themselves.
+	if manifest.MedianSampleSize != 1 {
+		t.Fatalf("manifest.MedianSampleSize = %d, want 1 (only pass 1 was clean)", manifest.MedianSampleSize)
+	}
 }
 
 // TestRunCapture_PartialFailure_TombstoneAndBijection is
@@ -1863,6 +2276,104 @@ func TestRunCapture_ProviderHTTPErrorNeverLeaksResponseBodyIntoManifest(t *testi
 	}
 }
 
+// TestRunCapture_UnusableResponse_SetsRequestOutcomeUnusable is the other
+// half of N4 (round-3 review of #2814): TestRunCapture_ProviderHTTPErrorNeverLeaksResponseBodyIntoManifest
+// above proves the transport-miss (401) path leaves RequestOutcome.Unusable
+// false, but nothing exercised the OTHER branch end to end — a response
+// that DID arrive (a real 200) but decoded to no usable completion at all,
+// which provider.IsUnusableResponse (and therefore captureProvider.Complete,
+// which is what actually sets manifest-level Unusable) treats as a
+// distinct, BILLED case from a 429/timeout/ceiling. Reuses the real
+// Anthropic adapter against an httptest server, exactly like the 401 test,
+// rather than hand-building a fake error that only ASSERTS it matches the
+// real shape.
+func TestRunCapture_UnusableResponse_SetsRequestOutcomeUnusable(t *testing.T) {
+	const emptyMarker = "TRIGGER_EMPTY_RESPONSE"
+
+	okBody, err := json.Marshal(map[string]any{
+		"content": []map[string]string{{"type": "text", "text": "```yaml\n" + validCandidate + "```"}},
+		"usage":   map[string]int{"input_tokens": 5, "output_tokens": 5},
+	})
+	if err != nil {
+		t.Fatalf("marshaling ok response fixture: %v", err)
+	}
+	// A 200 with an EMPTY content array: a real, arrived response that
+	// anthropic.go's adapter itself marks unusable ("empty response") -
+	// never a transport-level miss.
+	emptyBody, err := json.Marshal(map[string]any{
+		"content": []map[string]string{},
+		"usage":   map[string]int{"input_tokens": 5, "output_tokens": 0},
+	})
+	if err != nil {
+		t.Fatalf("marshaling empty response fixture: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		if strings.Contains(string(body), emptyMarker) {
+			_, _ = w.Write(emptyBody)
+			return
+		}
+		_, _ = w.Write(okBody)
+	}))
+	t.Cleanup(srv.Close)
+
+	requests := []Request{
+		capturePipelineRequest("req-ok"),
+		{
+			ID:     "req-empty",
+			Prompt: "read from the generator and write to the log " + emptyMarker,
+			Expect: Expect{SourceCategory: "generator", DestinationCategory: "log"},
+		},
+	}
+	base := &provider.Anthropic{BaseURL: srv.URL}
+	cp := &captureProvider{Provider: base, maxCalls: 1000, maxTokens: 1_000_000}
+	destDir := filepath.Join(t.TempDir(), "anthropic", "claude-sonnet-5-test")
+
+	manifest, _, wrote := runCapture(context.Background(), t, requests, cp, "anthropic", "claude-sonnet-5-test", 1, destDir)
+	if !wrote {
+		t.Fatal("expected the manifest to be written: 1/2 missing is at, not past, the run-failing threshold")
+	}
+
+	var gotReqEmpty RequestOutcome
+	found := false
+	for _, o := range manifest.RequestOutcomes {
+		if o.RequestID == "req-empty" {
+			gotReqEmpty, found = o, true
+		}
+	}
+	if !found {
+		t.Fatal("expected an outcome for req-empty")
+	}
+	if gotReqEmpty.Captured {
+		t.Fatal("req-empty: Captured = true, want false — an empty completion is still absence of data")
+	}
+	// The core regression: a response that DID arrive but decoded to
+	// nothing usable must be flagged Unusable, distinguishing it from a
+	// transport-level miss (429/timeout/ceiling) that never got a response
+	// at all — RequestOutcome's own doc comment on why the two must never
+	// share a code path (a BILLED, attempted call vs. one that never
+	// reached the provider).
+	if !gotReqEmpty.Unusable {
+		t.Fatal("req-empty: Unusable = false, want true — the provider responded (200) but decoded to no usable completion")
+	}
+
+	// The 401 case (this test's own sibling,
+	// TestRunCapture_ProviderHTTPErrorNeverLeaksResponseBodyIntoManifest)
+	// proves the negative for a transport miss; a healthy request in THIS
+	// same run proves the positive is not just "always true".
+	var gotReqOK RequestOutcome
+	for _, o := range manifest.RequestOutcomes {
+		if o.RequestID == "req-ok" {
+			gotReqOK = o
+		}
+	}
+	if !gotReqOK.Captured || gotReqOK.Unusable {
+		t.Fatalf("req-ok outcome = %+v, want Captured=true and Unusable=false", gotReqOK)
+	}
+}
+
 // TestRunCapture_MissingRequest_ScoredAsMissingNotFailedCandidate is the
 // regression test for a request with no completion being scored as a
 // failed model candidate rather than Missing (score.go's Result.Missing).
@@ -1922,6 +2433,301 @@ func TestRunCapture_MissingRequest_ScoredAsMissingNotFailedCandidate(t *testing.
 			t.Fatalf("pass %d: expected results for both req-b and the healthy requests, got %+v", i+1, rs.Results)
 		}
 	}
+}
+
+// refusesMarkedRequestProvider replies with well-formed, non-empty text
+// that never extracts into pipeline YAML ("I'm sorry, I can't help with
+// that.") for any request whose prompt contains marker, and a normal
+// fenced, extractable reply for every other request — modeling systematic
+// model refusal on ONE request alongside an otherwise-healthy pass (B2,
+// round-3 review of #2814), as distinct from a transport-level miss where
+// no response arrives at all (flakyAfterFirstCallProvider, above).
+type refusesMarkedRequestProvider struct {
+	marker     string
+	validReply string
+}
+
+func (p refusesMarkedRequestProvider) Name() string { return "refuses-marked" }
+
+func (p refusesMarkedRequestProvider) Complete(_ context.Context, req provider.CompletionRequest) (provider.CompletionResult, error) {
+	if strings.Contains(req.Prompt, p.marker) {
+		return provider.CompletionResult{Text: "I'm sorry, I can't help with that.", TokensUsed: 5}, nil
+	}
+	return provider.CompletionResult{Text: p.validReply, TokensUsed: 20}, nil
+}
+
+// TestRunCapture_SystematicRefusal_ScoresValidateFailNotPass is the
+// end-to-end regression test for B2 (round-3 review of #2814): a provider
+// that replies with well-formed but unparseable text for every attempt on
+// one request (systematic refusal) produces a completion recorded as raw
+// data — never Missing, since runCapture's "absence of data" branch never
+// fires when a real completion WAS recorded — but Generate never extracts
+// a candidate from it. Before this fix, ScoreRun scored the resulting
+// empty candidate a validate PASS (validate.RunBytes on zero bytes finds
+// nothing wrong), buildTranscript committed the same false PASS into the
+// refused request's own Transcript.Outcome, and the pass was never marked
+// degraded — inflating the headline numbers with exactly the failure this
+// corpus exists to measure. A second, healthy request is included so the
+// pass is merely degraded (not wiped), keeping this test isolated from B1's
+// separate allDegraded failure path (TestRunCapture_AllPassesDegraded_FailsTheRunAndFlagsUnreliable).
+func TestRunCapture_SystematicRefusal_ScoresValidateFailNotPass(t *testing.T) {
+	const marker = "TRIGGER_REFUSAL"
+	requests := []Request{
+		{
+			ID:     "req-refused",
+			Prompt: "read from the generator and write to the log " + marker,
+			Expect: Expect{SourceCategory: "generator", DestinationCategory: "log"},
+		},
+		capturePipelineRequest("req-ok"),
+	}
+	fake := refusesMarkedRequestProvider{marker: marker, validReply: "```yaml\n" + validCandidate + "```"}
+	cp := &captureProvider{Provider: fake, maxCalls: 1000, maxTokens: 1_000_000}
+	destDir := filepath.Join(t.TempDir(), "anthropic", "claude-sonnet-5-test")
+
+	manifest, passRuns, wrote := runCapture(context.Background(), t, requests, cp, "anthropic", "claude-sonnet-5-test", 1, destDir)
+	if !wrote {
+		t.Fatal("expected the manifest to be written: both requests were attempted and a completion was recorded for each")
+	}
+
+	// Both requests must be reported as CAPTURED (a completion was recorded
+	// for each — this is data, not absence of data), never Missing.
+	if manifest.CapturedCount != 2 || manifest.MissingCount != 0 {
+		t.Fatalf("manifest CapturedCount/MissingCount = %d/%d, want 2/0 — a refused-but-recorded completion is "+
+			"captured DATA, not a missing request", manifest.CapturedCount, manifest.MissingCount)
+	}
+
+	if len(passRuns) != 1 || len(passRuns[0].Results) != 2 {
+		t.Fatalf("unexpected passRuns shape: %+v", passRuns)
+	}
+	var gotRefused bool
+	for _, res := range passRuns[0].Results {
+		if res.RequestID != "req-refused" {
+			continue
+		}
+		gotRefused = true
+		if res.Missing {
+			t.Fatal("res.Missing = true, want false — a completion WAS recorded, this is not absence of data")
+		}
+		// The core regression: the empty candidate must score a hard fail
+		// on BOTH axes, not a validate PASS.
+		if res.ValidatePass {
+			t.Fatal("res.ValidatePass = true, want false — an empty/unparseable candidate must never score a validate PASS")
+		}
+		if res.SemanticMatch {
+			t.Fatal("res.SemanticMatch = true, want false")
+		}
+	}
+	if !gotRefused {
+		t.Fatalf("expected a result for req-refused, got %+v", passRuns[0].Results)
+	}
+
+	// The pass must be marked degraded — a request whose only completions
+	// never extracted a candidate is exactly as uninformative, for this
+	// purpose, as one the provider never answered at all.
+	if len(manifest.PassScores) != 1 || manifest.PassScores[0].MissingCount == 0 {
+		t.Fatalf("manifest.PassScores = %+v, want PassScores[0].MissingCount > 0", manifest.PassScores)
+	}
+	if len(manifest.DegradedPasses) == 0 {
+		t.Fatal("manifest.DegradedPasses is empty, want the one pass named")
+	}
+	if manifest.MediansUnreliable {
+		t.Fatal("manifest.MediansUnreliable = true, want false — req-ok keeps this pass merely degraded, not wiped")
+	}
+
+	// The committed transcript's own Outcome must not claim a pass either
+	// (B2's buildTranscript half of the fix).
+	data, err := os.ReadFile(filepath.Join(destDir, "req-refused.yaml"))
+	if err != nil {
+		t.Fatalf("reading committed transcript: %v", err)
+	}
+	var tr Transcript
+	if err := yaml.Unmarshal(data, &tr); err != nil {
+		t.Fatalf("unmarshaling transcript: %v", err)
+	}
+	if tr.Outcome.ValidatePass {
+		t.Fatal("committed Transcript.Outcome.ValidatePass = true, want false — the model never produced a usable candidate")
+	}
+}
+
+// TestRunCapture_ScopedRecapture_PatchesExistingManifest is the end-to-end
+// regression test for M1 (round-3 review of #2814): a scoped
+// `-run TestCaptureTranscripts/<id>` re-capture that turns a
+// previously-tombstoned id back into real data must patch that id's own
+// RequestOutcome (and CapturedCount/MissingCount) into the manifest.yaml
+// the last full run left behind — before this fix, runCapture mutated the
+// TREE (promoted the new transcript, removed the stale tombstone — H3's own
+// fix) but returned early without ever touching manifest.yaml, leaving a
+// committed file that still said captured: false for an id the tree now
+// has real data for.
+//
+// Scoping only happens via the real `go test -run` mechanism (Go's testing
+// package decides which t.Run(req.ID, ...) closures execute BEFORE
+// runCapture's own code ever sees it — there is no in-process way to
+// simulate "only 1 of 2 requests attempted" against a real *testing.T), so
+// this re-execs the already-built test binary the same way
+// TestRunCapture_AllPassesDegraded_FailsTheRunAndFlagsUnreliable does,
+// filtered to just the req-b subtest.
+func TestRunCapture_ScopedRecapture_PatchesExistingManifest(t *testing.T) {
+	const helperEnv = "CONDUIT_TEST_SCOPEDPATCH_HELPER"
+	const destDirEnv = "CONDUIT_TEST_SCOPEDPATCH_DESTDIR"
+
+	if os.Getenv(helperEnv) == "1" {
+		runScopedRecaptureHelper(t, os.Getenv(destDirEnv))
+		return
+	}
+
+	destDir := t.TempDir()
+	seedManifestForScopedRecapture(t, destDir)
+
+	cmd := exec.CommandContext(
+		context.Background(),
+		os.Args[0],
+		"-test.run=^TestRunCapture_ScopedRecapture_PatchesExistingManifest$/^req-b$",
+		"-test.v",
+	)
+	cmd.Env = append(os.Environ(), helperEnv+"=1", destDirEnv+"="+destDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("subprocess (scoped re-capture of req-b) failed: %v\noutput:\n%s", err, out)
+	}
+
+	// req-b.yaml must be promoted and its tombstone gone (H3's own fix,
+	// unaffected by M1 — asserted here too since M1's fix sits right next
+	// to that code).
+	if _, err := os.Stat(filepath.Join(destDir, "req-b.yaml")); err != nil {
+		t.Fatalf("expected req-b.yaml to be promoted: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "req-b"+tombstoneFileSuffix)); !os.IsNotExist(err) {
+		t.Fatalf("expected req-b's tombstone to be removed, stat err = %v", err)
+	}
+
+	data, rerr := os.ReadFile(filepath.Join(destDir, manifestFileName))
+	if rerr != nil {
+		t.Fatalf("reading patched manifest: %v", rerr)
+	}
+	var manifest Manifest
+	if err := yaml.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("unmarshaling patched manifest: %v", err)
+	}
+
+	// The core regression: req-b's OWN outcome must now say captured, with
+	// no stale failure reason, and the summary counts must reflect it.
+	var gotReqB, gotReqA bool
+	for _, o := range manifest.RequestOutcomes {
+		switch o.RequestID {
+		case "req-b":
+			gotReqB = true
+			if !o.Captured {
+				t.Fatal("patched req-b RequestOutcome.Captured = false, want true")
+			}
+			if o.FailureReason != "" {
+				t.Fatalf("patched req-b RequestOutcome.FailureReason = %q, want empty (stale reason must be cleared)",
+					o.FailureReason)
+			}
+		case "req-a":
+			gotReqA = true
+			if !o.Captured {
+				t.Fatal("req-a RequestOutcome.Captured = false, want true — untouched by this scoped run")
+			}
+		}
+	}
+	if !gotReqB || !gotReqA {
+		t.Fatalf("expected RequestOutcomes for both req-a and req-b, got %+v", manifest.RequestOutcomes)
+	}
+	if manifest.CapturedCount != 2 || manifest.MissingCount != 0 {
+		t.Fatalf("manifest CapturedCount/MissingCount = %d/%d, want 2/0 after the scoped re-capture",
+			manifest.CapturedCount, manifest.MissingCount)
+	}
+	// Medians/PassScores describe the LAST FULL run and must be untouched
+	// by a scoped run that has no full-corpus data to recompute them from.
+	if manifest.MedianValidatePassRate != 0.5 {
+		t.Fatalf("manifest.MedianValidatePassRate = %v, want 0.5 (untouched from the seeded full run)",
+			manifest.MedianValidatePassRate)
+	}
+}
+
+// seedManifestForScopedRecapture writes destDir into the state a prior FULL
+// run (req-a captured, req-b permanently missing) would have left it in:
+// req-a's committed transcript, req-b's tombstone, and a manifest.yaml
+// whose RequestOutcomes/counts/medians describe exactly that.
+func seedManifestForScopedRecapture(t *testing.T, destDir string) {
+	t.Helper()
+
+	reqA := capturePipelineRequest("req-a")
+	tr := Transcript{
+		SchemaVersion:      TranscriptSchemaVersion,
+		RequestID:          reqA.ID,
+		Provider:           "anthropic",
+		Model:              "claude-sonnet-5-test",
+		CapturedAt:         time.Now().UTC(),
+		CorpusPromptSHA256: sha256Hex(reqA.Prompt),
+		SystemPromptSHA256: sha256Hex(BuildSystemPrompt(BuiltinCatalog())),
+		CatalogFingerprint: CatalogFingerprint(),
+		Turns: []Turn{{
+			N: 1, UserPromptSHA256: sha256Hex(reqA.Prompt), TokensUsed: 20,
+			CompletionText: "```yaml\n" + validCandidate + "```",
+		}},
+		Outcome: Outcome{ValidatePass: true, SemanticMatch: true},
+	}
+	data, err := yaml.Marshal(tr)
+	if err != nil {
+		t.Fatalf("marshaling seed transcript: %v", err)
+	}
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		t.Fatalf("creating %q: %v", destDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(destDir, "req-a.yaml"), data, 0o600); err != nil {
+		t.Fatalf("writing seed transcript: %v", err)
+	}
+
+	writeTombstone(t, destDir, Tombstone{
+		SchemaVersion:      TranscriptSchemaVersion,
+		RequestID:          "req-b",
+		CorpusPromptSHA256: sha256Hex("read from the generator and write to the log TRIGGER_SCOPED_RECAPTURE"),
+		FailureCode:        "generate.provider_error (HTTP 429)",
+		CapturedAt:         time.Now().UTC(),
+	})
+
+	writeManifest(t, destDir, Manifest{
+		SchemaVersion:           TranscriptSchemaVersion,
+		Provider:                "anthropic",
+		Model:                   "claude-sonnet-5-test",
+		CapturedAt:              time.Now().UTC(),
+		RequestCount:            2,
+		Passes:                  1,
+		MedianValidatePassRate:  0.5,
+		MedianSemanticMatchRate: 0.5,
+		PassScores:              []PassScore{{Pass: 1, Total: 2, ValidatePassCount: 1, ValidatePassRate: 0.5, SemanticMatchCount: 1, SemanticMatchRate: 0.5}},
+		CapturedCount:           1,
+		MissingCount:            1,
+		RequestOutcomes: []RequestOutcome{
+			{RequestID: "req-a", Captured: true},
+			{RequestID: "req-b", Captured: false, FailureReason: "generate.provider_error (HTTP 429)"},
+		},
+	})
+}
+
+// runScopedRecaptureHelper is the real scenario
+// TestRunCapture_ScopedRecapture_PatchesExistingManifest runs inside its
+// re-exec'd subprocess, filtered to ONLY req-b's subtest (the requests
+// slice still names both — Go's own `-run` filtering is what makes this a
+// genuinely scoped run, exactly as a real `-run TestCaptureTranscripts/<id>`
+// invocation would): req-b now succeeds, simulating a clean re-capture of a
+// previously-failing request.
+func runScopedRecaptureHelper(t *testing.T, destDir string) {
+	t.Helper()
+	requests := []Request{
+		capturePipelineRequest("req-a"),
+		{
+			ID:     "req-b",
+			Prompt: "read from the generator and write to the log TRIGGER_SCOPED_RECAPTURE",
+			Expect: Expect{SourceCategory: "generator", DestinationCategory: "log"},
+		},
+	}
+	fake := &fakeProvider{replies: []string{"```yaml\n" + validCandidate + "```"}, tokens: 20}
+	cp := &captureProvider{Provider: fake, maxCalls: 1000, maxTokens: 1_000_000}
+
+	runCapture(context.Background(), t, requests, cp, "anthropic", "claude-sonnet-5-test", 1, destDir)
 }
 
 // TestCaptureCompletenessVerdict proves the threshold decision directly and
@@ -2096,6 +2902,234 @@ func TestReportCaptureCompleteness(t *testing.T) {
 			t.Fatal("expected neither Errorf nor Logf for a clean, fully-attempted run")
 		}
 	})
+}
+
+// TestSummarizePasses_AllDegraded_FlagsUnreliableFallback is the regression
+// test for B1 (round-3 review of #2814), reproducing the review's own
+// scenario directly against summarizePasses (no *testing.T-failing side
+// effects, so this test can safely assert the bad behavior is gone without
+// itself needing to fail): 5 requests, 3 capture passes, a provider that
+// dies after 3 successful calls (captureWallClockBudget expiring 60% into
+// pass 1, in the language of runCapture's own doc comment) — pass 1 captures
+// req-1..req-3 (which validate cleanly) and is missing req-4/req-5; passes 2
+// and 3 capture nothing at all. Every pass is therefore degraded
+// (missingCounts all > 0), which is exactly the case the pre-fix code
+// treated as "fall back to the median across every pass" — computing 0.00
+// even though the requests that WERE captured validated 3/3.
+//
+// Reverting the allDegraded field (and the fallback-is-unreliable framing in
+// summarizePasses' doc comment) does not change what this test asserts —
+// what it guards is the CALLER'S ability to tell the two cases apart, so the
+// meaningful regression coverage is that allDegraded comes back true here;
+// see TestRunCapture_AllPassesDegraded_FailsTheRunAndFlagsUnreliable below
+// for the end-to-end proof that runCapture actually acts on it.
+func TestSummarizePasses_AllDegraded_FlagsUnreliableFallback(t *testing.T) {
+	requests := []Request{
+		capturePipelineRequest("req-1"),
+		capturePipelineRequest("req-2"),
+		capturePipelineRequest("req-3"),
+		capturePipelineRequest("req-4"),
+		capturePipelineRequest("req-5"),
+	}
+	// Candidates map values here are ScoreRun/validateCandidate input
+	// directly (validate.RunBytes), never the fenced markdown a live
+	// provider reply would carry — that fence-stripping is extractCandidate's
+	// job inside Generate, a layer these summarizePasses unit tests bypass
+	// entirely (c.f. diesAfterNCallsProvider below, which DOES go through
+	// Generate and so DOES need the fence).
+
+	// Mirrors runCapture's own candidate map construction: a pass that never
+	// produced a completion for a request omits that key entirely (score.go's
+	// Result.Missing), never an empty-string stand-in.
+	pass1 := Candidates{"req-1": validCandidate, "req-2": validCandidate, "req-3": validCandidate}
+	pass2 := Candidates{}
+	pass3 := Candidates{}
+	missingCounts := []int{2, 5, 5} // req-4/req-5 missing pass 1; everything missing passes 2-3
+
+	ctx := context.Background()
+	ms := ScoreMedian(ctx, requests, []Candidates{pass1, pass2, pass3})
+	_, summary := summarizePasses(ms.Runs, missingCounts)
+
+	if !summary.allDegraded {
+		t.Fatal("summary.allDegraded = false, want true — every one of 3 passes had a nonzero missingCount")
+	}
+	if len(summary.degradedPasses) != 3 {
+		t.Fatalf("summary.degradedPasses = %v, want all 3 passes named", summary.degradedPasses)
+	}
+	// The regression this test exists to catch: the requests that WERE
+	// captured (pass 1's req-1..req-3) validate 3/3, but with no clean pass
+	// to compute a median from, the all-passes fallback still comes out to
+	// 0 (median of [0.6, 0, 0] == 0) — this is summarizePasses' documented
+	// fallback behavior, not a bug in this test; what matters is that
+	// allDegraded is true so the caller knows not to trust it.
+	if summary.validateRate != 0 {
+		t.Fatalf("summary.validateRate = %v, want 0 (median of [0.6, 0, 0]) — if this changed, update the "+
+			"scenario or the assertion, but confirm allDegraded is still what the caller relies on", summary.validateRate)
+	}
+}
+
+// TestSummarizePasses_ChronicSingleMissingRequest_NotAllDegraded is the
+// negative counterpart to TestSummarizePasses_AllDegraded_FlagsUnreliableFallback:
+// a single request that is chronically missing on EVERY pass (never any
+// OTHER request, and never a whole pass wiped) must NOT set allDegraded,
+// even though — same as the all-degraded case — no individual pass is
+// "clean" (missingCount == 0 for every one of them). This is exactly
+// TestRunCapture_PartialFailure_PreservesGoodTranscripts's own scenario
+// (req-b permanently rate-limited, req-a/req-c always captured) reduced to
+// summarizePasses directly: an over-broad allDegraded condition (n == 0
+// alone, without also requiring a wiped pass) would flip this ordinary,
+// below-threshold partial result — the exact case captureCompletenessVerdict
+// exists to treat as routine — into a hard failure of the whole capture run,
+// which is the regression this test guards against.
+func TestSummarizePasses_ChronicSingleMissingRequest_NotAllDegraded(t *testing.T) {
+	requests := []Request{
+		capturePipelineRequest("req-a"),
+		capturePipelineRequest("req-b"),
+		capturePipelineRequest("req-c"),
+	}
+	// req-b is missing from every pass; req-a/req-c are captured and valid
+	// on every pass — identical, stable degradation, not a wipeout.
+	pass := Candidates{"req-a": validCandidate, "req-c": validCandidate}
+	missingCounts := []int{1, 1, 1}
+
+	ctx := context.Background()
+	ms := ScoreMedian(ctx, requests, []Candidates{pass, pass, pass})
+	_, summary := summarizePasses(ms.Runs, missingCounts)
+
+	if summary.allDegraded {
+		t.Fatal("summary.allDegraded = true, want false — one chronically-missing request among three is " +
+			"ordinary partial-result noise (captureCompletenessVerdict's territory), not a wiped pass")
+	}
+	if len(summary.degradedPasses) != 3 {
+		t.Fatalf("summary.degradedPasses = %v, want all 3 passes named (missingCount 1 > 0 on every one)",
+			summary.degradedPasses)
+	}
+	// The fallback (median across all passes) is still what gets published
+	// here — but it is the SAME number a clean-pass median would have shown
+	// (every pass identically 2/3), which is why allDegraded correctly
+	// stays false: nothing about this number is misleading.
+	if want := 2.0 / 3.0; summary.validateRate != want {
+		t.Fatalf("summary.validateRate = %v, want %v", summary.validateRate, want)
+	}
+}
+
+// TestRunCapture_AllPassesDegraded_FailsTheRunAndFlagsUnreliable is the
+// end-to-end regression test for B1: runCapture itself, given the review's
+// exact "provider dies partway through pass 1" scenario, must (a) fail its
+// own `go test` run (t.Errorf — the same class of failure
+// captureCompletenessVerdict already uses for attemptedCount == 0) rather
+// than exit clean under a misleading 0.00 baseline, and (b) still write a
+// manifest.yaml — with MediansUnreliable: true — for whatever WAS captured
+// (req-1..req-3, which validate 3/3).
+//
+// Asserting "this call makes *testing.T fail" cannot be done in-process:
+// once ANY subtest calls t.Errorf, Go's testing package propagates that
+// failure to every ancestor including the top-level test binary (verified
+// empirically — there is no way to catch and discard it, which is exactly
+// why reportCaptureCompleteness above is tested through the fakeCompletenessSink
+// indirection instead of a real *testing.T). runCapture cannot take that same
+// indirection: its per-request t.Run(req.ID, ...) subtests are what let a
+// scoped `-run TestCaptureTranscripts/<id>` re-capture work at all (file
+// header), which requires a concrete *testing.T. So this test re-execs the
+// already-built test binary (os.Args[0], the standard os/exec-style pattern
+// for asserting a process exits nonzero) as a subprocess, lets THAT process's
+// real *testing.T take the real Errorf, and asserts on the parent side that
+// the subprocess failed and left the expected manifest on disk.
+func TestRunCapture_AllPassesDegraded_FailsTheRunAndFlagsUnreliable(t *testing.T) {
+	const helperEnv = "CONDUIT_TEST_ALLDEGRADED_HELPER"
+	const destDirEnv = "CONDUIT_TEST_ALLDEGRADED_DESTDIR"
+
+	if os.Getenv(helperEnv) == "1" {
+		runAllPassesDegradedHelper(t, os.Getenv(destDirEnv))
+		return
+	}
+
+	destDir := t.TempDir()
+	cmd := exec.CommandContext(
+		context.Background(),
+		os.Args[0],
+		"-test.run=^TestRunCapture_AllPassesDegraded_FailsTheRunAndFlagsUnreliable$",
+		"-test.v",
+	)
+	cmd.Env = append(os.Environ(), helperEnv+"=1", destDirEnv+"="+destDir)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected the subprocess (runCapture with every pass degraded) to exit nonzero via t.Errorf; "+
+			"output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "every one of 3 capture pass(es) was degraded") {
+		t.Fatalf("subprocess failed as expected, but not for the reason this test checks — output:\n%s", out)
+	}
+
+	data, rerr := os.ReadFile(filepath.Join(destDir, manifestFileName))
+	if rerr != nil {
+		t.Fatalf("expected manifest.yaml to still be written despite the failure: %v\nsubprocess output:\n%s", rerr, out)
+	}
+	var manifest Manifest
+	if err := yaml.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("unmarshaling manifest: %v", err)
+	}
+	if !manifest.MediansUnreliable {
+		t.Fatal("manifest.MediansUnreliable = false, want true")
+	}
+	if manifest.CapturedCount != 3 {
+		t.Fatalf("manifest.CapturedCount = %d, want 3 (req-1..req-3 captured on pass 1)", manifest.CapturedCount)
+	}
+	if manifest.MissingCount != 2 {
+		t.Fatalf("manifest.MissingCount = %d, want 2 (req-4/req-5 never captured on any pass)", manifest.MissingCount)
+	}
+	if len(manifest.DegradedPasses) != 3 {
+		t.Fatalf("manifest.DegradedPasses = %v, want all 3 passes named", manifest.DegradedPasses)
+	}
+}
+
+// diesAfterNCallsProvider returns a valid, passing completion for its first
+// n calls and errors on every call after that — modeling
+// captureWallClockBudget expiring (or a rate-limit storm starting) partway
+// through a multi-pass run, across every request rather than just one (c.f.
+// flakyAfterFirstCallProvider above, which flakes a single marked request).
+type diesAfterNCallsProvider struct {
+	n     int
+	reply string
+
+	mu    sync.Mutex
+	calls int
+}
+
+func (p *diesAfterNCallsProvider) Name() string { return "dies-after-n-calls" }
+
+func (p *diesAfterNCallsProvider) Complete(_ context.Context, _ provider.CompletionRequest) (provider.CompletionResult, error) {
+	p.mu.Lock()
+	p.calls++
+	n := p.calls
+	p.mu.Unlock()
+	if n > p.n {
+		return provider.CompletionResult{}, fmt.Errorf("capture ceiling: wall-clock deadline exceeded (simulated)")
+	}
+	return provider.CompletionResult{Text: p.reply, TokensUsed: 20}, nil
+}
+
+// runAllPassesDegradedHelper is the real scenario
+// TestRunCapture_AllPassesDegraded_FailsTheRunAndFlagsUnreliable runs inside
+// its re-exec'd subprocess: 5 requests, 3 passes, a provider that dies after
+// 3 successful calls — so pass 1 captures req-1..req-3 and is missing
+// req-4/req-5, and passes 2-3 capture nothing (the provider is already dead
+// by the time they start). This calls runCapture on the subprocess's OWN
+// real *testing.T, so the t.Errorf inside it (B1's fix) really does fail
+// this subprocess — that is the behavior under test.
+func runAllPassesDegradedHelper(t *testing.T, destDir string) {
+	t.Helper()
+	requests := []Request{
+		capturePipelineRequest("req-1"),
+		capturePipelineRequest("req-2"),
+		capturePipelineRequest("req-3"),
+		capturePipelineRequest("req-4"),
+		capturePipelineRequest("req-5"),
+	}
+	fake := &diesAfterNCallsProvider{n: 3, reply: "```yaml\n" + validCandidate + "```"}
+	cp := &captureProvider{Provider: fake, maxCalls: 1000, maxTokens: 1_000_000}
+
+	runCapture(context.Background(), t, requests, cp, "anthropic", "claude-sonnet-5-test", 3, destDir)
 }
 
 // TestScanAndPromoteScratch_OneViolationBlocksTheWholeBatch proves plan §5 /

--- a/cmd/conduit/internal/generate/transcript_capture_test.go
+++ b/cmd/conduit/internal/generate/transcript_capture_test.go
@@ -1104,10 +1104,53 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 // complexity under gocyclo's threshold, the same reason finishScopedRun,
 // summarizePasses, and preserveMediansIfNothingPromoted were split out for
 // earlier rounds).
-func logDegradedPassSummary(t *testing.T, degradedMedians passesSummary, passes int) {
-	t.Helper()
+// degradedSummaryArm names which explanation logDegradedPassSummary owes the
+// reader. Extracted from the switch so the CHOICE is testable, not just the
+// prose it selects.
+//
+// Round 6's review found the arm selection had zero coverage: reverting the
+// `sampleSize < passes` gate to the old `len(degradedPasses) > 0` left the
+// whole suite green, silently restoring the false "excluded ... so not dragged
+// toward zero" claim on a run where nothing was excluded. That claim being
+// wrong is the defect rounds 5 and 6 were both about, so it is the last thing
+// that should rest on a comment.
+type degradedSummaryArm int
+
+const (
+	// degradedSummaryNone: no pass was degraded; nothing to explain.
+	degradedSummaryNone degradedSummaryArm = iota
+	// degradedSummaryUnreliable: no pass saw the whole corpus and the
+	// fallback median cannot be trusted. Fails the run.
+	degradedSummaryUnreliable
+	// degradedSummaryExcluded: a genuine clean-pass median — the degraded
+	// passes really were left out, so "excluded" is a true claim.
+	degradedSummaryExcluded
+	// degradedSummaryFallbackEqual: every degraded pass missed the same
+	// reliably-attributed requests, so the all-pass fallback equals what a
+	// clean-pass median would have shown. Nothing was excluded, and saying
+	// otherwise would be the false claim.
+	degradedSummaryFallbackEqual
+)
+
+func chooseDegradedSummaryArm(degradedMedians passesSummary, passes int) degradedSummaryArm {
 	switch {
 	case degradedMedians.allDegraded:
+		return degradedSummaryUnreliable
+	case degradedMedians.sampleSize < passes:
+		return degradedSummaryExcluded
+	case len(degradedMedians.degradedPasses) > 0:
+		return degradedSummaryFallbackEqual
+	default:
+		return degradedSummaryNone
+	}
+}
+
+func logDegradedPassSummary(t *testing.T, degradedMedians passesSummary, passes int) {
+	t.Helper()
+	switch chooseDegradedSummaryArm(degradedMedians, passes) {
+	case degradedSummaryNone:
+		return
+	case degradedSummaryUnreliable:
 		// B1 fix (round-3 review of #2814), generalized by H1 (round-4
 		// review of #2814) and H1 x H2 (round-5 review of #2814): every one
 		// of `passes` passes lost the full corpus AND missingSetsAreReliable
@@ -1142,7 +1185,7 @@ func logDegradedPassSummary(t *testing.T, degradedMedians passesSummary, passes 
 			"median, and must not be used as this run's baseline. Whatever WAS captured is still promoted "+
 			"and recorded below (capturedCount/missingCount/requestOutcomes).",
 			passes, degradedMedians.validateRate, degradedMedians.semanticRate)
-	case degradedMedians.sampleSize < passes:
+	case degradedSummaryExcluded:
 		// A real, clean-pass-only median: degradedMedians.sampleSize (the
 		// clean-pass count) is strictly less than passes, meaning the
 		// degraded pass(es) named below were genuinely excluded from
@@ -1160,7 +1203,7 @@ func logDegradedPassSummary(t *testing.T, degradedMedians passesSummary, passes 
 			"manifest) — excluded from medianValidatePassRate/medianSemanticMatchRate so a wiped tail pass "+
 			"does not silently drag those numbers toward zero; requests affected may still show as captured "+
 			"overall (capturedCount/missingCount) if another pass produced them", degradedMedians.degradedPasses)
-	case len(degradedMedians.degradedPasses) > 0:
+	case degradedSummaryFallbackEqual:
 		// H1 (round-5 review of #2814): degradedMedians.sampleSize == passes
 		// here (the case above did NOT match), so — unlike the case above —
 		// nothing was actually excluded from the median: summarizePasses'
@@ -1236,7 +1279,13 @@ func finishScopedRun(t *testing.T, destDir string, outcomes []RequestOutcome, ca
 // rejects the moment anything actually loads it (corpusPromptSHA256
 // mismatch). Now this reads and parses the file exactly like readTranscript
 // does and requires RequestID and CorpusPromptSHA256 to still match req —
-// the same two checks LoadTranscripts itself runs — so a stale or
+// the two checks that can disagree with the CURRENT corpus. It does NOT
+// re-run validateTranscriptShape (SchemaVersion, Provider, Model,
+// SystemPromptSHA256, CatalogFingerprint, non-empty Turns and
+// CompletionText); LoadTranscripts covers those at load time. Nothing this
+// harness writes can fail them — buildTranscript always populates them — so
+// the split is deliberate rather than an oversight, and saying "the same
+// checks" would overstate it. So a stale or
 // content-mismatched file is never silently counted as captured. When it
 // returns false for an id that DOES have a file on disk, runCapture's
 // caller falls through to the missing/tombstone branch, which writes
@@ -4143,5 +4192,64 @@ func TestScanAndPromoteScratch_OneViolationBlocksTheWholeBatch(t *testing.T) {
 	}
 	if _, err := os.Stat(destDir); !os.IsNotExist(err) {
 		t.Fatalf("expected destDir %q to never have been created (nothing was ever promoted into it), stat err = %v", destDir, err)
+	}
+}
+
+// The arm logDegradedPassSummary picks IS the claim the reader acts on, so it
+// gets a test rather than a comment.
+//
+// Round 6's review found this selection had zero coverage: reverting the
+// `sampleSize < passes` gate to the old `len(degradedPasses) > 0` left the
+// entire suite green while restoring the false "excluded ... so not dragged
+// toward zero" message on a run where nothing was excluded. That exact false
+// claim is what rounds 5 and 6 were about, and it had recurred in five
+// consecutive rounds as a comment that drifted from the code. This is the
+// assertion that makes it fail loudly instead.
+func TestChooseDegradedSummaryArm(t *testing.T) {
+	const passes = 3
+
+	for _, tc := range []struct {
+		name    string
+		summary passesSummary
+		want    degradedSummaryArm
+	}{{
+		name:    "no degraded passes says nothing",
+		summary: passesSummary{sampleSize: passes},
+		want:    degradedSummaryNone,
+	}, {
+		// The medians cannot be trusted at all; this fails the run.
+		name:    "all degraded outranks everything",
+		summary: passesSummary{allDegraded: true, degradedPasses: []int{1, 2, 3}, sampleSize: passes},
+		want:    degradedSummaryUnreliable,
+	}, {
+		// Genuine exclusion: one clean pass carried the median, so the
+		// "excluded" wording is true.
+		name:    "a real clean-pass median may claim exclusion",
+		summary: passesSummary{degradedPasses: []int{2, 3}, sampleSize: 1},
+		want:    degradedSummaryExcluded,
+	}, {
+		// The regression: sampleSize == passes means the all-pass fallback
+		// ran and NOTHING was excluded. Claiming exclusion here is the false
+		// statement HIGH-1 was filed for.
+		name:    "fallback median must not claim exclusion",
+		summary: passesSummary{degradedPasses: []int{1, 2, 3}, sampleSize: passes},
+		want:    degradedSummaryFallbackEqual,
+	}, {
+		// Round 5's vacuous-truth case: a single-pass run cannot have
+		// excluded anything from its own median.
+		name:    "single degraded pass out of one cannot have excluded anything",
+		summary: passesSummary{degradedPasses: []int{1}, sampleSize: 1},
+		want:    degradedSummaryFallbackEqual,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := passes
+			if tc.name == "single degraded pass out of one cannot have excluded anything" {
+				p = 1
+			}
+			if got := chooseDegradedSummaryArm(tc.summary, p); got != tc.want {
+				t.Fatalf("chooseDegradedSummaryArm(%+v, passes=%d) = %d, want %d",
+					tc.summary, p, got, tc.want)
+			}
+		})
 	}
 }

--- a/cmd/conduit/internal/generate/transcript_capture_test.go
+++ b/cmd/conduit/internal/generate/transcript_capture_test.go
@@ -111,8 +111,16 @@
 //
 // The redaction gate above is deliberately untouched by any of this: it
 // remains all-or-nothing regardless of how many requests were captured or
-// missing — see scanAndPromoteScratch's own doc comment and
-// TestScanAndPromoteScratch_ViolationBlocksEvenWhenARequestIsMissing.
+// missing — a missing request never reaches scratchDir in the first place
+// (runCapture only calls writeScratchTranscript for a request that DID
+// produce a completion), so scanAndPromoteScratch's per-batch scan is
+// unaffected by how many OTHER requests in the same run were missing. This
+// holds by construction (see scanAndPromoteScratch's own doc comment), but
+// as of this writing no test exercises a batch combining a missing request
+// with a redaction violation among the captured ones directly;
+// TestScanAndPromoteScratch_OneViolationBlocksTheWholeBatch proves the
+// all-or-nothing guarantee itself (one violation blocks an otherwise-clean
+// batch) but its fixture has no missing request at all.
 package generate
 
 import (
@@ -124,6 +132,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -559,9 +568,19 @@ func writeManifest(t *testing.T, destDir string, m Manifest) {
 // The only load-bearing information for a reviewer — enough to tell "this
 // was a rate limit" from "this was a refusal" from "this was an auth
 // failure" — is the conduiterr CODE (conduiterr.Get) plus the HTTP status
-// when checkStatus recorded one (provider.HTTPStatus). Both are safe by
-// construction: a Code.Reason() is a registered, static string, never
-// user- or provider-controlled text, and the status is a bare integer.
+// when checkStatus recorded one (provider.HTTPStatus), or (nit from the
+// round-2 review of #2814) whether the failure was specifically the
+// calling context's deadline expiring (provider.IsTimeout). All three are
+// safe by construction: a Code.Reason() is a registered, static string,
+// never user- or provider-controlled text, the status is a bare integer,
+// and IsTimeout is a bool. Every provider adapter wraps EVERY failure —
+// auth rejection, rate limit, DNS miss, connection refused, our own
+// timeout — under the SAME CodeProviderError (see that var's doc comment,
+// provider/http.go), so without the HTTPStatus/IsTimeout discriminators
+// this reason would read identically for all of them; HTTPStatus alone
+// still can't tell "our own deadline expired" apart from every OTHER
+// transport-level miss (a DNS failure, a connection refused) — none of
+// those ever got far enough to have a status to report.
 //
 // Not every failure this package sees is a conduiterr — captureProvider's
 // own ceiling and wall-clock-deadline errors (transcript_capture_test.go)
@@ -580,8 +599,11 @@ func safeFailureReason(err error) string {
 	}
 	if ce, ok := conduiterr.Get(err); ok {
 		reason := ce.Code.Reason()
-		if status, ok := provider.HTTPStatus(err); ok {
+		switch status, hasStatus := provider.HTTPStatus(err); {
+		case hasStatus:
 			reason = fmt.Sprintf("%s (HTTP %d)", reason, status)
+		case provider.IsTimeout(err):
+			reason = fmt.Sprintf("%s (timeout)", reason)
 		}
 		return reason
 	}
@@ -669,7 +691,19 @@ func TestCaptureTranscripts(t *testing.T) {
 // TestRunCapture_PartialFailure_PreservesGoodTranscripts against a fake
 // provider and a scratch destDir — no live key, no network, and never
 // touching the real committed testdata/transcripts.
-func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captureProvider, providerName, model string, passes int, destDir string) (manifest Manifest, wrote bool) {
+// runCapture's third return value, passRuns, is every full-corpus pass's
+// RunScore — including Result.Missing per request per pass — exactly as
+// ScoreMedian computed it from the SAME Candidates maps runCapture itself
+// built (the manifest's own PassScores is a summary derived from this same
+// data, without RunScore.Results; see PassScore's doc comment for why the
+// committed file doesn't carry that detail). It exists so a test can assert
+// end-to-end on how runCapture's per-request closure populates Candidates —
+// in particular, that a request with no completion gets NO entry at all
+// (see the "absence of data" branch below) — rather than hand-building a
+// Candidates map that only ASSERTS it mirrors that behavior. Nil for a
+// scoped run that never reaches the full-corpus scoring step (wrote ==
+// false).
+func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captureProvider, providerName, model string, passes int, destDir string) (manifest Manifest, passRuns []RunScore, wrote bool) {
 	t.Helper()
 
 	runStart := time.Now().UTC()
@@ -697,6 +731,21 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 	lastFailureErr := make(map[string]error)
 
 	var scoreCandidatesList []Candidates
+	// scoreMissingCounts[i] is how many of len(requests) got NO entry in
+	// scoreCandidatesList[i] — i.e. how many corpus requests produced no
+	// completion on that specific pass (see the inline comment below on
+	// why passCandidates omits, rather than empty-strings, those entries).
+	// Kept as a parallel slice, index-aligned with scoreCandidatesList
+	// (and therefore with ms.Runs below), rather than added to
+	// RunScore/ScoreRun: score.go's Result.Missing already carries this
+	// per-request, and re-deriving the per-pass count from passCandidates'
+	// size here is cheaper than plumbing a new field through ScoreRun for
+	// a number runCapture already has for free. This is what lets a
+	// degraded tail pass (a rate-limit storm, or captureWallClockBudget
+	// expiring partway through) be excluded from the median instead of
+	// silently dragging MedianValidatePassRate/MedianSemanticMatchRate
+	// toward zero — see PassScore.MissingCount and Manifest.DegradedPasses.
+	var scoreMissingCounts []int
 	for pass := 1; pass <= passes; pass++ {
 		passCandidates := make(Candidates, len(requests))
 		for _, req := range requests {
@@ -764,6 +813,7 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 		// never per-pass.
 		if len(attempted) == len(requests) {
 			scoreCandidatesList = append(scoreCandidatesList, passCandidates)
+			scoreMissingCounts = append(scoreMissingCounts, len(requests)-len(passCandidates))
 		} else {
 			t.Logf("pass %d: %d/%d requests ran (a -run filter is scoping this to a subset) — "+
 				"excluded from corpus-level scoring and the manifest", pass, len(attempted), len(requests))
@@ -858,24 +908,26 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 	if len(scoreCandidatesList) != passes {
 		t.Logf("only %d/%d pass(es) captured the full corpus — skipping manifest.yaml "+
 			"(a scoped -run leaves the existing manifest untouched)", len(scoreCandidatesList), passes)
-		return Manifest{}, false
+		return Manifest{}, nil, false
 	}
 
 	ms := ScoreMedian(ctx, requests, scoreCandidatesList)
-	passScores := make([]PassScore, len(ms.Runs))
-	validateCounts := make([]int, len(ms.Runs))
-	semanticCounts := make([]int, len(ms.Runs))
-	for i, rs := range ms.Runs {
-		passScores[i] = PassScore{
-			Pass:               i + 1,
-			Total:              rs.Total,
-			ValidatePassCount:  rs.ValidatePassCount,
-			ValidatePassRate:   rs.ValidatePassRate,
-			SemanticMatchCount: rs.SemanticMatchCount,
-			SemanticMatchRate:  rs.SemanticMatchRate,
-		}
-		validateCounts[i] = rs.ValidatePassCount
-		semanticCounts[i] = rs.SemanticMatchCount
+	passScores, degradedMedians := summarizePasses(ms.Runs, scoreMissingCounts)
+
+	if len(degradedMedians.degradedPasses) > 0 {
+		// Deliberately a separate Logf, not folded into
+		// reportCaptureCompleteness below: that function's fail/log
+		// threshold (captureCompletenessVerdict) is scoped to REQUESTS
+		// missing from the whole run, and its majority-threshold math
+		// would be wrong applied to PASSES instead — a run can have every
+		// request captured (missingCount == 0, so
+		// reportCaptureCompleteness has nothing to say) while still
+		// having lost a tail pass to rate limiting, which is exactly the
+		// case this exists to surface.
+		t.Logf("pass(es) %v captured fewer than the full corpus (see passScores[].missingCount in the "+
+			"manifest) — excluded from medianValidatePassRate/medianSemanticMatchRate so a wiped tail pass "+
+			"does not silently drag those numbers toward zero; requests affected may still show as captured "+
+			"overall (capturedCount/missingCount) if another pass produced them", degradedMedians.degradedPasses)
 	}
 
 	manifest = Manifest{
@@ -891,11 +943,12 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 		CatalogFingerprint:       catalogFP,
 		SystemPromptSHA256:       systemSHA,
 		Passes:                   passes,
-		MedianValidatePassRate:   ms.ValidatePassRate,
-		MedianSemanticMatchRate:  ms.SemanticMatchRate,
-		MedianValidatePassCount:  medianInt(validateCounts),
-		MedianSemanticMatchCount: medianInt(semanticCounts),
+		MedianValidatePassRate:   degradedMedians.validateRate,
+		MedianSemanticMatchRate:  degradedMedians.semanticRate,
+		MedianValidatePassCount:  degradedMedians.validateCount,
+		MedianSemanticMatchCount: degradedMedians.semanticCount,
 		PassScores:               passScores,
+		DegradedPasses:           degradedMedians.degradedPasses,
 		CapturedCount:            capturedCount,
 		MissingCount:             missingCount,
 		RequestOutcomes:          outcomes,
@@ -903,8 +956,95 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 	writeManifest(t, destDir, manifest)
 	t.Logf("wrote manifest: %d/%d captured, %d calls, %d tokens, ~$%.2f estimated, median validate %.1f%%, median semantic %.1f%%",
 		capturedCount, len(attemptOrder), cp.totalCalls(), cp.totalTokens(), manifest.EstimatedCostUSD,
-		ms.ValidatePassRate*100, ms.SemanticMatchRate*100)
-	return manifest, true
+		degradedMedians.validateRate*100, degradedMedians.semanticRate*100)
+	return manifest, ms.Runs, true
+}
+
+// passesSummary is summarizePasses' reduction of a capture run's per-pass
+// RunScores down to the median rates/counts Manifest reports, plus which
+// passes were excluded from that median (see summarizePasses' own doc
+// comment).
+type passesSummary struct {
+	degradedPasses []int
+	validateRate   float64
+	semanticRate   float64
+	validateCount  float64
+	semanticCount  float64
+}
+
+// summarizePasses builds Manifest.PassScores and reduces runs (ms.Runs from
+// ScoreMedian) to the median rates/counts the manifest reports, given
+// missingCounts — index-aligned with runs, how many corpus requests
+// produced NO completion on that specific pass (runCapture's
+// scoreMissingCounts). Split out from runCapture as its own function (kept
+// runCapture's own cyclomatic complexity under gocyclo's threshold, and
+// this reduction is an independently-testable concern in its own right).
+//
+// A pass with missingCounts[i] > 0 is "degraded" (see PassScore.
+// MissingCount and Manifest.DegradedPasses for what that means and why —
+// H2, round-2 review of #2814): it is excluded from the returned median so
+// a wiped tail pass (a rate-limit storm, or captureWallClockBudget
+// expiring partway through) doesn't silently drag
+// MedianValidatePassRate/MedianSemanticMatchRate toward zero under a
+// manifest that otherwise reports MissingCount == 0 (a request captured on
+// an earlier pass but absent from a later one is NOT run-missing — see
+// Manifest.CapturedCount's doc comment — but ScoreRun DOES score the
+// absence on every pass that lacks it). Falls back to the median across
+// ALL passes (identical to this function's pre-H2 behavior, and
+// mathematically identical to ScoreMedian's own reduction) when every
+// single pass is degraded — with no clean pass to prefer, a 0.00 median
+// would be actively misleading.
+func summarizePasses(runs []RunScore, missingCounts []int) ([]PassScore, passesSummary) {
+	passScores := make([]PassScore, len(runs))
+	allValidateRates := make([]float64, len(runs))
+	allSemanticRates := make([]float64, len(runs))
+	allValidateCounts := make([]int, len(runs))
+	allSemanticCounts := make([]int, len(runs))
+
+	var degradedPasses []int
+	var cleanValidateRates, cleanSemanticRates []float64
+	var cleanValidateCounts, cleanSemanticCounts []int
+
+	for i, rs := range runs {
+		passMissing := missingCounts[i]
+		passScores[i] = PassScore{
+			Pass:               i + 1,
+			Total:              rs.Total,
+			ValidatePassCount:  rs.ValidatePassCount,
+			ValidatePassRate:   rs.ValidatePassRate,
+			SemanticMatchCount: rs.SemanticMatchCount,
+			SemanticMatchRate:  rs.SemanticMatchRate,
+			MissingCount:       passMissing,
+		}
+		allValidateRates[i] = rs.ValidatePassRate
+		allSemanticRates[i] = rs.SemanticMatchRate
+		allValidateCounts[i] = rs.ValidatePassCount
+		allSemanticCounts[i] = rs.SemanticMatchCount
+
+		if passMissing > 0 {
+			degradedPasses = append(degradedPasses, i+1)
+			continue
+		}
+		cleanValidateRates = append(cleanValidateRates, rs.ValidatePassRate)
+		cleanSemanticRates = append(cleanSemanticRates, rs.SemanticMatchRate)
+		cleanValidateCounts = append(cleanValidateCounts, rs.ValidatePassCount)
+		cleanSemanticCounts = append(cleanSemanticCounts, rs.SemanticMatchCount)
+	}
+
+	summary := passesSummary{
+		degradedPasses: degradedPasses,
+		validateRate:   median(allValidateRates),
+		semanticRate:   median(allSemanticRates),
+		validateCount:  medianInt(allValidateCounts),
+		semanticCount:  medianInt(allSemanticCounts),
+	}
+	if n := len(cleanValidateRates); n > 0 && n < len(runs) {
+		summary.validateRate = median(cleanValidateRates)
+		summary.semanticRate = median(cleanSemanticRates)
+		summary.validateCount = medianInt(cleanValidateCounts)
+		summary.semanticCount = medianInt(cleanSemanticCounts)
+	}
+	return passScores, summary
 }
 
 // captureCompletenessThreshold is the fraction of ATTEMPTED requests
@@ -1278,7 +1418,7 @@ func TestRunCapture_FullPipeline_FakeProvider(t *testing.T) {
 	destDir := filepath.Join(t.TempDir(), "anthropic", "claude-sonnet-5-test")
 	const passes = 2
 
-	manifest, wrote := runCapture(context.Background(), t, requests, cp, "anthropic", "claude-sonnet-5-test", passes, destDir)
+	manifest, _, wrote := runCapture(context.Background(), t, requests, cp, "anthropic", "claude-sonnet-5-test", passes, destDir)
 
 	if !wrote {
 		t.Fatal("expected a full-corpus run over both requests, across both passes, to write a manifest")
@@ -1392,7 +1532,7 @@ func TestRunCapture_PartialFailure_PreservesGoodTranscripts(t *testing.T) {
 	requests, cp, destDir, infraErr := partialFailureFixture(t)
 	const passes = 3
 
-	manifest, wrote := runCapture(context.Background(), t, requests, cp, "anthropic", "claude-sonnet-5-test", passes, destDir)
+	manifest, _, wrote := runCapture(context.Background(), t, requests, cp, "anthropic", "claude-sonnet-5-test", passes, destDir)
 
 	if !wrote {
 		t.Fatal("expected the manifest to still be written: 1/3 missing is below the run-failing threshold")
@@ -1453,11 +1593,116 @@ func TestRunCapture_PartialFailure_PreservesGoodTranscripts(t *testing.T) {
 	// The infra error is a plain fmt.Errorf, not a conduiterr — it takes
 	// safeFailureReason's literal-text fallback path (see that function's
 	// doc comment), so its text is preserved verbatim here. This is
-	// distinct from Test_RunCapture_ProviderHTTPErrorNeverLeaksResponseBodyIntoManifest,
+	// distinct from TestRunCapture_ProviderHTTPErrorNeverLeaksResponseBodyIntoManifest,
 	// which proves the structured (non-fallback) path for a REAL provider
 	// error never carries response-body text at all.
 	if gotReqB.Unusable {
 		t.Fatal("req-b outcome: Unusable = true, want false — a 429 is absence of data, not a billed refusal")
+	}
+}
+
+// flakyAfterFirstCallProvider succeeds the FIRST time it sees a request
+// whose prompt contains marker, then fails every subsequent time — a
+// request that captures cleanly on an early pass and then drops out of
+// every later one, simulating a rate-limit storm or captureWallClockBudget
+// expiring partway through a multi-pass run. Everything else is delegated
+// to the wrapped fakeProvider unchanged.
+type flakyAfterFirstCallProvider struct {
+	*fakeProvider
+	marker string
+	err    error
+
+	mu   sync.Mutex
+	seen int
+}
+
+func (p *flakyAfterFirstCallProvider) Complete(ctx context.Context, req provider.CompletionRequest) (provider.CompletionResult, error) {
+	if strings.Contains(req.Prompt, p.marker) {
+		p.mu.Lock()
+		p.seen++
+		n := p.seen
+		p.mu.Unlock()
+		if n > 1 {
+			return provider.CompletionResult{}, p.err
+		}
+	}
+	return p.fakeProvider.Complete(ctx, req)
+}
+
+// TestRunCapture_DegradedTailPass_ExcludedFromMedian is the regression test
+// for H2 (round-2 review of #2814): a request captured on pass 1 but absent
+// from every later pass is NOT run-missing (runCapture's capturedIDs check
+// only needs ONE pass to have produced it — manifest.MissingCount stays 0
+// here) — but score.go's ScoreRun scores that request as a hard FAIL on
+// every pass that lacks it, dragging medianValidatePassRate/
+// medianSemanticMatchRate toward zero under a manifest that otherwise
+// looks completely clean (MissingCount == 0 means
+// reportCaptureCompleteness has nothing to say, and generate-capture.yml's
+// banner is gated on MISSING, not on this).
+//
+// Unlike M1's weak regression test (transcript_capture_test.go's own review
+// history), this one drives the real runCapture end to end rather than
+// hand-building a Candidates map — reverting the clean-pass-median fix in
+// runCapture (i.e. always using ms.ValidatePassRate/ms.SemanticMatchRate
+// computed over ALL passes) makes this test fail: with req-b flaky on
+// passes 2-3, the naive full-corpus median comes out to 2/3 (0.667), not 1.
+func TestRunCapture_DegradedTailPass_ExcludedFromMedian(t *testing.T) {
+	const flakyMarker = "TRIGGER_TAIL_FLAKE"
+	requests := []Request{
+		capturePipelineRequest("req-a"),
+		{
+			ID:     "req-b",
+			Prompt: "read from the generator and write to the log " + flakyMarker,
+			Expect: Expect{SourceCategory: "generator", DestinationCategory: "log"},
+		},
+		capturePipelineRequest("req-c"),
+	}
+
+	reply := "```yaml\n" + validCandidate + "```"
+	base := &fakeProvider{replies: []string{reply}, tokens: 20}
+	flakyErr := fmt.Errorf("429: rate limited")
+	fp := &flakyAfterFirstCallProvider{fakeProvider: base, marker: flakyMarker, err: flakyErr}
+	cp := &captureProvider{Provider: fp, maxCalls: 1000, maxTokens: 1_000_000}
+
+	destDir := filepath.Join(t.TempDir(), "anthropic", "claude-sonnet-5-test")
+	const passes = 3
+
+	manifest, _, wrote := runCapture(context.Background(), t, requests, cp, "anthropic", "claude-sonnet-5-test", passes, destDir)
+
+	if !wrote {
+		t.Fatal("expected the manifest to still be written: req-b captured on pass 1, so nothing is run-missing")
+	}
+	if manifest.CapturedCount != 3 {
+		t.Fatalf("manifest.CapturedCount = %d, want 3 (req-b captured on pass 1 counts as captured overall)", manifest.CapturedCount)
+	}
+	if manifest.MissingCount != 0 {
+		t.Fatalf("manifest.MissingCount = %d, want 0 — this is exactly the H2 scenario: run-missing and "+
+			"pass-missing are different things", manifest.MissingCount)
+	}
+
+	wantDegraded := []int{2, 3}
+	if !reflect.DeepEqual(manifest.DegradedPasses, wantDegraded) {
+		t.Fatalf("manifest.DegradedPasses = %v, want %v", manifest.DegradedPasses, wantDegraded)
+	}
+	if len(manifest.PassScores) != passes {
+		t.Fatalf("len(manifest.PassScores) = %d, want %d", len(manifest.PassScores), passes)
+	}
+	wantPassMissing := []int{0, 1, 1}
+	for i, ps := range manifest.PassScores {
+		if ps.MissingCount != wantPassMissing[i] {
+			t.Fatalf("PassScores[%d].MissingCount = %d, want %d", i, ps.MissingCount, wantPassMissing[i])
+		}
+	}
+
+	// The regression this test guards against: only pass 1 is clean (all 3
+	// requests validate), so the median MUST be computed over pass 1 alone
+	// — 1.0 — never diluted by passes 2-3's req-b-scored-as-fail 2/3 rate.
+	if manifest.MedianValidatePassRate != 1 {
+		t.Fatalf("manifest.MedianValidatePassRate = %v, want 1 — a degraded tail pass must not drag this "+
+			"toward zero when MissingCount is 0 (H2)", manifest.MedianValidatePassRate)
+	}
+	if manifest.MedianSemanticMatchRate != 1 {
+		t.Fatalf("manifest.MedianSemanticMatchRate = %v, want 1 — same regression, semantic axis", manifest.MedianSemanticMatchRate)
 	}
 }
 
@@ -1474,7 +1719,7 @@ func TestRunCapture_PartialFailure_TombstoneAndBijection(t *testing.T) {
 	requests, cp, destDir, _ := partialFailureFixture(t)
 	const passes = 3
 
-	_, wrote := runCapture(context.Background(), t, requests, cp, "anthropic", "claude-sonnet-5-test", passes, destDir)
+	_, _, wrote := runCapture(context.Background(), t, requests, cp, "anthropic", "claude-sonnet-5-test", passes, destDir)
 	if !wrote {
 		t.Fatal("expected the manifest to still be written: 1/3 missing is below the run-failing threshold")
 	}
@@ -1500,8 +1745,17 @@ func TestRunCapture_PartialFailure_TombstoneAndBijection(t *testing.T) {
 	}
 }
 
-// Test_RunCapture_ProviderHTTPErrorNeverLeaksResponseBodyIntoManifest is the
-// regression test for the finding that a provider error's raw HTTP response
+// TestRunCapture_ProviderHTTPErrorNeverLeaksResponseBodyIntoManifest —
+// renamed from Test_RunCapture_... (round-2 review of #2814): the leading
+// underscore after "Test" broke substring matching against a `-run
+// 'TestRunCapture'` filter (Go's `-run` is a regexp match against the test
+// name; "Test_RunCapture" does not contain "TestRunCapture" as a substring
+// because of the underscore), which would silently skip this test — the
+// most important regression test in this file — from any invocation using
+// that pattern. Every other TestRunCapture_* test in this file already used
+// the no-underscore form; this was the one holdout.
+//
+// This is the regression test for the finding that a provider error's raw HTTP response
 // body (readErrorBody, provider/http.go — up to 512 bytes, provider-
 // controlled) could reach RequestOutcome.FailureReason and then
 // manifest.yaml, a committed file, completely unscanned. It drives a REAL
@@ -1514,7 +1768,7 @@ func TestRunCapture_PartialFailure_TombstoneAndBijection(t *testing.T) {
 // key). That text must never appear anywhere in the manifest — only the
 // structured, safe summary (safeFailureReason: a conduiterr code plus the
 // HTTP status) does.
-func Test_RunCapture_ProviderHTTPErrorNeverLeaksResponseBodyIntoManifest(t *testing.T) {
+func TestRunCapture_ProviderHTTPErrorNeverLeaksResponseBodyIntoManifest(t *testing.T) {
 	const failMarker = "TRIGGER_401"
 	const leakedSecret = "sk-ant-1234567890abcdefghijklmnop"
 	leakedBody := `{"error":{"type":"authentication_error","message":"Incorrect API key provided: ` + leakedSecret + `"}}`
@@ -1551,7 +1805,7 @@ func Test_RunCapture_ProviderHTTPErrorNeverLeaksResponseBodyIntoManifest(t *test
 	cp := &captureProvider{Provider: base, maxCalls: 1000, maxTokens: 1_000_000}
 	destDir := filepath.Join(t.TempDir(), "anthropic", "claude-sonnet-5-test")
 
-	manifest, wrote := runCapture(context.Background(), t, requests, cp, "anthropic", "claude-sonnet-5-test", 1, destDir)
+	manifest, _, wrote := runCapture(context.Background(), t, requests, cp, "anthropic", "claude-sonnet-5-test", 1, destDir)
 	if !wrote {
 		t.Fatal("expected the manifest to be written: 1/2 missing is at, not past, the run-failing threshold")
 	}
@@ -1616,42 +1870,57 @@ func Test_RunCapture_ProviderHTTPErrorNeverLeaksResponseBodyIntoManifest(t *test
 // (empty string on this path) BEFORE checking len(raw) == 0, so the map
 // always carried a key for the id — ScoreRun then saw `ok == true` and
 // scored a 429 as "the model produced a candidate that failed validation"
-// instead of "no candidate was ever produced". This proves runCapture's
-// contract with ScoreRun directly: a Candidates map built the same way
-// runCapture builds it (see the "absence of data" branch in its per-request
-// closure) must have NO entry at all for a request with no completion, so
-// ScoreRun reports Missing.
+// instead of "no candidate was ever produced".
+//
+// M1 (round-2 review of #2814): the previous version of this test never
+// called runCapture at all — it hand-built a Candidates map "mirroring
+// exactly what runCapture's per-request closure does today" and asserted
+// on ScoreRun directly, which is a property that was already true before
+// the fix and stays true if the fix is reverted; it is not a regression
+// test for runCapture's own map-building bug. This version drives the real
+// runCapture end to end (reusing partialFailureFixture's permanently-failing
+// req-b, shared with TestRunCapture_PartialFailure_PreservesGoodTranscripts)
+// and inspects the per-pass RunScore.Results runCapture's own passRuns
+// return value carries — so it fails if runCapture ever again inserts an
+// empty-string entry instead of omitting the key.
 func TestRunCapture_MissingRequest_ScoredAsMissingNotFailedCandidate(t *testing.T) {
-	requests := []Request{capturePipelineRequest("req-ok"), capturePipelineRequest("req-missing")}
+	requests, cp, destDir, _ := partialFailureFixture(t)
+	const passes = 3
 
-	// Mirrors exactly what runCapture's per-request closure does today:
-	// only a request whose raw completions are non-empty gets a
-	// passCandidates entry at all.
-	candidates := Candidates{"req-ok": validCandidate}
+	_, passRuns, wrote := runCapture(context.Background(), t, requests, cp, "anthropic", "claude-sonnet-5-test", passes, destDir)
+	if !wrote {
+		t.Fatal("expected the manifest to still be written: 1/3 missing is below the run-failing threshold")
+	}
+	if len(passRuns) != passes {
+		t.Fatalf("len(passRuns) = %d, want %d", len(passRuns), passes)
+	}
 
-	rs := ScoreRun(context.Background(), requests, candidates)
-
-	var gotMissing, gotOK bool
-	for _, res := range rs.Results {
-		switch res.RequestID {
-		case "req-missing":
-			gotMissing = true
-			if !res.Missing {
-				t.Fatal("req-missing: Missing = false, want true — a request with no completion must never be " +
-					"scored as a failed candidate")
-			}
-			if res.ValidatePass {
-				t.Fatal("req-missing: ValidatePass = true, want false")
-			}
-		case "req-ok":
-			gotOK = true
-			if res.Missing {
-				t.Fatal("req-ok: Missing = true, want false")
+	for i, rs := range passRuns {
+		var gotMissing, gotOK bool
+		for _, res := range rs.Results {
+			switch res.RequestID {
+			case "req-b": // permanently fails every pass, per partialFailureFixture
+				gotMissing = true
+				if !res.Missing {
+					t.Fatalf("pass %d: req-b: Missing = false, want true — a request runCapture never got a "+
+						"completion for must never be scored as a failed candidate", i+1)
+				}
+				if res.ValidatePass {
+					t.Fatalf("pass %d: req-b: ValidatePass = true, want false", i+1)
+				}
+				if res.SemanticMatch {
+					t.Fatalf("pass %d: req-b: SemanticMatch = true, want false", i+1)
+				}
+			case "req-a", "req-c":
+				gotOK = true
+				if res.Missing {
+					t.Fatalf("pass %d: %s: Missing = true, want false", i+1, res.RequestID)
+				}
 			}
 		}
-	}
-	if !gotMissing || !gotOK {
-		t.Fatalf("expected results for both req-ok and req-missing, got %+v", rs.Results)
+		if !gotMissing || !gotOK {
+			t.Fatalf("pass %d: expected results for both req-b and the healthy requests, got %+v", i+1, rs.Results)
+		}
 	}
 }
 

--- a/cmd/conduit/internal/generate/transcript_capture_test.go
+++ b/cmd/conduit/internal/generate/transcript_capture_test.go
@@ -812,28 +812,35 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 	lastFailureErr := make(map[string]error)
 
 	var scoreCandidatesList []Candidates
-	// scoreMissingCounts[i] is how many of len(requests) contributed NO
-	// USABLE candidate to scoreCandidatesList[i] — either no completion was
-	// ever recorded on that pass (no map entry — see the inline comment
-	// below on why passCandidates omits, rather than empty-strings, those
-	// entries) OR a completion WAS recorded but never extracted into
-	// pipeline YAML (an empty/whitespace-only entry: Generate exhausted
-	// every attempt without ever producing a candidate — B2, round-3 review
-	// of #2814). requestsMissingUsableCandidate treats both the same way
-	// ScoreRun (score.go) itself does — a pass full of unparseable
-	// completions is exactly as degraded as one the provider never answered
-	// at all. Kept as a parallel slice, index-aligned with
-	// scoreCandidatesList (and therefore with ms.Runs below), rather than
-	// added to RunScore/ScoreRun: score.go's Result.Missing already carries
-	// the no-completion half of this per-request, and re-deriving the
-	// per-pass count from passCandidates here is cheaper than plumbing a
-	// new field through ScoreRun for a number runCapture already has for
-	// free. This is what lets a degraded tail pass (a rate-limit storm, or
+	// scoreMissingSets[i] is which of requests' ids contributed NO USABLE
+	// candidate to scoreCandidatesList[i] — either no completion was ever
+	// recorded on that pass (no map entry — see the inline comment below on
+	// why passCandidates omits, rather than empty-strings, those entries)
+	// OR a completion WAS recorded but never extracted into pipeline YAML
+	// (an empty/whitespace-only entry: Generate exhausted every attempt
+	// without ever producing a candidate — B2, round-3 review of #2814).
+	// requestsMissingUsableCandidate treats both the same way ScoreRun
+	// (score.go) itself does — a pass full of unparseable completions is
+	// exactly as degraded as one the provider never answered at all. Kept
+	// as a parallel slice, index-aligned with scoreCandidatesList (and
+	// therefore with ms.Runs below), rather than added to RunScore/ScoreRun:
+	// score.go's Result.Missing already carries the no-completion half of
+	// this per-request, and re-deriving the per-pass set from
+	// passCandidates here is cheaper than plumbing a new field through
+	// ScoreRun for something runCapture already has for free. This is what
+	// lets a degraded tail pass (a rate-limit storm, or
 	// captureWallClockBudget expiring partway through) be excluded from the
 	// median instead of silently dragging
 	// MedianValidatePassRate/MedianSemanticMatchRate toward zero — see
 	// PassScore.MissingCount and Manifest.DegradedPasses.
-	var scoreMissingCounts []int
+	//
+	// H1 (round-4 review of #2814): this used to be scoreMissingCounts, a
+	// parallel []int — a per-pass COUNT alone cannot tell summarizePasses
+	// whether two degraded passes missed the same requests or different
+	// ones, which is exactly the distinction between a stable partial
+	// result and a misleading one (allMissingSetsEqual). The id set is the
+	// smallest thing that preserves that distinction.
+	var scoreMissingSets [][]string
 	for pass := 1; pass <= passes; pass++ {
 		passCandidates := make(Candidates, len(requests))
 		for _, req := range requests {
@@ -914,7 +921,7 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 		// never per-pass.
 		if len(attempted) == len(requests) {
 			scoreCandidatesList = append(scoreCandidatesList, passCandidates)
-			scoreMissingCounts = append(scoreMissingCounts, requestsMissingUsableCandidate(requests, passCandidates))
+			scoreMissingSets = append(scoreMissingSets, requestsMissingUsableCandidate(requests, passCandidates))
 		} else {
 			t.Logf("pass %d: %d/%d requests ran (a -run filter is scoping this to a subset) — "+
 				"excluded from corpus-level scoring and the manifest", pass, len(attempted), len(requests))
@@ -951,11 +958,21 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 	t.Logf("promoted %d transcript(s) into %q", len(moved), destDir)
 
 	// capturedIDs is derived straight from what scanAndPromoteScratch
-	// actually promoted — the single source of truth for "captured", so
-	// this can never disagree with what landed in destDir (in particular:
-	// if the redaction gate above blocked the whole batch, moved is empty
-	// and EVERY attempted request reports as missing here, which is
-	// correct — nothing was promoted for any of them).
+	// actually promoted THIS run (in particular: if the redaction gate
+	// above blocked the whole batch, moved is empty and every attempted
+	// request has no entry here, correctly — nothing was promoted for any
+	// of them). It is deliberately NOT the sole source of truth for
+	// "captured" any more — see requestIsCaptured (H2 fix, round-4 review
+	// of #2814): an earlier run may have already committed a real
+	// transcript for an id THIS run's own attempt failed to reproduce
+	// (provider down, rate-limited, a tripped ceiling, …), and that data is
+	// still good. An earlier version of this code treated capturedIDs
+	// alone as authoritative, recording Captured: false plus a
+	// FailureReason for exactly that id, and only noticed the
+	// already-on-disk case late enough to skip writing a (redundant)
+	// tombstone over it — leaving RequestOutcomes, and therefore the
+	// committed manifest.yaml, contradicting a tree that still had real
+	// data for this id.
 	capturedIDs := make(map[string]bool, len(moved))
 	for _, name := range moved {
 		capturedIDs[strings.TrimSuffix(name, ".yaml")] = true
@@ -964,16 +981,17 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 	outcomes := make([]RequestOutcome, len(attemptOrder))
 	capturedCount, missingCount := 0, 0
 	for i, req := range attemptOrder {
-		captured := capturedIDs[req.ID]
+		captured := requestIsCaptured(capturedIDs, req.ID, destDir)
 		outcomes[i] = RequestOutcome{RequestID: req.ID, Captured: captured}
 
-		tombstonePath := filepath.Join(destDir, req.ID+tombstoneFileSuffix)
 		if captured {
 			capturedCount++
 			// A previous run's tombstone for this id, if any, is now
-			// stale — this id has real data again, and LoadTranscripts
-			// hard-errors on an id carrying both a transcript and a
-			// tombstone (transcript.go).
+			// stale — this id has real data again (whether promoted THIS
+			// run or already on disk from an earlier one), and
+			// LoadTranscripts hard-errors on an id carrying both a
+			// transcript and a tombstone (transcript.go).
+			tombstonePath := filepath.Join(destDir, req.ID+tombstoneFileSuffix)
 			if err := os.Remove(tombstonePath); err != nil && !os.IsNotExist(err) {
 				t.Fatalf("removing stale tombstone %q: %v", tombstonePath, err)
 			}
@@ -988,13 +1006,6 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 		outcomes[i].FailureReason = reason
 		outcomes[i].Unusable = unusable[req.ID]
 
-		if _, err := os.Stat(filepath.Join(destDir, req.ID+".yaml")); err == nil {
-			// An earlier run already committed a real transcript for this
-			// id; THIS run's failure to reproduce it does not retroactively
-			// invalidate that data — never overwrite a real transcript
-			// with a tombstone.
-			continue
-		}
 		writeTombstone(t, destDir, Tombstone{
 			SchemaVersion:      TranscriptSchemaVersion,
 			RequestID:          req.ID,
@@ -1015,14 +1026,19 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 	}
 
 	ms := ScoreMedian(ctx, requests, scoreCandidatesList)
-	passScores, degradedMedians := summarizePasses(ms.Runs, scoreMissingCounts)
+	passScores, degradedMedians := summarizePasses(ms.Runs, scoreMissingSets)
 
 	switch {
 	case degradedMedians.allDegraded:
-		// B1 fix (round-3 review of #2814): every one of `passes` passes
-		// lost the full corpus (a rate-limit storm, or
+		// B1 fix (round-3 review of #2814), generalized by H1 (round-4
+		// review of #2814): every one of `passes` passes lost the full
+		// corpus AND the passes disagree about which requests they missed
+		// (allMissingSetsEqual is false) — a rate-limit storm or
 		// captureWallClockBudget expiring partway through and wiping every
-		// pass from that point on) — summarizePasses has no clean pass
+		// pass from that point on is one way to get here, but so is a
+		// provider that rotates which single request it answers pass to
+		// pass (no pass ever wiped, yet no two passes miss the same
+		// requests either). Either way summarizePasses has no clean pass
 		// left to compute a median FROM, so validateRate/semanticRate below
 		// are its all-passes fallback, which scores every missing request
 		// as a hard fail with nothing to dilute it. Treated as a hard
@@ -1038,7 +1054,7 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 		// Manifest.MediansUnreliable (set below) carries the same fact
 		// into the committed file for a reader who never sees the PR body.
 		t.Errorf("every one of %d capture pass(es) was degraded (see passScores[].missingCount) — no pass "+
-			"produced a completion for the full corpus, so medianValidatePassRate (%.3f) and "+
+			"contributed a usable candidate for the full corpus, so medianValidatePassRate (%.3f) and "+
 			"medianSemanticMatchRate (%.3f) below are a fallback computed across ALL passes, with every "+
 			"missing request scored as a hard fail and no clean pass to dilute that — NOT a reliable "+
 			"median, and must not be used as this run's baseline. Whatever WAS captured is still promoted "+
@@ -1053,15 +1069,32 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 		// request captured (missingCount == 0, so
 		// reportCaptureCompleteness has nothing to say) while still
 		// having lost a tail pass to rate limiting, which is exactly the
-		// case this exists to surface. Only reached when at least one
-		// OTHER pass was clean (the allDegraded case above is handled
-		// separately), so "excluded... so a wiped tail pass does not
-		// silently drag those numbers toward zero" is actually true here.
+		// case this exists to surface. Reached whenever at least one pass
+		// is degraded but summarizePasses did NOT judge the situation
+		// misleading (allDegraded above is false) — either because at
+		// least one OTHER pass was clean, or because every degraded pass
+		// missed the exact same request set (a stable, non-misleading
+		// partial result — allMissingSetsEqual; H1, round-4 review of
+		// #2814 fixed an earlier version of this comment that assumed only
+		// the first case was possible here, which was never true: a
+		// chronic single-missing-request run also reaches this branch with
+		// ZERO clean passes).
 		t.Logf("pass(es) %v captured fewer than the full corpus (see passScores[].missingCount in the "+
 			"manifest) — excluded from medianValidatePassRate/medianSemanticMatchRate so a wiped tail pass "+
 			"does not silently drag those numbers toward zero; requests affected may still show as captured "+
 			"overall (capturedCount/missingCount) if another pass produced them", degradedMedians.degradedPasses)
 	}
+
+	// H2 fix (round-4 review of #2814): a run that promoted NOTHING new
+	// learned nothing about the corpus's quality — passScores/
+	// degradedMedians above, computed from zero completions, are pure,
+	// uninformative zeros, not a real measurement, and must not overwrite
+	// an existing manifest.yaml's real ones. See
+	// preserveMediansIfNothingPromoted's own doc comment. Split out from
+	// this function (kept runCapture's own cyclomatic complexity under
+	// gocyclo's threshold, the same reason finishScopedRun and
+	// summarizePasses were split out for earlier rounds of #2814's review).
+	passScores, degradedMedians = preserveMediansIfNothingPromoted(t, destDir, moved, passScores, degradedMedians)
 
 	manifest = Manifest{
 		SchemaVersion:            TranscriptSchemaVersion,
@@ -1128,6 +1161,76 @@ func finishScopedRun(t *testing.T, destDir string, outcomes []RequestOutcome, ca
 	t.Logf("patched manifest.yaml's requestOutcomes/capturedCount/missingCount for %d scoped request(s); "+
 		"medians/passScores still describe the last full run", len(outcomes))
 	return patched, nil, true
+}
+
+// requestIsCaptured reports whether id counts as captured for this run's
+// RequestOutcome/CapturedCount/MissingCount bookkeeping: either
+// scanAndPromoteScratch promoted it THIS run (capturedIDs), or an earlier
+// run already left a real "<id>.yaml" transcript in destDir that this run's
+// own failure to reproduce does not invalidate (H2 fix, round-4 review of
+// #2814 — see capturedIDs' own doc comment in runCapture for the
+// contradiction this replaces). Split out as its own function, rather than
+// inlined as an `if` in runCapture, purely to keep that function's
+// cyclomatic complexity under gocyclo's threshold (the same reason
+// finishScopedRun, summarizePasses, and preserveMediansIfNothingPromoted
+// were split out for earlier rounds of #2814's review) — there is no
+// independent testability reason for the split here, unlike those.
+func requestIsCaptured(capturedIDs map[string]bool, id, destDir string) bool {
+	if capturedIDs[id] {
+		return true
+	}
+	_, err := os.Stat(filepath.Join(destDir, id+".yaml"))
+	return err == nil
+}
+
+// preserveMediansIfNothingPromoted is runCapture's H2 fix (round-4 review of
+// #2814): moved is what scanAndPromoteScratch actually promoted THIS run
+// (runCapture's own single source of truth for "captured"); when it is
+// empty, every scoreCandidatesList entry this run built was empty too, so
+// passScores/degradedMedians — computed by summarizePasses from zero
+// completions — are pure, uninformative zeros, not a real measurement of
+// anything. Writing them into manifest.yaml would silently replace an
+// EXISTING file's real, previously-measured
+// Median*/PassScores/DegradedPasses/MediansUnreliable fields with a
+// fabricated 0.00 baseline from a run that never generated anything to
+// score — the reviewer's "a run that promoted nothing learned nothing about
+// the corpus" concern, and the second half of the same failure mode the
+// disposition-carry-forward fix in runCapture's own outcomes loop addresses
+// for CapturedCount/MissingCount/RequestOutcomes: a run with nothing new to
+// report must not look like a run that MEASURED zero quality.
+//
+// Returns passScores/degradedMedians unchanged when moved is non-empty
+// (the common case), or when there is no existing manifest.yaml to load
+// (LoadManifest errors) — a first-ever run has no real baseline to
+// preserve, so the fresh, if uninformative, zeros stand; that scenario is
+// also independently caught by reportCaptureCompleteness's
+// captureCompletenessVerdict, which fails a run that attempted requests and
+// captured none of them regardless of what this function does.
+func preserveMediansIfNothingPromoted(
+	t *testing.T, destDir string, moved []string, passScores []PassScore, degradedMedians passesSummary,
+) ([]PassScore, passesSummary) {
+	t.Helper()
+	if len(moved) > 0 {
+		return passScores, degradedMedians
+	}
+
+	prior, err := LoadManifest(filepath.Join(destDir, manifestFileName))
+	if err != nil {
+		return passScores, degradedMedians
+	}
+
+	t.Logf("this run promoted no new transcripts — preserving the existing manifest's median/pass-score "+
+		"fields (from a run of %d passes) rather than overwriting them with zeros this run never measured",
+		prior.Passes)
+	return prior.PassScores, passesSummary{
+		degradedPasses: prior.DegradedPasses,
+		validateRate:   prior.MedianValidatePassRate,
+		semanticRate:   prior.MedianSemanticMatchRate,
+		validateCount:  prior.MedianValidatePassCount,
+		semanticCount:  prior.MedianSemanticMatchCount,
+		sampleSize:     prior.MedianSampleSize,
+		allDegraded:    prior.MediansUnreliable,
+	}
 }
 
 // patchManifestForScopedRun updates an EXISTING manifest.yaml in destDir
@@ -1262,9 +1365,9 @@ func TestPatchManifestForScopedRun_AppendsUnknownID(t *testing.T) {
 	}
 }
 
-// requestsMissingUsableCandidate counts, for one pass's passCandidates, how
-// many corpus requests contributed no USABLE candidate — either no
-// completion was ever recorded for that request this pass (no map entry:
+// requestsMissingUsableCandidate returns, for one pass's passCandidates, the
+// corpus request ids that pass contributed no USABLE candidate for — either
+// no completion was ever recorded for that request this pass (no map entry:
 // passCandidates[req.ID] then reads as Go's zero value for string, "",
 // exactly like an explicit empty entry would) or a completion WAS recorded
 // but every attempt failed to extract pipeline YAML from it (an explicit
@@ -1276,14 +1379,51 @@ func TestPatchManifestForScopedRun_AppendsUnknownID(t *testing.T) {
 // nothing but unparseable garbage for every request is exactly as degraded,
 // for Manifest.DegradedPasses/MedianValidatePassRate purposes, as one the
 // provider never answered at all.
-func requestsMissingUsableCandidate(requests []Request, passCandidates Candidates) int {
-	missing := 0
+//
+// The result is in requests order (the same []Request slice for every pass
+// of a run), never re-sorted — that makes it directly, positionally
+// comparable across passes (allMissingSetsEqual) without a separate sort
+// step. H1 (round-4 review of #2814): this used to return only a count,
+// which cannot distinguish "every pass missed the same requests" (a stable,
+// non-misleading partial result) from "each pass missed a DIFFERENT subset"
+// (the rotating-429s case that made a corpus scoring 1.00 on every
+// individual request publish a 0.20 median) — summarizePasses needs the
+// actual id set, not just how many.
+func requestsMissingUsableCandidate(requests []Request, passCandidates Candidates) []string {
+	var missing []string
 	for _, req := range requests {
 		if strings.TrimSpace(passCandidates[req.ID]) == "" {
-			missing++
+			missing = append(missing, req.ID)
 		}
 	}
 	return missing
+}
+
+// allMissingSetsEqual reports whether every pass in sets missed exactly the
+// same corpus request ids, in the same order. Every element of sets was
+// built by requestsMissingUsableCandidate from the SAME requests slice (one
+// call per pass, within a single runCapture invocation), so a set that
+// misses the same ids as another pass always lists them in the same
+// position — a direct, positional comparison is exact set equality here,
+// not merely same-length.
+//
+// len(sets) < 2 is vacuously true: there is nothing to disagree with.
+func allMissingSetsEqual(sets [][]string) bool {
+	if len(sets) < 2 {
+		return true
+	}
+	first := sets[0]
+	for _, s := range sets[1:] {
+		if len(s) != len(first) {
+			return false
+		}
+		for i, id := range first {
+			if s[i] != id {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // passesSummary is summarizePasses' reduction of a capture run's per-pass
@@ -1306,25 +1446,34 @@ type passesSummary struct {
 	// over 3 both render as one number without this.
 	sampleSize int
 	// allDegraded is true when every pass in runs was degraded (no pass
-	// produced a completion for the full corpus) AND at least one of those
-	// passes was WIPED (missing every single corpus request, not just
-	// some) — see summarizePasses' doc comment for why both conditions are
-	// required, and for what the four fields above mean in that case.
-	// runCapture treats this as a hard failure (B1, round-3 review of
-	// #2814), the same class of thing captureCompletenessVerdict already
-	// does for attemptedCount == 0.
+	// contributed a usable candidate for the full corpus) AND those
+	// degraded passes do not all miss the SAME set of request ids
+	// (!allMissingSetsEqual) — see summarizePasses' doc comment for why
+	// both conditions are required, and for what the four fields above
+	// mean in that case. runCapture treats this as a hard failure (B1,
+	// round-3 review of #2814), the same class of thing
+	// captureCompletenessVerdict already does for attemptedCount == 0.
+	//
+	// H1 (round-4 review of #2814): this used to require "at least one
+	// pass was WIPED (missing every request)" instead of "the missing sets
+	// disagree" — a proxy that missed the actual failure mode: 5 passes
+	// each capturing exactly one different request (never a whole pass
+	// wiped, so the old condition never fired) still leaves n == 0 with a
+	// DIFFERENT set of missing ids every time, which is exactly as
+	// misleading as a wipe. See allMissingSetsEqual's doc comment.
 	allDegraded bool
 }
 
 // summarizePasses builds Manifest.PassScores and reduces runs (ms.Runs from
 // ScoreMedian) to the median rates/counts the manifest reports, given
-// missingCounts — index-aligned with runs, how many corpus requests
-// produced NO completion on that specific pass (runCapture's
-// scoreMissingCounts). Split out from runCapture as its own function (kept
-// runCapture's own cyclomatic complexity under gocyclo's threshold, and
-// this reduction is an independently-testable concern in its own right).
+// missingSets — index-aligned with runs, the corpus request ids that pass
+// contributed no usable candidate for (runCapture's scoreMissingSets,
+// requestsMissingUsableCandidate). Split out from runCapture as its own
+// function (kept runCapture's own cyclomatic complexity under gocyclo's
+// threshold, and this reduction is an independently-testable concern in its
+// own right).
 //
-// A pass with missingCounts[i] > 0 is "degraded" (see PassScore.
+// A pass with len(missingSets[i]) > 0 is "degraded" (see PassScore.
 // MissingCount and Manifest.DegradedPasses for what that means and why —
 // H2, round-2 review of #2814): it is excluded from the returned median so
 // a wiped tail pass (a rate-limit storm, or captureWallClockBudget
@@ -1341,30 +1490,44 @@ type passesSummary struct {
 // (identical to this function's pre-H2 behavior, and mathematically
 // identical to ScoreMedian's own reduction), which is NOT "the median
 // across every clean pass" those fields otherwise mean, because
-// scoreMissingCounts still scores every missing request as a hard fail on
+// scoreMissingSets still scores every missing request as a hard fail on
 // both axes (score.go's ScoreRun) with no clean pass to dilute that.
 //
 // That fallback is not automatically UNTRUSTWORTHY, though: a single
 // request that is chronically missing across every pass (the same one
 // request, every time — ordinary live-provider noise, already handled as a
 // routine partial result by captureCompletenessVerdict below its majority
-// threshold) leaves every pass's own rate identical and stable, so the
-// all-passes median equals what a "clean-pass" median would have shown
-// too. The case that IS misleading is B1 (round-3 review of #2814): one or
-// more passes WIPED entirely (missing every single corpus request, not
-// just one) — the signature of captureWallClockBudget expiring before a
-// pass even started, or a rate-limit storm eating the whole pass — which
-// contributes a raw, uninformative 0 to the median regardless of how well
-// the requests that WERE captured actually scored. Reproduced: 3 passes,
-// 2 wiped down to zero after a wall-clock budget expiry midway through
-// pass 1, computes a median of 0.00 even though every request captured on
-// pass 1 validated cleanly — the fallback IS what produces that
-// misleadingly low number, not a defense against one. allDegraded (below)
-// is true only when BOTH conditions hold (no clean pass AND at least one
-// wiped pass), so the caller can fail the run for the actual failure mode
-// without also failing on ordinary single-request flakiness — see
-// runCapture's own handling and Manifest.MediansUnreliable.
-func summarizePasses(runs []RunScore, missingCounts []int) ([]PassScore, passesSummary) {
+// threshold) leaves every pass's own missing SET identical, and therefore
+// every pass's own rate identical and stable too, so the all-passes median
+// equals what a "clean-pass" median would have shown too. The case that IS
+// misleading is when the degraded passes disagree about WHICH requests they
+// missed — B1 (round-3 review of #2814) found this via the special case of
+// one or more passes WIPED entirely (missing every single corpus request,
+// which trivially disagrees with a partially-degraded pass's smaller
+// missing set): the signature of captureWallClockBudget expiring before a
+// pass even started, or a rate-limit storm eating the whole pass.
+// Reproduced: 3 passes, 2 wiped down to zero after a wall-clock budget
+// expiry midway through pass 1, computes a median of 0.00 even though every
+// request captured on pass 1 validated cleanly — the fallback IS what
+// produces that misleadingly low number, not a defense against one.
+//
+// H1 (round-4 review of #2814): "at least one pass was WIPED" is only ONE
+// way the missing sets can disagree, and checking for it specifically
+// missed the more general failure mode — 5 passes, each capturing exactly
+// one different request and missing the other four (rotating 429s: pass p
+// captures only request p) has NO wiped pass at all (every pass captures
+// something) yet still disagrees pass to pass about which four requests it
+// missed, and is exactly as misleading as a wipe: every individual request
+// actually validates 1/1 when captured, but the old WIPED-only condition
+// read this as a stable partial result and published a 0.20 median.
+// allMissingSetsEqual replaces the narrower wipe check with the general
+// one: are the degraded passes missing the SAME requests, or different
+// ones. allDegraded (below) is true only when BOTH conditions hold (no
+// clean pass AND the missing sets disagree), so the caller can fail the
+// run for the actual failure mode without also failing on ordinary
+// single-request flakiness — see runCapture's own handling and
+// Manifest.MediansUnreliable.
+func summarizePasses(runs []RunScore, missingSets [][]string) ([]PassScore, passesSummary) {
 	passScores := make([]PassScore, len(runs))
 	allValidateRates := make([]float64, len(runs))
 	allSemanticRates := make([]float64, len(runs))
@@ -1372,12 +1535,12 @@ func summarizePasses(runs []RunScore, missingCounts []int) ([]PassScore, passesS
 	allSemanticCounts := make([]int, len(runs))
 
 	var degradedPasses []int
+	var degradedMissingSets [][]string
 	var cleanValidateRates, cleanSemanticRates []float64
 	var cleanValidateCounts, cleanSemanticCounts []int
-	var anyPassWiped bool
 
 	for i, rs := range runs {
-		passMissing := missingCounts[i]
+		passMissing := len(missingSets[i])
 		passScores[i] = PassScore{
 			Pass:               i + 1,
 			Total:              rs.Total,
@@ -1394,18 +1557,7 @@ func summarizePasses(runs []RunScore, missingCounts []int) ([]PassScore, passesS
 
 		if passMissing > 0 {
 			degradedPasses = append(degradedPasses, i+1)
-			// A WIPED pass (missing every single corpus request — Total > 0
-			// and passMissing == Total) is what makes the all-passes
-			// fallback below untrustworthy (see allDegraded): it is the
-			// signature of captureWallClockBudget expiring before the pass
-			// even started, or a rate-limit storm that ate the whole pass,
-			// not ordinary per-request noise (one chronically-flaky
-			// request, present in every OTHER pass's missingCounts too,
-			// still leaves each pass's rate a stable, meaningful number —
-			// see allDegraded's own doc comment).
-			if rs.Total > 0 && passMissing == rs.Total {
-				anyPassWiped = true
-			}
+			degradedMissingSets = append(degradedMissingSets, missingSets[i])
 			continue
 		}
 		cleanValidateRates = append(cleanValidateRates, rs.ValidatePassRate)
@@ -1430,20 +1582,22 @@ func summarizePasses(runs []RunScore, missingCounts []int) ([]PassScore, passesS
 		summary.semanticCount = medianInt(cleanSemanticCounts)
 		summary.sampleSize = n
 	}
-	// allDegraded requires BOTH no clean pass (n == 0) AND at least one
-	// WIPED pass — n == 0 alone is not enough: a single request that is
-	// chronically missing across every pass (present in no pass's
-	// candidates at all, but the SAME one request every time) also leaves
-	// n == 0, yet every pass's rate is identical and stable — reporting the
+	// allDegraded requires BOTH no clean pass (n == 0) AND the degraded
+	// passes disagreeing about which requests they missed
+	// (!allMissingSetsEqual) — n == 0 alone is not enough: a single
+	// request that is chronically missing across every pass (present in no
+	// pass's candidates at all, but the SAME one request every time, so
+	// every degraded pass's missing set is identical) also leaves n == 0,
+	// yet every pass's rate is identical and stable — reporting the
 	// all-passes median in that case is not misleading, it is the true
 	// answer, and this is exactly the "normal partial result" scenario
 	// captureCompletenessVerdict already treats as routine below its
-	// majority threshold. Requiring a wiped pass too narrows this to the
-	// actual failure mode B1 (round-3 review of #2814) found: one or more
-	// passes contributing a raw, uninformative 0 because they captured
-	// NOTHING, dragging the median toward zero in a way no individual
-	// pass's own rate would suggest.
-	summary.allDegraded = n == 0 && anyPassWiped
+	// majority threshold. Comparing the actual missing-id sets (H1, round-4
+	// review of #2814) narrows this to the real failure mode: passes that
+	// disagree about which requests they captured, whether that disagreement
+	// takes the form of one pass wiped entirely (B1, round-3 review of
+	// #2814) or several passes each capturing a different rotating subset.
+	summary.allDegraded = n == 0 && !allMissingSetsEqual(degradedMissingSets)
 	return passScores, summary
 }
 
@@ -2116,6 +2270,102 @@ func TestRunCapture_DegradedTailPass_ExcludedFromMedian(t *testing.T) {
 	// that without computing Passes - len(DegradedPasses) themselves.
 	if manifest.MedianSampleSize != 1 {
 		t.Fatalf("manifest.MedianSampleSize = %d, want 1 (only pass 1 was clean)", manifest.MedianSampleSize)
+	}
+}
+
+// TestRunCapture_SecondRunCapturesNothing_PreservesFirstRunsGoodManifest is
+// the regression test for H2 (round-4 review of #2814): a run that promotes
+// NOTHING new must not overwrite a manifest.yaml that already describes a
+// fully-captured, well-scoring corpus with Captured: false dispositions and
+// a 0.00 median, for requests that are still sitting right there on disk
+// with real data.
+//
+// Reproduced against the pre-fix code before writing this test: run 1
+// captures req-a and req-b cleanly (manifest: CapturedCount=2,
+// MissingCount=0, MedianValidatePassRate=1). Run 2, same destDir, same
+// requests, provider now permanently down from the very first call —
+// nothing new is promoted, but req-a.yaml/req-b.yaml are still on disk from
+// run 1 and LoadTranscripts would still load both fine. The pre-fix
+// manifest.yaml then reported CapturedCount=0, MissingCount=2, both
+// outcomes Captured: false with a FailureReason, and MedianValidatePassRate
+// stamped back down to 0 — even though nothing about the actual corpus
+// changed. That manifest diff alone is what generate-capture.yml's "Check
+// whether any transcript changed" step sees, which (since the PR body's
+// #2814 "partial results" fix stopped discarding a failed `go test` run's
+// output outright) is what turns a run that captured nothing into a
+// published PR whose entire diff is a regression, under a banner claiming
+// it is "safe to review."
+//
+// Reverting either half of the H2 fix (the disposition carry-forward in
+// runCapture's outcomes loop, or the median-preservation guarded on
+// len(moved) == 0) makes this test fail.
+func TestRunCapture_SecondRunCapturesNothing_PreservesFirstRunsGoodManifest(t *testing.T) {
+	requests := []Request{
+		capturePipelineRequest("req-a"),
+		capturePipelineRequest("req-b"),
+	}
+	destDir := filepath.Join(t.TempDir(), "anthropic", "claude-sonnet-5-test")
+	const passes = 1
+
+	// Run 1: provider succeeds on every call — both requests captured
+	// cleanly, giving this destDir a real, good manifest.yaml to protect.
+	goodProvider := &diesAfterNCallsProvider{n: 1000, reply: "```yaml\n" + validCandidate + "```"}
+	cp1 := &captureProvider{Provider: goodProvider, maxCalls: 1000, maxTokens: 1_000_000}
+	first, _, wrote1 := runCapture(context.Background(), t, requests, cp1, "anthropic", "claude-sonnet-5-test", passes, destDir)
+	if !wrote1 {
+		t.Fatal("expected the first run to write a manifest")
+	}
+	if first.CapturedCount != 2 || first.MissingCount != 0 {
+		t.Fatalf("first run: CapturedCount/MissingCount = %d/%d, want 2/0", first.CapturedCount, first.MissingCount)
+	}
+	if first.MedianValidatePassRate != 1 {
+		t.Fatalf("first run: MedianValidatePassRate = %v, want 1", first.MedianValidatePassRate)
+	}
+
+	// Run 2: SAME destDir, same requests — the provider is down from the
+	// very first call, so nothing new is promoted this run (moved == 0
+	// inside runCapture).
+	deadProvider := &diesAfterNCallsProvider{n: 0, reply: "```yaml\n" + validCandidate + "```"}
+	cp2 := &captureProvider{Provider: deadProvider, maxCalls: 1000, maxTokens: 1_000_000}
+	second, _, wrote2 := runCapture(context.Background(), t, requests, cp2, "anthropic", "claude-sonnet-5-test", passes, destDir)
+	if !wrote2 {
+		t.Fatal("expected the second run to still write/patch a manifest")
+	}
+
+	// The two transcripts from run 1 must still be on disk, untouched.
+	for _, id := range []string{"req-a", "req-b"} {
+		if _, err := os.Stat(filepath.Join(destDir, id+".yaml")); err != nil {
+			t.Fatalf("expected %q to still be on disk after the second (failed) run: %v", id, err)
+		}
+	}
+
+	if second.CapturedCount != 2 {
+		t.Fatalf("second run: manifest.CapturedCount = %d, want 2 — req-a/req-b are still real, committed "+
+			"transcripts on disk; this run's failure to reproduce them does not make them missing", second.CapturedCount)
+	}
+	if second.MissingCount != 0 {
+		t.Fatalf("second run: manifest.MissingCount = %d, want 0", second.MissingCount)
+	}
+	for _, o := range second.RequestOutcomes {
+		if !o.Captured || o.FailureReason != "" || o.Unusable {
+			t.Fatalf("second run: outcome for %q = %+v, want Captured=true, no FailureReason, not Unusable",
+				o.RequestID, o)
+		}
+	}
+
+	// The core H2 regression: a run that captured nothing new must not
+	// stamp a fabricated 0.00 median over the real one run 1 measured.
+	if second.MedianValidatePassRate != first.MedianValidatePassRate {
+		t.Fatalf("second run: MedianValidatePassRate = %v, want %v (preserved from the first run, which is "+
+			"the only run that ever measured anything)", second.MedianValidatePassRate, first.MedianValidatePassRate)
+	}
+	if second.MedianSemanticMatchRate != first.MedianSemanticMatchRate {
+		t.Fatalf("second run: MedianSemanticMatchRate = %v, want %v (preserved)",
+			second.MedianSemanticMatchRate, first.MedianSemanticMatchRate)
+	}
+	if !reflect.DeepEqual(second.PassScores, first.PassScores) {
+		t.Fatalf("second run: PassScores = %+v, want the first run's preserved PassScores: %+v",
+			second.PassScores, first.PassScores)
 	}
 }
 
@@ -2944,11 +3194,19 @@ func TestSummarizePasses_AllDegraded_FlagsUnreliableFallback(t *testing.T) {
 	pass1 := Candidates{"req-1": validCandidate, "req-2": validCandidate, "req-3": validCandidate}
 	pass2 := Candidates{}
 	pass3 := Candidates{}
-	missingCounts := []int{2, 5, 5} // req-4/req-5 missing pass 1; everything missing passes 2-3
+	// req-4/req-5 missing pass 1; everything missing passes 2-3 — built via
+	// requestsMissingUsableCandidate itself (runCapture's own derivation),
+	// not hand-typed, so this test can never silently drift from what
+	// production code actually computes.
+	missingSets := [][]string{
+		requestsMissingUsableCandidate(requests, pass1),
+		requestsMissingUsableCandidate(requests, pass2),
+		requestsMissingUsableCandidate(requests, pass3),
+	}
 
 	ctx := context.Background()
 	ms := ScoreMedian(ctx, requests, []Candidates{pass1, pass2, pass3})
-	_, summary := summarizePasses(ms.Runs, missingCounts)
+	_, summary := summarizePasses(ms.Runs, missingSets)
 
 	if !summary.allDegraded {
 		t.Fatal("summary.allDegraded = false, want true — every one of 3 passes had a nonzero missingCount")
@@ -2990,11 +3248,12 @@ func TestSummarizePasses_ChronicSingleMissingRequest_NotAllDegraded(t *testing.T
 	// req-b is missing from every pass; req-a/req-c are captured and valid
 	// on every pass — identical, stable degradation, not a wipeout.
 	pass := Candidates{"req-a": validCandidate, "req-c": validCandidate}
-	missingCounts := []int{1, 1, 1}
+	missingSet := requestsMissingUsableCandidate(requests, pass) // ["req-b"] every time
+	missingSets := [][]string{missingSet, missingSet, missingSet}
 
 	ctx := context.Background()
 	ms := ScoreMedian(ctx, requests, []Candidates{pass, pass, pass})
-	_, summary := summarizePasses(ms.Runs, missingCounts)
+	_, summary := summarizePasses(ms.Runs, missingSets)
 
 	if summary.allDegraded {
 		t.Fatal("summary.allDegraded = true, want false — one chronically-missing request among three is " +
@@ -3010,6 +3269,64 @@ func TestSummarizePasses_ChronicSingleMissingRequest_NotAllDegraded(t *testing.T
 	// stays false: nothing about this number is misleading.
 	if want := 2.0 / 3.0; summary.validateRate != want {
 		t.Fatalf("summary.validateRate = %v, want %v", summary.validateRate, want)
+	}
+}
+
+// TestSummarizePasses_RotatingSubset_FlagsAllDegraded is the regression test
+// for H1 (round-4 review of #2814): the WIPED-pass-only proxy that used to
+// gate allDegraded missed this exact scenario. 5 requests, 5 passes, pass p
+// captures ONLY request p (a rotating 429: every OTHER request fails on
+// that pass) — no pass is ever wiped (every pass captures exactly one
+// request, so passMissing == 4 < 5 == Total on every pass, and the old
+// `passMissing == rs.Total` wipe check never fires), yet the passes
+// thoroughly disagree about WHICH request they captured: pass 1's missing
+// set is {req-2,req-3,req-4,req-5}, pass 2's is {req-1,req-3,req-4,req-5},
+// and so on — five different sets, never equal to each other.
+//
+// Reproduced against the pre-fix code before writing this test: every
+// individual request validates 1/1 whenever it IS captured (true corpus
+// quality 1.00), but summarizePasses' all-passes fallback computes a median
+// of 0.20 (each pass scores exactly 1/5 = 0.20, so the median of five
+// identical 0.20s is 0.20) — and the old condition
+// (n == 0 && anyPassWiped) read this as a stable, non-misleading partial
+// result and left allDegraded false, publishing 0.20 as this run's
+// baseline. Reverting the allMissingSetsEqual-based fix (restoring the
+// wipe-only check) makes this test fail: allDegraded comes back false.
+func TestSummarizePasses_RotatingSubset_FlagsAllDegraded(t *testing.T) {
+	requests := []Request{
+		capturePipelineRequest("req-1"),
+		capturePipelineRequest("req-2"),
+		capturePipelineRequest("req-3"),
+		capturePipelineRequest("req-4"),
+		capturePipelineRequest("req-5"),
+	}
+
+	passes := make([]Candidates, len(requests))
+	missingSets := make([][]string, len(requests))
+	for p := range requests {
+		// Pass p (0-indexed here, request p+1 in id terms) captures ONLY
+		// requests[p] — every other request is missing this pass, exactly
+		// the "rotating 429" scenario from the round-4 review.
+		passes[p] = Candidates{requests[p].ID: validCandidate}
+		missingSets[p] = requestsMissingUsableCandidate(requests, passes[p])
+	}
+
+	ctx := context.Background()
+	ms := ScoreMedian(ctx, requests, passes)
+	_, summary := summarizePasses(ms.Runs, missingSets)
+
+	if !summary.allDegraded {
+		t.Fatal("summary.allDegraded = false, want true — every pass captured a DIFFERENT single request, " +
+			"so the passes disagree about which requests they missed even though no pass was ever wiped " +
+			"(this is exactly the H1 regression: a wipe-only check misses this case)")
+	}
+	if len(summary.degradedPasses) != len(requests) {
+		t.Fatalf("summary.degradedPasses = %v, want all %d passes named", summary.degradedPasses, len(requests))
+	}
+	if want := 0.2; summary.validateRate != want {
+		t.Fatalf("summary.validateRate = %v, want %v (median of five identical 0.2 passes) — if this changed, "+
+			"update the scenario, but confirm allDegraded is still what the caller relies on not to be misled "+
+			"by it", summary.validateRate, want)
 	}
 }
 

--- a/cmd/conduit/internal/generate/transcript_capture_test.go
+++ b/cmd/conduit/internal/generate/transcript_capture_test.go
@@ -58,6 +58,17 @@
 // single violating file aborts promoting ALL of them, so a violating
 // transcript can never reach the working tree.
 //
+// manifest.yaml and every "<id>.missing.yaml" tombstone (below) get the SAME
+// guarantee for a different reason: neither is a Transcript, so
+// ScanTranscriptForSecrets' struct-shaped scan cannot see their own free-text
+// fields at all (RequestOutcome.FailureReason, Tombstone.FailureCode). Those
+// fields are held to a stricter rule instead — safeFailureReason NEVER
+// returns a provider's own error text (only a conduiterr code plus an HTTP
+// status, see its own doc comment) — and the result is still scanned
+// (reasonFindings, below) before anything is promoted, and again by
+// TestTranscripts_CarryNoSecretMaterial (secrets_scan_test.go) as raw text on
+// every PR, independent of this test ever having run.
+//
 // # Partial results
 //
 // A per-request failure is one of two very different things, and this
@@ -81,6 +92,23 @@
 //     which request(s) are missing and why (Manifest.RequestOutcomes),
 //     rather than requiring a reader to infer it from an absent file.
 //
+// Absence of data itself splits further, via RequestOutcome.Unusable
+// (provider.IsUnusableResponse): a transport-level miss (no response ever
+// arrived — a 429, a timeout, a tripped ceiling) is reported separately from
+// a response that DID arrive but was unusable (a decode failure, or a
+// well-formed but empty completion — a refusal). The second case is a
+// BILLED, attempted call — captureProvider.Complete counts its tokens toward
+// Manifest.TotalTokensUsed even though it produced no transcript — and must
+// never be reported the same way a rate limit is.
+//
+// A request that ends this run still missing (of either kind) gets a
+// committed "<id>.missing.yaml" Tombstone (transcript.go) in place of a
+// transcript — the artifact that lets LoadTranscripts' bijection check tell
+// "this id was attempted and legitimately came back empty" apart from "this
+// id was renamed out from under its transcript", the same distinction
+// Manifest.RequestOutcomes makes for a human reading the diff, now made for
+// the code that enforces the corpus's shape too.
+//
 // The redaction gate above is deliberately untouched by any of this: it
 // remains all-or-nothing regardless of how many requests were captured or
 // missing — see scanAndPromoteScratch's own doc comment and
@@ -90,6 +118,9 @@ package generate
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -99,7 +130,10 @@ import (
 	"testing"
 	"time"
 
+	json "github.com/goccy/go-json"
+
 	"github.com/conduitio/conduit/cmd/conduit/internal/generate/provider"
+	"github.com/conduitio/conduit/pkg/foundation/cerrors/conduiterr"
 	"github.com/conduitio/yaml/v3"
 )
 
@@ -292,6 +326,20 @@ func (c *captureProvider) Complete(ctx context.Context, req provider.CompletionR
 
 	res, err := c.Provider.Complete(ctx, req)
 	if err != nil {
+		// A call that reached the provider and got billed — a refusal
+		// (provider.IsUnusableResponse) — still reports its token usage on
+		// res even though it also returns an error (see anthropic.go's
+		// "empty response" branch and its siblings): that usage counts
+		// toward BOTH this run's cumulative token ceiling and
+		// Manifest.TotalTokensUsed exactly like a successful call's does.
+		// It is never appended to c.recorded, though — recorded backs
+		// buildTranscript's Turns, and a refusal produced no completion
+		// text worth committing as a turn.
+		if res.TokensUsed > 0 {
+			c.mu.Lock()
+			c.tokens += res.TokensUsed
+			c.mu.Unlock()
+		}
 		return res, err
 	}
 
@@ -497,6 +545,67 @@ func writeManifest(t *testing.T, destDir string, m Manifest) {
 	}
 }
 
+// safeFailureReason summarizes err for a value that ends up committed to
+// manifest.yaml (RequestOutcome.FailureReason) or a tombstone
+// (Tombstone.FailureCode) forever. It NEVER returns the provider's own
+// error text: a provider error message may embed up to 512 bytes of raw
+// response body (readErrorBody, provider/http.go) that can echo back
+// caller-supplied or provider-controlled content — a 401 body quoting the
+// rejected key, a *url.Error carrying credentials embedded in a base URL —
+// and this package's manifest.yaml has no content-based redaction of its
+// own before this fix (TestTranscripts_CarryNoSecretMaterial used to skip
+// it by name).
+//
+// The only load-bearing information for a reviewer — enough to tell "this
+// was a rate limit" from "this was a refusal" from "this was an auth
+// failure" — is the conduiterr CODE (conduiterr.Get) plus the HTTP status
+// when checkStatus recorded one (provider.HTTPStatus). Both are safe by
+// construction: a Code.Reason() is a registered, static string, never
+// user- or provider-controlled text, and the status is a bare integer.
+//
+// Not every failure this package sees is a conduiterr — captureProvider's
+// own ceiling and wall-clock-deadline errors (transcript_capture_test.go)
+// are plain fmt.Errorf values built entirely from static text and integers
+// this test computed itself, never provider-controlled content — so those
+// fall back to their literal Error() text. Callers still run
+// scanTextForSecrets over the RESULT before trusting it (see runCapture's
+// reasonFindings check): not because this function is expected to leak
+// (it never touches a conduiterr's Error()/message text, only its Code),
+// but because that fallback text has never technically been proven safe
+// the way the structured path has, and the same scan gates everything else
+// destined for a committed file.
+func safeFailureReason(err error) string {
+	if err == nil {
+		return "no completion recorded"
+	}
+	if ce, ok := conduiterr.Get(err); ok {
+		reason := ce.Code.Reason()
+		if status, ok := provider.HTTPStatus(err); ok {
+			reason = fmt.Sprintf("%s (HTTP %d)", reason, status)
+		}
+		return reason
+	}
+	return err.Error()
+}
+
+// writeTombstone commits a Tombstone for a corpus request whose capture
+// never produced a transcript on any pass — see the Tombstone type doc
+// comment (transcript.go) for why LoadTranscripts' bijection check needs an
+// explicit file here rather than tolerating a missing one.
+func writeTombstone(t *testing.T, destDir string, ts Tombstone) {
+	t.Helper()
+	data, err := yaml.Marshal(ts)
+	if err != nil {
+		t.Fatalf("marshaling tombstone %q: %v", ts.RequestID, err)
+	}
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		t.Fatalf("creating %q: %v", destDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(destDir, ts.RequestID+tombstoneFileSuffix), data, 0o600); err != nil {
+		t.Fatalf("writing tombstone %q: %v", ts.RequestID, err)
+	}
+}
+
 // TestCaptureTranscripts is the entry point described in the file-level doc
 // comment above. It is a thin shell around runCapture: guard-check, resolve
 // config, build the live provider, then hand off — see runCapture's doc
@@ -574,15 +683,18 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 	// this run actually exercised — the full corpus for a normal run, or
 	// the one id a scoped `-run TestCaptureTranscripts/<id>` re-capture
 	// names (t.Run never invokes the closure below for a filtered-out id,
-	// so both maps stay accurate for free). lastFailureReason holds, per
-	// request id, the most recent "no completion recorded" error seen
-	// across every pass — overwritten on every occurrence and deleted the
+	// so both maps stay accurate for free). lastFailureErr holds, per
+	// request id, the most recent error seen for a pass that recorded NO
+	// completion at all — overwritten on every occurrence and deleted the
 	// moment a pass DOES capture that id, so it reflects only the reason a
 	// STILL-missing request is missing, never a transient blip a later pass
-	// recovered from.
+	// recovered from. It stores the raw error (not a string): the string
+	// destined for a committed file is computed later, by safeFailureReason,
+	// deliberately never from err.Error() directly — see that function's
+	// doc comment.
 	var attemptOrder []Request
 	attempted := make(map[string]bool, len(requests))
-	lastFailureReason := make(map[string]string)
+	lastFailureErr := make(map[string]error)
 
 	var scoreCandidatesList []Candidates
 	for pass := 1; pass <= passes; pass++ {
@@ -597,7 +709,6 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 				cp.startRequest()
 				gen, genErr := Generate(ctx, Input{Prompt: req.Prompt, Provider: cp, Model: model})
 				raw := cp.recordedTurns()
-				passCandidates[req.ID] = gen.Candidate
 
 				if len(raw) == 0 {
 					// Absence of data (see the file-level "Partial results"
@@ -611,15 +722,20 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 					// fail the whole go test run and discard every OTHER
 					// transcript already captured; captureCompletenessVerdict
 					// below is what decides when enough of these should.
-					reason := "no completion recorded"
-					if genErr != nil {
-						reason = genErr.Error()
-					}
-					lastFailureReason[req.ID] = reason
+					//
+					// passCandidates deliberately gets NO entry for req.ID
+					// here (never a key with an empty value) — ScoreRun
+					// (score.go) reports a MISSING key as Result.Missing;
+					// setting an empty-string candidate instead would score
+					// this exactly like a model that produced a candidate
+					// and failed validation, which is a different, wrong
+					// story for a request the provider never even answered.
+					lastFailureErr[req.ID] = genErr
 					t.Logf("pass %d: %q produced no completion (absence of data): %v", pass, req.ID, genErr)
 					return
 				}
-				delete(lastFailureReason, req.ID)
+				delete(lastFailureErr, req.ID)
+				passCandidates[req.ID] = gen.Candidate
 
 				tr := buildTranscript(req, gen, raw, providerName, model, systemSHA, catalogFP, time.Now().UTC())
 				writeScratchTranscript(t, scratchDir, tr)
@@ -636,12 +752,44 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 			})
 		}
 
-		if len(passCandidates) == len(requests) {
+		// attempted is checked AFTER every pass rather than passCandidates'
+		// size: passCandidates now deliberately omits a key for any request
+		// with no completion this pass (see above), so its size no longer
+		// says anything about whether the FULL corpus was attempted — only
+		// about how many of the attempted requests produced a candidate.
+		// attempted is unconditional (set at the top of the t.Run closure
+		// regardless of outcome) and, once a full-corpus run's first pass
+		// completes, stays at len(requests) for every later pass too — a
+		// `-run` filter's scope is fixed for the whole `go test` invocation,
+		// never per-pass.
+		if len(attempted) == len(requests) {
 			scoreCandidatesList = append(scoreCandidatesList, passCandidates)
 		} else {
 			t.Logf("pass %d: %d/%d requests ran (a -run filter is scoping this to a subset) — "+
-				"excluded from corpus-level scoring and the manifest", pass, len(passCandidates), len(requests))
+				"excluded from corpus-level scoring and the manifest", pass, len(attempted), len(requests))
 		}
+	}
+
+	// Every still-missing request's manifest-safe failure reason is
+	// computed BEFORE anything is promoted, so a redaction-scan hit here
+	// aborts the whole batch — nothing gets promoted, no manifest, no
+	// tombstone — exactly like a violation found inside a transcript's own
+	// content does (scanAndPromoteScratch below). safeFailureReason itself
+	// never returns raw provider text, but the scan runs over its result
+	// anyway as the same defence-in-depth every other field destined for a
+	// committed file gets; see safeFailureReason's doc comment for why.
+	safeReasons := make(map[string]string, len(lastFailureErr))
+	unusable := make(map[string]bool, len(lastFailureErr))
+	var reasonFindings []string
+	for id, ferr := range lastFailureErr {
+		reason := safeFailureReason(ferr)
+		reasonFindings = append(reasonFindings, scanTextForSecrets(reason)...)
+		safeReasons[id] = reason
+		unusable[id] = provider.IsUnusableResponse(ferr)
+	}
+	if len(reasonFindings) > 0 {
+		t.Fatalf("redaction scan found %d issue(s) in a request's failure reason — refusing to promote ANY captured "+
+			"transcript into %q:\n%s", len(reasonFindings), destDir, strings.Join(reasonFindings, "\n"))
 	}
 
 	moved, findings := scanAndPromoteScratch(ctx, t, scratchDir, destDir)
@@ -667,26 +815,45 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 	for i, req := range attemptOrder {
 		captured := capturedIDs[req.ID]
 		outcomes[i] = RequestOutcome{RequestID: req.ID, Captured: captured}
+
+		tombstonePath := filepath.Join(destDir, req.ID+tombstoneFileSuffix)
 		if captured {
 			capturedCount++
+			// A previous run's tombstone for this id, if any, is now
+			// stale — this id has real data again, and LoadTranscripts
+			// hard-errors on an id carrying both a transcript and a
+			// tombstone (transcript.go).
+			if err := os.Remove(tombstonePath); err != nil && !os.IsNotExist(err) {
+				t.Fatalf("removing stale tombstone %q: %v", tombstonePath, err)
+			}
 			continue
 		}
+
 		missingCount++
-		reason := lastFailureReason[req.ID]
+		reason := safeReasons[req.ID]
 		if reason == "" {
 			reason = "no completion recorded"
 		}
 		outcomes[i].FailureReason = reason
+		outcomes[i].Unusable = unusable[req.ID]
+
+		if _, err := os.Stat(filepath.Join(destDir, req.ID+".yaml")); err == nil {
+			// An earlier run already committed a real transcript for this
+			// id; THIS run's failure to reproduce it does not retroactively
+			// invalidate that data — never overwrite a real transcript
+			// with a tombstone.
+			continue
+		}
+		writeTombstone(t, destDir, Tombstone{
+			SchemaVersion:      TranscriptSchemaVersion,
+			RequestID:          req.ID,
+			CorpusPromptSHA256: sha256Hex(req.Prompt),
+			FailureCode:        reason,
+			CapturedAt:         runStart,
+		})
 	}
 
-	if missingCount > 0 {
-		fail, msg := captureCompletenessVerdict(len(attemptOrder), capturedCount, missingCount, outcomes)
-		if fail {
-			t.Errorf("%s", msg)
-		} else {
-			t.Logf("%s", msg)
-		}
-	}
+	reportCaptureCompleteness(t, len(attemptOrder), capturedCount, missingCount, outcomes)
 
 	if len(scoreCandidatesList) != passes {
 		t.Logf("only %d/%d pass(es) captured the full corpus — skipping manifest.yaml "+
@@ -749,14 +916,60 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 // discard 27 already-paid-for transcripts.
 const captureCompletenessThreshold = 0.5
 
-// captureCompletenessVerdict is runCapture's threshold decision for a
-// nonzero missingCount, pure and directly testable
-// (TestCaptureCompletenessVerdict) without a fake provider or *testing.T:
-// given the final captured/missing split for whatever requests this run
-// actually attempted, it reports whether the run should be failed and the
-// message that failure (or note) should carry — always naming both what WAS
-// captured and what was NOT (missing id and reason), per the requirement
-// that a reader never has to infer a failure from an absent file.
+// completenessSink is the minimal *testing.T surface
+// reportCaptureCompleteness needs. It exists so a test can supply a fake
+// implementation and observe whether the fail branch fired, without needing
+// a real *testing.T — a hand-constructed &testing.T{} is not safe to use
+// (its internal state is only valid when created by the testing package's
+// own Run), so there is no other way to exercise this wiring's fail path
+// without also failing whatever test triggers it.
+type completenessSink interface {
+	Errorf(format string, args ...any)
+	Logf(format string, args ...any)
+}
+
+// reportCaptureCompleteness wraps captureCompletenessVerdict's decision and
+// reports it to sink — split out from runCapture so both the fail and
+// no-fail branches are directly testable (TestReportCaptureCompleteness)
+// without spending a real *testing.T's failure on a scenario that is
+// SUPPOSED to fail.
+//
+// It calls captureCompletenessVerdict whenever there is anything to report
+// on — a nonzero missingCount, OR attemptedCount itself being zero (see that
+// function's doc comment for why zero attempted must never be silently
+// treated as "nothing to report"). The only case that reports nothing at
+// all is a clean, fully-attempted run.
+func reportCaptureCompleteness(sink completenessSink, attemptedCount, capturedCount, missingCount int, outcomes []RequestOutcome) {
+	if attemptedCount > 0 && missingCount == 0 {
+		return
+	}
+	fail, msg := captureCompletenessVerdict(attemptedCount, capturedCount, missingCount, outcomes)
+	if fail {
+		sink.Errorf("%s", msg)
+	} else {
+		sink.Logf("%s", msg)
+	}
+}
+
+// captureCompletenessVerdict is runCapture's threshold decision, pure and
+// directly testable (TestCaptureCompletenessVerdict) without a fake
+// provider or *testing.T: given the final captured/missing split for
+// whatever requests this run actually attempted, it reports whether the run
+// should be failed and the message that failure (or note) should carry —
+// always naming both what WAS captured and what was NOT (missing id and
+// reason), per the requirement that a reader never has to infer a failure
+// from an absent file.
+//
+// attemptedCount == 0 is ALWAYS a hard failure, regardless of
+// missingCount (which is also always 0 in that case — capturedCount +
+// missingCount == attemptedCount is an invariant of how runCapture builds
+// outcomes). A `-run` pattern or a `request_id` workflow input that matches
+// nothing in the corpus (a typo, or an id no longer in
+// testdata/eval_requests.yaml) attempts ZERO requests — the OLD unconditional
+// `attemptedCount == 0 || missingCount == 0 -> return false, ""` guard let a
+// run like that exit clean with an empty message, which reportCaptureCompleteness
+// would then treat as "nothing to report" and generate-capture.yml's `capture`
+// job would exit green having captured and published nothing at all.
 //
 // Below the threshold — including one flaky 429, one pass tripping a
 // ceiling, or a single rate-limited request — this is ordinary live-provider
@@ -774,7 +987,15 @@ const captureCompletenessThreshold = 0.5
 // manifest for whatever WAS captured regardless of this verdict — this
 // function controls only how loud the `go test` signal is.
 func captureCompletenessVerdict(attemptedCount, capturedCount, missingCount int, outcomes []RequestOutcome) (fail bool, message string) {
-	if attemptedCount == 0 || missingCount == 0 {
+	if attemptedCount == 0 {
+		return true, fmt.Sprintf(
+			"0/%d captured, %d/%d missing (zero requests were attempted) — the run captured nothing to report "+
+				"on; check the -run pattern or request_id input (one that matches nothing in the corpus silently "+
+				"attempts zero requests) and the corpus file itself",
+			attemptedCount, missingCount, attemptedCount,
+		)
+	}
+	if missingCount == 0 {
 		return false, ""
 	}
 
@@ -1138,9 +1359,16 @@ func (p *failOnPromptProvider) Complete(ctx context.Context, req provider.Comple
 // so an unexpected Errorf here would fail this test too) while still
 // promoting the two good transcripts and recording req-b's absence
 // honestly, both in the promoted files and in the manifest.
-func TestRunCapture_PartialFailure_PreservesGoodTranscripts(t *testing.T) {
+// partialFailureFixture builds the shared 3-request, 1-permanent-failure
+// scenario TestRunCapture_PartialFailure_PreservesGoodTranscripts and
+// TestRunCapture_PartialFailure_TombstoneAndBijection both drive runCapture
+// with — split into its own function (rather than duplicated) so the two
+// tests stay independently under gocyclo's complexity limit while still
+// exercising the identical setup.
+func partialFailureFixture(t *testing.T) (requests []Request, cp *captureProvider, destDir string, infraErr error) {
+	t.Helper()
 	const failMarker = "TRIGGER_INFRA_FAILURE"
-	requests := []Request{
+	requests = []Request{
 		capturePipelineRequest("req-a"),
 		{
 			ID:     "req-b",
@@ -1152,11 +1380,16 @@ func TestRunCapture_PartialFailure_PreservesGoodTranscripts(t *testing.T) {
 
 	reply := "```yaml\n" + validCandidate + "```"
 	base := &fakeProvider{replies: []string{reply}, tokens: 20}
-	infraErr := fmt.Errorf("429: rate limited")
+	infraErr = fmt.Errorf("429: rate limited")
 	fp := &failOnPromptProvider{fakeProvider: base, marker: failMarker, err: infraErr}
-	cp := &captureProvider{Provider: fp, maxCalls: 1000, maxTokens: 1_000_000}
+	cp = &captureProvider{Provider: fp, maxCalls: 1000, maxTokens: 1_000_000}
 
-	destDir := filepath.Join(t.TempDir(), "anthropic", "claude-sonnet-5-test")
+	destDir = filepath.Join(t.TempDir(), "anthropic", "claude-sonnet-5-test")
+	return requests, cp, destDir, infraErr
+}
+
+func TestRunCapture_PartialFailure_PreservesGoodTranscripts(t *testing.T) {
+	requests, cp, destDir, infraErr := partialFailureFixture(t)
 	const passes = 3
 
 	manifest, wrote := runCapture(context.Background(), t, requests, cp, "anthropic", "claude-sonnet-5-test", passes, destDir)
@@ -1216,6 +1449,210 @@ func TestRunCapture_PartialFailure_PreservesGoodTranscripts(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(destDir, manifestFileName)); err != nil {
 		t.Fatalf("expected manifest.yaml to have been written despite the partial failure: %v", err)
 	}
+
+	// The infra error is a plain fmt.Errorf, not a conduiterr — it takes
+	// safeFailureReason's literal-text fallback path (see that function's
+	// doc comment), so its text is preserved verbatim here. This is
+	// distinct from Test_RunCapture_ProviderHTTPErrorNeverLeaksResponseBodyIntoManifest,
+	// which proves the structured (non-fallback) path for a REAL provider
+	// error never carries response-body text at all.
+	if gotReqB.Unusable {
+		t.Fatal("req-b outcome: Unusable = true, want false — a 429 is absence of data, not a billed refusal")
+	}
+}
+
+// TestRunCapture_PartialFailure_TombstoneAndBijection is
+// TestRunCapture_PartialFailure_PreservesGoodTranscripts's sibling, split
+// out to keep both functions under gocyclo's complexity limit rather than
+// packing every assertion for this one scenario into a single test: it
+// proves the tombstone half of the SAME scenario — req-b (permanently
+// failing) gets a committed "<id>.missing.yaml" and req-a/req-c (captured)
+// get none — and that LoadTranscripts then loads the resulting directory
+// cleanly, which is the integration proof that findings 1/2/4/6 actually
+// compose into a corpus a consumer can load.
+func TestRunCapture_PartialFailure_TombstoneAndBijection(t *testing.T) {
+	requests, cp, destDir, _ := partialFailureFixture(t)
+	const passes = 3
+
+	_, wrote := runCapture(context.Background(), t, requests, cp, "anthropic", "claude-sonnet-5-test", passes, destDir)
+	if !wrote {
+		t.Fatal("expected the manifest to still be written: 1/3 missing is below the run-failing threshold")
+	}
+
+	if _, err := os.Stat(filepath.Join(destDir, "req-b"+tombstoneFileSuffix)); err != nil {
+		t.Fatalf("expected a tombstone for req-b: %v", err)
+	}
+	for _, id := range []string{"req-a", "req-c"} {
+		if _, err := os.Stat(filepath.Join(destDir, id+tombstoneFileSuffix)); !os.IsNotExist(err) {
+			t.Fatalf("expected NO tombstone for captured id %q, stat err = %v", id, err)
+		}
+	}
+
+	loaded, err := LoadTranscripts(destDir, requests)
+	if err != nil {
+		t.Fatalf("LoadTranscripts(%q) = %v, want no error", destDir, err)
+	}
+	if len(loaded.ByID) != 2 {
+		t.Fatalf("LoadTranscripts: len(ByID) = %d, want 2", len(loaded.ByID))
+	}
+	if _, ok := loaded.Tombstoned["req-b"]; !ok {
+		t.Fatal("LoadTranscripts: expected req-b in Tombstoned")
+	}
+}
+
+// Test_RunCapture_ProviderHTTPErrorNeverLeaksResponseBodyIntoManifest is the
+// regression test for the finding that a provider error's raw HTTP response
+// body (readErrorBody, provider/http.go — up to 512 bytes, provider-
+// controlled) could reach RequestOutcome.FailureReason and then
+// manifest.yaml, a committed file, completely unscanned. It drives a REAL
+// provider.Anthropic against an httptest server: one request always
+// succeeds (so the run stays at 1/2 = 50% missing, AT the run-failing
+// threshold but not past it — captureCompletenessVerdict's own "exactly
+// half missing" boundary case — so runCapture never calls t.Errorf on this
+// test's own *t), the other always gets a 401 whose body is deliberately
+// shaped like a real leak (echoing back what looks like a rejected API
+// key). That text must never appear anywhere in the manifest — only the
+// structured, safe summary (safeFailureReason: a conduiterr code plus the
+// HTTP status) does.
+func Test_RunCapture_ProviderHTTPErrorNeverLeaksResponseBodyIntoManifest(t *testing.T) {
+	const failMarker = "TRIGGER_401"
+	const leakedSecret = "sk-ant-1234567890abcdefghijklmnop"
+	leakedBody := `{"error":{"type":"authentication_error","message":"Incorrect API key provided: ` + leakedSecret + `"}}`
+
+	okBody, err := json.Marshal(map[string]any{
+		"content": []map[string]string{{"type": "text", "text": "```yaml\n" + validCandidate + "```"}},
+		"usage":   map[string]int{"input_tokens": 5, "output_tokens": 5},
+	})
+	if err != nil {
+		t.Fatalf("marshaling ok response fixture: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if strings.Contains(string(body), failMarker) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = io.WriteString(w, leakedBody)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(okBody)
+	}))
+	t.Cleanup(srv.Close)
+
+	requests := []Request{
+		capturePipelineRequest("req-ok"),
+		{
+			ID:     "req-401",
+			Prompt: "read from the generator and write to the log " + failMarker,
+			Expect: Expect{SourceCategory: "generator", DestinationCategory: "log"},
+		},
+	}
+	base := &provider.Anthropic{BaseURL: srv.URL}
+	cp := &captureProvider{Provider: base, maxCalls: 1000, maxTokens: 1_000_000}
+	destDir := filepath.Join(t.TempDir(), "anthropic", "claude-sonnet-5-test")
+
+	manifest, wrote := runCapture(context.Background(), t, requests, cp, "anthropic", "claude-sonnet-5-test", 1, destDir)
+	if !wrote {
+		t.Fatal("expected the manifest to be written: 1/2 missing is at, not past, the run-failing threshold")
+	}
+
+	data, err := os.ReadFile(filepath.Join(destDir, manifestFileName))
+	if err != nil {
+		t.Fatalf("reading manifest: %v", err)
+	}
+	if strings.Contains(string(data), leakedSecret) {
+		t.Fatalf("manifest.yaml carries the leaked secret verbatim:\n%s", data)
+	}
+	if strings.Contains(string(data), "Incorrect API key") {
+		t.Fatalf("manifest.yaml carries the raw provider response body:\n%s", data)
+	}
+
+	var gotReq401 RequestOutcome
+	found := false
+	for _, o := range manifest.RequestOutcomes {
+		if o.RequestID == "req-401" {
+			gotReq401, found = o, true
+		}
+	}
+	if !found {
+		t.Fatal("expected an outcome for req-401")
+	}
+	if gotReq401.Captured {
+		t.Fatal("req-401: Captured = true, want false")
+	}
+	if strings.Contains(gotReq401.FailureReason, leakedSecret) {
+		t.Fatalf("req-401: FailureReason carries the leaked secret: %q", gotReq401.FailureReason)
+	}
+	// The structured summary IS present and useful: the code plus the HTTP
+	// status, which is exactly what a reviewer needs to triage a 401
+	// without ever seeing the response body.
+	if !strings.Contains(gotReq401.FailureReason, "HTTP 401") {
+		t.Fatalf("req-401: FailureReason = %q, want it to name the HTTP status", gotReq401.FailureReason)
+	}
+
+	// req-401 also gets a tombstone, and the tombstone is subject to
+	// exactly the same guarantee — it is the other place a manifest-safe
+	// (never raw) reason gets committed.
+	tsData, err := os.ReadFile(filepath.Join(destDir, "req-401"+tombstoneFileSuffix))
+	if err != nil {
+		t.Fatalf("reading tombstone for req-401: %v", err)
+	}
+	if strings.Contains(string(tsData), leakedSecret) {
+		t.Fatalf("tombstone for req-401 carries the leaked secret verbatim:\n%s", tsData)
+	}
+
+	// And the redaction test itself (secrets_scan_test.go) must also catch
+	// this if the structured path is ever bypassed — it scans manifest.yaml
+	// and every tombstone as raw text, not as a parsed Transcript.
+	if findings := scanTextForSecrets(string(data)); len(findings) > 0 {
+		t.Fatalf("scanTextForSecrets found findings in a manifest that should already be clean: %v", findings)
+	}
+}
+
+// TestRunCapture_MissingRequest_ScoredAsMissingNotFailedCandidate is the
+// regression test for a request with no completion being scored as a
+// failed model candidate rather than Missing (score.go's Result.Missing).
+// Before the fix, runCapture set passCandidates[req.ID] = gen.Candidate
+// (empty string on this path) BEFORE checking len(raw) == 0, so the map
+// always carried a key for the id — ScoreRun then saw `ok == true` and
+// scored a 429 as "the model produced a candidate that failed validation"
+// instead of "no candidate was ever produced". This proves runCapture's
+// contract with ScoreRun directly: a Candidates map built the same way
+// runCapture builds it (see the "absence of data" branch in its per-request
+// closure) must have NO entry at all for a request with no completion, so
+// ScoreRun reports Missing.
+func TestRunCapture_MissingRequest_ScoredAsMissingNotFailedCandidate(t *testing.T) {
+	requests := []Request{capturePipelineRequest("req-ok"), capturePipelineRequest("req-missing")}
+
+	// Mirrors exactly what runCapture's per-request closure does today:
+	// only a request whose raw completions are non-empty gets a
+	// passCandidates entry at all.
+	candidates := Candidates{"req-ok": validCandidate}
+
+	rs := ScoreRun(context.Background(), requests, candidates)
+
+	var gotMissing, gotOK bool
+	for _, res := range rs.Results {
+		switch res.RequestID {
+		case "req-missing":
+			gotMissing = true
+			if !res.Missing {
+				t.Fatal("req-missing: Missing = false, want true — a request with no completion must never be " +
+					"scored as a failed candidate")
+			}
+			if res.ValidatePass {
+				t.Fatal("req-missing: ValidatePass = true, want false")
+			}
+		case "req-ok":
+			gotOK = true
+			if res.Missing {
+				t.Fatal("req-ok: Missing = true, want false")
+			}
+		}
+	}
+	if !gotMissing || !gotOK {
+		t.Fatalf("expected results for both req-ok and req-missing, got %+v", rs.Results)
+	}
 }
 
 // TestCaptureCompletenessVerdict proves the threshold decision directly and
@@ -1272,6 +1709,17 @@ func TestCaptureCompletenessVerdict(t *testing.T) {
 			outcomes: outcomesFor("only-request"),
 			wantFail: true,
 		},
+		{
+			// The regression case: a typo'd -run pattern or request_id
+			// input matches nothing in the corpus, so NOTHING is attempted
+			// at all — the old `attemptedCount == 0 || missingCount == 0`
+			// guard treated this identically to a clean, fully-successful
+			// run (false, ""), which is how a capture job could exit green
+			// having captured nothing.
+			name:      "zero attempted -> explicit failure, never a silent green",
+			attempted: 0, captured: 0, missing: 0,
+			wantFail: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1313,54 +1761,72 @@ func idRange(n int, prefix string) []string {
 	return ids
 }
 
-// TestScanAndPromoteScratch_ViolationBlocksEvenWhenARequestIsMissing proves
-// requirement 4 of the partial-results follow-up: the redaction gate stays
-// all-or-nothing even in exactly the shape partial-capture support
-// introduces — fewer scratch files than corpus requests, because one
-// request never produced a completion. A missing request must never be
-// mistaken for "one fewer file to scan" in a way that lets the OTHER two
-// promote despite a secret in one of them.
-func TestScanAndPromoteScratch_ViolationBlocksEvenWhenARequestIsMissing(t *testing.T) {
-	cleanReply := "```yaml\n" + validCandidate + "```"
-	secretReply := "```yaml\n" + validCandidate + "```\nnote: sk-ant-1234567890abcdefghijklmnop"
+// fakeCompletenessSink implements completenessSink without a *testing.T, so
+// TestReportCaptureCompleteness can exercise BOTH of
+// reportCaptureCompleteness's branches — including the one that calls
+// Errorf — without failing the test doing the exercising.
+type fakeCompletenessSink struct {
+	errorfCalled bool
+	logfCalled   bool
+	lastMsg      string
+}
 
-	// Three corpus requests, but only two ever produce a transcript —
-	// req-missing is simulated absence of data: it has NO file in
-	// scratchDir at all, exactly what a permanently-failing request leaves
-	// behind under the new partial-capture handling.
-	requests := []Request{capturePipelineRequest("req-clean"), capturePipelineRequest("req-secret")}
-	fake := &fakeProvider{replies: []string{cleanReply, secretReply}, tokens: 10}
-	cp := &captureProvider{Provider: fake, maxCalls: 1000, maxTokens: 1_000_000}
+func (f *fakeCompletenessSink) Errorf(format string, args ...any) {
+	f.errorfCalled = true
+	f.lastMsg = fmt.Sprintf(format, args...)
+}
 
-	system := BuildSystemPrompt(BuiltinCatalog())
-	systemSHA := sha256Hex(system)
-	catalogFP := CatalogFingerprint()
+func (f *fakeCompletenessSink) Logf(format string, args ...any) {
+	f.logfCalled = true
+	f.lastMsg = fmt.Sprintf(format, args...)
+}
 
-	scratchDir := t.TempDir()
-	for _, req := range requests {
-		cp.startRequest()
-		gen, genErr := Generate(context.Background(), Input{Prompt: req.Prompt, Provider: cp, Model: "claude-sonnet-5-test"})
-		raw := cp.recordedTurns()
-		if len(raw) == 0 {
-			t.Fatalf("setup: no completion recorded for %q: %v", req.ID, genErr)
+// TestReportCaptureCompleteness is the regression test for the previously
+// untested "if fail { t.Errorf } else { t.Logf }" wiring in runCapture: both
+// halves are exercised directly here via fakeCompletenessSink, including the
+// fail branch, which could never be exercised through runCapture itself
+// without also failing whichever test called it.
+func TestReportCaptureCompleteness(t *testing.T) {
+	t.Run("below threshold logs, never errors", func(t *testing.T) {
+		sink := &fakeCompletenessSink{}
+		reportCaptureCompleteness(sink, 28, 27, 1, []RequestOutcome{
+			{RequestID: "kafka-connect-unwrap-to-postgres", FailureReason: "generate.provider_error (HTTP 429)"},
+		})
+		if sink.errorfCalled {
+			t.Fatalf("Errorf called for a below-threshold miss: %q", sink.lastMsg)
 		}
-		tr := buildTranscript(req, gen, raw, "anthropic", "claude-sonnet-5-test", systemSHA, catalogFP, time.Now().UTC())
-		writeScratchTranscript(t, scratchDir, tr)
-	}
-	// req-missing deliberately gets no writeScratchTranscript call at all.
+		if !sink.logfCalled {
+			t.Fatal("expected Logf to be called")
+		}
+	})
 
-	destDir := filepath.Join(t.TempDir(), "anthropic", "claude-sonnet-5-test")
-	moved, findings := scanAndPromoteScratch(context.Background(), t, scratchDir, destDir)
+	t.Run("past threshold errors", func(t *testing.T) {
+		sink := &fakeCompletenessSink{}
+		outcomes := make([]RequestOutcome, 20)
+		for i := range outcomes {
+			outcomes[i] = RequestOutcome{RequestID: fmt.Sprintf("req-%d", i), FailureReason: "generate.provider_error"}
+		}
+		reportCaptureCompleteness(sink, 28, 8, 20, outcomes)
+		if !sink.errorfCalled {
+			t.Fatal("expected Errorf to be called for a past-threshold miss")
+		}
+	})
 
-	if len(findings) == 0 {
-		t.Fatal("expected the secret-carrying transcript to produce at least one finding")
-	}
-	if len(moved) != 0 {
-		t.Fatalf("expected NOTHING promoted (not even req-clean) when any finding exists, got %v", moved)
-	}
-	if _, err := os.Stat(destDir); !os.IsNotExist(err) {
-		t.Fatalf("expected destDir %q to never have been created, stat err = %v", destDir, err)
-	}
+	t.Run("zero attempted errors, never silently reports nothing", func(t *testing.T) {
+		sink := &fakeCompletenessSink{}
+		reportCaptureCompleteness(sink, 0, 0, 0, nil)
+		if !sink.errorfCalled {
+			t.Fatal("expected Errorf to be called when zero requests were attempted")
+		}
+	})
+
+	t.Run("nothing missing calls neither", func(t *testing.T) {
+		sink := &fakeCompletenessSink{}
+		reportCaptureCompleteness(sink, 28, 28, 0, nil)
+		if sink.errorfCalled || sink.logfCalled {
+			t.Fatal("expected neither Errorf nor Logf for a clean, fully-attempted run")
+		}
+	})
 }
 
 // TestScanAndPromoteScratch_OneViolationBlocksTheWholeBatch proves plan §5 /

--- a/cmd/conduit/internal/generate/transcript_capture_test.go
+++ b/cmd/conduit/internal/generate/transcript_capture_test.go
@@ -57,6 +57,34 @@
 // does scanAndPromoteScratch copy anything into testdata/transcripts — a
 // single violating file aborts promoting ALL of them, so a violating
 // transcript can never reach the working tree.
+//
+// # Partial results
+//
+// A per-request failure is one of two very different things, and this
+// package never conflates them (see RequestOutcome, transcript.go):
+//
+//   - The model tried and never produced a passing candidate. That is DATA
+//     — a real completion was recorded, buildTranscript captures it, and
+//     Transcript.Outcome records the (failing) verdict. This has never
+//     aborted anything and still doesn't.
+//   - No completion was ever recorded for the request — a 429, a timeout, a
+//     tripped ceiling, or a pre-call refusal. That is ABSENCE of data.
+//     Before this package's partial-results follow-up, this case called
+//     t.Errorf, which fails the whole `go test` process; combined with
+//     generate-capture.yml's `set -euo pipefail`, ONE such request threw
+//     away every other transcript the run had already paid for and
+//     legitimately captured — the incident this section exists to prevent.
+//     It is now logged (t.Logf), tracked per request, and only fails the
+//     run outright once captureCompletenessVerdict's threshold — a STRICT
+//     MAJORITY of the attempted requests missing — is crossed. Below that,
+//     whatever was captured is promoted and manifest.yaml records exactly
+//     which request(s) are missing and why (Manifest.RequestOutcomes),
+//     rather than requiring a reader to infer it from an absent file.
+//
+// The redaction gate above is deliberately untouched by any of this: it
+// remains all-or-nothing regardless of how many requests were captured or
+// missing — see scanAndPromoteScratch's own doc comment and
+// TestScanAndPromoteScratch_ViolationBlocksEvenWhenARequestIsMissing.
 package generate
 
 import (
@@ -516,15 +544,22 @@ func TestCaptureTranscripts(t *testing.T) {
 // already-ceiling-wrapped provider (real or fake — captureProvider does not
 // care) and the directory to promote into, it runs every pass, builds and
 // scratch-writes each request's transcript, redaction-scans and promotes the
-// batch, and — only for a run that captured every given request in every
-// pass — scores the run (ScoreMedian) and writes manifest.yaml.
+// batch, and — for a run that attempted the FULL corpus (never scoped by a
+// `-run` filter to a subset) — scores the run (ScoreMedian) and writes
+// manifest.yaml, INCLUDING for a run where some requests never produced a
+// completion at all (see the file's "Partial results" doc comment):
+// whatever a pass DID capture is promoted and recorded regardless, and
+// captureCompletenessVerdict decides only how loud the `go test` signal is,
+// never whether anything gets preserved. A scoped `-run` (a targeted
+// re-capture of one id) still writes no manifest.yaml, unchanged from
+// before — that file always describes the whole corpus, never a subset.
 //
 // Split out from TestCaptureTranscripts so the FULL pipeline (transcript
 // construction, the redaction-scan-then-promote gate, scoring, manifest
-// provenance) is exercised by TestRunCapture_FullPipeline_FakeProvider
-// against a fake provider and a scratch destDir — no live key, no network, and
-// never touching the real
-// committed testdata/transcripts.
+// provenance) is exercised by TestRunCapture_FullPipeline_FakeProvider and
+// TestRunCapture_PartialFailure_PreservesGoodTranscripts against a fake
+// provider and a scratch destDir — no live key, no network, and never
+// touching the real committed testdata/transcripts.
 func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captureProvider, providerName, model string, passes int, destDir string) (manifest Manifest, wrote bool) {
 	t.Helper()
 
@@ -535,20 +570,56 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 
 	scratchDir := t.TempDir()
 
+	// attemptOrder/attempted track, in corpus order, exactly the requests
+	// this run actually exercised — the full corpus for a normal run, or
+	// the one id a scoped `-run TestCaptureTranscripts/<id>` re-capture
+	// names (t.Run never invokes the closure below for a filtered-out id,
+	// so both maps stay accurate for free). lastFailureReason holds, per
+	// request id, the most recent "no completion recorded" error seen
+	// across every pass — overwritten on every occurrence and deleted the
+	// moment a pass DOES capture that id, so it reflects only the reason a
+	// STILL-missing request is missing, never a transient blip a later pass
+	// recovered from.
+	var attemptOrder []Request
+	attempted := make(map[string]bool, len(requests))
+	lastFailureReason := make(map[string]string)
+
 	var scoreCandidatesList []Candidates
 	for pass := 1; pass <= passes; pass++ {
 		passCandidates := make(Candidates, len(requests))
 		for _, req := range requests {
 			t.Run(req.ID, func(t *testing.T) {
+				if !attempted[req.ID] {
+					attempted[req.ID] = true
+					attemptOrder = append(attemptOrder, req)
+				}
+
 				cp.startRequest()
 				gen, genErr := Generate(ctx, Input{Prompt: req.Prompt, Provider: cp, Model: model})
 				raw := cp.recordedTurns()
 				passCandidates[req.ID] = gen.Candidate
 
 				if len(raw) == 0 {
-					t.Errorf("pass %d: no completion recorded for %q: %v", pass, req.ID, genErr)
+					// Absence of data (see the file-level "Partial results"
+					// doc comment): no completion was EVER recorded for this
+					// attempt — a 429, a timeout, a tripped ceiling, or a
+					// pre-call refusal, never a model that tried and produced
+					// a bad answer (that case has raw != empty and falls
+					// through to buildTranscript below, where it is captured
+					// as ordinary, if failing, data). Logged, not
+					// t.Errorf'd — a single infra blip on one pass must not
+					// fail the whole go test run and discard every OTHER
+					// transcript already captured; captureCompletenessVerdict
+					// below is what decides when enough of these should.
+					reason := "no completion recorded"
+					if genErr != nil {
+						reason = genErr.Error()
+					}
+					lastFailureReason[req.ID] = reason
+					t.Logf("pass %d: %q produced no completion (absence of data): %v", pass, req.ID, genErr)
 					return
 				}
+				delete(lastFailureReason, req.ID)
 
 				tr := buildTranscript(req, gen, raw, providerName, model, systemSHA, catalogFP, time.Now().UTC())
 				writeScratchTranscript(t, scratchDir, tr)
@@ -557,9 +628,9 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 					// Partial success: at least one completion was recorded
 					// and promoted to scratch, but the request never cleared
 					// the budget (or a later call in this same request tripped
-					// a ceiling). Flag it loudly rather than silently
-					// committing a transcript for a request that never
-					// actually succeeded.
+					// a ceiling). This IS data — Transcript.Outcome records
+					// the real (failing) verdict — never "missing", so it is
+					// flagged for visibility only, not tracked as absent.
 					t.Logf("pass %d: %q did not clear the generation budget: %v", pass, req.ID, genErr)
 				}
 			})
@@ -579,6 +650,43 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 			len(findings), destDir, strings.Join(findings, "\n"))
 	}
 	t.Logf("promoted %d transcript(s) into %q", len(moved), destDir)
+
+	// capturedIDs is derived straight from what scanAndPromoteScratch
+	// actually promoted — the single source of truth for "captured", so
+	// this can never disagree with what landed in destDir (in particular:
+	// if the redaction gate above blocked the whole batch, moved is empty
+	// and EVERY attempted request reports as missing here, which is
+	// correct — nothing was promoted for any of them).
+	capturedIDs := make(map[string]bool, len(moved))
+	for _, name := range moved {
+		capturedIDs[strings.TrimSuffix(name, ".yaml")] = true
+	}
+
+	outcomes := make([]RequestOutcome, len(attemptOrder))
+	capturedCount, missingCount := 0, 0
+	for i, req := range attemptOrder {
+		captured := capturedIDs[req.ID]
+		outcomes[i] = RequestOutcome{RequestID: req.ID, Captured: captured}
+		if captured {
+			capturedCount++
+			continue
+		}
+		missingCount++
+		reason := lastFailureReason[req.ID]
+		if reason == "" {
+			reason = "no completion recorded"
+		}
+		outcomes[i].FailureReason = reason
+	}
+
+	if missingCount > 0 {
+		fail, msg := captureCompletenessVerdict(len(attemptOrder), capturedCount, missingCount, outcomes)
+		if fail {
+			t.Errorf("%s", msg)
+		} else {
+			t.Logf("%s", msg)
+		}
+	}
 
 	if len(scoreCandidatesList) != passes {
 		t.Logf("only %d/%d pass(es) captured the full corpus — skipping manifest.yaml "+
@@ -621,12 +729,80 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 		MedianValidatePassCount:  medianInt(validateCounts),
 		MedianSemanticMatchCount: medianInt(semanticCounts),
 		PassScores:               passScores,
+		CapturedCount:            capturedCount,
+		MissingCount:             missingCount,
+		RequestOutcomes:          outcomes,
 	}
 	writeManifest(t, destDir, manifest)
-	t.Logf("wrote manifest: %d calls, %d tokens, ~$%.2f estimated, median validate %.1f%%, median semantic %.1f%%",
-		cp.totalCalls(), cp.totalTokens(), manifest.EstimatedCostUSD,
+	t.Logf("wrote manifest: %d/%d captured, %d calls, %d tokens, ~$%.2f estimated, median validate %.1f%%, median semantic %.1f%%",
+		capturedCount, len(attemptOrder), cp.totalCalls(), cp.totalTokens(), manifest.EstimatedCostUSD,
 		ms.ValidatePassRate*100, ms.SemanticMatchRate*100)
 	return manifest, true
+}
+
+// captureCompletenessThreshold is the fraction of ATTEMPTED requests
+// (missingCount / attemptedCount) that must be missing before a capture run
+// is failed outright rather than merely noted — see
+// captureCompletenessVerdict for the full reasoning. A strict majority: the
+// incident this exists to fix captured 27/28 (3.6% missing) and should have
+// been treated as a normal, publishable partial result, not a reason to
+// discard 27 already-paid-for transcripts.
+const captureCompletenessThreshold = 0.5
+
+// captureCompletenessVerdict is runCapture's threshold decision for a
+// nonzero missingCount, pure and directly testable
+// (TestCaptureCompletenessVerdict) without a fake provider or *testing.T:
+// given the final captured/missing split for whatever requests this run
+// actually attempted, it reports whether the run should be failed and the
+// message that failure (or note) should carry — always naming both what WAS
+// captured and what was NOT (missing id and reason), per the requirement
+// that a reader never has to infer a failure from an absent file.
+//
+// Below the threshold — including one flaky 429, one pass tripping a
+// ceiling, or a single rate-limited request — this is ordinary live-provider
+// noise, not a build-breaking event: the captured transcripts are exactly as
+// valid as a clean run's, and the missing id is a normal, cheap follow-up
+// (`-run TestCaptureTranscripts/<id>`, ~$0.03 per plan §4's per-request
+// cost). fail is false, and the returned message is still non-empty so
+// runCapture can log (not fail on) it.
+//
+// At or past a strict majority missing, something systemic broke — a
+// revoked key, a provider outage, a ceiling misconfigured too low (plan §10
+// failure modes #7-9) — and the artifact is no longer representative of the
+// corpus it claims to measure. fail is true. Note that a true verdict does
+// NOT mean nothing gets preserved: runCapture promotes and writes the
+// manifest for whatever WAS captured regardless of this verdict — this
+// function controls only how loud the `go test` signal is.
+func captureCompletenessVerdict(attemptedCount, capturedCount, missingCount int, outcomes []RequestOutcome) (fail bool, message string) {
+	if attemptedCount == 0 || missingCount == 0 {
+		return false, ""
+	}
+
+	missingIDs := make([]string, 0, missingCount)
+	for _, o := range outcomes {
+		if !o.Captured {
+			missingIDs = append(missingIDs, fmt.Sprintf("%s (%s)", o.RequestID, o.FailureReason))
+		}
+	}
+	missingFrac := float64(missingCount) / float64(attemptedCount)
+
+	if missingFrac > captureCompletenessThreshold {
+		return true, fmt.Sprintf(
+			"most of this run failed to capture anything: %d/%d captured, %d/%d missing (%.0f%%) — "+
+				"this is not a usable partial artifact; investigate before re-running (a revoked key, a "+
+				"provider outage, or a ceiling set too low are the likely causes — plan §10 failure modes "+
+				"#7-9). Whatever WAS captured is still promoted and recorded below. missing: %s",
+			capturedCount, attemptedCount, missingCount, attemptedCount, missingFrac*100, strings.Join(missingIDs, ", "),
+		)
+	}
+
+	return false, fmt.Sprintf(
+		"%d/%d captured, %d/%d missing (%.1f%%, at or below the %.0f%% run-failing threshold) — "+
+			"a normal partial result from live-provider noise; re-capture the missing id(s) with "+
+			"-run TestCaptureTranscripts/<id> when convenient. missing: %s",
+		capturedCount, attemptedCount, missingCount, attemptedCount, missingFrac*100, captureCompletenessThreshold*100,
+		strings.Join(missingIDs, ", "),
+	)
 }
 
 // captureCommandString renders the invocation for Manifest.CaptureCommand,
@@ -929,6 +1105,261 @@ func TestRunCapture_FullPipeline_FakeProvider(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(destDir, manifestFileName)); err != nil {
 		t.Fatalf("expected manifest.yaml to have been written to destDir: %v", err)
+	}
+}
+
+// failOnPromptProvider wraps a fakeProvider but forces every call whose
+// PROMPT contains marker to fail with err, regardless of pass or retry —
+// simulating "this one corpus request never produces a completion, ever"
+// (a 429 that never clears, a revoked scope, …) without needing a new field
+// on fakeProvider itself (whose own `err` applies to every call
+// unconditionally, which cannot express "only THIS request fails").
+// Everything else is delegated to the wrapped fakeProvider unchanged.
+type failOnPromptProvider struct {
+	*fakeProvider
+	marker string
+	err    error
+}
+
+func (p *failOnPromptProvider) Complete(ctx context.Context, req provider.CompletionRequest) (provider.CompletionResult, error) {
+	if strings.Contains(req.Prompt, p.marker) {
+		return provider.CompletionResult{}, p.err
+	}
+	return p.fakeProvider.Complete(ctx, req)
+}
+
+// TestRunCapture_PartialFailure_PreservesGoodTranscripts is this package's
+// regression test for the incident described in the file's "Partial
+// results" doc comment: a 3-passes-over-3-requests run where ONE request
+// (req-b) never produces a single completion on ANY pass — a permanent,
+// simulated 429 — while req-a and req-c succeed on every pass. 1/3 missing
+// (33%) is below captureCompletenessThreshold, so this proves the run
+// SUCCEEDS (no t.Errorf — this test calls runCapture with its own real *t,
+// so an unexpected Errorf here would fail this test too) while still
+// promoting the two good transcripts and recording req-b's absence
+// honestly, both in the promoted files and in the manifest.
+func TestRunCapture_PartialFailure_PreservesGoodTranscripts(t *testing.T) {
+	const failMarker = "TRIGGER_INFRA_FAILURE"
+	requests := []Request{
+		capturePipelineRequest("req-a"),
+		{
+			ID:     "req-b",
+			Prompt: "read from the generator and write to the log " + failMarker,
+			Expect: Expect{SourceCategory: "generator", DestinationCategory: "log"},
+		},
+		capturePipelineRequest("req-c"),
+	}
+
+	reply := "```yaml\n" + validCandidate + "```"
+	base := &fakeProvider{replies: []string{reply}, tokens: 20}
+	infraErr := fmt.Errorf("429: rate limited")
+	fp := &failOnPromptProvider{fakeProvider: base, marker: failMarker, err: infraErr}
+	cp := &captureProvider{Provider: fp, maxCalls: 1000, maxTokens: 1_000_000}
+
+	destDir := filepath.Join(t.TempDir(), "anthropic", "claude-sonnet-5-test")
+	const passes = 3
+
+	manifest, wrote := runCapture(context.Background(), t, requests, cp, "anthropic", "claude-sonnet-5-test", passes, destDir)
+
+	if !wrote {
+		t.Fatal("expected the manifest to still be written: 1/3 missing is below the run-failing threshold")
+	}
+	if manifest.CapturedCount != 2 {
+		t.Fatalf("manifest.CapturedCount = %d, want 2", manifest.CapturedCount)
+	}
+	if manifest.MissingCount != 1 {
+		t.Fatalf("manifest.MissingCount = %d, want 1", manifest.MissingCount)
+	}
+
+	// The two good transcripts must be promoted — the whole point of this
+	// fix is that req-b's failure never discards them.
+	for _, id := range []string{"req-a", "req-c"} {
+		if _, err := os.Stat(filepath.Join(destDir, id+".yaml")); err != nil {
+			t.Fatalf("expected %q to have been promoted despite req-b's failure: %v", id, err)
+		}
+	}
+	// req-b never produced a completion, so no transcript can exist for it —
+	// promoting an empty/fabricated one would be worse than promoting
+	// nothing.
+	if _, err := os.Stat(filepath.Join(destDir, "req-b.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("expected req-b to have NO transcript, stat err = %v", err)
+	}
+
+	var gotReqB RequestOutcome
+	found := false
+	for _, o := range manifest.RequestOutcomes {
+		if o.RequestID == "req-b" {
+			gotReqB, found = o, true
+		}
+	}
+	if !found {
+		t.Fatal("expected manifest.RequestOutcomes to include an entry for req-b")
+	}
+	if gotReqB.Captured {
+		t.Fatal("req-b outcome: Captured = true, want false")
+	}
+	if gotReqB.FailureReason == "" {
+		t.Fatal("req-b outcome: FailureReason must explain why it is missing, got empty string")
+	}
+	if !strings.Contains(gotReqB.FailureReason, infraErr.Error()) {
+		t.Fatalf("req-b outcome: FailureReason = %q, want it to name the underlying error %q", gotReqB.FailureReason, infraErr.Error())
+	}
+
+	for _, id := range []string{"req-a", "req-c"} {
+		for _, o := range manifest.RequestOutcomes {
+			if o.RequestID == id && (!o.Captured || o.FailureReason != "") {
+				t.Fatalf("%s outcome = %+v, want Captured=true and no FailureReason", id, o)
+			}
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(destDir, manifestFileName)); err != nil {
+		t.Fatalf("expected manifest.yaml to have been written despite the partial failure: %v", err)
+	}
+}
+
+// TestCaptureCompletenessVerdict proves the threshold decision directly and
+// without a *testing.T in the loop (calling runCapture with a scenario that
+// crosses the failure threshold would fail THIS test too — see
+// TestRunCapture_PartialFailure_PreservesGoodTranscripts's doc comment for
+// why that test stays below the threshold): the incident's own 1/28 (3.6%)
+// must not fail; a strict majority missing must; the boundary (exactly half)
+// falls on the "not yet most" side; a fully-failed scoped single-request
+// re-capture (1/1 missing) must fail loudly, not print an empty message.
+func TestCaptureCompletenessVerdict(t *testing.T) {
+	outcomesFor := func(missingIDs ...string) []RequestOutcome {
+		out := make([]RequestOutcome, len(missingIDs))
+		for i, id := range missingIDs {
+			out[i] = RequestOutcome{RequestID: id, Captured: false, FailureReason: "429: rate limited"}
+		}
+		return out
+	}
+
+	tests := []struct {
+		name                         string
+		attempted, captured, missing int
+		outcomes                     []RequestOutcome
+		wantFail                     bool
+		wantEmptyMessage             bool
+	}{
+		{
+			name:      "nothing missing -> success, no message",
+			attempted: 28, captured: 28, missing: 0,
+			wantFail:         false,
+			wantEmptyMessage: true,
+		},
+		{
+			name:      "the incident itself: 1/28 missing -> below threshold, not a failure",
+			attempted: 28, captured: 27, missing: 1,
+			outcomes: outcomesFor("kafka-connect-unwrap-to-postgres"),
+			wantFail: false,
+		},
+		{
+			name:      "exactly half missing -> still not 'most', not a failure",
+			attempted: 28, captured: 14, missing: 14,
+			outcomes: outcomesFor(idRange(14, "req")...),
+			wantFail: false,
+		},
+		{
+			name:      "just past half missing -> most of the corpus, fails",
+			attempted: 28, captured: 13, missing: 15,
+			outcomes: outcomesFor(idRange(15, "req")...),
+			wantFail: true,
+		},
+		{
+			name:      "a fully-failed scoped single-request recapture -> 100% missing, fails",
+			attempted: 1, captured: 0, missing: 1,
+			outcomes: outcomesFor("only-request"),
+			wantFail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fail, msg := captureCompletenessVerdict(tt.attempted, tt.captured, tt.missing, tt.outcomes)
+			if fail != tt.wantFail {
+				t.Fatalf("captureCompletenessVerdict(...) fail = %v, want %v (msg: %q)", fail, tt.wantFail, msg)
+			}
+			if tt.wantEmptyMessage {
+				if msg != "" {
+					t.Fatalf("expected an empty message when nothing is missing, got %q", msg)
+				}
+				return
+			}
+			if msg == "" {
+				t.Fatal("expected a non-empty message naming what was and wasn't captured")
+			}
+			capturedStr := fmt.Sprintf("%d/%d captured", tt.captured, tt.attempted)
+			if !strings.Contains(msg, capturedStr) {
+				t.Fatalf("message %q does not name what was captured (%q)", msg, capturedStr)
+			}
+			for _, o := range tt.outcomes {
+				if !strings.Contains(msg, o.RequestID) {
+					t.Fatalf("message %q does not name missing id %q", msg, o.RequestID)
+				}
+			}
+		})
+	}
+}
+
+// idRange returns n synthetic ids "<prefix>-0".."<prefix>-<n-1>", used by
+// TestCaptureCompletenessVerdict's boundary cases where the exact ids don't
+// matter, only the count.
+func idRange(n int, prefix string) []string {
+	ids := make([]string, n)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("%s-%d", prefix, i)
+	}
+	return ids
+}
+
+// TestScanAndPromoteScratch_ViolationBlocksEvenWhenARequestIsMissing proves
+// requirement 4 of the partial-results follow-up: the redaction gate stays
+// all-or-nothing even in exactly the shape partial-capture support
+// introduces — fewer scratch files than corpus requests, because one
+// request never produced a completion. A missing request must never be
+// mistaken for "one fewer file to scan" in a way that lets the OTHER two
+// promote despite a secret in one of them.
+func TestScanAndPromoteScratch_ViolationBlocksEvenWhenARequestIsMissing(t *testing.T) {
+	cleanReply := "```yaml\n" + validCandidate + "```"
+	secretReply := "```yaml\n" + validCandidate + "```\nnote: sk-ant-1234567890abcdefghijklmnop"
+
+	// Three corpus requests, but only two ever produce a transcript —
+	// req-missing is simulated absence of data: it has NO file in
+	// scratchDir at all, exactly what a permanently-failing request leaves
+	// behind under the new partial-capture handling.
+	requests := []Request{capturePipelineRequest("req-clean"), capturePipelineRequest("req-secret")}
+	fake := &fakeProvider{replies: []string{cleanReply, secretReply}, tokens: 10}
+	cp := &captureProvider{Provider: fake, maxCalls: 1000, maxTokens: 1_000_000}
+
+	system := BuildSystemPrompt(BuiltinCatalog())
+	systemSHA := sha256Hex(system)
+	catalogFP := CatalogFingerprint()
+
+	scratchDir := t.TempDir()
+	for _, req := range requests {
+		cp.startRequest()
+		gen, genErr := Generate(context.Background(), Input{Prompt: req.Prompt, Provider: cp, Model: "claude-sonnet-5-test"})
+		raw := cp.recordedTurns()
+		if len(raw) == 0 {
+			t.Fatalf("setup: no completion recorded for %q: %v", req.ID, genErr)
+		}
+		tr := buildTranscript(req, gen, raw, "anthropic", "claude-sonnet-5-test", systemSHA, catalogFP, time.Now().UTC())
+		writeScratchTranscript(t, scratchDir, tr)
+	}
+	// req-missing deliberately gets no writeScratchTranscript call at all.
+
+	destDir := filepath.Join(t.TempDir(), "anthropic", "claude-sonnet-5-test")
+	moved, findings := scanAndPromoteScratch(context.Background(), t, scratchDir, destDir)
+
+	if len(findings) == 0 {
+		t.Fatal("expected the secret-carrying transcript to produce at least one finding")
+	}
+	if len(moved) != 0 {
+		t.Fatalf("expected NOTHING promoted (not even req-clean) when any finding exists, got %v", moved)
+	}
+	if _, err := os.Stat(destDir); !os.IsNotExist(err) {
+		t.Fatalf("expected destDir %q to never have been created, stat err = %v", destDir, err)
 	}
 }
 

--- a/cmd/conduit/internal/generate/transcript_capture_test.go
+++ b/cmd/conduit/internal/generate/transcript_capture_test.go
@@ -980,12 +980,25 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 
 	outcomes := make([]RequestOutcome, len(attemptOrder))
 	capturedCount, missingCount := 0, 0
+	// carriedForwardIDs is every id THIS run counts as captured SOLELY
+	// because requestIsCaptured found a valid transcript already on disk —
+	// never because scanAndPromoteScratch promoted anything for it this
+	// run. Fed into summarizePasses (H1 x H2 fix, round-5 review of #2814):
+	// the equal-missing-sets exemption that lets a chronically-missing
+	// request avoid tripping MediansUnreliable is only sound when that
+	// request is ALSO visible as run-missing (MissingCount > 0) — which is
+	// exactly what breaks when an id in every pass's missing set is only
+	// "captured" via carry-forward. See summarizePasses' own doc comment.
+	var carriedForwardIDs []string
 	for i, req := range attemptOrder {
-		captured := requestIsCaptured(capturedIDs, req.ID, destDir)
-		outcomes[i] = RequestOutcome{RequestID: req.ID, Captured: captured}
+		outcome, carriedForward := classifyRequestOutcome(req, destDir, capturedIDs, lastFailureErr, safeReasons)
+		outcomes[i] = outcome
 
-		if captured {
+		if outcome.Captured {
 			capturedCount++
+			if carriedForward {
+				carriedForwardIDs = append(carriedForwardIDs, req.ID)
+			}
 			// A previous run's tombstone for this id, if any, is now
 			// stale — this id has real data again (whether promoted THIS
 			// run or already on disk from an earlier one), and
@@ -1026,64 +1039,7 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 	}
 
 	ms := ScoreMedian(ctx, requests, scoreCandidatesList)
-	passScores, degradedMedians := summarizePasses(ms.Runs, scoreMissingSets)
-
-	switch {
-	case degradedMedians.allDegraded:
-		// B1 fix (round-3 review of #2814), generalized by H1 (round-4
-		// review of #2814): every one of `passes` passes lost the full
-		// corpus AND the passes disagree about which requests they missed
-		// (allMissingSetsEqual is false) — a rate-limit storm or
-		// captureWallClockBudget expiring partway through and wiping every
-		// pass from that point on is one way to get here, but so is a
-		// provider that rotates which single request it answers pass to
-		// pass (no pass ever wiped, yet no two passes miss the same
-		// requests either). Either way summarizePasses has no clean pass
-		// left to compute a median FROM, so validateRate/semanticRate below
-		// are its all-passes fallback, which scores every missing request
-		// as a hard fail with nothing to dilute it. Treated as a hard
-		// failure of this `go test` run, the same class of thing
-		// captureCompletenessVerdict already does for attemptedCount == 0:
-		// t.Errorf (not t.Fatalf) so the manifest below still gets written
-		// with whatever WAS captured (see captureCompletenessVerdict's own
-		// doc comment on why a true verdict there does not mean nothing is
-		// preserved — the same reasoning applies here), but the `go test`
-		// exit code goes nonzero, which generate-capture.yml's `capture`
-		// job turns into CAPTURE_RESULT != "success" — the [!WARNING]
-		// PARTIAL-capture banner and title, not the routine [!NOTE] one.
-		// Manifest.MediansUnreliable (set below) carries the same fact
-		// into the committed file for a reader who never sees the PR body.
-		t.Errorf("every one of %d capture pass(es) was degraded (see passScores[].missingCount) — no pass "+
-			"contributed a usable candidate for the full corpus, so medianValidatePassRate (%.3f) and "+
-			"medianSemanticMatchRate (%.3f) below are a fallback computed across ALL passes, with every "+
-			"missing request scored as a hard fail and no clean pass to dilute that — NOT a reliable "+
-			"median, and must not be used as this run's baseline. Whatever WAS captured is still promoted "+
-			"and recorded below (capturedCount/missingCount/requestOutcomes).",
-			passes, degradedMedians.validateRate, degradedMedians.semanticRate)
-	case len(degradedMedians.degradedPasses) > 0:
-		// Deliberately a separate Logf, not folded into
-		// reportCaptureCompleteness below: that function's fail/log
-		// threshold (captureCompletenessVerdict) is scoped to REQUESTS
-		// missing from the whole run, and its majority-threshold math
-		// would be wrong applied to PASSES instead — a run can have every
-		// request captured (missingCount == 0, so
-		// reportCaptureCompleteness has nothing to say) while still
-		// having lost a tail pass to rate limiting, which is exactly the
-		// case this exists to surface. Reached whenever at least one pass
-		// is degraded but summarizePasses did NOT judge the situation
-		// misleading (allDegraded above is false) — either because at
-		// least one OTHER pass was clean, or because every degraded pass
-		// missed the exact same request set (a stable, non-misleading
-		// partial result — allMissingSetsEqual; H1, round-4 review of
-		// #2814 fixed an earlier version of this comment that assumed only
-		// the first case was possible here, which was never true: a
-		// chronic single-missing-request run also reaches this branch with
-		// ZERO clean passes).
-		t.Logf("pass(es) %v captured fewer than the full corpus (see passScores[].missingCount in the "+
-			"manifest) — excluded from medianValidatePassRate/medianSemanticMatchRate so a wiped tail pass "+
-			"does not silently drag those numbers toward zero; requests affected may still show as captured "+
-			"overall (capturedCount/missingCount) if another pass produced them", degradedMedians.degradedPasses)
-	}
+	passScores, degradedMedians := summarizePasses(ms.Runs, scoreMissingSets, carriedForwardIDs)
 
 	// H2 fix (round-4 review of #2814): a run that promoted NOTHING new
 	// learned nothing about the corpus's quality — passScores/
@@ -1094,7 +1050,21 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 	// this function (kept runCapture's own cyclomatic complexity under
 	// gocyclo's threshold, the same reason finishScopedRun and
 	// summarizePasses were split out for earlier rounds of #2814's review).
-	passScores, degradedMedians = preserveMediansIfNothingPromoted(t, destDir, moved, passScores, degradedMedians)
+	//
+	// Moved BEFORE the switch below (round-5 review of #2814): the switch
+	// decides whether to t.Errorf/t.Logf based on degradedMedians, and a
+	// run that promoted nothing built degradedMedians from zero completions
+	// — evaluating the switch on THAT synthetic data (before it gets
+	// replaced by preserveMediansIfNothingPromoted, or correctly flagged
+	// unreliable by it on a shape mismatch) risked t.Errorf-ing a `go test`
+	// run whose real, preserved manifest was perfectly fine — exactly the
+	// interaction TestRunCapture_SecondRunCapturesNothing_PreservesFirstRunsGoodManifest
+	// guards against: reordering this after the switch makes that test
+	// fail with a spurious t.Errorf even though its own assertions still
+	// pass.
+	passScores, degradedMedians = preserveMediansIfNothingPromoted(t, destDir, moved, requests, passes, passScores, degradedMedians)
+
+	logDegradedPassSummary(t, degradedMedians, passes)
 
 	manifest = Manifest{
 		SchemaVersion:            TranscriptSchemaVersion,
@@ -1126,6 +1096,89 @@ func runCapture(ctx context.Context, t *testing.T, requests []Request, cp *captu
 		capturedCount, len(attemptOrder), cp.totalCalls(), cp.totalTokens(), manifest.EstimatedCostUSD,
 		degradedMedians.validateRate*100, degradedMedians.semanticRate*100)
 	return manifest, ms.Runs, true
+}
+
+// logDegradedPassSummary reports, via t, what (if anything) degradedMedians
+// means for this run's own `go test` outcome — split out from runCapture
+// (M1-3/H1 x H2, round-5 review of #2814: kept runCapture's own cyclomatic
+// complexity under gocyclo's threshold, the same reason finishScopedRun,
+// summarizePasses, and preserveMediansIfNothingPromoted were split out for
+// earlier rounds).
+func logDegradedPassSummary(t *testing.T, degradedMedians passesSummary, passes int) {
+	t.Helper()
+	switch {
+	case degradedMedians.allDegraded:
+		// B1 fix (round-3 review of #2814), generalized by H1 (round-4
+		// review of #2814) and H1 x H2 (round-5 review of #2814): every one
+		// of `passes` passes lost the full corpus AND missingSetsAreReliable
+		// is false for those degraded passes — a rate-limit storm or
+		// captureWallClockBudget expiring partway through and wiping every
+		// pass from that point on is one way to get here, but so is a
+		// provider that rotates which single request it answers pass to
+		// pass, or a chronically-missing request that is ALSO only counted
+		// captured via H2's on-disk carry-forward (see
+		// missingSetsAreReliable's own doc comment). Either way
+		// summarizePasses has no clean pass left to compute a median FROM,
+		// so validateRate/semanticRate below are its all-passes fallback,
+		// which scores every missing request as a hard fail with nothing to
+		// dilute it. Treated as a hard failure of this `go test` run, the
+		// same class of thing captureCompletenessVerdict already does for
+		// attemptedCount == 0: t.Errorf (not t.Fatalf) so the manifest below
+		// still gets written with whatever WAS captured (see
+		// captureCompletenessVerdict's own doc comment on why a true
+		// verdict there does not mean nothing is preserved — the same
+		// reasoning applies here), but the `go test` exit code goes
+		// nonzero, which generate-capture.yml's `capture` job turns into
+		// CAPTURE_RESULT != "success" — the [!WARNING] PARTIAL-capture
+		// banner and title, not the routine [!NOTE] one. Manifest.
+		// MediansUnreliable (set below) carries the same fact into the
+		// committed file for a reader who never sees the PR body. This is
+		// also the branch preserveMediansIfNothingPromoted's own shape-
+		// mismatch case (M4) reaches, above.
+		t.Errorf("every one of %d capture pass(es) was degraded (see passScores[].missingCount) — no pass "+
+			"contributed a usable candidate for the full corpus, so medianValidatePassRate (%.3f) and "+
+			"medianSemanticMatchRate (%.3f) below are a fallback computed across ALL passes, with every "+
+			"missing request scored as a hard fail and no clean pass to dilute that — NOT a reliable "+
+			"median, and must not be used as this run's baseline. Whatever WAS captured is still promoted "+
+			"and recorded below (capturedCount/missingCount/requestOutcomes).",
+			passes, degradedMedians.validateRate, degradedMedians.semanticRate)
+	case degradedMedians.sampleSize < passes:
+		// A real, clean-pass-only median: degradedMedians.sampleSize (the
+		// clean-pass count) is strictly less than passes, meaning the
+		// degraded pass(es) named below were genuinely excluded from
+		// medianValidatePassRate/medianSemanticMatchRate — the "excluded"
+		// claim this message makes is actually true here. Deliberately a
+		// separate Logf, not folded into reportCaptureCompleteness: that
+		// function's fail/log threshold (captureCompletenessVerdict) is
+		// scoped to REQUESTS missing from the whole run, and its
+		// majority-threshold math would be wrong applied to PASSES instead
+		// — a run can have every request captured (missingCount == 0, so
+		// reportCaptureCompleteness has nothing to say) while still having
+		// lost a tail pass to rate limiting, which is exactly the case this
+		// exists to surface.
+		t.Logf("pass(es) %v captured fewer than the full corpus (see passScores[].missingCount in the "+
+			"manifest) — excluded from medianValidatePassRate/medianSemanticMatchRate so a wiped tail pass "+
+			"does not silently drag those numbers toward zero; requests affected may still show as captured "+
+			"overall (capturedCount/missingCount) if another pass produced them", degradedMedians.degradedPasses)
+	case len(degradedMedians.degradedPasses) > 0:
+		// H1 (round-5 review of #2814): degradedMedians.sampleSize == passes
+		// here (the case above did NOT match), so — unlike the case above —
+		// nothing was actually excluded from the median: summarizePasses'
+		// all-passes fallback ran (n == 0, no clean pass existed) but
+		// missingSetsAreReliable held, so the fallback's number equals what
+		// a clean-pass median would have shown anyway. The previous version
+		// of this message unconditionally claimed "excluded... so [it does]
+		// not silently drag those numbers toward zero" even in this branch,
+		// which is false when nothing was excluded — the identical false
+		// claim generate-capture.yml's own DEGRADED banner made before its
+		// own fix (see that workflow's "Compute the summary" step).
+		t.Logf("pass(es) %v captured fewer than the full corpus (see passScores[].missingCount in the "+
+			"manifest), but every degraded pass missed the SAME, reliably-attributed request(s) — "+
+			"medianValidatePassRate/medianSemanticMatchRate below are the all-pass fallback median, which "+
+			"equals what a clean-pass median would have shown too (nothing was excluded, and this is not "+
+			"misleading); requests affected may still show as captured overall (capturedCount/missingCount) "+
+			"if another pass, or an earlier run's transcript, produced them", degradedMedians.degradedPasses)
+	}
 }
 
 // finishScopedRun is runCapture's return path for a scoped
@@ -1163,24 +1216,103 @@ func finishScopedRun(t *testing.T, destDir string, outcomes []RequestOutcome, ca
 	return patched, nil, true
 }
 
-// requestIsCaptured reports whether id counts as captured for this run's
-// RequestOutcome/CapturedCount/MissingCount bookkeeping: either
-// scanAndPromoteScratch promoted it THIS run (capturedIDs), or an earlier
-// run already left a real "<id>.yaml" transcript in destDir that this run's
-// own failure to reproduce does not invalidate (H2 fix, round-4 review of
-// #2814 — see capturedIDs' own doc comment in runCapture for the
-// contradiction this replaces). Split out as its own function, rather than
-// inlined as an `if` in runCapture, purely to keep that function's
-// cyclomatic complexity under gocyclo's threshold (the same reason
-// finishScopedRun, summarizePasses, and preserveMediansIfNothingPromoted
-// were split out for earlier rounds of #2814's review) — there is no
-// independent testability reason for the split here, unlike those.
-func requestIsCaptured(capturedIDs map[string]bool, id, destDir string) bool {
-	if capturedIDs[id] {
-		return true
+// requestIsCaptured reports whether req already has a VALID transcript on
+// disk in destDir — the H2 fix's (round-4 review of #2814) disk-fallback
+// half: an earlier run may have already committed a real transcript for an
+// id THIS run's own attempt failed to reproduce (provider down,
+// rate-limited, a tripped ceiling, …), and that data is still good.
+// runCapture calls this only after checking capturedIDs (this run's own
+// promotions) itself — see capturedIDs' own doc comment there for the
+// contradiction the disk-fallback half replaces — so this function is never
+// the sole source of "captured", only the fallback.
+//
+// M5 (round-5 review of #2814): a bare os.Stat used to be the entire check
+// here — true for a directory, a zero-byte file, or (the actually dangerous
+// case) a transcript captured for a DIFFERENT prompt under an id that was
+// never renamed. Reproduced: edit a request's prompt without touching its
+// id, run with the provider down, and the pre-fix version reported the
+// stale, now-mismatched transcript as captured — a manifest.yaml claiming a
+// fully-captured corpus for a tree LoadTranscripts (transcript.go) hard-
+// rejects the moment anything actually loads it (corpusPromptSHA256
+// mismatch). Now this reads and parses the file exactly like readTranscript
+// does and requires RequestID and CorpusPromptSHA256 to still match req —
+// the same two checks LoadTranscripts itself runs — so a stale or
+// content-mismatched file is never silently counted as captured. When it
+// returns false for an id that DOES have a file on disk, runCapture's
+// caller falls through to the missing/tombstone branch, which writes
+// "<id>.missing.yaml" alongside the (untouched, still mismatched) stale
+// "<id>.yaml" — deliberately not resolved automatically: LoadTranscripts
+// hard-errors on an id carrying both, which is the loud, specific failure
+// this situation deserves rather than a silently wrong manifest.
+//
+// No TOCTOU concern reading then trusting this file: destDir is written
+// only by this process for the duration of one runCapture call (doc.go's
+// invariants), never concurrently by anything else.
+func requestIsCaptured(req Request, destDir string) bool {
+	data, err := os.ReadFile(filepath.Join(destDir, req.ID+".yaml"))
+	if err != nil {
+		return false
 	}
-	_, err := os.Stat(filepath.Join(destDir, id+".yaml"))
-	return err == nil
+	var t Transcript
+	if err := yaml.Unmarshal(data, &t); err != nil {
+		return false
+	}
+	return t.RequestID == req.ID && t.CorpusPromptSHA256 == sha256Hex(req.Prompt)
+}
+
+// classifyRequestOutcome builds one request's RequestOutcome for
+// runCapture's outcomes loop, and separately reports whether a Captured
+// == true outcome came ONLY from requestIsCaptured's on-disk carry-forward
+// (carriedForward) rather than from anything promoted THIS run. Split out
+// from runCapture (M2/M5, round-5 review of #2814 — the same reason
+// finishScopedRun, summarizePasses, and preserveMediansIfNothingPromoted
+// were split out for earlier rounds: keeps runCapture's own cyclomatic
+// complexity under gocyclo's threshold) — there is no independent
+// testability reason for the split here either, unlike those three.
+//
+// capturedIDs is what scanAndPromoteScratch promoted THIS run (runCapture's
+// own single source of truth for "captured"); lastFailureErr and
+// safeReasons are runCapture's own per-id tracking of the most recent
+// pass this run attempted that produced no completion, and its
+// manifest-safe rendering — see their declarations in runCapture for the
+// full reasoning.
+func classifyRequestOutcome(
+	req Request, destDir string, capturedIDs map[string]bool, lastFailureErr map[string]error, safeReasons map[string]string,
+) (outcome RequestOutcome, carriedForward bool) {
+	promotedThisRun := capturedIDs[req.ID]
+	captured := promotedThisRun
+	if !captured {
+		// M5 (round-5 review of #2814): requestIsCaptured now reads and
+		// shape/hash-validates the on-disk file rather than trusting a
+		// bare os.Stat — see that function's own doc comment.
+		captured = requestIsCaptured(req, destDir)
+	}
+	outcome = RequestOutcome{RequestID: req.ID, Captured: captured}
+	if !captured {
+		return outcome, false
+	}
+	if promotedThisRun {
+		return outcome, false
+	}
+
+	// M2 (round-5 review of #2814): H2 dropped this — a run carrying an id
+	// forward from an earlier run's real transcript is still captured
+	// overall, but if THIS run's own attempt(s) never produced a completion
+	// for it either (lastFailureErr still has an entry — every pass this
+	// run tried came back with no completion, none of them ever deleted
+	// it), that fact must not vanish from the only committed record of why
+	// a run could not reproduce a request. FailureReason is otherwise
+	// "always empty when Captured is true" (see its own doc comment) —
+	// this is the one deliberate exception, and it stays empty whenever
+	// this run DID reproduce the request on at least one pass.
+	if _, failedThisRun := lastFailureErr[req.ID]; failedThisRun {
+		reason := safeReasons[req.ID]
+		if reason == "" {
+			reason = "no completion recorded"
+		}
+		outcome.FailureReason = reason
+	}
+	return outcome, true
 }
 
 // preserveMediansIfNothingPromoted is runCapture's H2 fix (round-4 review of
@@ -1206,8 +1338,31 @@ func requestIsCaptured(capturedIDs map[string]bool, id, destDir string) bool {
 // also independently caught by reportCaptureCompleteness's
 // captureCompletenessVerdict, which fails a run that attempted requests and
 // captured none of them regardless of what this function does.
+//
+// M4 (round-5 review of #2814): the prior manifest is only reused when its
+// OWN shape still matches this run's — prior.RequestCount == len(requests)
+// AND prior.Passes == passes. Without that check, a corpus that grew (or a
+// passes flag that changed) between runs let a shape-mismatched prior
+// manifest's medians publish unchanged: reproduced with a corpus growing
+// 4 -> 6 requests between two runs, the second (1 pass, provider dead)
+// published requestCount: 6 with a 1.000 median carried straight from the
+// OLD 4-request run, three passScores[].total still reading 4, and
+// capturedAt/corpusCommitSha/captureCommand all refreshed to the NEW run —
+// nothing in the file marked the medians as describing a different,
+// smaller corpus. The documented backstop (captureCompletenessVerdict
+// failing a run that captured NONE of its requests) does not catch this:
+// H2's carry-forward keeps capturedCount nonzero (the 4 old requests are
+// still really on disk), so that verdict never fires. When the shape
+// doesn't match, THIS run's own (zero, honestly-measured-from-nothing)
+// passScores/degradedMedians are kept instead of the prior's, and
+// degradedMedians.allDegraded is forced true — reusing
+// Manifest.MediansUnreliable's existing "do not trust this as a baseline"
+// signal (and the same t.Errorf/CAPTURE_RESULT!=success path runCapture's
+// own switch already gives that field) rather than inventing a parallel
+// staleness field nothing else in the pipeline knows to check.
 func preserveMediansIfNothingPromoted(
-	t *testing.T, destDir string, moved []string, passScores []PassScore, degradedMedians passesSummary,
+	t *testing.T, destDir string, moved []string, requests []Request, passes int,
+	passScores []PassScore, degradedMedians passesSummary,
 ) ([]PassScore, passesSummary) {
 	t.Helper()
 	if len(moved) > 0 {
@@ -1216,6 +1371,16 @@ func preserveMediansIfNothingPromoted(
 
 	prior, err := LoadManifest(filepath.Join(destDir, manifestFileName))
 	if err != nil {
+		return passScores, degradedMedians
+	}
+
+	if prior.RequestCount != len(requests) || prior.Passes != passes {
+		t.Logf("this run promoted no new transcripts, and the existing manifest describes a different-shaped "+
+			"run (requestCount %d, passes %d) than this one (requestCount %d, passes %d) — not safe to reuse "+
+			"as this run's median/pass-score fields; flagging this run's medians unreliable instead of "+
+			"publishing a shape-mismatched baseline (M4, round-5 review of #2814)",
+			prior.RequestCount, prior.Passes, len(requests), passes)
+		degradedMedians.allDegraded = true
 		return passScores, degradedMedians
 	}
 
@@ -1414,13 +1579,68 @@ func allMissingSetsEqual(sets [][]string) bool {
 	}
 	first := sets[0]
 	for _, s := range sets[1:] {
-		if len(s) != len(first) {
+		if !idSetEqual(s, first) {
 			return false
 		}
-		for i, id := range first {
-			if s[i] != id {
-				return false
-			}
+	}
+	return true
+}
+
+// idSetEqual reports whether a and b name exactly the same ids in the same
+// order — the positional comparison allMissingSetsEqual documents is safe
+// for, factored out so missingSetsAreReliable (below) can reuse it against a
+// set built from a DIFFERENT source (RequestOutcomes) than the two
+// missing-set slices it was originally written to compare.
+func idSetEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, id := range a {
+		if b[i] != id {
+			return false
+		}
+	}
+	return true
+}
+
+// missingSetsAreReliable is the equal-missing-sets exemption's full
+// soundness check: every pass in sets must miss the same ids (
+// allMissingSetsEqual) AND none of those ids may be captured overall SOLELY
+// through H2's on-disk carry-forward (carriedForwardIDs — runCapture's
+// requestIsCaptured disk fallback, never this run's own promotion).
+//
+// H1 x H2 interaction (HIGH-1, round-5 review of #2814): the equal-sets
+// exemption (H1, round-4 review) was justified on the premise that "a
+// chronically-missing request is ALSO visible as Manifest.MissingCount > 0"
+// — a reader who distrusts a stable-looking degraded median still has
+// MissingCount and RequestOutcomes to point at the culprit. H2 (same round)
+// broke that premise: requestIsCaptured now also reports a request captured
+// when an EARLIER run already committed a real transcript for it, even if
+// every pass THIS run attempted came back with nothing. Reproduced: 3
+// requests, 3 passes, run 2 on the same destDir, req-b 429s on every call —
+// every pass's missing set is identically [req-b] (the exemption's ONLY
+// check, pre-fix), so allDegraded stayed false and MediansUnreliable was
+// never set, even though req-b is captured this run ONLY via carry-forward
+// and the median silently dropped from 1.000 to 0.667 with nothing else in
+// the file explaining why. Requiring the agreed-upon missing set to be
+// disjoint from carriedForwardIDs restores the exemption's original
+// premise: an id in the missing set that is captured only by carry-forward
+// is NOT visible via MissingCount (MissingCount == 0 for it), so the
+// exemption must not apply.
+func missingSetsAreReliable(sets [][]string, carriedForwardIDs []string) bool {
+	if !allMissingSetsEqual(sets) {
+		return false
+	}
+	if len(sets) == 0 || len(carriedForwardIDs) == 0 {
+		return true
+	}
+	carried := make(map[string]bool, len(carriedForwardIDs))
+	for _, id := range carriedForwardIDs {
+		carried[id] = true
+	}
+	for _, id := range sets[0] {
+		if carried[id] {
+			return false
 		}
 	}
 	return true
@@ -1438,21 +1658,31 @@ type passesSummary struct {
 	semanticCount  float64
 	// sampleSize is how many passes actually contributed to
 	// validateRate/semanticRate/validateCount/semanticCount above — the
-	// number of clean passes ordinarily, or every pass (len(runs)) when
-	// allDegraded's fallback is in effect. N3 (round-3 review of #2814):
+	// number of clean passes ordinarily, or every pass (len(runs)) whenever
+	// NO pass was clean (n == 0, the all-passes fallback) — REGARDLESS of
+	// whether allDegraded ends up true or false for that run (M1-3, round-5
+	// review of #2814: a prior version of this comment tied the fallback to
+	// "allDegraded's fallback", implying they always coincide; they do not
+	// — the chronic-single-missing-request case has n == 0, and therefore
+	// this same len(runs) fallback, while allDegraded correctly stays
+	// false). N3 (round-3 review of #2814):
 	// exposed via Manifest.MedianSampleSize so a reader isn't left
 	// inferring "how many passes is this median actually over" from
 	// Passes minus len(DegradedPasses) — a median over 1 pass and a median
 	// over 3 both render as one number without this.
 	sampleSize int
 	// allDegraded is true when every pass in runs was degraded (no pass
-	// contributed a usable candidate for the full corpus) AND those
-	// degraded passes do not all miss the SAME set of request ids
-	// (!allMissingSetsEqual) — see summarizePasses' doc comment for why
-	// both conditions are required, and for what the four fields above
-	// mean in that case. runCapture treats this as a hard failure (B1,
-	// round-3 review of #2814), the same class of thing
-	// captureCompletenessVerdict already does for attemptedCount == 0.
+	// contributed a usable candidate for the full corpus) AND
+	// missingSetsAreReliable is false for those degraded passes' missing
+	// sets — see summarizePasses' doc comment for why both conditions are
+	// required, and for what the four fields above mean in that case.
+	// runCapture treats this as a hard failure (B1, round-3 review of
+	// #2814), the same class of thing captureCompletenessVerdict already
+	// does for attemptedCount == 0. preserveMediansIfNothingPromoted (M4,
+	// round-5 review of #2814) also sets this directly, independent of
+	// runs/missingSets, when a preserved prior manifest's own shape
+	// (RequestCount/Passes) doesn't match this run's — see that function's
+	// doc comment.
 	//
 	// H1 (round-4 review of #2814): this used to require "at least one
 	// pass was WIPED (missing every request)" instead of "the missing sets
@@ -1461,6 +1691,10 @@ type passesSummary struct {
 	// wiped, so the old condition never fired) still leaves n == 0 with a
 	// DIFFERENT set of missing ids every time, which is exactly as
 	// misleading as a wipe. See allMissingSetsEqual's doc comment.
+	//
+	// H1 x H2 (round-5 review of #2814): agreeing missing sets alone is
+	// not enough either — see missingSetsAreReliable's own doc comment for
+	// the carry-forward interaction that broke the round-4 exemption.
 	allDegraded bool
 }
 
@@ -1527,7 +1761,20 @@ type passesSummary struct {
 // run for the actual failure mode without also failing on ordinary
 // single-request flakiness — see runCapture's own handling and
 // Manifest.MediansUnreliable.
-func summarizePasses(runs []RunScore, missingSets [][]string) ([]PassScore, passesSummary) {
+//
+// H1 x H2 (HIGH-1, round-5 review of #2814): agreeing missing sets are
+// necessary but no longer sufficient — carriedForwardIDs (runCapture's
+// requestIsCaptured disk fallback: an id captured overall ONLY because an
+// earlier run already committed a real transcript for it, never because
+// THIS run reproduced it) is what the equal-sets exemption's premise
+// ("chronically missing is also visible as MissingCount > 0") silently
+// depends on. When a degraded pass's agreed-upon missing set contains an id
+// that is only captured via carry-forward, that premise is false — the id
+// reads as fully captured (MissingCount == 0) even though every pass this
+// run attempted came back with nothing for it — so the exemption must not
+// apply. See missingSetsAreReliable's own doc comment for the full
+// reasoning and a worked repro.
+func summarizePasses(runs []RunScore, missingSets [][]string, carriedForwardIDs []string) ([]PassScore, passesSummary) {
 	passScores := make([]PassScore, len(runs))
 	allValidateRates := make([]float64, len(runs))
 	allSemanticRates := make([]float64, len(runs))
@@ -1583,21 +1830,23 @@ func summarizePasses(runs []RunScore, missingSets [][]string) ([]PassScore, pass
 		summary.sampleSize = n
 	}
 	// allDegraded requires BOTH no clean pass (n == 0) AND the degraded
-	// passes disagreeing about which requests they missed
-	// (!allMissingSetsEqual) — n == 0 alone is not enough: a single
-	// request that is chronically missing across every pass (present in no
-	// pass's candidates at all, but the SAME one request every time, so
-	// every degraded pass's missing set is identical) also leaves n == 0,
-	// yet every pass's rate is identical and stable — reporting the
-	// all-passes median in that case is not misleading, it is the true
-	// answer, and this is exactly the "normal partial result" scenario
-	// captureCompletenessVerdict already treats as routine below its
-	// majority threshold. Comparing the actual missing-id sets (H1, round-4
-	// review of #2814) narrows this to the real failure mode: passes that
-	// disagree about which requests they captured, whether that disagreement
-	// takes the form of one pass wiped entirely (B1, round-3 review of
-	// #2814) or several passes each capturing a different rotating subset.
-	summary.allDegraded = n == 0 && !allMissingSetsEqual(degradedMissingSets)
+	// passes' missing sets failing missingSetsAreReliable — n == 0 alone is
+	// not enough: a single request that is chronically missing across every
+	// pass (present in no pass's candidates at all, but the SAME one
+	// request every time, so every degraded pass's missing set is
+	// identical) also leaves n == 0, yet every pass's rate is identical and
+	// stable — reporting the all-passes median in that case is not
+	// misleading, it is the true answer, and this is exactly the "normal
+	// partial result" scenario captureCompletenessVerdict already treats as
+	// routine below its majority threshold, PROVIDED that request is not
+	// ALSO being reported captured through disk carry-forward (H1 x H2,
+	// round-5 review of #2814 — see missingSetsAreReliable's own doc
+	// comment). Comparing the actual missing-id sets (H1, round-4 review of
+	// #2814) narrows this to the real failure mode: passes that disagree
+	// about which requests they captured, whether that disagreement takes
+	// the form of one pass wiped entirely (B1, round-3 review of #2814) or
+	// several passes each capturing a different rotating subset.
+	summary.allDegraded = n == 0 && !missingSetsAreReliable(degradedMissingSets, carriedForwardIDs)
 	return passScores, summary
 }
 
@@ -2299,6 +2548,13 @@ func TestRunCapture_DegradedTailPass_ExcludedFromMedian(t *testing.T) {
 // Reverting either half of the H2 fix (the disposition carry-forward in
 // runCapture's outcomes loop, or the median-preservation guarded on
 // len(moved) == 0) makes this test fail.
+//
+// M2 (round-5 review of #2814): both req-a and req-b DO get a FailureReason
+// now, even though Captured stays true — this run's own attempt genuinely
+// failed to reproduce them (the dead provider), and that fact must not
+// vanish just because an earlier run's real transcript is still being
+// counted. See RequestOutcome.FailureReason's own doc comment for why this
+// is the one case it is non-empty alongside Captured == true.
 func TestRunCapture_SecondRunCapturesNothing_PreservesFirstRunsGoodManifest(t *testing.T) {
 	requests := []Request{
 		capturePipelineRequest("req-a"),
@@ -2347,8 +2603,14 @@ func TestRunCapture_SecondRunCapturesNothing_PreservesFirstRunsGoodManifest(t *t
 		t.Fatalf("second run: manifest.MissingCount = %d, want 0", second.MissingCount)
 	}
 	for _, o := range second.RequestOutcomes {
-		if !o.Captured || o.FailureReason != "" || o.Unusable {
-			t.Fatalf("second run: outcome for %q = %+v, want Captured=true, no FailureReason, not Unusable",
+		// M2 (round-5 review of #2814): Captured stays true (carried
+		// forward from run 1's real data) but FailureReason is now non-empty
+		// — this run's own attempt for both ids genuinely produced nothing,
+		// and that must still be visible in the committed manifest even
+		// though it isn't what makes Captured false.
+		if !o.Captured || o.FailureReason == "" || o.Unusable {
+			t.Fatalf("second run: outcome for %q = %+v, want Captured=true, a non-empty FailureReason "+
+				"(this run's own attempt failed even though carry-forward keeps it captured), not Unusable",
 				o.RequestID, o)
 		}
 	}
@@ -3206,7 +3468,11 @@ func TestSummarizePasses_AllDegraded_FlagsUnreliableFallback(t *testing.T) {
 
 	ctx := context.Background()
 	ms := ScoreMedian(ctx, requests, []Candidates{pass1, pass2, pass3})
-	_, summary := summarizePasses(ms.Runs, missingSets)
+	// carriedForwardIDs is nil: these unit tests exercise summarizePasses
+	// directly, with no destDir/disk state at all, so there is nothing to
+	// carry forward — see missingSetsAreReliable's own doc comment for what
+	// this argument guards against (HIGH-1, round-5 review of #2814).
+	_, summary := summarizePasses(ms.Runs, missingSets, nil)
 
 	if !summary.allDegraded {
 		t.Fatal("summary.allDegraded = false, want true — every one of 3 passes had a nonzero missingCount")
@@ -3253,7 +3519,11 @@ func TestSummarizePasses_ChronicSingleMissingRequest_NotAllDegraded(t *testing.T
 
 	ctx := context.Background()
 	ms := ScoreMedian(ctx, requests, []Candidates{pass, pass, pass})
-	_, summary := summarizePasses(ms.Runs, missingSets)
+	// carriedForwardIDs is nil: these unit tests exercise summarizePasses
+	// directly, with no destDir/disk state at all, so there is nothing to
+	// carry forward — see missingSetsAreReliable's own doc comment for what
+	// this argument guards against (HIGH-1, round-5 review of #2814).
+	_, summary := summarizePasses(ms.Runs, missingSets, nil)
 
 	if summary.allDegraded {
 		t.Fatal("summary.allDegraded = true, want false — one chronically-missing request among three is " +
@@ -3313,7 +3583,11 @@ func TestSummarizePasses_RotatingSubset_FlagsAllDegraded(t *testing.T) {
 
 	ctx := context.Background()
 	ms := ScoreMedian(ctx, requests, passes)
-	_, summary := summarizePasses(ms.Runs, missingSets)
+	// carriedForwardIDs is nil: these unit tests exercise summarizePasses
+	// directly, with no destDir/disk state at all, so there is nothing to
+	// carry forward — see missingSetsAreReliable's own doc comment for what
+	// this argument guards against (HIGH-1, round-5 review of #2814).
+	_, summary := summarizePasses(ms.Runs, missingSets, nil)
 
 	if !summary.allDegraded {
 		t.Fatal("summary.allDegraded = false, want true — every pass captured a DIFFERENT single request, " +
@@ -3447,6 +3721,384 @@ func runAllPassesDegradedHelper(t *testing.T, destDir string) {
 	cp := &captureProvider{Provider: fake, maxCalls: 1000, maxTokens: 1_000_000}
 
 	runCapture(context.Background(), t, requests, cp, "anthropic", "claude-sonnet-5-test", 3, destDir)
+}
+
+// TestRunCapture_ChronicPerPassMiss_CapturedViaDiskCarryForward_FlagsUnreliable
+// is the regression test for HIGH-1, the round-5 review of #2814's blocker:
+// H1's (round-4) equal-missing-sets exemption for MediansUnreliable and H2's
+// (round-4) on-disk carry-forward combine to publish a fabricated quality
+// regression with NO evidence anywhere in the committed manifest.
+//
+// The exemption's premise was "a chronically-missing request is ALSO
+// visible as Manifest.MissingCount > 0" — a reader who distrusts a stable-
+// looking degraded median still has MissingCount/RequestOutcomes to point
+// at the culprit. H2 breaks that premise for exactly this scenario: run 1
+// captures req-b (among others) cleanly, giving it a real committed
+// transcript; run 2, same destDir, req-b 429s on EVERY call of EVERY pass —
+// req-b's missing set is identical pass to pass (the exemption's only
+// check, pre-fix), but requestIsCaptured's disk fallback still reports it
+// captured overall, so MissingCount stays 0 and RequestOutcomes says
+// Captured: true. Before this fix, MediansUnreliable never fired and the
+// manifest published medianValidatePassRate dropping from run 1's 1.000 to
+// run 2's 0.667 with nothing else in the file explaining why.
+//
+// Because this scenario makes runCapture's own t.Errorf fire (same as
+// TestRunCapture_AllPassesDegraded_FailsTheRunAndFlagsUnreliable, whose own
+// doc comment explains why that cannot be asserted in-process), this
+// re-execs the built test binary the same way.
+//
+// Reverting missingSetsAreReliable back to a bare allMissingSetsEqual call
+// (dropping the carriedForwardIDs check) makes this test fail:
+// MediansUnreliable comes back false.
+func TestRunCapture_ChronicPerPassMiss_CapturedViaDiskCarryForward_FlagsUnreliable(t *testing.T) {
+	const helperEnv = "CONDUIT_TEST_CHRONICCARRYFORWARD_HELPER"
+	const destDirEnv = "CONDUIT_TEST_CHRONICCARRYFORWARD_DESTDIR"
+
+	if os.Getenv(helperEnv) == "1" {
+		runChronicPerPassMissCarryForwardHelper(t, os.Getenv(destDirEnv))
+		return
+	}
+
+	destDir := t.TempDir()
+
+	// Run 1 (parent process): a provider that succeeds unconditionally,
+	// including for req-b's prompt — gives req-b a real, valid, committed
+	// transcript to carry forward. partialFailureFixture's own cp/destDir
+	// are unused here (both processes independently rebuild the same
+	// deterministic `requests` slice — no cross-process state to share).
+	requests, _, _, _ := partialFailureFixture(t)
+	cleanProvider := &diesAfterNCallsProvider{n: 1000, reply: "```yaml\n" + validCandidate + "```"}
+	cpClean := &captureProvider{Provider: cleanProvider, maxCalls: 1000, maxTokens: 1_000_000}
+	first, _, wrote1 := runCapture(context.Background(), t, requests, cpClean, "anthropic", "claude-sonnet-5-test", 3, destDir)
+	if !wrote1 {
+		t.Fatal("expected the first run to write a manifest")
+	}
+	if first.MedianValidatePassRate != 1 || first.MediansUnreliable {
+		t.Fatalf("first run: MedianValidatePassRate/MediansUnreliable = %v/%v, want 1/false",
+			first.MedianValidatePassRate, first.MediansUnreliable)
+	}
+
+	// Run 2 (the subprocess): req-b 429s on every call, every pass — the
+	// real regression scenario.
+	cmd := exec.CommandContext(
+		context.Background(),
+		os.Args[0],
+		"-test.run=^TestRunCapture_ChronicPerPassMiss_CapturedViaDiskCarryForward_FlagsUnreliable$",
+		"-test.v",
+	)
+	cmd.Env = append(os.Environ(), helperEnv+"=1", destDirEnv+"="+destDir)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected the subprocess (run 2, req-b chronically missing but carried forward from run 1) "+
+			"to exit nonzero via t.Errorf; output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "every one of 3 capture pass(es) was degraded") {
+		t.Fatalf("subprocess failed as expected, but not for the reason this test checks — output:\n%s", out)
+	}
+
+	data, rerr := os.ReadFile(filepath.Join(destDir, manifestFileName))
+	if rerr != nil {
+		t.Fatalf("expected manifest.yaml to still be written despite the failure: %v\nsubprocess output:\n%s", rerr, out)
+	}
+	var manifest Manifest
+	if err := yaml.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("unmarshaling manifest: %v", err)
+	}
+
+	// The core HIGH-1 regression: MediansUnreliable must be true, even
+	// though CapturedCount/MissingCount show a fully-captured corpus.
+	if !manifest.MediansUnreliable {
+		t.Fatal("manifest.MediansUnreliable = false, want true — req-b is captured every pass ONLY via disk " +
+			"carry-forward from run 1, so the equal-missing-sets exemption must not apply")
+	}
+	if manifest.CapturedCount != 3 || manifest.MissingCount != 0 {
+		t.Fatalf("manifest.CapturedCount/MissingCount = %d/%d, want 3/0 — this IS the fabrication HIGH-1 "+
+			"describes: MissingCount alone gives no evidence req-b ever failed this run, which is exactly "+
+			"why MediansUnreliable must carry that signal instead", manifest.CapturedCount, manifest.MissingCount)
+	}
+	wantDegraded := []int{1, 2, 3}
+	if !reflect.DeepEqual(manifest.DegradedPasses, wantDegraded) {
+		t.Fatalf("manifest.DegradedPasses = %v, want %v", manifest.DegradedPasses, wantDegraded)
+	}
+	if want := 2.0 / 3.0; manifest.MedianValidatePassRate != want {
+		t.Fatalf("manifest.MedianValidatePassRate = %v, want %v (the reviewer's own repro: 1.000 -> 0.667)",
+			manifest.MedianValidatePassRate, want)
+	}
+
+	// M2 (round-5 review of #2814), verified in the same scenario: req-b's
+	// own outcome, though Captured, must still explain that THIS run's own
+	// attempt failed — otherwise MediansUnreliable would be the ONLY
+	// evidence left in the file.
+	var gotReqB RequestOutcome
+	found := false
+	for _, o := range manifest.RequestOutcomes {
+		if o.RequestID == "req-b" {
+			gotReqB, found = o, true
+		}
+	}
+	if !found || !gotReqB.Captured || gotReqB.FailureReason == "" {
+		t.Fatalf("req-b outcome = %+v (found=%v), want Captured=true with a non-empty FailureReason (M2)",
+			gotReqB, found)
+	}
+}
+
+// runChronicPerPassMissCarryForwardHelper is run 2 of
+// TestRunCapture_ChronicPerPassMiss_CapturedViaDiskCarryForward_FlagsUnreliable's
+// scenario, inside its re-exec'd subprocess — mirrors
+// runAllPassesDegradedHelper's own reasoning for why this needs a real
+// *testing.T in a subprocess rather than an in-process call.
+func runChronicPerPassMissCarryForwardHelper(t *testing.T, destDir string) {
+	t.Helper()
+	requests, cp, _, _ := partialFailureFixture(t)
+	runCapture(context.Background(), t, requests, cp, "anthropic", "claude-sonnet-5-test", 3, destDir)
+}
+
+// TestPreserveMediansIfNothingPromoted_ShapeMismatch_FlagsUnreliableNotStale
+// is the regression test for MEDIUM-4 (round-5 review of #2814):
+// preserveMediansIfNothingPromoted used to reuse a prior manifest's
+// medians/PassScores with no check that the prior run even describes the
+// SAME corpus. Reproduced: run 1 captures a 4-request corpus cleanly over 3
+// passes (median 1.000); the corpus then grows to 6 requests, and run 2 (1
+// pass, provider fully dead) promotes nothing new. Pre-fix, the published
+// manifest.yaml said requestCount: 6 with medianValidatePassRate: 1.000 and
+// three passScores[].total entries still reading 4 — a corpus a third of
+// which was never captured, reporting a perfect score, with
+// capturedAt/corpusCommitSha/captureCommand all refreshed to run 2 so
+// nothing marked the medians as foreign. The documented backstop
+// (captureCompletenessVerdict failing a run that captured NONE of its
+// requests) does not catch this: H2's carry-forward keeps capturedCount at
+// 4 (the old requests are still really on disk), so that verdict never
+// fires.
+//
+// This scenario also makes runCapture's own t.Errorf fire (the shape
+// mismatch forces degradedMedians.allDegraded, same signal
+// TestRunCapture_AllPassesDegraded_FailsTheRunAndFlagsUnreliable uses), so
+// it re-execs the built test binary the same way.
+//
+// Reverting JUST the RequestCount/Passes shape guard in
+// preserveMediansIfNothingPromoted (while keeping HIGH-1's carriedForwardIDs
+// fix) still makes this test fail: MediansUnreliable comes back false and
+// PassScores[].Total comes back 4, both wrongly carried from run 1's
+// shape — because preserveMediansIfNothingPromoted runs unconditionally
+// whenever moved is empty and unconditionally overwrites whatever
+// summarizePasses computed for THIS run, including a correctly-computed
+// allDegraded=true.
+func TestPreserveMediansIfNothingPromoted_ShapeMismatch_FlagsUnreliableNotStale(t *testing.T) {
+	const helperEnv = "CONDUIT_TEST_SHAPEMISMATCH_HELPER"
+	const destDirEnv = "CONDUIT_TEST_SHAPEMISMATCH_DESTDIR"
+
+	if os.Getenv(helperEnv) == "1" {
+		runShapeMismatchHelper(t, os.Getenv(destDirEnv))
+		return
+	}
+
+	destDir := t.TempDir()
+
+	// Run 1 (parent process): 4 requests, 3 passes, clean — a real baseline
+	// to protect (or, pre-fix, to wrongly leak into a differently-shaped
+	// run).
+	oldRequests := []Request{
+		capturePipelineRequest("req-1"),
+		capturePipelineRequest("req-2"),
+		capturePipelineRequest("req-3"),
+		capturePipelineRequest("req-4"),
+	}
+	cleanProvider := &diesAfterNCallsProvider{n: 1000, reply: "```yaml\n" + validCandidate + "```"}
+	cpClean := &captureProvider{Provider: cleanProvider, maxCalls: 1000, maxTokens: 1_000_000}
+	first, _, wrote1 := runCapture(context.Background(), t, oldRequests, cpClean, "anthropic", "claude-sonnet-5-test", 3, destDir)
+	if !wrote1 {
+		t.Fatal("expected the first run to write a manifest")
+	}
+	if first.MedianValidatePassRate != 1 || first.RequestCount != 4 {
+		t.Fatalf("first run: MedianValidatePassRate/RequestCount = %v/%d, want 1/4",
+			first.MedianValidatePassRate, first.RequestCount)
+	}
+
+	// Run 2 (the subprocess): the corpus grows to 6 requests, 1 pass, the
+	// provider is fully dead — nothing new is promoted.
+	cmd := exec.CommandContext(
+		context.Background(),
+		os.Args[0],
+		"-test.run=^TestPreserveMediansIfNothingPromoted_ShapeMismatch_FlagsUnreliableNotStale$",
+		"-test.v",
+	)
+	cmd.Env = append(os.Environ(), helperEnv+"=1", destDirEnv+"="+destDir)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected the subprocess (run 2, shape-mismatched, nothing promoted) to exit nonzero via "+
+			"t.Errorf; output:\n%s", out)
+	}
+
+	data, rerr := os.ReadFile(filepath.Join(destDir, manifestFileName))
+	if rerr != nil {
+		t.Fatalf("expected manifest.yaml to still be written despite the failure: %v\nsubprocess output:\n%s", rerr, out)
+	}
+	var manifest Manifest
+	if err := yaml.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("unmarshaling manifest: %v", err)
+	}
+
+	if manifest.RequestCount != 6 {
+		t.Fatalf("manifest.RequestCount = %d, want 6", manifest.RequestCount)
+	}
+	// The core MEDIUM-4 regression: MediansUnreliable must be true, and
+	// PassScores must describe THIS run's own (zero) shape — never the
+	// prior run's stale 4-request one.
+	if !manifest.MediansUnreliable {
+		t.Fatal("manifest.MediansUnreliable = false, want true — the prior manifest describes a " +
+			"different-shaped corpus (4 requests, 3 passes) than this run (6 requests, 1 pass) and must not " +
+			"be published as this run's baseline")
+	}
+	for i, ps := range manifest.PassScores {
+		if ps.Total != 6 {
+			t.Fatalf("manifest.PassScores[%d].Total = %d, want 6 (this run's own corpus size) — a value of "+
+				"4 here would mean the prior run's shape leaked through despite the mismatch", i, ps.Total)
+		}
+	}
+	// The old 4 requests are still real, valid, on-disk transcripts (H2
+	// carry-forward) — only the 2 new ones were never captured by anything.
+	if manifest.CapturedCount != 4 || manifest.MissingCount != 2 {
+		t.Fatalf("manifest.CapturedCount/MissingCount = %d/%d, want 4/2", manifest.CapturedCount, manifest.MissingCount)
+	}
+}
+
+// runShapeMismatchHelper is run 2 of
+// TestPreserveMediansIfNothingPromoted_ShapeMismatch_FlagsUnreliableNotStale's
+// scenario, inside its re-exec'd subprocess.
+func runShapeMismatchHelper(t *testing.T, destDir string) {
+	t.Helper()
+	newRequests := []Request{
+		capturePipelineRequest("req-1"),
+		capturePipelineRequest("req-2"),
+		capturePipelineRequest("req-3"),
+		capturePipelineRequest("req-4"),
+		capturePipelineRequest("req-5"),
+		capturePipelineRequest("req-6"),
+	}
+	deadProvider := &diesAfterNCallsProvider{n: 0, reply: "```yaml\n" + validCandidate + "```"}
+	cpDead := &captureProvider{Provider: deadProvider, maxCalls: 1000, maxTokens: 1_000_000}
+	runCapture(context.Background(), t, newRequests, cpDead, "anthropic", "claude-sonnet-5-test", 1, destDir)
+}
+
+// TestRequestIsCaptured_RejectsContentMismatch is the focused unit
+// regression test for MEDIUM-5 (round-5 review of #2814): a bare os.Stat
+// used to be the entire check requestIsCaptured ran, which is true for a
+// directory, a zero-byte file, or (the dangerous case here) a transcript
+// captured for a DIFFERENT prompt under an id that was never renamed.
+// Reverting requestIsCaptured back to a bare os.Stat makes this test fail:
+// a mismatched-content file would be reported captured.
+func TestRequestIsCaptured_RejectsContentMismatch(t *testing.T) {
+	destDir := t.TempDir()
+	original := Request{ID: "req-a", Prompt: "read from the generator and write to the log"}
+	edited := Request{ID: "req-a", Prompt: "read from the generator and write to the log (edited)"}
+
+	// No file at all: never captured.
+	if requestIsCaptured(original, destDir) {
+		t.Fatal("requestIsCaptured() = true with no file on disk, want false")
+	}
+
+	writeScratchTranscript(t, destDir, Transcript{
+		SchemaVersion:      TranscriptSchemaVersion,
+		RequestID:          original.ID,
+		Provider:           "anthropic",
+		Model:              "claude-sonnet-5-test",
+		CorpusPromptSHA256: sha256Hex(original.Prompt),
+		SystemPromptSHA256: "deadbeef",
+		CatalogFingerprint: "deadbeef",
+		Turns:              []Turn{{N: 1, UserPromptSHA256: "deadbeef", TokensUsed: 1, CompletionText: "x"}},
+	})
+
+	// Same prompt as when captured: valid, counts as captured.
+	if !requestIsCaptured(original, destDir) {
+		t.Fatal("requestIsCaptured() = false for a valid, matching transcript, want true")
+	}
+	// Edited prompt under the SAME id: the file on disk answers a
+	// DIFFERENT question now — must not count as captured.
+	if requestIsCaptured(edited, destDir) {
+		t.Fatal("requestIsCaptured() = true for a transcript captured against a DIFFERENT prompt under the " +
+			"same id, want false — this is exactly the edited-prompt-unchanged-id case AC 1.20 exists to catch")
+	}
+
+	// Corrupt/non-YAML content: never captured, never a panic.
+	if err := os.WriteFile(filepath.Join(destDir, "req-corrupt.yaml"), []byte("not: valid: yaml: :::"), 0o600); err != nil {
+		t.Fatalf("writing corrupt fixture: %v", err)
+	}
+	if requestIsCaptured(Request{ID: "req-corrupt", Prompt: "x"}, destDir) {
+		t.Fatal("requestIsCaptured() = true for unparseable YAML, want false")
+	}
+}
+
+// TestRunCapture_EditedPromptUnderUnchangedID_NotCountedCaptured is the
+// end-to-end sibling of TestRequestIsCaptured_RejectsContentMismatch (M5,
+// round-5 review of #2814): drives runCapture itself rather than calling
+// requestIsCaptured directly, and proves the fallback this situation lands
+// in — a tombstone written ALONGSIDE the stale, mismatched transcript —
+// is exactly what makes LoadTranscripts (transcript.go) hard-error on load,
+// per requestIsCaptured's own doc comment ("the loud, specific failure this
+// situation deserves rather than a silently wrong manifest").
+func TestRunCapture_EditedPromptUnderUnchangedID_NotCountedCaptured(t *testing.T) {
+	destDir := filepath.Join(t.TempDir(), "anthropic", "claude-sonnet-5-test")
+	original := []Request{capturePipelineRequest("req-a"), capturePipelineRequest("req-b")}
+
+	cleanProvider := &diesAfterNCallsProvider{n: 1000, reply: "```yaml\n" + validCandidate + "```"}
+	cpClean := &captureProvider{Provider: cleanProvider, maxCalls: 1000, maxTokens: 1_000_000}
+	first, _, wrote1 := runCapture(context.Background(), t, original, cpClean, "anthropic", "claude-sonnet-5-test", 1, destDir)
+	if !wrote1 || first.CapturedCount != 2 {
+		t.Fatalf("expected the first run to capture both requests cleanly, got %+v", first)
+	}
+
+	// req-a's prompt is edited under its UNCHANGED id; req-b is untouched.
+	// The provider is fully dead this run, so nothing new is promoted.
+	edited := []Request{
+		{
+			ID: "req-a", Prompt: "read from the generator and write to the log (edited)",
+			Expect: Expect{SourceCategory: "generator", DestinationCategory: "log"},
+		},
+		capturePipelineRequest("req-b"),
+	}
+	deadProvider := &diesAfterNCallsProvider{n: 0, reply: "```yaml\n" + validCandidate + "```"}
+	cpDead := &captureProvider{Provider: deadProvider, maxCalls: 1000, maxTokens: 1_000_000}
+	second, _, wrote2 := runCapture(context.Background(), t, edited, cpDead, "anthropic", "claude-sonnet-5-test", 1, destDir)
+	if !wrote2 {
+		t.Fatal("expected the second run to still write a manifest")
+	}
+
+	// The core MEDIUM-5 regression: req-a must NOT count as captured — the
+	// on-disk file answers a prompt this run no longer asks.
+	if second.CapturedCount != 1 || second.MissingCount != 1 {
+		t.Fatalf("second.CapturedCount/MissingCount = %d/%d, want 1/1 — req-a's stale, mismatched transcript "+
+			"must not be counted captured", second.CapturedCount, second.MissingCount)
+	}
+	var gotReqA RequestOutcome
+	for _, o := range second.RequestOutcomes {
+		if o.RequestID == "req-a" {
+			gotReqA = o
+		}
+	}
+	if gotReqA.Captured {
+		t.Fatalf("req-a outcome = %+v, want Captured=false", gotReqA)
+	}
+
+	// Both the stale transcript AND the new tombstone now exist for req-a —
+	// deliberately not auto-resolved (see requestIsCaptured's doc comment).
+	if _, err := os.Stat(filepath.Join(destDir, "req-a.yaml")); err != nil {
+		t.Fatalf("expected the stale req-a.yaml to still be on disk, untouched: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "req-a"+tombstoneFileSuffix)); err != nil {
+		t.Fatalf("expected a NEW tombstone for req-a: %v", err)
+	}
+
+	// The safety net: LoadTranscripts must hard-error on the coexistence,
+	// naming req-a specifically — never silently pick one file over the
+	// other.
+	_, loadErr := LoadTranscripts(destDir, edited)
+	if loadErr == nil {
+		t.Fatal("LoadTranscripts(destDir, edited) = nil error, want a hard error — req-a carries BOTH a " +
+			"transcript and a tombstone")
+	}
+	if !strings.Contains(loadErr.Error(), "req-a") || !strings.Contains(loadErr.Error(), "BOTH") {
+		t.Fatalf("LoadTranscripts error = %q, want it to name req-a and explain the transcript+tombstone conflict", loadErr.Error())
+	}
 }
 
 // TestScanAndPromoteScratch_OneViolationBlocksTheWholeBatch proves plan §5 /

--- a/cmd/conduit/internal/generate/transcript_test.go
+++ b/cmd/conduit/internal/generate/transcript_test.go
@@ -94,10 +94,10 @@ func writeTombstoneFixture(t *testing.T, dir, id string, ts Tombstone) {
 	}
 }
 
-// Test_LoadTranscripts_HappyPath pins that a well-formed, complete transcript
+// TestLoadTranscripts_HappyPath pins that a well-formed, complete transcript
 // directory loads cleanly and every entry classifies StalenessFresh — the
 // baseline every perturbation test below is a deviation from.
-func Test_LoadTranscripts_HappyPath(t *testing.T) {
+func TestLoadTranscripts_HappyPath(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	reqs := twoRequestCorpus()
@@ -116,11 +116,11 @@ func Test_LoadTranscripts_HappyPath(t *testing.T) {
 	}
 }
 
-// Test_LoadTranscripts_ManifestFileIsSkipped pins that manifest.yaml sitting
+// TestLoadTranscripts_ManifestFileIsSkipped pins that manifest.yaml sitting
 // alongside per-request transcripts is never treated as a malformed
 // transcript (it has none of Transcript's required fields) or as an "extra"
 // bijection violation.
-func Test_LoadTranscripts_ManifestFileIsSkipped(t *testing.T) {
+func TestLoadTranscripts_ManifestFileIsSkipped(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	reqs := twoRequestCorpus()
@@ -137,11 +137,11 @@ func Test_LoadTranscripts_ManifestFileIsSkipped(t *testing.T) {
 // --- Bijection (AC 1.19): a file added or removed on either side must
 // hard-error naming the offending id. ---
 
-// Test_LoadTranscripts_MissingTranscript_ErrorsNamingTheID is the "removed
+// TestLoadTranscripts_MissingTranscript_ErrorsNamingTheID is the "removed
 // file" half of AC 1.19: a corpus request with no transcript must hard-error,
 // naming that request's id, rather than silently scoring it as a
 // Result.Missing fail the way a live ScoreRun would (§3.3's whole point).
-func Test_LoadTranscripts_MissingTranscript_ErrorsNamingTheID(t *testing.T) {
+func TestLoadTranscripts_MissingTranscript_ErrorsNamingTheID(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	reqs := twoRequestCorpus()
@@ -154,11 +154,11 @@ func Test_LoadTranscripts_MissingTranscript_ErrorsNamingTheID(t *testing.T) {
 	is.True(!strings.Contains(err.Error(), "req-a")) // req-a is fine; only the offending id is named as missing
 }
 
-// Test_LoadTranscripts_ExtraTranscript_ErrorsNamingTheID is the "added file"
+// TestLoadTranscripts_ExtraTranscript_ErrorsNamingTheID is the "added file"
 // half of AC 1.19: a transcript for an id the corpus doesn't have (e.g. a
 // corpus entry renamed and the old transcript file left behind, or simply
 // never removed) must hard-error naming that id.
-func Test_LoadTranscripts_ExtraTranscript_ErrorsNamingTheID(t *testing.T) {
+func TestLoadTranscripts_ExtraTranscript_ErrorsNamingTheID(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	reqs := twoRequestCorpus()
@@ -176,13 +176,13 @@ func Test_LoadTranscripts_ExtraTranscript_ErrorsNamingTheID(t *testing.T) {
 	is.True(strings.Contains(err.Error(), "req-a-renamed"))
 }
 
-// Test_LoadTranscripts_RenamedCorpusID_ErrorsOnBothSides is the literal
+// TestLoadTranscripts_RenamedCorpusID_ErrorsOnBothSides is the literal
 // "corpus id renamed" scenario the plan calls out (§3.3): renaming req-a to
 // req-a-v2 in the corpus, with the transcript directory untouched, must
 // error naming req-a-v2 as missing AND req-a as extra — never absorbed as a
 // passing 1/2 = 50% (the harness's analogue of "27/28 = 96%, still above the
 // floor").
-func Test_LoadTranscripts_RenamedCorpusID_ErrorsOnBothSides(t *testing.T) {
+func TestLoadTranscripts_RenamedCorpusID_ErrorsOnBothSides(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	reqs := twoRequestCorpus()
@@ -209,11 +209,11 @@ func Test_LoadTranscripts_RenamedCorpusID_ErrorsOnBothSides(t *testing.T) {
 // "this id was attempted and came back empty" fact, never a blanket
 // tolerance for an absent file. ---
 
-// Test_LoadTranscripts_TombstonedID_LoadsCleanly proves the core of the
+// TestLoadTranscripts_TombstonedID_LoadsCleanly proves the core of the
 // fix: a corpus id with a committed "<id>.missing.yaml" instead of a
 // transcript loads without error, is reported via LoadResult.Tombstoned,
 // and is NOT present in ByID.
-func Test_LoadTranscripts_TombstonedID_LoadsCleanly(t *testing.T) {
+func TestLoadTranscripts_TombstonedID_LoadsCleanly(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	reqs := twoRequestCorpus()
@@ -234,13 +234,13 @@ func Test_LoadTranscripts_TombstonedID_LoadsCleanly(t *testing.T) {
 	is.Equal(ts.FailureCode, "generate.provider_error (HTTP 429)")
 }
 
-// Test_LoadTranscripts_RenamedCorpusID_StillErrors_EvenWithATombstonePresent
+// TestLoadTranscripts_RenamedCorpusID_StillErrors_EvenWithATombstonePresent
 // is the test that distinguishes the two cases a tombstone must never
 // blur together: renaming req-a to req-a-v2 in the corpus, with req-b
 // legitimately tombstoned, must still hard-error naming req-a-v2 as
 // missing — a tombstone existing for a DIFFERENT id must never be read as
 // "some id in this directory accounts for the gap".
-func Test_LoadTranscripts_RenamedCorpusID_StillErrors_EvenWithATombstonePresent(t *testing.T) {
+func TestLoadTranscripts_RenamedCorpusID_StillErrors_EvenWithATombstonePresent(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	reqs := twoRequestCorpus()
@@ -258,10 +258,10 @@ func Test_LoadTranscripts_RenamedCorpusID_StillErrors_EvenWithATombstonePresent(
 	is.True(strings.Contains(err.Error(), "no corpus entry: req-a"))
 }
 
-// Test_LoadTranscripts_TombstonePromptEditedUnderSameID_Errors mirrors AC
+// TestLoadTranscripts_TombstonePromptEditedUnderSameID_Errors mirrors AC
 // 1.20 for a tombstone: a request's prompt edited without a re-capture must
 // still be caught even when the id in question has no transcript at all.
-func Test_LoadTranscripts_TombstonePromptEditedUnderSameID_Errors(t *testing.T) {
+func TestLoadTranscripts_TombstonePromptEditedUnderSameID_Errors(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	reqs := twoRequestCorpus()
@@ -279,11 +279,11 @@ func Test_LoadTranscripts_TombstonePromptEditedUnderSameID_Errors(t *testing.T) 
 	is.True(strings.Contains(err.Error(), "corpusPromptSHA256"))
 }
 
-// Test_LoadTranscripts_TombstoneAndTranscriptBothPresent_Errors proves an
+// TestLoadTranscripts_TombstoneAndTranscriptBothPresent_Errors proves an
 // id can never carry both a transcript and a tombstone — a
 // self-contradictory commit state that must never resolve by silently
 // preferring one file over the other.
-func Test_LoadTranscripts_TombstoneAndTranscriptBothPresent_Errors(t *testing.T) {
+func TestLoadTranscripts_TombstoneAndTranscriptBothPresent_Errors(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	reqs := twoRequestCorpus()
@@ -297,10 +297,10 @@ func Test_LoadTranscripts_TombstoneAndTranscriptBothPresent_Errors(t *testing.T)
 	is.True(strings.Contains(err.Error(), "BOTH a transcript"))
 }
 
-// Test_LoadTranscripts_MalformedTombstone_Errors mirrors
-// Test_LoadTranscripts_WrongSchemaVersion_Errors for a tombstone: never
+// TestLoadTranscripts_MalformedTombstone_Errors mirrors
+// TestLoadTranscripts_WrongSchemaVersion_Errors for a tombstone: never
 // silently absorbed as "missing".
-func Test_LoadTranscripts_MalformedTombstone_Errors(t *testing.T) {
+func TestLoadTranscripts_MalformedTombstone_Errors(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	reqs := twoRequestCorpus()
@@ -314,15 +314,15 @@ func Test_LoadTranscripts_MalformedTombstone_Errors(t *testing.T) {
 	is.True(strings.Contains(err.Error(), "failureCode"))
 }
 
-// Test_LoadTranscripts_EmptyTombstoneFile_Errors is a nit from the round-2
-// review of #2814: Test_LoadTranscripts_MalformedTombstone_Errors above only
+// TestLoadTranscripts_EmptyTombstoneFile_Errors is a nit from the round-2
+// review of #2814: TestLoadTranscripts_MalformedTombstone_Errors above only
 // pins an otherwise-well-formed Tombstone with FailureCode cleared, never a
 // genuinely empty (0-byte) file — e.g. a truncated write, or `touch`'d by a
 // human mid-fix. yaml.Unmarshal on an empty document succeeds (returns a
 // zero-value Tombstone) rather than erroring, so this exercises
 // validateTombstoneShape's FIRST check (schemaVersion) rather than the last
 // (failureCode) — a different code path than the existing test covers.
-func Test_LoadTranscripts_EmptyTombstoneFile_Errors(t *testing.T) {
+func TestLoadTranscripts_EmptyTombstoneFile_Errors(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	reqs := twoRequestCorpus()
@@ -335,12 +335,12 @@ func Test_LoadTranscripts_EmptyTombstoneFile_Errors(t *testing.T) {
 	is.True(strings.Contains(err.Error(), "schemaVersion"))
 }
 
-// Test_LoadTranscripts_UnparseableTombstoneFile_Errors is the other half of
+// TestLoadTranscripts_UnparseableTombstoneFile_Errors is the other half of
 // the same nit: content that isn't valid YAML AT ALL (as opposed to valid
 // YAML missing a required field) must fail at the yaml.Unmarshal step
 // itself (readTombstone's "parsing tombstone" error), never reach
 // validateTombstoneShape.
-func Test_LoadTranscripts_UnparseableTombstoneFile_Errors(t *testing.T) {
+func TestLoadTranscripts_UnparseableTombstoneFile_Errors(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	reqs := twoRequestCorpus()
@@ -352,8 +352,8 @@ func Test_LoadTranscripts_UnparseableTombstoneFile_Errors(t *testing.T) {
 	is.True(strings.Contains(err.Error(), "parsing tombstone"))
 }
 
-// Test_LoadTranscripts_OrphanedTombstone_ErrorsNamingTheID is the tombstone
-// analogue of Test_LoadTranscripts_ExtraTranscript_ErrorsNamingTheID above,
+// TestLoadTranscripts_OrphanedTombstone_ErrorsNamingTheID is the tombstone
+// analogue of TestLoadTranscripts_ExtraTranscript_ErrorsNamingTheID above,
 // pinned separately per a nit from the round-2 review of #2814: a
 // "<id>.missing.yaml" for an id absent from the corpus (e.g. a corpus entry
 // renamed, or a request removed outright, with its old tombstone left
@@ -362,7 +362,7 @@ func Test_LoadTranscripts_UnparseableTombstoneFile_Errors(t *testing.T) {
 // ORPHANED tombstone ... is exactly as much a bijection problem as an
 // orphaned transcript"), but no test exercised a tombstone taking this path
 // specifically until now.
-func Test_LoadTranscripts_OrphanedTombstone_ErrorsNamingTheID(t *testing.T) {
+func TestLoadTranscripts_OrphanedTombstone_ErrorsNamingTheID(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	reqs := twoRequestCorpus()
@@ -381,11 +381,11 @@ func Test_LoadTranscripts_OrphanedTombstone_ErrorsNamingTheID(t *testing.T) {
 
 // --- corpusPromptSHA256 (AC 1.20): a prompt edited under an unchanged id. ---
 
-// Test_LoadTranscripts_PromptEditedUnderSameID_Errors is AC 1.20: bijection
+// TestLoadTranscripts_PromptEditedUnderSameID_Errors is AC 1.20: bijection
 // alone passes here (the id didn't move), so this is a DIFFERENT check —
 // corpusPromptSHA256 must equal sha256Hex of the CURRENT corpus prompt for
 // that id, and a hand-edited prompt with no re-capture must hard-error.
-func Test_LoadTranscripts_PromptEditedUnderSameID_Errors(t *testing.T) {
+func TestLoadTranscripts_PromptEditedUnderSameID_Errors(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	reqs := twoRequestCorpus()
@@ -406,7 +406,7 @@ func Test_LoadTranscripts_PromptEditedUnderSameID_Errors(t *testing.T) {
 
 // --- Malformed transcripts: never silently absorbed as "missing". ---
 
-func Test_LoadTranscripts_WrongSchemaVersion_Errors(t *testing.T) {
+func TestLoadTranscripts_WrongSchemaVersion_Errors(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	reqs := twoRequestCorpus()
@@ -422,7 +422,7 @@ func Test_LoadTranscripts_WrongSchemaVersion_Errors(t *testing.T) {
 	is.True(strings.Contains(err.Error(), "schemaVersion"))
 }
 
-func Test_LoadTranscripts_RequestIDDisagreesWithFilename_Errors(t *testing.T) {
+func TestLoadTranscripts_RequestIDDisagreesWithFilename_Errors(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	reqs := twoRequestCorpus()
@@ -434,7 +434,7 @@ func Test_LoadTranscripts_RequestIDDisagreesWithFilename_Errors(t *testing.T) {
 	is.True(strings.Contains(err.Error(), "does not match its filename"))
 }
 
-func Test_LoadTranscripts_NoTurns_Errors(t *testing.T) {
+func TestLoadTranscripts_NoTurns_Errors(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	reqs := twoRequestCorpus()
@@ -465,12 +465,12 @@ func Test_ClassifyStaleness(t *testing.T) {
 	is.Equal(classifyStaleness(semantic, "sys-new", "cat-new"), StalenessSemanticDrift)
 }
 
-// Test_LoadTranscripts_StaleTranscript_LoadsWithoutError pins that a
+// TestLoadTranscripts_StaleTranscript_LoadsWithoutError pins that a
 // transcript whose recorded grounding no longer matches the current binary
 // is NOT a load error — only its Staleness field reflects the drift. A
 // red-on-every-connector-bump loader would be exactly the flaky-gate failure
 // §3.3 refuses to reintroduce.
-func Test_LoadTranscripts_StaleTranscript_LoadsWithoutError(t *testing.T) {
+func TestLoadTranscripts_StaleTranscript_LoadsWithoutError(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
 	reqs := twoRequestCorpus()
@@ -534,4 +534,70 @@ func Test_LoadManifest_MissingFile_Errors(t *testing.T) {
 	is := is.New(t)
 	_, err := LoadManifest(filepath.Join(t.TempDir(), "does-not-exist.yaml"))
 	is.True(err != nil)
+}
+
+// --- Committed tree ---
+
+// TestLoadTranscripts_CommittedTreeLoadsCleanly is the regression test for
+// B3 (round-3 review of #2814): every OTHER LoadTranscripts test above
+// exercises it against a synthetic t.TempDir() fixture this file builds
+// itself — nothing in CI ever calls it against the REAL committed
+// testdata/transcripts tree, so a tree LoadTranscripts would reject (H3's
+// both-files case if a future `git rm` step in generate-capture.yml misses
+// one, a corpus id renamed inside the same PR window, a partially-promoted
+// tree left by a `go test` panic or -timeout kill between promotion and the
+// tombstone loop) merges green with nothing to catch it — the PR body's
+// "Manifest numbers look sane" checkbox is a human where a test belongs.
+//
+// This walks every real testdata/transcripts/<provider>/<model> leaf
+// directory and requires LoadRequests + LoadTranscripts to succeed against
+// it, skipping cleanly — never failing — whenever nothing is committed yet,
+// exactly like TestTranscripts_CarryNoSecretMaterial (secrets_scan_test.go)
+// does for the same reason: an empty corpus is not a broken one. Every
+// currently-committed subtree is captured against testdata/eval_requests.yaml
+// (doc.go, transcript.go's CorpusCommitSHA doc comment) — if a future corpus
+// other than that one ever gets its own transcripts directory, this test
+// needs to learn which corpus backs which subtree rather than assuming one
+// for all of them.
+func TestLoadTranscripts_CommittedTreeLoadsCleanly(t *testing.T) {
+	root := "testdata/transcripts"
+
+	providerDirs, err := os.ReadDir(root)
+	if os.IsNotExist(err) {
+		t.Skip("no transcripts directory yet (testdata/transcripts) — nothing to load")
+	}
+	if err != nil {
+		t.Fatalf("reading %q: %v", root, err)
+	}
+
+	requests, err := LoadRequests("testdata/eval_requests.yaml")
+	if err != nil {
+		t.Fatalf("loading corpus: %v", err)
+	}
+
+	var checked int
+	for _, pd := range providerDirs {
+		if !pd.IsDir() {
+			continue
+		}
+		providerDir := filepath.Join(root, pd.Name())
+		modelDirs, err := os.ReadDir(providerDir)
+		if err != nil {
+			t.Fatalf("reading %q: %v", providerDir, err)
+		}
+		for _, md := range modelDirs {
+			if !md.IsDir() {
+				continue
+			}
+			dir := filepath.Join(providerDir, md.Name())
+			if _, err := LoadTranscripts(dir, requests); err != nil {
+				t.Errorf("LoadTranscripts(%q) against the real committed tree: %v", dir, err)
+			}
+			checked++
+		}
+	}
+	if checked == 0 {
+		t.Skip("no provider/model transcript subtree committed yet — nothing to load")
+	}
+	t.Logf("LoadTranscripts succeeded against %d committed provider/model subtree(s) under %s", checked, root)
 }

--- a/cmd/conduit/internal/generate/transcript_test.go
+++ b/cmd/conduit/internal/generate/transcript_test.go
@@ -69,6 +69,31 @@ func twoRequestCorpus() []Request {
 	}
 }
 
+// validTombstone returns a well-formed Tombstone for request r, hashed
+// against r.Prompt — a fixture LoadTranscripts accepts as satisfying
+// bijection for r.ID, before any test perturbs it.
+func validTombstone(r Request) Tombstone {
+	return Tombstone{
+		SchemaVersion:      TranscriptSchemaVersion,
+		RequestID:          r.ID,
+		CorpusPromptSHA256: sha256Hex(r.Prompt),
+		FailureCode:        "generate.provider_error (HTTP 429)",
+		CapturedAt:         time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+// writeTombstoneFixture marshals ts to dir/<id>.missing.yaml.
+func writeTombstoneFixture(t *testing.T, dir, id string, ts Tombstone) {
+	t.Helper()
+	data, err := yaml.Marshal(ts)
+	if err != nil {
+		t.Fatalf("marshaling tombstone %q: %v", id, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, id+tombstoneFileSuffix), data, 0o600); err != nil {
+		t.Fatalf("writing tombstone %q: %v", id, err)
+	}
+}
+
 // Test_LoadTranscripts_HappyPath pins that a well-formed, complete transcript
 // directory loads cleanly and every entry classifies StalenessFresh — the
 // baseline every perturbation test below is a deviation from.
@@ -172,9 +197,121 @@ func Test_LoadTranscripts_RenamedCorpusID_ErrorsOnBothSides(t *testing.T) {
 
 	_, err := LoadTranscripts(dir, renamed)
 	is.True(err != nil)
-	is.True(strings.Contains(err.Error(), "no transcript: req-a-v2"))    // corpus id with no transcript
-	is.True(strings.Contains(err.Error(), "no corpus entry: req-a"))     // transcript id with no corpus entry (not the "req-a-v2" substring)
-	is.True(!strings.Contains(err.Error(), "no corpus entry: req-a-v2")) // the extra id is req-a, never req-a-v2
+	is.True(strings.Contains(err.Error(), "no transcript or tombstone: req-a-v2")) // corpus id with no transcript
+	is.True(strings.Contains(err.Error(), "no corpus entry: req-a"))               // transcript id with no corpus entry (not the "req-a-v2" substring)
+	is.True(!strings.Contains(err.Error(), "no corpus entry: req-a-v2"))           // the extra id is req-a, never req-a-v2
+}
+
+// --- Tombstones: a legitimately-missing transcript satisfies bijection,
+// but a RENAMED corpus id must still hard-error even when tombstones exist
+// elsewhere in the same directory. This is the load-bearing distinction the
+// partial-results follow-up needs: a tombstone is an explicit, reviewable
+// "this id was attempted and came back empty" fact, never a blanket
+// tolerance for an absent file. ---
+
+// Test_LoadTranscripts_TombstonedID_LoadsCleanly proves the core of the
+// fix: a corpus id with a committed "<id>.missing.yaml" instead of a
+// transcript loads without error, is reported via LoadResult.Tombstoned,
+// and is NOT present in ByID.
+func Test_LoadTranscripts_TombstonedID_LoadsCleanly(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	reqs := twoRequestCorpus()
+	writeTranscript(t, dir, "req-a", validTranscript(reqs[0]))
+	writeTombstoneFixture(t, dir, "req-b", validTombstone(reqs[1]))
+
+	got, err := LoadTranscripts(dir, reqs)
+	is.NoErr(err)
+	is.Equal(len(got.ByID), 1)
+	_, ok := got.ByID["req-a"]
+	is.True(ok)
+	_, ok = got.ByID["req-b"]
+	is.True(!ok) // req-b has no transcript, only a tombstone
+
+	is.Equal(len(got.Tombstoned), 1)
+	ts, ok := got.Tombstoned["req-b"]
+	is.True(ok)
+	is.Equal(ts.FailureCode, "generate.provider_error (HTTP 429)")
+}
+
+// Test_LoadTranscripts_RenamedCorpusID_StillErrors_EvenWithATombstonePresent
+// is the test that distinguishes the two cases a tombstone must never
+// blur together: renaming req-a to req-a-v2 in the corpus, with req-b
+// legitimately tombstoned, must still hard-error naming req-a-v2 as
+// missing — a tombstone existing for a DIFFERENT id must never be read as
+// "some id in this directory accounts for the gap".
+func Test_LoadTranscripts_RenamedCorpusID_StillErrors_EvenWithATombstonePresent(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	reqs := twoRequestCorpus()
+	writeTranscript(t, dir, "req-a", validTranscript(reqs[0]))
+	writeTombstoneFixture(t, dir, "req-b", validTombstone(reqs[1]))
+
+	renamed := []Request{
+		{ID: "req-a-v2", Prompt: reqs[0].Prompt}, // req-a renamed, transcript left behind under "req-a"
+		reqs[1],                                  // req-b unchanged, still tombstoned
+	}
+
+	_, err := LoadTranscripts(dir, renamed)
+	is.True(err != nil)
+	is.True(strings.Contains(err.Error(), "no transcript or tombstone: req-a-v2"))
+	is.True(strings.Contains(err.Error(), "no corpus entry: req-a"))
+}
+
+// Test_LoadTranscripts_TombstonePromptEditedUnderSameID_Errors mirrors AC
+// 1.20 for a tombstone: a request's prompt edited without a re-capture must
+// still be caught even when the id in question has no transcript at all.
+func Test_LoadTranscripts_TombstonePromptEditedUnderSameID_Errors(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	reqs := twoRequestCorpus()
+	writeTranscript(t, dir, "req-a", validTranscript(reqs[0]))
+	writeTombstoneFixture(t, dir, "req-b", validTombstone(reqs[1]))
+
+	edited := []Request{
+		reqs[0],
+		{ID: "req-b", Prompt: "a completely different prompt text, edited without a re-capture"},
+	}
+
+	_, err := LoadTranscripts(dir, edited)
+	is.True(err != nil)
+	is.True(strings.Contains(err.Error(), "req-b"))
+	is.True(strings.Contains(err.Error(), "corpusPromptSHA256"))
+}
+
+// Test_LoadTranscripts_TombstoneAndTranscriptBothPresent_Errors proves an
+// id can never carry both a transcript and a tombstone — a
+// self-contradictory commit state that must never resolve by silently
+// preferring one file over the other.
+func Test_LoadTranscripts_TombstoneAndTranscriptBothPresent_Errors(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	reqs := twoRequestCorpus()
+	writeTranscript(t, dir, "req-a", validTranscript(reqs[0]))
+	writeTranscript(t, dir, "req-b", validTranscript(reqs[1]))
+	writeTombstoneFixture(t, dir, "req-b", validTombstone(reqs[1]))
+
+	_, err := LoadTranscripts(dir, reqs)
+	is.True(err != nil)
+	is.True(strings.Contains(err.Error(), "req-b"))
+	is.True(strings.Contains(err.Error(), "BOTH a transcript"))
+}
+
+// Test_LoadTranscripts_MalformedTombstone_Errors mirrors
+// Test_LoadTranscripts_WrongSchemaVersion_Errors for a tombstone: never
+// silently absorbed as "missing".
+func Test_LoadTranscripts_MalformedTombstone_Errors(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	reqs := twoRequestCorpus()
+	writeTranscript(t, dir, "req-a", validTranscript(reqs[0]))
+	bad := validTombstone(reqs[1])
+	bad.FailureCode = ""
+	writeTombstoneFixture(t, dir, "req-b", bad)
+
+	_, err := LoadTranscripts(dir, reqs)
+	is.True(err != nil)
+	is.True(strings.Contains(err.Error(), "failureCode"))
 }
 
 // --- corpusPromptSHA256 (AC 1.20): a prompt edited under an unchanged id. ---

--- a/cmd/conduit/internal/generate/transcript_test.go
+++ b/cmd/conduit/internal/generate/transcript_test.go
@@ -314,6 +314,71 @@ func Test_LoadTranscripts_MalformedTombstone_Errors(t *testing.T) {
 	is.True(strings.Contains(err.Error(), "failureCode"))
 }
 
+// Test_LoadTranscripts_EmptyTombstoneFile_Errors is a nit from the round-2
+// review of #2814: Test_LoadTranscripts_MalformedTombstone_Errors above only
+// pins an otherwise-well-formed Tombstone with FailureCode cleared, never a
+// genuinely empty (0-byte) file — e.g. a truncated write, or `touch`'d by a
+// human mid-fix. yaml.Unmarshal on an empty document succeeds (returns a
+// zero-value Tombstone) rather than erroring, so this exercises
+// validateTombstoneShape's FIRST check (schemaVersion) rather than the last
+// (failureCode) — a different code path than the existing test covers.
+func Test_LoadTranscripts_EmptyTombstoneFile_Errors(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	reqs := twoRequestCorpus()
+	writeTranscript(t, dir, "req-a", validTranscript(reqs[0]))
+	is.NoErr(os.WriteFile(filepath.Join(dir, "req-b"+tombstoneFileSuffix), nil, 0o600))
+
+	_, err := LoadTranscripts(dir, reqs)
+	is.True(err != nil)
+	is.True(strings.Contains(err.Error(), "req-b"+tombstoneFileSuffix))
+	is.True(strings.Contains(err.Error(), "schemaVersion"))
+}
+
+// Test_LoadTranscripts_UnparseableTombstoneFile_Errors is the other half of
+// the same nit: content that isn't valid YAML AT ALL (as opposed to valid
+// YAML missing a required field) must fail at the yaml.Unmarshal step
+// itself (readTombstone's "parsing tombstone" error), never reach
+// validateTombstoneShape.
+func Test_LoadTranscripts_UnparseableTombstoneFile_Errors(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	reqs := twoRequestCorpus()
+	writeTranscript(t, dir, "req-a", validTranscript(reqs[0]))
+	is.NoErr(os.WriteFile(filepath.Join(dir, "req-b"+tombstoneFileSuffix), []byte(":::not valid yaml:::["), 0o600))
+
+	_, err := LoadTranscripts(dir, reqs)
+	is.True(err != nil)
+	is.True(strings.Contains(err.Error(), "parsing tombstone"))
+}
+
+// Test_LoadTranscripts_OrphanedTombstone_ErrorsNamingTheID is the tombstone
+// analogue of Test_LoadTranscripts_ExtraTranscript_ErrorsNamingTheID above,
+// pinned separately per a nit from the round-2 review of #2814: a
+// "<id>.missing.yaml" for an id absent from the corpus (e.g. a corpus entry
+// renamed, or a request removed outright, with its old tombstone left
+// behind) is exactly as much a bijection violation as an orphaned real
+// transcript — checkBijection's own doc comment says so explicitly ("an
+// ORPHANED tombstone ... is exactly as much a bijection problem as an
+// orphaned transcript"), but no test exercised a tombstone taking this path
+// specifically until now.
+func Test_LoadTranscripts_OrphanedTombstone_ErrorsNamingTheID(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	reqs := twoRequestCorpus()
+	for _, r := range reqs {
+		writeTranscript(t, dir, r.ID, validTranscript(r))
+	}
+	// An orphaned tombstone — as if req-a-orphan were removed from the
+	// corpus (or renamed) but its tombstone file was left in place.
+	stray := validTombstone(Request{ID: "req-a-orphan", Prompt: "prompt for an orphaned request"})
+	writeTombstoneFixture(t, dir, "req-a-orphan", stray)
+
+	_, err := LoadTranscripts(dir, reqs)
+	is.True(err != nil)
+	is.True(strings.Contains(err.Error(), "req-a-orphan"))
+}
+
 // --- corpusPromptSHA256 (AC 1.20): a prompt edited under an unchanged id. ---
 
 // Test_LoadTranscripts_PromptEditedUnderSameID_Errors is AC 1.20: bijection

--- a/cmd/conduit/internal/generate/validate_score.go
+++ b/cmd/conduit/internal/generate/validate_score.go
@@ -16,6 +16,7 @@ package generate
 
 import (
 	"context"
+	"strings"
 
 	"github.com/conduitio/conduit/cmd/conduit/internal/validate"
 )
@@ -41,6 +42,37 @@ import (
 // Now that RunBytes exists (cmd/conduit/internal/validate/engine.go:129),
 // this function is the ONLY thing that needed to change, exactly as
 // promised — no disk write, no temp file, no caller (ScoreRun) touched.
+//
+// An empty or whitespace-only candidate is special-cased rather than
+// handed to validate.RunBytes (B2, round-3 review of #2814):
+// validate.RunBytes on zero bytes reports zero findings — there is nothing
+// in an empty document to find a problem WITH — so Report.OK() would read
+// true, scoring a validate PASS for a request the model never produced
+// anything usable for. That happens for real: runCapture
+// (transcript_capture_test.go) stores gen.Candidate verbatim in its
+// Candidates map even when every attempt failed extraction (raw completions
+// WERE recorded — this is DATA, never treated as an absent request — but
+// none of them parsed into pipeline YAML), which is exactly what an empty
+// string here means. ScoreRun (score.go) ALSO guards this directly and is
+// the authoritative layer for the harness's own numbers — it is the one
+// place both the validate AND semantic axes are scored for a request, and
+// only it can fail SemanticMatch too, which this function has no way to
+// reach. This is the second, narrower layer, kept in sync so any OTHER
+// present or future caller of validateCandidate gets a correct answer too.
 func validateCandidate(ctx context.Context, candidate string) validate.Report {
+	if strings.TrimSpace(candidate) == "" {
+		return validate.Report{
+			Summary: validate.Summary{Files: 1, Errors: 1},
+			Files: []validate.FileReport{{
+				Path: InMemoryCandidateName,
+				OK:   false,
+				Findings: []validate.Finding{{
+					Severity: validate.SeverityError,
+					Code:     "generate.empty_candidate",
+					Message:  "the candidate is empty or whitespace-only — nothing was generated to validate",
+				}},
+			}},
+		}
+	}
 	return validate.RunBytes(ctx, InMemoryCandidateName, []byte(candidate), candidateValidateOptions())
 }


### PR DESCRIPTION
## Problem

The first live capture run made 27 of 28 requests successfully. One request failed on all 3
passes, `go test` exited nonzero, and because the workflow runs under `set -euo pipefail` with
the default success-only step gating, **every step after "Run the live capture" was skipped** —
so 27 good transcripts, already paid for with ~$3 and 15 minutes of real Anthropic spend, were
never uploaded or published.

Discarding an irreplaceable artifact because 1 of 28 requests hit transient infra is the wrong
failure direction. The redaction gate is the one thing that *should* be all-or-nothing, and it
still is.

## What changed

**`runCapture` distinguishes two failure kinds that were previously conflated.**

- A request whose generation legitimately never produced a passing candidate is **data**: a
  transcript is still built and promoted, carrying its real failing `Outcome`. That is a result
  about the model, and it is exactly what the corpus is for.
- A request that produced **no completion at all** (429, timeout, a tripped spend ceiling, a
  pre-call refusal) is *absence* of data. Tracked separately, never silently merged into
  "missing" transcripts that would break the corpus bijection with no explanation of why.

**Manifest gains `CapturedCount`, `MissingCount`, `RequestOutcomes`** so a reviewer reads
"27 captured, 1 failed for reason X" straight out of `manifest.yaml` rather than inferring it
from a file that isn't there.

**`captureCompletenessVerdict`** fails the run outright only once a strict majority of attempted
requests produced no completion at all (`captureCompletenessThreshold = 0.5`). Below that,
ordinary live-provider noise is logged and published. The incident's own 1/28 (3.6%) now
succeeds and publishes cleanly.

**`generate-capture.yml`**: the capture job's check-changes/upload steps run under `!cancelled()`
rather than the implicit success gate, so whatever was promoted before a threshold failure is
still uploaded. `publish` no longer implicitly requires capture success — it opens a PR whenever
anything changed on disk, and flags a non-success capture with an explicit warning banner and a
review-checklist item instead of letting it pass as routine.

## Tests

`transcript_capture_test.go` grows the cases that matter: the no-completion-at-all path, the
failing-candidate-is-still-data path, and the threshold boundary in both directions.

~~the redaction gate proven directly against `scanAndPromoteScratch` with a secret *and* a
simultaneously-missing request in the same batch~~ — **this claim was false and is corrected
below (round-2 review, M2): no test exercises that combination.** The all-or-nothing guarantee
holds by construction (a missing request never reaches `scratchDir` in the first place, so
`scanAndPromoteScratch`'s per-batch scan can't see how many other requests were missing), but the
test that was cited as proof of it (`TestScanAndPromoteScratch_ViolationBlocksEvenWhenARequestIsMissing`)
was deleted in the round-2 commits, and its replacement
(`TestScanAndPromoteScratch_OneViolationBlocksTheWholeBatch`) has no missing request in its
fixture at all.

## Round 2 review response

Round 2 found 3 new defects (2 introduced by round 2's own commits), 2 weak regression tests, and
several nits. All fixed in the latest commit; see that commit message for full detail. Summary,
with what was corrected in the framing above each finding first appeared in:

- **H1 — `manifest_path` empty on the first capture run.** `git status --porcelain`'s default
  `-unormal` collapses a wholly-untracked directory (a new provider/model subtree, which doesn't
  exist on `main` before the first real run) into a single `?? dir/` line, so the `grep` deriving
  `manifest_path` matched nothing even though a manifest was written — the opposite of the
  `find`-replacement's stated goal. **The claim that this derivation "is unambiguous and never
  confused with an earlier run's manifest" was true for the confusion it targeted but silent on
  this one; corrected in code comments.** Fixed with `-uall`; reproduced empty on a fresh tree
  before fixing, confirmed non-empty after.
- **H2 — a `missingCount: 0` run could publish `medianValidatePassRate: 0.00` under a routine
  title.** A request captured on one pass and wiped from later ones (rate-limit storm,
  `captureWallClockBudget` expiring) doesn't raise `MissingCount` but does drag the median down.
  **The doc comment's claim that "`MissingCount` is never silently absorbed into ... the scored
  rates" was false; corrected.** Fixed with per-pass `PassScore.MissingCount`,
  `Manifest.DegradedPasses`, and a median that excludes degraded passes; the workflow banner now
  gates on a separate `degraded` signal too.
- **H3 — the recovery path the banner recommends produces a corpus `LoadTranscripts` permanently
  rejects.** Re-capturing a previously-missing id promotes a real transcript and removes the stale
  tombstone in the `capture` job's own checkout, but the uploaded artifact can't represent that
  deletion, so `publish`'s checkout of `main` still carries it — the PR lands both files, which
  `LoadTranscripts` hard-errors on. Fixed: `publish` now `git rm`s any stale tombstone whose id was
  just promoted, before staging.
- **M1 — the "missing scored as Missing" regression test never called `runCapture`.** It
  hand-built a `Candidates` map "mirroring" `runCapture`'s behavior and asserted on `ScoreRun`
  directly — true before the fix and still true with the fix reverted. `runCapture` now returns
  its per-pass `RunScore`s so this test drives the real pipeline end to end; confirmed it fails
  when the original bug is reintroduced.
- **M2 — see the strikethrough above.** The all-or-nothing redaction guarantee holds by
  construction; the test cited as proof of it doesn't exist anymore, and its replacement doesn't
  cover the combination. Framing corrected rather than a new test invented to match a claim that
  was never accurate.

Nits also addressed: `provider.IsTimeout`/`MarkIfTimeout` so a committed failure reason can tell
"our own deadline expired" apart from every other transport-level miss (DNS failure, connection
refused) that previously collapsed to the same string; a naming fix so
`-run 'TestRunCapture'` actually matches every `TestRunCapture_*` test (one had carried a leading
underscore that broke substring matching, silently excludable from exactly the filter someone
would reach for); new tests for an orphaned tombstone, an empty tombstone file, and unparseable
tombstone YAML; and a doc clarification on which `Manifest` fields carry no in-process secret scan
and why that's safe (operator-controlled inputs, not provider text, backstopped by the untagged
raw-text test).

Verification for the round-2 fixes: `go build`/`vet`/`test -race` (both tagged and untagged) all
green; `golangci-lint` and `actionlint` clean; `gofumpt` clean. H1's empty-`manifest_path`
behavior was reproduced on a genuinely fresh scratch repo before fixing. H3's tombstone-survival
bug was reproduced against a scratch git repo mirroring the exact two-run scenario. M1's rewritten
test was confirmed to fail with the original bug reintroduced and the H2 regression test was
confirmed to fail with the fix reverted (0.667 vs. the expected 1.0).

## Round 3 review response

Round 3 found 2 new High findings (both in code round 2 added), one pre-existing gap the
partial-results feature made load-bearing, 3 Mediums, and 8 nits. All fixed in the latest commit;
full detail there. Summary:

- **B1 (High, new) — the all-degraded fallback could publish `medianValidatePassRate: 0.00` as a
  green, committed baseline.** When every pass was degraded, `summarizePasses` fell back to a
  median across ALL passes (missing requests scored as hard fails), with nothing marking that
  number unreliable. Reproduced: 5 requests, 3 passes, provider dies after 3 successful calls —
  `degradedPasses: [1 2 3]`, median 0.00, job green, even though the 3 transcripts that WERE
  captured validated 3/3. Fixed narrowly, not broadly: the new `allDegraded`/
  `Manifest.MediansUnreliable` requires BOTH no clean pass AND at least one pass *wiped*
  (`missingCount == Total`) — a single chronically-missing request (present in every pass's
  `missingCount`, but never wiping a WHOLE pass) still leaves every pass's own rate stable, and
  correctly does NOT trip this. **Round 4 found this two-condition narrowing itself wrong: "at
  least one pass wiped" is only one way passes can disagree about what they missed, and checking
  for it specifically let a rotating-subset case through the fallback undetected — see the Round 4
  section below.** That distinction mattered in practice: an earlier, broader "no
  clean pass" version of this fix turned `TestRunCapture_PartialFailure_PreservesGoodTranscripts`'s
  own below-threshold scenario into a hard failure — reintroducing a milder version of the exact
  incident this whole package exists to prevent. `runCapture` now fails the run (`t.Errorf`) the
  same way `captureCompletenessVerdict` already does for `attemptedCount == 0`, which
  `generate-capture.yml`'s existing `CAPTURE_RESULT != success` branch already turns into the
  `[!WARNING]` PARTIAL-capture title — no new workflow wiring needed for that half.
- **B2 (High, new) — a request the model never produced parseable YAML for scored a validate
  PASS.** `validate.RunBytes` on empty bytes reports zero findings, so an empty candidate's
  `Report.OK()` read true — a 100%-refusal pass scored 100% validate-pass. Fixed at two layers:
  `ScoreRun` (the one place both axes are scored) hard-fails an empty/whitespace candidate
  directly, and `validateCandidate` itself (defense in depth — its own doc comment claims to
  mirror the shipped gate). Also fixed `buildTranscript`'s `Outcome` (guarded on
  `last.Candidate != ""` — a zero-valued `Report` also reads `OK()==true`) and
  `requestsMissingUsableCandidate` (an all-refusal pass is now marked degraded, not silently
  "clean"). Reproduced end to end before fixing; new tests at the `validateCandidate("")`/
  `ScoreRun` level and end to end through `runCapture`.
- **B3 (High, pre-existing, made load-bearing by this PR) — nothing in CI validates the committed
  `testdata/transcripts` tree.** `LoadTranscripts` was only ever exercised against synthetic
  `t.TempDir()` fixtures. `TestLoadTranscripts_CommittedTreeLoadsCleanly` now walks every real
  provider/model subtree and requires `LoadRequests`+`LoadTranscripts` to succeed, skipping
  cleanly when none is committed yet (there's nothing committed today). Verified it catches a real
  bad tree (planted a transcript missing a required field, confirmed the test fails, removed the
  fixture).
- **M1 — a scoped `--request_id` re-capture mutated the tree but never touched `manifest.yaml`.**
  Re-capturing a previously-tombstoned id into real data left `manifest.yaml` still saying
  `captured: false` for it. `patchManifestForScopedRun` now patches just that id's
  `RequestOutcome` plus `CapturedCount`/`MissingCount`, leaving medians/`PassScores` exactly as the
  last full run recorded them. Verified end to end via subprocess re-exec — the only way to
  genuinely drive a `-run`-scoped subset against a real `*testing.T` (Go propagates any subtest
  failure to the whole process; there is no safe in-process way to simulate "only 1 of N requests
  attempted").
- **M2 — `degradedPasses` rendered as a bare key with no values**, and the degraded-only banner
  opened with an empty quoted paragraph. Fixed the summary step's extraction with an awk state
  machine that follows `degradedPasses`' indented list items while keeping every other field
  (in particular `passScores[].missingCount`) correctly excluded, and restructured the banner so
  each block prepends its own blank line only when it actually fires.
- **M3 — `git rm` without `--ignore-unmatch` could hard-fail `publish` at exit 128** if `capture`
  and `publish`'s checkouts diverge on a stale tombstone. One flag.

Nits also addressed: guarded `manifest_path` derivation against more than one match (warns,
still picks the first deterministically); corrected the "no promotion -> no git status change"
header comment (`-uall` also surfaces unrelated stray files on a non-pristine tree); added
`Manifest.MedianSampleSize` so a reader isn't left computing — or miscomputing, under
`MediansUnreliable` — how many passes a median actually came from; added direct tests for
`safeFailureReason`'s timeout/HTTP-status paths and an end-to-end `RequestOutcome.Unusable`
assertion (previously untested at the manifest-wiring level); replaced an HTTP-handler-goroutine
`t.Fatal` with `panic` (invalid `*testing.T` use off the test goroutine); renamed
`Test_LoadTranscripts_*`/`Test_Adapters_*` to drop the leading-underscore substring-match footgun
the round-2 fix applied only to `TestRunCapture_*`; anchored the workflow's `-run` pattern so a
`request_id` never prefix-matches a different one; named systematic model refusal
(`RequestOutcome.Unusable`) as a fourth cause in `captureCompletenessVerdict`'s majority-missing
message. Also fixed "end state 5": the summary step now tells a genuine `go test` crash apart from
an intentionally-empty scoped re-capture, using `CAPTURE_RESULT`.

~~**One adjacent issue found during this round's self-review, not fixed here (pre-existing, out of
this round's scope):** `RequestOutcome.Captured` can read `false` for an id whose real transcript
file is still genuinely present on disk, if a LATER run's own attempt for that id fails while an
EARLIER run's file for it is deliberately left untouched (the "never overwrite a real transcript
with a tombstone" guard). This is not new — it predates round 3 and applies to full runs too, not
just scoped ones — but M1's fix means a scoped run can now patch this stale-looking outcome into a
manifest more visibly than before. Flagging for a follow-up rather than fixing opportunistically
here, to keep this round's diff scoped to the enumerated findings.~~ — **deferring this was wrong
(round-4 review, H2): it is not cosmetic. A run that captures nothing new stamps `Captured: false`
plus a fabricated 0.00 median over a manifest that already had real, honest data — and the
`!cancelled()` change earlier in this SAME PR is exactly what turns that from a discarded `go test`
run into a published PR whose whole diff is a regression. Fixed in Round 4 below, not deferred.**

Verification for round 3: `go build`/`vet`, untagged and `-tags=generate_capture -race` tests all
green; `golangci-lint` clean in both build-tag configurations (including a `#nosec` vs `//nolint`
resolution for a gosec finding that only fires under `-tags=generate_capture`, so it doesn't
flip-flop between "needed" and "unused" depending on which mode lints it); `actionlint` clean;
`gofumpt` clean. B1, B2, and M1 were each reproduced before fixing and confirmed to fail with the
fix reverted.

## Round 4 review response

Round 4 was the fourth consecutive block, and on rounds 2, 3, and 4 the previous round's fix
introduced the next round's defect. This round's fixes were verified empirically (built/reproduced
before fixing, confirmed each new test fails with its fix reverted) specifically because of that
pattern — see "Verification" below for what was actually run, not just implemented.

- **M2 (the reason this cycle kept repeating) — nothing in CI compiled, linted, or ran the
  `generate_capture`-tagged suite.** The only tagged invocation anywhere was
  `generate-capture.yml`'s live-capture job (`-run "^TestCaptureTranscripts$"`, real
  `ANTHROPIC_API_KEY`), so ~3,200 lines of `transcript_capture_test.go` — every regression test
  this PR's credibility rests on across all four rounds — ran nowhere automatically and was linted
  nowhere. A compile break would have surfaced only when a $3 live run was already in flight, and
  removing the `#nosec` at `transcript.go:510` was verified, empirically, to be silently accepted
  by golangci-lint without the tag (`0 issues`) and caught (`G703: Path traversal via taint
  analysis`) with it — so the tagged lint config is not redundant with the untagged one. Fixed:
  `.github/workflows/test.yml`'s `test` job now runs `go build -tags=generate_capture ./...` plus a
  `go test -tags=generate_capture` invocation naming every non-live test in the file (no API key in
  scope — `decideCaptureGuard` refuses `TestCaptureTranscripts` regardless of `-run`, so it's
  excluded from the list rather than relied on to no-op); `.golangci.yml` gets
  `run.build-tags: [generate_capture]`. Verified: both the build and the named test list pass
  (`-race` too) under the tag, `golangci-lint run` is `0 issues` under the real config with the tag
  added, and `actionlint`/`gofumpt` are clean on the workflow change.
- **H1 — `anyPassWiped` was the wrong proxy for "the all-passes fallback is misleading"; the
  original incident's failure mode survived.** The invariant excusing the fallback (a chronically
  missing SAME request every pass leaves every pass's rate stable, so the fallback equals a
  clean-pass median) requires every degraded pass to miss the *same set* of requests —
  `anyPassWiped == false` never implied that. Reproduced end-to-end before fixing: 5 requests, 5
  passes, pass *p* captures only request *p* (rotating 429s) — no pass is ever wiped (every pass
  captures exactly one request), yet `capturedCount=5 missingCount=0 degradedPasses=[1 2 3 4 5]
  mediansUnreliable=false medianValidatePassRate=0.200`, even though every individual request's
  true quality is 1.000: a green job, a `[!NOTE]` banner claiming a median "computed excluding the
  degraded pass(es)" when there was nothing to exclude from, and `medianSampleSize: 5` contradicting
  its own doc comment. Fixed: `requestsMissingUsableCandidate` now returns the missing **id set**,
  not a count; `allMissingSetsEqual` compares those sets across passes; `allDegraded = n == 0 &&
  !allMissingSetsEqual(degradedMissingSets)`. The existing chronic-single-missing and all-degraded
  regression tests keep their verdicts unchanged under the new rule (verified — both still pass);
  a new `TestSummarizePasses_RotatingSubset_FlagsAllDegraded` reproduces the rotating case directly
  and was confirmed to fail (`allDegraded = false`) against the reverted (wipe-only) proxy.
- **H2 — a run that captured nothing overwrote a good committed manifest with zeros, and this PR's
  own `!cancelled()` change is what turns that into a published PR.** Deferred as cosmetic in round
  3 — wrongly, per the correction above. Reproduced before fixing: run 1 captures two requests
  cleanly (`medianValidatePassRate: 1.0`); run 2 (same requests, provider down from the first call)
  writes `capturedCount=0 missingCount=2` with both medians stamped to `0.0`, even though both
  transcripts are still on disk and `LoadTranscripts` loads them fine — `writeManifest` was
  unconditional for a full run, so honest
  medians were destroyed and replaced by an all-zeros record describing a tree that was actually
  complete, `git status` went dirty, and `publish` opened a PR whose entire diff was that
  regression, under a `[!WARNING]` banner asserting it was "safe to review." Fixed in two parts:
  (1) `runCapture`'s outcomes loop now checks whether a real `<id>.yaml` already exists on disk
  *before* counting an id as missing — `requestIsCaptured` treats it as `Captured: true`,
  incrementing `capturedCount`/decrementing `missingCount` instead of stamping a contradiction; (2)
  when a run promotes nothing new at all (`len(moved) == 0`), `preserveMediansIfNothingPromoted`
  loads the existing `manifest.yaml` and carries its `Median*`/`PassScores`/`DegradedPasses`/
  `MediansUnreliable` fields forward rather than overwriting them with the fresh run's
  uninformative zeros — a run that learned nothing about the corpus's quality must not look like
  a run that measured zero quality. A new `TestRunCapture_SecondRunCapturesNothing_PreservesFirstRunsGoodManifest`
  drives both runs through the real `runCapture` end to end; confirmed it fails (on the disposition
  assertions, then separately on the median assertions) with each half of the fix reverted
  independently.
- **M1 — doc comments describing `MissingCount`/`DegradedPasses` as "produced NO completion" went
  stale the moment B2 (round 3) added the empty-extraction case.** Consequence beyond docs:
  `MediansUnreliable` can now fire on a pass where the provider answered every request but none
  parsed, and `runCapture`'s own `t.Errorf`/log text still said "no pass produced a completion for
  the full corpus" — false for that scenario, the fourth consecutive round with a wrong comment
  about the medians' provenance. Fixed the doc comments on both fields plus the inline messages in
  `runCapture` that made the same claim.
- **L1 — `ScoreRun`'s empty-candidate guard had no assertion unique to it.** `validateCandidate`'s
  own guard and `scoreSemantic("")`'s incidental non-match meant the existing test passed
  regardless of whether `ScoreRun`'s own short-circuit ran at all — verified by neutering the
  branch directly and watching the old test still pass. Added an exact-string assertion on
  `SemanticIssues[0]` (the message only `ScoreRun`'s own guard produces); confirmed it fails against
  the neutered branch.
- **L2 — one `generate-capture.yml` branch still produced a routine title on an anomaly.** The
  "success, tree changed, but no manifest.yaml at all" arm (never expected for a full run) emitted
  `degraded=0`, so it got the plain `chore(generate): capture provider transcripts` title
  indistinguishable from a totally unremarkable run. That arm now sets `degraded=1`.

**What the review got right that this response does not relitigate:** the two false PR-body claims
above (H1's "narrowly, not broadly" framing, and H2's "cosmetic, deferred" framing) — both
corrected in place above rather than reworded here. **One thing worth stating plainly:** the
`degraded=1` fix for L2 reuses the existing DEGRADED banner text ("At least one capture pass...
check `passScores[].missingCount`"), which is not a precise description of "no manifest exists at
all" — the summary block above it already carries the accurate anomaly message, so the banner is
an approximation for this one arm, not a fabrication, but a future round tightening that banner's
wording per-cause would be a legitimate nit.

Verification for round 4: `go build`/`vet`, untagged and `-tags=generate_capture -race`, all green
across the whole repo (not just this package) — this round's own M2 fix means that is now something
CI checks too, not just something run by hand. `golangci-lint run ./...` is `0 issues` with the new
`build-tags` config; `actionlint` clean on both changed workflow files; `gofumpt`/`goimports` clean.
H1's rotating-subset case and H2's overwrite case were both reproduced against the pre-fix code
before any fix was written, and every new regression test (`TestSummarizePasses_RotatingSubset_FlagsAllDegraded`,
`TestRunCapture_SecondRunCapturesNothing_PreservesFirstRunsGoodManifest`, the `ScoreRun`
exact-string assertion) was independently confirmed to fail when its corresponding fix is reverted
and pass with it restored.


## Round 5 review response

Round 5 was the fifth consecutive block, and unlike rounds 2-4 the defect was an **interaction**
between two of round 4's own fixes (H1's equal-missing-sets exemption and H2's on-disk
carry-forward), not a single fix going stale on its own. Fixed with that interaction explicitly in
mind: every new fix below was tested in combination with the others, not just in isolation — see
"Verification" for what was actually run.

- **HIGH-1 (the blocker) — H1's equal-sets exemption and H2's on-disk carry-forward combined to
  publish a fabricated quality regression with no evidence anywhere in the file.** The exemption's
  premise was "a chronically-missing request is ALSO visible via `Manifest.MissingCount > 0`" —
  H2's `requestIsCaptured` broke that premise the moment it started reporting a request captured
  from an EARLIER run's real transcript even when every pass THIS run attempted came back with
  nothing. Reproduced exactly as described: 3 requests, 3 passes, run 2 on the same `destDir`,
  req-b 429s on every call — `missingCount: 0`, `mediansUnreliable: false`, `medianValidatePassRate`
  dropping from 1.000 to 0.667 with nothing else in the file explaining why. Fixed at the predicate
  layer (`missingSetsAreReliable`, `transcript_capture_test.go`): the equal-sets exemption now also
  requires that none of the agreed-upon missing ids is captured *only* through carry-forward
  (`carriedForwardIDs`, threaded from `runCapture`'s outcomes loop through `summarizePasses`) — the
  agreement check alone is necessary but no longer sufficient. Also fixed the banner/log layer
  separately (see MEDIUM-1/2/3 below): both `runCapture`'s own log and `generate-capture.yml`'s
  DEGRADED signal now gate on `MedianSampleSize < Passes` (did real exclusion happen), not on
  `DegradedPasses`' mere presence — the old gate fired the "excluded... so not dragged toward zero"
  claim even in the exempted, nothing-excluded case, which is what let a fabricated 0.667 look
  routine. The `allMissingSetsEqual`-for-`len(sets) < 2` vacuous-truth note (a single-pass run can
  never set `MediansUnreliable`) is intentional, not a residual bug: with one pass there is nothing
  for passes to disagree about, and the banner fix (`MedianSampleSize < Passes`, false when
  `sampleSize == passes == 1`) is what stops that case from rendering a false "excluded" claim —
  confirmed empirically the reviewer's own single-pass repro no longer produces a misleading banner.
  New end-to-end regression test:
  `TestRunCapture_ChronicPerPassMiss_CapturedViaDiskCarryForward_FlagsUnreliable` (re-execs a
  subprocess, same pattern as the existing all-degraded test, since this scenario also makes
  `runCapture`'s own `t.Errorf` fire) — confirmed to fail (no `t.Errorf`, `MediansUnreliable` stays
  false) when `missingSetsAreReliable` is reverted to a bare `allMissingSetsEqual` call.

- **MEDIUM-2 — H2 dropped `FailureReason` on the carry-forward path.** A run whose own attempt
  genuinely failed to reproduce a request, but whose `Captured` stays `true` via carry-forward, had
  no committed record that this run ever tried and failed — the one field that exists specifically
  to explain "why is this request missing" went silent the moment `Captured` flipped back to
  `true`. Fixed: `RequestOutcome.FailureReason` is now also set (as the one deliberate exception to
  "always empty when `Captured` is true," documented on the field) whenever carry-forward is what
  makes an id captured AND this run's own last attempt for it produced no completion
  (`lastFailureErr` still has an entry, meaning no pass this run made ever deleted it).
  `TestRunCapture_SecondRunCapturesNothing_PreservesFirstRunsGoodManifest`'s own assertions were
  updated to match (it previously asserted `FailureReason == ""` for both ids in exactly this
  scenario — that assertion was the bug's own blind spot, not a correct expectation) and the new
  HIGH-1 test asserts the non-empty reason directly.

- **MEDIUM-4 — `preserveMediansIfNothingPromoted` carried medians forward with no shape or
  provenance check.** Reproduced: run 1 (4 requests, 3 passes, median 1.000), corpus grows to 6,
  run 2 (1 pass, provider dead) published `requestCount: 6` with the stale `median 1.000` and three
  `passScores[].total` entries still reading 4 — `capturedAt`/`corpusCommitSha`/`captureCommand`
  all refreshed to run 2, nothing marking the medians as foreign. Confirmed the documented backstop
  (`captureCompletenessVerdict` failing a run that captured none of its requests) does NOT catch
  this — H2's carry-forward keeps `capturedCount` at 4 (the old requests are still really on disk),
  so that verdict never fires. Fixed: `preserveMediansIfNothingPromoted` now only reuses a prior
  manifest's `Median*`/`PassScores` when `prior.RequestCount == len(requests) &&
  prior.Passes == passes`; on a mismatch it keeps THIS run's own (honestly-computed-from-nothing)
  `passScores`/`degradedMedians` and forces `degradedMedians.allDegraded = true` — reusing
  `Manifest.MediansUnreliable`'s existing "do not trust this as a baseline" signal (and the same
  `t.Errorf`/`CAPTURE_RESULT != success` path) rather than adding a parallel staleness field nothing
  else in the pipeline would know to check. New subprocess-based regression test
  `TestPreserveMediansIfNothingPromoted_ShapeMismatch_FlagsUnreliableNotStale` — confirmed to fail
  (median stays 1.000, `PassScores[].Total` stays 4, no `t.Errorf`) with just the shape guard
  reverted, even with HIGH-1's `carriedForwardIDs` fix still in place: the two fixes are genuinely
  independent (HIGH-1's own signal gets computed correctly for this scenario too, but
  `preserveMediansIfNothingPromoted` unconditionally overwrote it before this fix existed).

- **MEDIUM-5 — `requestIsCaptured` validated nothing about the file's content.** A bare `os.Stat`
  was the entire check — true for a directory, a zero-byte file, or a transcript captured against a
  DIFFERENT prompt under an id that was never renamed. Reproduced: edit a request's prompt under an
  unchanged id, run with the provider down, and the manifest asserted a fully-captured corpus for a
  tree `LoadTranscripts` hard-rejects on load (`corpusPromptSHA256` mismatch) — a false manifest,
  not silent corruption (the untagged `TestLoadTranscripts_CommittedTreeLoadsCleanly` still catches
  it on the next PR that touches the committed tree), but false all the same. Fixed:
  `requestIsCaptured` now reads and parses the on-disk file and requires `RequestID` and
  `CorpusPromptSHA256` to still match the current corpus entry — the same two checks
  `LoadTranscripts` itself runs. When they don't match, the id falls through to the normal
  missing/tombstone path, which writes `<id>.missing.yaml` ALONGSIDE the stale, mismatched
  `<id>.yaml` — deliberately not auto-resolved: `LoadTranscripts` hard-errors on that coexistence,
  which is the loud, specific failure this situation deserves rather than a silently wrong
  manifest. New tests: a focused `TestRequestIsCaptured_RejectsContentMismatch` (unit-level, direct)
  and an end-to-end `TestRunCapture_EditedPromptUnderUnchangedID_NotCountedCaptured` that also
  asserts `LoadTranscripts` actually errors on the resulting tree — both confirmed to fail against a
  bare-`os.Stat` revert.

- **MEDIUM-1/2/3 (doc sweep) — fifth round running with stale comments, several caused by this
  round's own fixes.** Corrected `transcript.go`'s `MedianValidatePassRate`/`MedianSampleSize`/
  `DegradedPasses`/`MediansUnreliable`/`RequestOutcome` doc comments, all of which either
  (a) claimed the all-passes fallback runs only when `MediansUnreliable` is true (it runs whenever
  no pass was clean, regardless), (b) described `Captured` as meaning only "a pass produced a
  completion" (carry-forward makes that incomplete — round 4's own gap), or (c) described
  `FailureReason` as always empty when `Captured` is true (MEDIUM-2 above adds the one exception).
  Also corrected `generate-capture.yml`'s stale "a run where every pass was degraded never reaches
  this line" framing to name both places that can now be true (H1 x H2's runtime path and M4's
  shape-mismatch path) and rewrote the `#nosec G703` comment in `transcript.go` (LOW-2 below).
  Per the reviewer's structural suggestion: the two invariants that most needed a test instead of a
  comment (the equal-sets exemption's soundness, and the shape-match requirement for median
  preservation) now have one each (HIGH-1's and MEDIUM-4's new tests) — a comment describing either
  incorrectly will now fail `go test`, not just look wrong on the next read.

- **LOW-1 — `go build -tags=generate_capture ./...` was a no-op verification.** `go build` never
  compiles `_test.go` files, tagged or not, so it never actually exercised
  `transcript_capture_test.go` at all. Verified: a planted syntax error left `go build` green while
  `go vet`/`go test` correctly failed. Replaced with `go vet -tags=generate_capture
  ./cmd/conduit/internal/generate/...` (which does compile/type-check `_test.go` files) as a cheap
  pre-flight ahead of the real `go test` coverage on the same line.

- **LOW-3 — the `-run` allowlist regex was fail-open.** It matched all tests at the time it was
  written, but this PR's own two new tests
  (`TestPreserveMediansIfNothingPromoted_ShapeMismatch_FlagsUnreliableNotStale`,
  `TestRequestIsCaptured_RejectsContentMismatch`) do not match ANY of its 11 prefixes — they would
  have silently never run in this gate, `go test` still exiting 0. Replaced with
  `-skip '^TestCaptureTranscripts$'` and no `-run`: fail-safe by construction, and verified the new
  tests are now actually picked up (`go test -tags=generate_capture -v -skip
  '^TestCaptureTranscripts$' ...` output includes both).

- **LOW-4 — `-race` added** to the tagged CI step in `test.yml` (green locally in under 4s).

- **LOW-2 — the `#nosec` comment's justification ("real CI's golangci-lint job does not pass that
  tag") was already false.** `.golangci.yml`'s own `run.build-tags: [generate_capture]` (added in
  round 4, the SAME PR that wrote this comment) means the real, required `golangci-lint` job DOES
  build with the tag on every PR. The suppression itself is still correct — this is a genuine false
  positive under the trust-boundary reasoning above it — but the comment now says so directly
  instead of citing a distinction that stopped being true before it was ever read.

**Correcting the PR body, per the round-5 reviewer's explicit ask:**

- The claim (implicit in round 4's own "Fixed:" line above) that `allMissingSetsEqual` alone is the
  correct net for `MediansUnreliable` is **false** — see HIGH-1 above; it needed the
  `carriedForwardIDs` check added this round.
- Round 4's verification line crediting `go build -tags=generate_capture ./...` with compile
  coverage of the tagged test file is **false** — see LOW-1 above; `go build` never compiled it.
  `go vet` (this round's fix) is what actually provides that coverage; the `go test` line always
  did too.
- Round 4's "H2 was verified end to end" claim did not extend to this round's failure mode: neither
  MEDIUM-4 (shape mismatch) nor MEDIUM-5 (content mismatch) was covered by any test before this
  round — both are new gaps in the SAME carry-forward mechanism H2 introduced, not previously
  claimed as covered and later found lacking.

**What the review got right, verified independently rather than taken on faith:** the vacuous-truth
note on `allMissingSetsEqual` (`len(sets) < 2`) is real but does not, on inspection, need a code fix
of its own — the banner/log fix (gating on `MedianSampleSize < Passes` instead of `DegradedPasses`'
presence) is what actually resolves the single-pass repro, and reproducing it before and after
confirmed that directly (see HIGH-1 above).

Verification for round 5: reproduced HIGH-1's two-run case, MEDIUM-4's corpus-shape case, and
MEDIUM-5's edited-prompt case against the pre-fix code before writing any fix. After fixing, ran
the new tests in combination — specifically confirmed each fails when ONLY its own fix is reverted
while the others stay in place (HIGH-1 reverted alone, MEDIUM-4 reverted alone with HIGH-1 intact,
MEDIUM-5 reverted alone), not just all-fixes-vs-no-fixes. `go vet`/`go build`, untagged and
`-tags=generate_capture -race`, all green across the whole repo. `golangci-lint run ./...` is
`0 issues` (required a `classifyRequestOutcome`/`logDegradedPassSummary` extraction to keep
`runCapture` under gocyclo's threshold after this round's own additions pushed it over).
`actionlint` clean on both changed workflow files. `gofumpt` clean.

## Risk tier

Tier 2 — CLI-adjacent tooling and CI. No engine or data-path change. Nothing here runs in a
pipeline.

## Roadmap

v0.20 WS1 (`conduit generate`), slice A5a-3 follow-up.


