### PR TITLE
fix(pipelines): correct postgres-pgvector-rag's prerequisites in both directions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -148,8 +148,10 @@ and for their agents._
       `postgres-pgvector-rag`). Of the templates named when this line was written, only
       `postgres-pgvector-rag` exists; `postgres-iceberg`, `mysql-snowflake`, `shopify-warehouse` and
       `kafka-clickhouse` are still outstanding, and Iceberg is itself a Phase-2 item below.
-      `postgres-pgvector-rag` also depends on `conduit connectors install pgvector`, which needs a
-      registry index inside its freshness window — see the note under _Public registry_
+      `postgres-pgvector-rag` also depends on a pgvector destination connector that is not yet
+      registry-installable at all — `conduit-connector-pgvector` has no tagged release, not just a
+      stale index — so today the template's prerequisite note points at a local build instead of
+      `conduit connectors install pgvector`. Revisit once that repo cuts a first tagged release.
 - [ ] Community-contributed templates with the same publishing flow as connectors
 
 ### Deployment fundamentals (12-factor citizenship — the universal answer)

--- a/cmd/conduit/root/pipelines/template_gallery.go
+++ b/cmd/conduit/root/pipelines/template_gallery.go
@@ -233,16 +233,22 @@ func galleryCatalogSpec() []GalleryTemplate {
 			// The pgvector and processor entries below must each state
 			// their registry-availability truthfully — see
 			// TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality
-			// in template_gallery_test.go for the drift guard and the
-			// exact condition under which it (and this comment) should be
-			// revisited: github.com/conduitio/conduit-connector-pgvector
-			// cutting its first tagged release.
+			// in template_gallery_test.go for the drift guard. Two independent
+			// conditions retire two independent claims here: the pgvector
+			// entry is revisited when
+			// github.com/conduitio/conduit-connector-pgvector cuts its first
+			// tagged release; the processor entry is revisited when
+			// https://github.com/ConduitIO/conduit/issues/2818 is fixed
+			// (today, `conduit processor-plugins install` refuses every
+			// processor on every build — see that issue and the entry
+			// below).
 			Prerequisites: []string{
 				"Run the pipeline with pipeline architecture v2 (`--preview.pipeline-arch-v2`, or " +
 					"`preview.pipeline-arch-v2: true` in the config). The chunking processor fans one source " +
 					"record into many chunk records, and record fan-out is only supported by architecture v2; " +
-					"on the default engine the pipeline fails at the chunk step with an \"unknown record type\" " +
-					"error. Architecture v2 is a preview engine — see its status before relying on it in production.",
+					"on the default engine the pipeline refuses to run at the chunk step with a " +
+					"`pipeline.fanout_requires_arch_v2` error (FailedPrecondition) naming this flag. Architecture " +
+					"v2 is a preview engine — see its status before relying on it in production.",
 				"pgvector destination: NOT installable from the registry yet — " +
 					"github.com/conduitio/conduit-connector-pgvector has no tagged release, so there is no " +
 					"version to pass to `conduit connectors install`. Build it yourself: clone the repo and " +
@@ -250,11 +256,16 @@ func galleryCatalogSpec() []GalleryTemplate {
 					"the directory --connectors.path points at (defaults to `connectors/` next to " +
 					"conduit.yaml). Switch to the registry install once that repo cuts a tagged release.",
 				"conduit-processor-ai's chunking (ai.chunk) and embedding (ai.embed) processors ARE " +
-					"published to the signed registry — install them with `conduit processor-plugins install " +
-					"ai.chunk` and `conduit processor-plugins install ai.embed`. To test an unreleased change " +
-					"instead, build from a github.com/conduitio/conduit-processor-ai checkout " +
-					"(`GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-chunk.wasm ./cmd/chunking`, likewise " +
-					"`./cmd/embedding`) and place the .wasm files under --processors.path.",
+					"published to the signed registry at 0.1.0 — but `conduit processor-plugins install " +
+					"ai.chunk` and `conduit processor-plugins install ai.embed` currently refuse both, on " +
+					"every build, with a `registry.incompatible_version` error: the compatibility gate " +
+					"compares this build's conduit-connector-protocol module version against each " +
+					"processor's minProtocolVersion instead of an actual processor-protocol version — a " +
+					"bug tracked as https://github.com/ConduitIO/conduit/issues/2818. `--bundle` is not a " +
+					"workaround; it applies the identical version check offline. Until #2818 is fixed, " +
+					"build the processors yourself from a github.com/conduitio/conduit-processor-ai " +
+					"checkout (`GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-chunk.wasm ./cmd/chunking`, " +
+					"likewise `./cmd/embedding`) and place the .wasm files under --processors.path.",
 			},
 		},
 	}

--- a/cmd/conduit/root/pipelines/template_gallery.go
+++ b/cmd/conduit/root/pipelines/template_gallery.go
@@ -229,22 +229,32 @@ func galleryCatalogSpec() []GalleryTemplate {
 			// (init.go's InitResult.Prerequisites / Render) so the command
 			// never emits a bare YAML that fails opaquely on first
 			// `conduit run` — see this field's doc comment.
+			//
+			// The pgvector and processor entries below must each state
+			// their registry-availability truthfully — see
+			// TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality
+			// in template_gallery_test.go for the drift guard and the
+			// exact condition under which it (and this comment) should be
+			// revisited: github.com/conduitio/conduit-connector-pgvector
+			// cutting its first tagged release.
 			Prerequisites: []string{
 				"Run the pipeline with pipeline architecture v2 (`--preview.pipeline-arch-v2`, or " +
 					"`preview.pipeline-arch-v2: true` in the config). The chunking processor fans one source " +
 					"record into many chunk records, and record fan-out is only supported by architecture v2; " +
 					"on the default engine the pipeline fails at the chunk step with an \"unknown record type\" " +
 					"error. Architecture v2 is a preview engine — see its status before relying on it in production.",
-				"Install the pgvector destination connector: `conduit connectors install pgvector@<version>` " +
-					"(run `conduit connectors search pgvector` to see available versions).",
-				"conduit-processor-ai's chunking (ai.chunk) and embedding (ai.embed) processors are " +
-					"standalone WASM plugins, installed with `conduit processor-plugins install ai.chunk` " +
-					"and `conduit processor-plugins install ai.embed`. Once conduit-processor-ai publishes " +
-					"signed artifacts to the registry, those commands fetch and verify them directly; until " +
-					"the registry serves processors, install from a signed bundle with `--bundle <path>`, or " +
-					"for local development build them from a github.com/conduitio/conduit-processor-ai " +
-					"checkout (`GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-chunk.wasm ./cmd/chunking`, " +
-					"likewise `./cmd/embedding`) and place the .wasm files under --processors.path.",
+				"pgvector destination: NOT installable from the registry yet — " +
+					"github.com/conduitio/conduit-connector-pgvector has no tagged release, so there is no " +
+					"version to pass to `conduit connectors install`. Build it yourself: clone the repo and " +
+					"run `go build -o conduit-connector-pgvector ./cmd/connector`, then place the binary under " +
+					"the directory --connectors.path points at (defaults to `connectors/` next to " +
+					"conduit.yaml). Switch to the registry install once that repo cuts a tagged release.",
+				"conduit-processor-ai's chunking (ai.chunk) and embedding (ai.embed) processors ARE " +
+					"published to the signed registry — install them with `conduit processor-plugins install " +
+					"ai.chunk` and `conduit processor-plugins install ai.embed`. To test an unreleased change " +
+					"instead, build from a github.com/conduitio/conduit-processor-ai checkout " +
+					"(`GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-chunk.wasm ./cmd/chunking`, likewise " +
+					"`./cmd/embedding`) and place the .wasm files under --processors.path.",
 			},
 		},
 	}

--- a/cmd/conduit/root/pipelines/template_gallery.go
+++ b/cmd/conduit/root/pipelines/template_gallery.go
@@ -246,7 +246,7 @@ func galleryCatalogSpec() []GalleryTemplate {
 				"Run the pipeline with pipeline architecture v2 (`--preview.pipeline-arch-v2`, or " +
 					"`preview.pipeline-arch-v2: true` in the config). The chunking processor fans one source " +
 					"record into many chunk records, and record fan-out is only supported by architecture v2; " +
-					"on the default engine the pipeline refuses to run at the chunk step with a " +
+					"on the default engine the pipeline fails at the chunk step with a " +
 					"`pipeline.fanout_requires_arch_v2` error (FailedPrecondition) naming this flag. Architecture " +
 					"v2 is a preview engine — see its status before relying on it in production.",
 				"pgvector destination: NOT installable from the registry yet — " +

--- a/cmd/conduit/root/pipelines/template_gallery_test.go
+++ b/cmd/conduit/root/pipelines/template_gallery_test.go
@@ -39,6 +39,7 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -453,8 +454,20 @@ func TestInitCommand_TemplateScaffold_PgvectorRAG_EmitsPrerequisites(t *testing.
 // plugin's install command falsely described as working). This version
 // asserts the specific facts a reader needs for ai.chunk/ai.embed —
 // published, currently blocked, why, and the actual working fallback —
-// instead of a substring both the true and false prose would contain. It is
-// intentionally hand-maintained per plugin rather than table/map-driven:
+// instead of a substring both the true and false prose would contain.
+//
+// Be precise about the limit of that, because it is easy to read this guard
+// as stronger than it is: every assertion below is a PRESENCE check. It
+// catches a fact being removed or reworded away — which is how the original
+// bug happened, and how the eventual "#2818 is fixed" edit will look, since
+// that rewrite necessarily drops `registry.incompatible_version`. It does
+// NOT catch a contradicting clause ADDED alongside facts that all still
+// hold: prose asserting "...#2818 — now fixed, both installs succeed" next
+// to every currently-asserted string passes this test. Detecting that would
+// mean parsing intent out of English, which a unit test cannot do; the
+// mitigation is that the realistic edit trips the guard anyway.
+//
+// It is intentionally hand-maintained per plugin rather than table/map-driven:
 // this guard's whole job is to catch prose making a false claim about ONE
 // specific plugin's install path, which a generic per-name loop (matching
 // on a name->bool ground-truth map) cannot distinguish from a differently
@@ -513,7 +526,7 @@ func TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality(t *testin
 	// authored entirely in this repo (template_gallery.go) — not a general
 	// claim that substring matching soundly detects "is this a working
 	// instruction or a warning."
-	t.Run("pgvector", func(t *testing.T) {
+	t.Run("pgvector_not_registry_installable", func(t *testing.T) {
 		is := is.New(t)
 		is.True(!strings.Contains(joined, "connectors install pgvector"))
 		is.True(strings.Contains(joined, "go build -o conduit-connector-pgvector"))
@@ -525,6 +538,36 @@ func TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality(t *testin
 	// gate that reads the CONNECTOR protocol module instead of a processor
 	// protocol version). Assert the specific facts, not a phrase the old
 	// false prose also contained.
+	// (4) The template README mirrors this prose for a reader who never runs
+	// `pipelines init`. Nothing enforced that mirror before this check, while
+	// the PR that introduced it claimed the two "cannot drift apart
+	// silently" — README/source drift being the exact bug class this guard
+	// exists to catch, one level up. Assert the load-bearing facts appear in
+	// both, so correcting one file and forgetting the other fails here.
+	//
+	// The test's working directory is the package directory, so this relative
+	// path is stable under `go test ./...` from anywhere in the repo.
+	t.Run("readme_mirrors_the_prerequisites", func(t *testing.T) {
+		is := is.New(t)
+		readme, err := os.ReadFile(filepath.Join(
+			"templates", templateNamePostgresPgvectorRAG, "README.md"))
+		is.NoErr(err)
+		text := string(readme)
+
+		for _, fact := range []string{
+			"0.1.0",                                  // the published processor version
+			"registry.incompatible_version",          // why the hosted install fails
+			"2818",                                   // the tracking issue
+			"go build -o conduit-connector-pgvector", // the pgvector fallback
+			"GOOS=wasip1 GOARCH=wasm",                // the processor fallback
+			"pipeline.fanout_requires_arch_v2",       // the real arch-v2 error
+		} {
+			is.True(strings.Contains(text, fact)) // README must state this fact too
+		}
+		// Same never-claim rule as (2), applied to the README.
+		is.True(!strings.Contains(text, "connectors install pgvector`"))
+	})
+
 	t.Run("ai.chunk_ai.embed_published_but_blocked", func(t *testing.T) {
 		is := is.New(t)
 		for _, name := range []string{"ai.chunk", "ai.embed"} {

--- a/cmd/conduit/root/pipelines/template_gallery_test.go
+++ b/cmd/conduit/root/pipelines/template_gallery_test.go
@@ -39,6 +39,7 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"regexp"
 	"slices"
 	"strings"
 	"testing"
@@ -379,9 +380,12 @@ func TestGalleryTemplates_ScaffoldParseableYAML(t *testing.T) {
 // that fails opaquely on first `conduit run` because a plugin isn't
 // present"): scaffolding postgres-pgvector-rag must surface its
 // GalleryTemplate.Prerequisites in BOTH the --json result and the
-// human-readable Render output, naming the exact `conduit connectors
-// install pgvector@<version>` command and the `conduit processor-plugins
-// install ai.chunk`/`ai.embed` commands for the two WASM processors.
+// human-readable Render output, naming the working `conduit
+// processor-plugins install ai.chunk`/`ai.embed` commands for the two WASM
+// processors and pointing at a local build for pgvector (which is not
+// registry-installable — see
+// TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality for the
+// drift guard on that claim).
 func TestInitCommand_TemplateScaffold_PgvectorRAG_EmitsPrerequisites(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
@@ -403,7 +407,7 @@ func TestInitCommand_TemplateScaffold_PgvectorRAG_EmitsPrerequisites(t *testing.
 	is.True(len(result.Prerequisites) >= 2)
 
 	joined := strings.Join(result.Prerequisites, "\n")
-	is.True(strings.Contains(joined, "conduit connectors install pgvector@"))
+	is.True(strings.Contains(joined, "go build -o conduit-connector-pgvector ./cmd/connector"))
 	is.True(strings.Contains(joined, "conduit processor-plugins install ai.chunk"))
 	is.True(strings.Contains(joined, "conduit processor-plugins install ai.embed"))
 
@@ -414,8 +418,94 @@ func TestInitCommand_TemplateScaffold_PgvectorRAG_EmitsPrerequisites(t *testing.
 	cmd2.SetOut(&out2)
 	cmd2.SetArgs([]string{"--pipelines.path=" + dir, "--template=postgres-pgvector-rag", "--force"})
 	is.NoErr(cmd2.Execute())
-	is.True(strings.Contains(out2.String(), "conduit connectors install pgvector@"))
+	is.True(strings.Contains(out2.String(), "go build -o conduit-connector-pgvector ./cmd/connector"))
 }
+
+// TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality is a
+// drift guard for a docs-honesty bug that shipped in two opposite
+// directions at once: the pgvector prerequisite told users to run
+// `conduit connectors install pgvector@<version>`, a command that can never
+// succeed (github.com/conduitio/conduit-connector-pgvector has zero git
+// tags and zero releases, so there is no version to resolve), while the
+// processor prerequisite said the hosted install "goes live once
+// conduit-processor-ai publishes signed artifacts" when ai.chunk@0.1.0 and
+// ai.embed@0.1.0 were already live in the registry index (verified against
+// ConduitIO/conduit-connector-registry@main's index/index.json, version 10,
+// 2026-08-21T19:26:17Z: both carry a real artifact + slsaProvenance entry;
+// pgvector is entirely absent from the published connectors list).
+//
+// There is no offline way for a unit test to query the live registry index,
+// so this test does two things instead:
+//
+//  1. Generically: every non-built-in plugin postgres-pgvector-rag's own
+//     pipeline.yaml references must be named somewhere in the prerequisite
+//     note, so a plugin silently dropped from the prose (the OTHER possible
+//     drift) fails here too.
+//  2. Specifically, per plugin: knownPublishedRegistryPlugins below is a
+//     manually maintained ground-truth snapshot. A plugin listed there must
+//     have its working install command documented; a plugin NOT listed
+//     (currently just pgvector) must NOT have `conduit connectors install
+//     <name>` written as an instruction to run.
+//
+// DELETE the pgvector special-case below (and add "pgvector": true to
+// knownPublishedRegistryPlugins) the moment
+// github.com/conduitio/conduit-connector-pgvector cuts a tagged release
+// that ConduitIO/conduit-connector-registry's index.json picks up — at
+// that point `conduit connectors install pgvector@<version>` becomes a
+// claim this test should REQUIRE, not forbid, and template_gallery.go's
+// Prerequisites/README.md's table should switch back to the registry
+// install path.
+func TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality(t *testing.T) {
+	is := is.New(t)
+
+	var tmpl *GalleryTemplate
+	for i := range galleryTemplates {
+		if galleryTemplates[i].Name == templateNamePostgresPgvectorRAG {
+			tmpl = &galleryTemplates[i]
+		}
+	}
+	is.True(tmpl != nil)
+
+	joined := strings.Join(tmpl.Prerequisites, "\n")
+
+	pluginRefs := galleryTemplatePluginNameRE.FindAllStringSubmatch(tmpl.YAML, -1)
+	is.True(len(pluginRefs) > 0) // the regex itself must still match the fixture's plugin lines
+
+	// knownPublishedRegistryPlugins: verified live against
+	// ConduitIO/conduit-connector-registry@main's index/index.json (version
+	// 10, 2026-08-21T19:26:17Z). Keep in sync with reality, not aspiration.
+	knownPublishedRegistryPlugins := map[string]bool{
+		"ai.chunk": true,
+		"ai.embed": true,
+		// pgvector: deliberately absent, see the "DELETE" comment above.
+	}
+
+	for _, m := range pluginRefs {
+		kind, name := m[1], m[2]
+		if kind == "builtin" {
+			continue // built-ins need no install step
+		}
+
+		// (1) Every non-built-in plugin referenced by the shipped YAML must
+		// be named in the prerequisite prose somewhere.
+		is.True(strings.Contains(joined, name))
+
+		// (2) A plugin without evidence of being published must not have a
+		// `conduit connectors install <name>` instruction in the prose; a
+		// plugin with evidence must have ITS install command documented.
+		installInstruction := "connectors install " + name
+		if knownPublishedRegistryPlugins[name] {
+			is.True(strings.Contains(joined, "install "+name)) // ai.chunk/ai.embed use `processor-plugins install`
+		} else {
+			is.True(!strings.Contains(joined, installInstruction))
+		}
+	}
+}
+
+// galleryTemplatePluginNameRE extracts "plugin: \"kind:name\"" references
+// from a rendered pipeline.yaml fixture, e.g. `plugin: "standalone:pgvector"`
+// -> kind="standalone", name="pgvector".
+var galleryTemplatePluginNameRE = regexp.MustCompile(`plugin:\s*"?(builtin|standalone):([A-Za-z0-9_.-]+)"?`)
 
 // TestInitCommand_TemplateScaffold_BuiltinOnlyTemplate_NoPrerequisites is
 // the converse: a built-in-only template (generator-log) must never carry a

--- a/cmd/conduit/root/pipelines/template_gallery_test.go
+++ b/cmd/conduit/root/pipelines/template_gallery_test.go
@@ -55,6 +55,14 @@ import (
 	"github.com/matryer/is"
 )
 
+// galleryTemplatePluginNameRE extracts "plugin: \"kind:name\"" references
+// from a rendered pipeline.yaml fixture, e.g. `plugin: "standalone:pgvector"`
+// -> kind="standalone", name="pgvector". Anchored to the start of the line
+// (ignoring leading whitespace, (?m)^\s*) so a commented-out fixture line
+// (`# plugin: "standalone:pgvector"`) does NOT match — the `#` prefix means
+// "plugin:" is no longer the first token on the line.
+var galleryTemplatePluginNameRE = regexp.MustCompile(`(?m)^\s*plugin:\s*"?(builtin|standalone):([A-Za-z0-9_.-]+)"?`)
+
 // TestGalleryCatalog_Valid proves the real, shipped catalog satisfies every
 // structural invariant validateGalleryCatalog enforces — redundant with the
 // package-init panic in the narrow sense that a broken catalog would already
@@ -380,12 +388,12 @@ func TestGalleryTemplates_ScaffoldParseableYAML(t *testing.T) {
 // that fails opaquely on first `conduit run` because a plugin isn't
 // present"): scaffolding postgres-pgvector-rag must surface its
 // GalleryTemplate.Prerequisites in BOTH the --json result and the
-// human-readable Render output, naming the working `conduit
-// processor-plugins install ai.chunk`/`ai.embed` commands for the two WASM
-// processors and pointing at a local build for pgvector (which is not
-// registry-installable — see
-// TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality for the
-// drift guard on that claim).
+// human-readable Render output, citing the `conduit
+// processor-plugins install ai.chunk`/`ai.embed` commands (which currently
+// refuse both processors — see
+// TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality) and
+// pointing at a local build for all three non-built-in plugins (pgvector,
+// ai.chunk, ai.embed).
 func TestInitCommand_TemplateScaffold_PgvectorRAG_EmitsPrerequisites(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
@@ -410,6 +418,7 @@ func TestInitCommand_TemplateScaffold_PgvectorRAG_EmitsPrerequisites(t *testing.
 	is.True(strings.Contains(joined, "go build -o conduit-connector-pgvector ./cmd/connector"))
 	is.True(strings.Contains(joined, "conduit processor-plugins install ai.chunk"))
 	is.True(strings.Contains(joined, "conduit processor-plugins install ai.embed"))
+	is.True(strings.Contains(joined, "GOOS=wasip1 GOARCH=wasm"))
 
 	// The human-readable Render path must surface the same note, not just
 	// the --json payload.
@@ -422,90 +431,122 @@ func TestInitCommand_TemplateScaffold_PgvectorRAG_EmitsPrerequisites(t *testing.
 }
 
 // TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality is a
-// drift guard for a docs-honesty bug that shipped in two opposite
-// directions at once: the pgvector prerequisite told users to run
-// `conduit connectors install pgvector@<version>`, a command that can never
-// succeed (github.com/conduitio/conduit-connector-pgvector has zero git
-// tags and zero releases, so there is no version to resolve), while the
-// processor prerequisite said the hosted install "goes live once
-// conduit-processor-ai publishes signed artifacts" when ai.chunk@0.1.0 and
-// ai.embed@0.1.0 were already live in the registry index (verified against
+// drift guard for a docs-honesty bug that shipped in two opposite directions
+// at once: the pgvector prerequisite told users to run `conduit connectors
+// install pgvector@<version>`, a command that can never succeed
+// (github.com/conduitio/conduit-connector-pgvector has zero git tags and
+// zero releases, so there is no version to resolve), while the processor
+// prerequisite said the hosted install "goes live once conduit-processor-ai
+// publishes signed artifacts" when ai.chunk@0.1.0 and ai.embed@0.1.0 were
+// already live in the registry index (verified against
 // ConduitIO/conduit-connector-registry@main's index/index.json, version 10,
 // 2026-08-21T19:26:17Z: both carry a real artifact + slsaProvenance entry;
 // pgvector is entirely absent from the published connectors list).
 //
-// There is no offline way for a unit test to query the live registry index,
-// so this test does two things instead:
+// A prior version of this guard replaced a stale phrase check
+// (`strings.Contains(joined, "install "+name)`) that a false claim could
+// satisfy just as easily as a true one: the ORIGINAL buggy prose also
+// contained the literal text "install ai.chunk" — the lie was in the
+// surrounding clause ("goes live once..."), not the command name. That is
+// why the guard caught only ONE direction of the bug (a plugin told to
+// `connectors install` something unpublished) and never the other (a
+// plugin's install command falsely described as working). This version
+// asserts the specific facts a reader needs for ai.chunk/ai.embed —
+// published, currently blocked, why, and the actual working fallback —
+// instead of a substring both the true and false prose would contain. It is
+// intentionally hand-maintained per plugin rather than table/map-driven:
+// this guard's whole job is to catch prose making a false claim about ONE
+// specific plugin's install path, which a generic per-name loop (matching
+// on a name->bool ground-truth map) cannot distinguish from a differently
+// false claim that still satisfies a generic "is it mentioned" check — see
+// TestInitCommand_TemplateScaffold_PgvectorRAG_EmitsPrerequisites's history
+// for exactly that failure mode. A fourth non-built-in plugin would need
+// its own explicit block added below; the generic loop immediately below
+// only catches it being silently DROPPED from the prose, not a false claim
+// about its specific install path — that gap is accepted, not enforced,
+// because there is no offline way for a unit test to query the live
+// registry index and confirm what "true" would even mean for an unknown
+// future plugin.
 //
-//  1. Generically: every non-built-in plugin postgres-pgvector-rag's own
-//     pipeline.yaml references must be named somewhere in the prerequisite
-//     note, so a plugin silently dropped from the prose (the OTHER possible
-//     drift) fails here too.
-//  2. Specifically, per plugin: knownPublishedRegistryPlugins below is a
-//     manually maintained ground-truth snapshot. A plugin listed there must
-//     have its working install command documented; a plugin NOT listed
-//     (currently just pgvector) must NOT have `conduit connectors install
-//     <name>` written as an instruction to run.
-//
-// DELETE the pgvector special-case below (and add "pgvector": true to
-// knownPublishedRegistryPlugins) the moment
+// REVISIT the pgvector block below the moment
 // github.com/conduitio/conduit-connector-pgvector cuts a tagged release
-// that ConduitIO/conduit-connector-registry's index.json picks up — at
-// that point `conduit connectors install pgvector@<version>` becomes a
-// claim this test should REQUIRE, not forbid, and template_gallery.go's
+// that ConduitIO/conduit-connector-registry's index.json picks up — at that
+// point `conduit connectors install pgvector@<version>` becomes a claim
+// this test should REQUIRE, not forbid, and template_gallery.go's
 // Prerequisites/README.md's table should switch back to the registry
-// install path.
+// install path. REVISIT the ai.chunk/ai.embed block the moment
+// https://github.com/ConduitIO/conduit/issues/2818 is fixed and
+// `conduit processor-plugins install ai.chunk`/`ai.embed` actually succeed
+// against a real running build.
 func TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality(t *testing.T) {
 	is := is.New(t)
 
-	var tmpl *GalleryTemplate
-	for i := range galleryTemplates {
-		if galleryTemplates[i].Name == templateNamePostgresPgvectorRAG {
-			tmpl = &galleryTemplates[i]
-		}
-	}
-	is.True(tmpl != nil)
+	tmpl, ok := lookupGalleryTemplate(templateNamePostgresPgvectorRAG)
+	is.True(ok)
 
 	joined := strings.Join(tmpl.Prerequisites, "\n")
 
 	pluginRefs := galleryTemplatePluginNameRE.FindAllStringSubmatch(tmpl.YAML, -1)
 	is.True(len(pluginRefs) > 0) // the regex itself must still match the fixture's plugin lines
 
-	// knownPublishedRegistryPlugins: verified live against
-	// ConduitIO/conduit-connector-registry@main's index/index.json (version
-	// 10, 2026-08-21T19:26:17Z). Keep in sync with reality, not aspiration.
-	knownPublishedRegistryPlugins := map[string]bool{
-		"ai.chunk": true,
-		"ai.embed": true,
-		// pgvector: deliberately absent, see the "DELETE" comment above.
-	}
-
+	// (1) Generic, name-agnostic check: every non-built-in plugin the shipped
+	// YAML references must be named somewhere in the prerequisite prose, so a
+	// plugin silently DROPPED from the prose (the other possible drift) fails
+	// here too. Run per-plugin via t.Run so a failure names the plugin
+	// instead of reporting only a line number.
 	for _, m := range pluginRefs {
 		kind, name := m[1], m[2]
 		if kind == "builtin" {
 			continue // built-ins need no install step
 		}
-
-		// (1) Every non-built-in plugin referenced by the shipped YAML must
-		// be named in the prerequisite prose somewhere.
-		is.True(strings.Contains(joined, name))
-
-		// (2) A plugin without evidence of being published must not have a
-		// `conduit connectors install <name>` instruction in the prose; a
-		// plugin with evidence must have ITS install command documented.
-		installInstruction := "connectors install " + name
-		if knownPublishedRegistryPlugins[name] {
-			is.True(strings.Contains(joined, "install "+name)) // ai.chunk/ai.embed use `processor-plugins install`
-		} else {
-			is.True(!strings.Contains(joined, installInstruction))
-		}
+		t.Run(name, func(t *testing.T) {
+			is := is.New(t)
+			is.True(strings.Contains(joined, name))
+		})
 	}
-}
 
-// galleryTemplatePluginNameRE extracts "plugin: \"kind:name\"" references
-// from a rendered pipeline.yaml fixture, e.g. `plugin: "standalone:pgvector"`
-// -> kind="standalone", name="pgvector".
-var galleryTemplatePluginNameRE = regexp.MustCompile(`plugin:\s*"?(builtin|standalone):([A-Za-z0-9_.-]+)"?`)
+	// (2) pgvector: no tagged release exists anywhere, so a registry install
+	// can never succeed — the prose must never claim otherwise. This substring
+	// check is a heuristic, not a proof: a truthful sentence that happened to
+	// read "do not run `conduit connectors install pgvector`" would also trip
+	// it. That is an accepted, narrow false-positive risk given the prose is
+	// authored entirely in this repo (template_gallery.go) — not a general
+	// claim that substring matching soundly detects "is this a working
+	// instruction or a warning."
+	t.Run("pgvector", func(t *testing.T) {
+		is := is.New(t)
+		is.True(!strings.Contains(joined, "connectors install pgvector"))
+		is.True(strings.Contains(joined, "go build -o conduit-connector-pgvector"))
+	})
+
+	// (3) ai.chunk/ai.embed: published to the signed registry (0.1.0 per the
+	// live index, see doc comment above) BUT currently refused on every build
+	// via registry.incompatible_version (#2818 — a processor compatibility
+	// gate that reads the CONNECTOR protocol module instead of a processor
+	// protocol version). Assert the specific facts, not a phrase the old
+	// false prose also contained.
+	t.Run("ai.chunk_ai.embed_published_but_blocked", func(t *testing.T) {
+		is := is.New(t)
+		for _, name := range []string{"ai.chunk", "ai.embed"} {
+			// The command that currently fails is still cited, so a user who
+			// hits the error recognizes it — but see check (4) below for what
+			// must accompany it.
+			is.True(strings.Contains(joined, "conduit processor-plugins install "+name))
+		}
+		is.True(strings.Contains(joined, "0.1.0"))                         // the published version, not just "published"
+		is.True(strings.Contains(joined, "registry.incompatible_version")) // the actual error code
+		is.True(strings.Contains(joined, "2818"))                          // the tracking issue
+		is.True(strings.Contains(joined, "GOOS=wasip1 GOARCH=wasm"))       // the real, working fallback
+		is.True(strings.Contains(joined, "./cmd/chunking"))
+		is.True(strings.Contains(joined, "./cmd/embedding"))
+		// --bundle hits the identical version algebra offline (bundle.go), so
+		// the prose must say so explicitly rather than offer it as an
+		// unqualified escape hatch (a positive assertion, not a bare
+		// "--bundle" absence check — the fact IS worth stating, just not as
+		// a working alternative).
+		is.True(strings.Contains(joined, "not a workaround"))
+	})
+}
 
 // TestInitCommand_TemplateScaffold_BuiltinOnlyTemplate_NoPrerequisites is
 // the converse: a built-in-only template (generator-log) must never carry a

--- a/cmd/conduit/root/pipelines/templates/postgres-pgvector-rag/README.md
+++ b/cmd/conduit/root/pipelines/templates/postgres-pgvector-rag/README.md
@@ -39,7 +39,7 @@ gate compares this build's `conduit-connector-protocol` module version (a connec
 version) against each processor's `minProtocolVersion`, rather than an actual processor-protocol
 version — tracked as [issue #2818](https://github.com/ConduitIO/conduit/issues/2818).
 `--bundle` is not a workaround: it applies the identical version algebra offline. A registry install
-for the pgvector destination is separately, permanently impossible today for an unrelated
+for the pgvector destination is separately impossible today for an unrelated
 reason — `conduit-connector-pgvector` has not cut a tagged release, so there is no version for
 `conduit connectors install` to resolve. Until both are fixed, all three non-built-in plugins this
 template needs must be built from source (see the table above). `conduit pipelines init --template
@@ -50,7 +50,7 @@ is scaffolded.
 
 The chunking processor fans one source record into **many** chunk records (one per chunk). Record
 fan-out (`sdk.MultiRecord`) is only supported by **pipeline architecture v2**; the default engine is
-one-record-in-one-record-out and refuses to run, at the chunk step, with a
+one-record-in-one-record-out and fails, at the chunk step, with a
 `pipeline.fanout_requires_arch_v2` error (`FailedPrecondition`) naming this flag. Run this pipeline
 with `--preview.pipeline-arch-v2` (or `preview.pipeline-arch-v2: true` in the config). Architecture v2
 is currently a **preview** engine — it is more allocation-efficient than the default but does not yet

--- a/cmd/conduit/root/pipelines/templates/postgres-pgvector-rag/README.md
+++ b/cmd/conduit/root/pipelines/templates/postgres-pgvector-rag/README.md
@@ -29,15 +29,17 @@ is):
 
 | Plugin | Kind | Install |
 | --- | --- | --- |
-| `standalone:pgvector` (destination) | Registry-installed Go connector (`conduit-connector-pgvector`) | `conduit connectors install pgvector@<version>` |
-| `standalone:ai.chunk` (processor) | Standalone WASM processor (`conduit-processor-ai`) | `conduit processor-plugins install ai.chunk` once it's published to the signed registry; until then `conduit processor-plugins install --bundle <signed.tgz>`, or build `./cmd/chunking` (`GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-chunk.wasm ./cmd/chunking`) and place the `.wasm` under `--processors.path`. |
-| `standalone:ai.embed` (processor) | Standalone WASM processor (`conduit-processor-ai`) | `conduit processor-plugins install ai.embed` (same options as above; build `./cmd/embedding`). |
+| `standalone:pgvector` (destination) | Standalone Go connector (`conduit-connector-pgvector`) | **Not yet in the registry** — the repo has no tagged release, so there is no version to pass to `conduit connectors install`. Build it: clone the repo, `go build -o conduit-connector-pgvector ./cmd/connector`, and place the binary under `--connectors.path`. Switch to the registry install once a tagged release ships. |
+| `standalone:ai.chunk` (processor) | Standalone WASM processor (`conduit-processor-ai`) | `conduit processor-plugins install ai.chunk` — published to the signed registry now. For an unreleased change, build `./cmd/chunking` (`GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-chunk.wasm ./cmd/chunking`) and place the `.wasm` under `--processors.path`. |
+| `standalone:ai.embed` (processor) | Standalone WASM processor (`conduit-processor-ai`) | `conduit processor-plugins install ai.embed` — published to the signed registry now (same local-build option as above; build `./cmd/embedding`). |
 
-The `conduit processor-plugins install` / `uninstall` commands exist, and
-`conduit pipelines init --template postgres-pgvector-rag` names them in its prerequisite note every
-time this template is scaffolded. The hosted `install ai.chunk` / `install ai.embed` fetch goes live
-once `conduit-processor-ai` publishes signed processor artifacts to the registry; until then use the
-offline `--bundle` path or a local build.
+The `conduit processor-plugins install` / `uninstall` commands exist and are live against the
+signed registry: `ai.chunk` and `ai.embed` both resolve today. A registry install for the pgvector
+destination is not yet possible — `conduit-connector-pgvector` has not cut a tagged release, so there
+is no version for `conduit connectors install` to resolve — so the only working path for the
+destination connector is a local build (see the table above). `conduit pipelines init --template
+postgres-pgvector-rag` names both realities in its prerequisite note every time this template is
+scaffolded.
 
 ## Requires pipeline architecture v2
 

--- a/cmd/conduit/root/pipelines/templates/postgres-pgvector-rag/README.md
+++ b/cmd/conduit/root/pipelines/templates/postgres-pgvector-rag/README.md
@@ -30,26 +30,31 @@ is):
 | Plugin | Kind | Install |
 | --- | --- | --- |
 | `standalone:pgvector` (destination) | Standalone Go connector (`conduit-connector-pgvector`) | **Not yet in the registry** — the repo has no tagged release, so there is no version to pass to `conduit connectors install`. Build it: clone the repo, `go build -o conduit-connector-pgvector ./cmd/connector`, and place the binary under `--connectors.path`. Switch to the registry install once a tagged release ships. |
-| `standalone:ai.chunk` (processor) | Standalone WASM processor (`conduit-processor-ai`) | `conduit processor-plugins install ai.chunk` — published to the signed registry now. For an unreleased change, build `./cmd/chunking` (`GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-chunk.wasm ./cmd/chunking`) and place the `.wasm` under `--processors.path`. |
-| `standalone:ai.embed` (processor) | Standalone WASM processor (`conduit-processor-ai`) | `conduit processor-plugins install ai.embed` — published to the signed registry now (same local-build option as above; build `./cmd/embedding`). |
+| `standalone:ai.chunk` (processor) | Standalone WASM processor (`conduit-processor-ai`) | Published to the signed registry at **0.1.0** — but `conduit processor-plugins install ai.chunk` currently refuses it on every build with `registry.incompatible_version` ([#2818](https://github.com/ConduitIO/conduit/issues/2818)). Build it: clone `conduit-processor-ai`, `GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-chunk.wasm ./cmd/chunking`, and place the `.wasm` under `--processors.path`. |
+| `standalone:ai.embed` (processor) | Standalone WASM processor (`conduit-processor-ai`) | Published to the signed registry at **0.1.0** — same `registry.incompatible_version` failure ([#2818](https://github.com/ConduitIO/conduit/issues/2818)). Build it the same way (`./cmd/embedding`). |
 
-The `conduit processor-plugins install` / `uninstall` commands exist and are live against the
-signed registry: `ai.chunk` and `ai.embed` both resolve today. A registry install for the pgvector
-destination is not yet possible — `conduit-connector-pgvector` has not cut a tagged release, so there
-is no version for `conduit connectors install` to resolve — so the only working path for the
-destination connector is a local build (see the table above). `conduit pipelines init --template
-postgres-pgvector-rag` names both realities in its prerequisite note every time this template is
-scaffolded.
+`ai.chunk` and `ai.embed` ARE published to the signed registry (0.1.0), but installing either
+currently fails on **every** build with a `registry.incompatible_version` error: the compatibility
+gate compares this build's `conduit-connector-protocol` module version (a connector protocol
+version) against each processor's `minProtocolVersion`, rather than an actual processor-protocol
+version — tracked as [issue #2818](https://github.com/ConduitIO/conduit/issues/2818).
+`--bundle` is not a workaround: it applies the identical version algebra offline. A registry install
+for the pgvector destination is separately, permanently impossible today for an unrelated
+reason — `conduit-connector-pgvector` has not cut a tagged release, so there is no version for
+`conduit connectors install` to resolve. Until both are fixed, all three non-built-in plugins this
+template needs must be built from source (see the table above). `conduit pipelines init --template
+postgres-pgvector-rag` names all three realities in its prerequisite note every time this template
+is scaffolded.
 
 ## Requires pipeline architecture v2
 
 The chunking processor fans one source record into **many** chunk records (one per chunk). Record
 fan-out (`sdk.MultiRecord`) is only supported by **pipeline architecture v2**; the default engine is
-one-record-in-one-record-out and rejects a fan-out with an `"unknown record type"` error at the
-chunk step. Run this pipeline with `--preview.pipeline-arch-v2` (or `preview.pipeline-arch-v2: true`
-in the config). Architecture v2 is currently a **preview** engine — it is more allocation-efficient
-than the default but does not yet have automatic error-recovery parity; review its status before
-depending on it for production data.
+one-record-in-one-record-out and refuses to run, at the chunk step, with a
+`pipeline.fanout_requires_arch_v2` error (`FailedPrecondition`) naming this flag. Run this pipeline
+with `--preview.pipeline-arch-v2` (or `preview.pipeline-arch-v2: true` in the config). Architecture v2
+is currently a **preview** engine — it is more allocation-efficient than the default but does not yet
+have automatic error-recovery parity; review its status before depending on it for production data.
 
 You'll also need the pgvector target table created ahead of time, matching the `dimension` you
 configure (768 for the template's default `nomic-embed-text` model):


### PR DESCRIPTION
## The bug

The `postgres-pgvector-rag` template's prerequisites — the text `conduit pipelines init
--template postgres-pgvector-rag` prints so the user knows what to install — are wrong in both
directions. A user following the CLI's own instructions cannot get this template running.

Ground truth, checked against the live published index (`ConduitIO/conduit-connector-registry`
`index/index.json`, version 10, `2026-08-21T19:26:17Z`):

- Published connectors: `file`, `generator`, `kafka`, `log`, `postgres`. **`pgvector` is not
  there.** `conduit-connector-pgvector` exists as a repo but has zero tags and zero releases.
  `rag-e2e.yml` builds it from a pinned SHA, which is why e2e is green while a user cannot
  reproduce it.
- Published processors: `ai.chunk@0.1.0` and `ai.embed@0.1.0`, each with a real `artifact` and
  `slsaProvenance` entry.

So the CLI told users to run `conduit connectors install pgvector@<version>` (nothing to
install, no version to name — and `conduit connectors search pgvector` returns nothing either),
while telling them the ai.chunk/ai.embed hosted install wasn't live yet and to use `--bundle`.

## What changed

- **pgvector**: states plainly that there is no registry install yet and why (no tagged
  release), and gives the path that works today — clone, `go build -o
  conduit-connector-pgvector ./cmd/connector`, drop the binary under `--connectors.path`. The
  build command matches `buildPgvectorConnectorBinary` in the existing RAG e2e integration test,
  and the discovery mechanism was verified against `pkg/plugin/connector/standalone/registry.go`
  (it reads every file in the directory and queries its spec over the plugin protocol — no
  filename convention required to function).
- **ai.chunk / ai.embed**: states that both are published to the signed registry at 0.1.0, but
  that `conduit processor-plugins install` currently refuses both on every build. Gives the
  build-from-source path as the one that actually works right now.
- Mirrored in the template README's plugin table so the two cannot drift apart silently.
- `ROADMAP.md` carried a milder version of the same error — it framed pgvector as an
  index-freshness problem, when the real state is that there is no tagged release to
  freshness-check. Corrected.

## Not in scope

ADRs, design docs, and postmortems that also mention `connectors install pgvector` were left
alone — ADRs are immutable per CLAUDE.md, and the others are point-in-time records rather than
live operational guidance. `ROADMAP.md` is treated as continuously maintained, so it was fixed.

**The underlying gaps are not fixed here.** Tagging and publishing `conduit-connector-pgvector`
to the registry is separate work (it needs the gated signing environment). Making
`conduit processor-plugins install` actually succeed for `ai.chunk`/`ai.embed` is tracked
separately as
[issue #2818](https://github.com/ConduitIO/conduit/issues/2818) — the compatibility
gate compares this build's `conduit-connector-protocol` module version (pinned `v0.9.5`) against
each processor's `minProtocolVersion` (`0.14.0`) instead of an actual processor-protocol version,
so it refuses every build regardless of the running Conduit version; separately,
`minConduitVersion: 0.20.0` loses to every `v0.20.0` nightly under plain semver precedence, since
every build shipping this template necessarily _is_ a nightly. `--bundle` is not an escape hatch
either — it applies the identical compatibility algebra offline. **Until #2818 is fixed, all
three non-built-in plugins this template needs — `pgvector`, `ai.chunk`, `ai.embed` — must be
built from source.** This PR makes the CLI say so plainly, instead of claiming any of the three
installs work today.

## Round 2: adversarial review findings and resolutions

An adversarial pre-merge review returned **block**. It agreed the pgvector half was right and
well-evidenced, and blocked because the processor half replaced one false claim ("not live yet,
use `--bundle`") with a different false claim ("installable from the registry today") — the exact
failure mode this PR exists to fix. Findings and what changed:

1. **Blocker — the "processors are installable" claim was false.** Verified directly:
   `conduit processor-plugins install ai.chunk --dry-run --json` returns
   `registry.incompatible_version` on every build (root-caused above; filed as #2818, not fixed
   here). Rewrote both `template_gallery.go`'s `Prerequisites` and the README's plugin table to
   state the publication fact and the compatibility-gate failure together, citing the error code
   and #2818, with the build-from-source path restored as the one that actually works — see "What
   changed" above.
2. **High — the drift guard's "published" branch was toothless.** Its assertion
   (`strings.Contains(joined, "install "+name)`) was satisfied by the ORIGINAL false prose too
   ("goes live once `conduit-processor-ai` publishes signed artifacts" still contains the substring
   "install ai.chunk") — the guard caught the pgvector direction of the bug and silently passed
   the processor direction, which is exactly why the false "installable" claim above shipped
   without the test catching it. Rewrote
   `TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality` to assert the specific
   facts a reader needs per plugin (published version, exact error code, tracking issue, the
   real build command) instead of a substring both true and false prose would contain. Removed
   the hand-maintained `knownPublishedRegistryPlugins` map — a generic map can't distinguish
   "mentioned" from "falsely claimed to work", so the fix replaces it with explicit, per-plugin
   assertions rather than trying to make the map "stale-proof". The remaining gap — a fourth
   non-built-in plugin only gets the generic "is it mentioned" check unless it gets its own
   explicit block — is documented in the test's comment as an accepted limitation, not silently
   left implicit.

   Perturbation-tested against the new guard: (1) revert the pgvector prose to the pre-this-PR
   text → **fails**. (2) revert the processor prose to the old false "use `--bundle`" text →
   **fails** (this is the direction that used to slip through). (3) a cosmetic-only reword →
   **passes**.

   Correcting the record on this PR's own earlier claim: "this one fails on the thing that
   actually went wrong" was only half true — it failed on the pgvector direction, not the
   processor direction, which is precisely what let the processor overclaim ship in the first
   version of this PR.
3. **Medium — the untouched arch-v2 prerequisite quoted a stale error.** Both
   `template_gallery.go` and the README claimed the default engine "fails at the chunk step with
   an `unknown record type` error." That stopped being true in `a980aa0` (#2715):
   `sdk.MultiRecord` now gets its own branch emitting the actionable
   `pipeline.fanout_requires_arch_v2` error (`FailedPrecondition`); `"unknown record type"` is now
   only the `default:` fallthrough. The flag and the fan-out-requires-v2 claim were still correct
   — only the quoted error string was stale. Both files now quote the real error code.
4. **Nits.** Replaced the hand-rolled `&galleryTemplates[i]` catalog lookup with the existing
   `lookupGalleryTemplate` helper; split the drift-guard assertions into `t.Run` subtests keyed by
   plugin name so a failure names the plugin instead of only a line number; moved
   `galleryTemplatePluginNameRE` next to the imports (repo style) and anchored it to the start of
   the line so it no longer matches a commented-out fixture line.

## Verified

`go build ./...` clean; `go test ./cmd/conduit/root/pipelines/...` all `ok` (including the three
perturbation runs above); `golangci-lint run ./cmd/conduit/root/pipelines/...` 0 issues; `go vet`
clean; `gofmt -l` clean on all changed Go files; `generate-llms` re-run with zero diff (the
generator doesn't currently surface gallery prerequisite text); markdownlint clean on the changed
Markdown file. The `registry.incompatible_version` failure was reproduced directly against a
locally built binary, not taken on description alone.

## Risk tier

Tier 2 — CLI-surface text and its test. No engine or data-path change.

## Roadmap

v0.20, RAG template (WS8, docs-honesty).
