### PR TITLE
fix(registry): processor install refused on every build (#2818)

### DIFF
--- a/cmd/conduit/root/pipelines/template_gallery.go
+++ b/cmd/conduit/root/pipelines/template_gallery.go
@@ -233,15 +233,15 @@ func galleryCatalogSpec() []GalleryTemplate {
 			// The pgvector and processor entries below must each state
 			// their registry-availability truthfully — see
 			// TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality
-			// in template_gallery_test.go for the drift guard. Two independent
-			// conditions retire two independent claims here: the pgvector
+			// in template_gallery_test.go for the drift guard. The pgvector
 			// entry is revisited when
 			// github.com/conduitio/conduit-connector-pgvector cuts its first
-			// tagged release; the processor entry is revisited when
-			// https://github.com/ConduitIO/conduit/issues/2818 is fixed
-			// (today, `conduit processor-plugins install` refuses every
-			// processor on every build — see that issue and the entry
-			// below).
+			// tagged release. The processor entry was revisited when
+			// https://github.com/ConduitIO/conduit/issues/2818 was fixed:
+			// `conduit processor-plugins install` no longer refuses every
+			// processor on every build — it now correctly requires
+			// minConduitVersion 0.20.0 (a real requirement these processors
+			// declare), not an always-false protocol-version comparison.
 			Prerequisites: []string{
 				"Run the pipeline with pipeline architecture v2 (`--preview.pipeline-arch-v2`, or " +
 					"`preview.pipeline-arch-v2: true` in the config). The chunking processor fans one source " +
@@ -255,17 +255,19 @@ func galleryCatalogSpec() []GalleryTemplate {
 					"run `go build -o conduit-connector-pgvector ./cmd/connector`, then place the binary under " +
 					"the directory --connectors.path points at (defaults to `connectors/` next to " +
 					"conduit.yaml). Switch to the registry install once that repo cuts a tagged release.",
-				"conduit-processor-ai's chunking (ai.chunk) and embedding (ai.embed) processors ARE " +
-					"published to the signed registry at 0.1.0 — but `conduit processor-plugins install " +
-					"ai.chunk` and `conduit processor-plugins install ai.embed` currently refuse both, on " +
-					"every build, with a `registry.incompatible_version` error: the compatibility gate " +
-					"compares this build's conduit-connector-protocol module version against each " +
-					"processor's minProtocolVersion instead of an actual processor-protocol version — a " +
-					"bug tracked as https://github.com/ConduitIO/conduit/issues/2818. `--bundle` is not a " +
-					"workaround; it applies the identical version check offline. Until #2818 is fixed, " +
-					"build the processors yourself from a github.com/conduitio/conduit-processor-ai " +
-					"checkout (`GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-chunk.wasm ./cmd/chunking`, " +
-					"likewise `./cmd/embedding`) and place the .wasm files under --processors.path.",
+				"conduit-processor-ai's chunking (ai.chunk) and embedding (ai.embed) processors are " +
+					"published to the signed registry at 0.1.0 and install via `conduit processor-plugins " +
+					"install ai.chunk` / `conduit processor-plugins install ai.embed` — the " +
+					"`registry.incompatible_version` refusal tracked as " +
+					"https://github.com/ConduitIO/conduit/issues/2818 is fixed. Both still genuinely require " +
+					"minConduitVersion 0.20.0: a v0.19.0 stable Conduit is correctly refused with " +
+					"`registry.incompatible_version` (it really is too old), while a v0.20.0 nightly (this " +
+					"project's nightly train) or the eventual v0.20.0 stable release satisfies it. `--bundle` " +
+					"applies the identical version algebra offline, so it is not a workaround for the version " +
+					"requirement either. If you're running an older Conduit and cannot upgrade, build the " +
+					"processors yourself from a github.com/conduitio/conduit-processor-ai checkout " +
+					"(`GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-chunk.wasm ./cmd/chunking`, likewise " +
+					"`./cmd/embedding`) and place the .wasm files under --processors.path.",
 			},
 		},
 	}

--- a/cmd/conduit/root/pipelines/template_gallery_test.go
+++ b/cmd/conduit/root/pipelines/template_gallery_test.go
@@ -390,11 +390,11 @@ func TestGalleryTemplates_ScaffoldParseableYAML(t *testing.T) {
 // present"): scaffolding postgres-pgvector-rag must surface its
 // GalleryTemplate.Prerequisites in BOTH the --json result and the
 // human-readable Render output, citing the `conduit
-// processor-plugins install ai.chunk`/`ai.embed` commands (which currently
-// refuse both processors — see
+// processor-plugins install ai.chunk`/`ai.embed` commands (installable as of
+// issue #2818's fix, still gated on minConduitVersion 0.20.0 — see
 // TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality) and
-// pointing at a local build for all three non-built-in plugins (pgvector,
-// ai.chunk, ai.embed).
+// pointing at a local build as the fallback for pgvector (always) and
+// ai.chunk/ai.embed (only on a pre-0.20.0 Conduit).
 func TestInitCommand_TemplateScaffold_PgvectorRAG_EmitsPrerequisites(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
@@ -459,13 +459,21 @@ func TestInitCommand_TemplateScaffold_PgvectorRAG_EmitsPrerequisites(t *testing.
 // Be precise about the limit of that, because it is easy to read this guard
 // as stronger than it is: every assertion below is a PRESENCE check. It
 // catches a fact being removed or reworded away — which is how the original
-// bug happened, and how the eventual "#2818 is fixed" edit will look, since
-// that rewrite necessarily drops `registry.incompatible_version`. It does
-// NOT catch a contradicting clause ADDED alongside facts that all still
-// hold: prose asserting "...#2818 — now fixed, both installs succeed" next
-// to every currently-asserted string passes this test. Detecting that would
-// mean parsing intent out of English, which a unit test cannot do; the
-// mitigation is that the realistic edit trips the guard anyway.
+// bug happened. Detecting a contradicting clause added alongside facts that
+// all still hold would mean parsing intent out of English, which a unit
+// test cannot do.
+//
+// UPDATE (issue #2818 fixed): the ai.chunk/ai.embed block below was
+// rewritten once `conduit processor-plugins install ai.chunk`/`ai.embed`
+// actually succeeded against a real running build (see
+// pkg/registry/resolve_realindex_test.go for the resolution-level proof,
+// and this package's own manual verification: `conduit processor-plugins
+// install ai.chunk --dry-run --json` against the live index). The
+// remaining, still-real constraint is minConduitVersion 0.20.0: a v0.19.0
+// stable Conduit is correctly refused, a v0.20.0 nightly or later is not.
+// `registry.incompatible_version` is still asserted below — it is still
+// the code returned for that legitimate refusal, just no longer the code
+// returned unconditionally on every build regardless of version.
 //
 // It is intentionally hand-maintained per plugin rather than table/map-driven:
 // this guard's whole job is to catch prose making a false claim about ONE
@@ -487,10 +495,7 @@ func TestInitCommand_TemplateScaffold_PgvectorRAG_EmitsPrerequisites(t *testing.
 // point `conduit connectors install pgvector@<version>` becomes a claim
 // this test should REQUIRE, not forbid, and template_gallery.go's
 // Prerequisites/README.md's table should switch back to the registry
-// install path. REVISIT the ai.chunk/ai.embed block the moment
-// https://github.com/ConduitIO/conduit/issues/2818 is fixed and
-// `conduit processor-plugins install ai.chunk`/`ai.embed` actually succeed
-// against a real running build.
+// install path.
 func TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality(t *testing.T) {
 	is := is.New(t)
 
@@ -533,11 +538,12 @@ func TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality(t *testin
 	})
 
 	// (3) ai.chunk/ai.embed: published to the signed registry (0.1.0 per the
-	// live index, see doc comment above) BUT currently refused on every build
-	// via registry.incompatible_version (#2818 — a processor compatibility
-	// gate that reads the CONNECTOR protocol module instead of a processor
-	// protocol version). Assert the specific facts, not a phrase the old
-	// false prose also contained.
+	// live index, see doc comment above) and installable via
+	// `conduit processor-plugins install` (#2818's always-false protocol
+	// comparison is fixed) — but still genuinely gated on minConduitVersion
+	// 0.20.0, so registry.incompatible_version remains the correct code for
+	// a too-old running Conduit. Assert the specific facts, not a phrase the
+	// old false prose also contained.
 	// (4) The template README mirrors this prose for a reader who never runs
 	// `pipelines init`. Nothing enforced that mirror before this check, while
 	// the PR that introduced it claimed the two "cannot drift apart
@@ -556,10 +562,12 @@ func TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality(t *testin
 
 		for _, fact := range []string{
 			"0.1.0",                                  // the published processor version
-			"registry.incompatible_version",          // why the hosted install fails
-			"2818",                                   // the tracking issue
+			"minConduitVersion",                      // the real, still-enforced requirement
+			"0.20.0",                                 // its actual value
+			"registry.incompatible_version",          // the code for a too-old Conduit
+			"2818",                                   // the tracking issue, now fixed
 			"go build -o conduit-connector-pgvector", // the pgvector fallback
-			"GOOS=wasip1 GOARCH=wasm",                // the processor fallback
+			"GOOS=wasip1 GOARCH=wasm",                // the processor fallback, for pre-0.20.0 builds
 			"pipeline.fanout_requires_arch_v2",       // the real arch-v2 error
 		} {
 			is.True(strings.Contains(text, fact)) // README must state this fact too
@@ -568,18 +576,21 @@ func TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality(t *testin
 		is.True(!strings.Contains(text, "connectors install pgvector`"))
 	})
 
-	t.Run("ai.chunk_ai.embed_published_but_blocked", func(t *testing.T) {
+	t.Run("ai.chunk_ai.embed_published_and_installable", func(t *testing.T) {
 		is := is.New(t)
 		for _, name := range []string{"ai.chunk", "ai.embed"} {
-			// The command that currently fails is still cited, so a user who
-			// hits the error recognizes it — but see check (4) below for what
-			// must accompany it.
+			// The install command is cited as a WORKING instruction now, not
+			// a doomed one — but see check (4) below for what must
+			// accompany it.
 			is.True(strings.Contains(joined, "conduit processor-plugins install "+name))
 		}
 		is.True(strings.Contains(joined, "0.1.0"))                         // the published version, not just "published"
-		is.True(strings.Contains(joined, "registry.incompatible_version")) // the actual error code
-		is.True(strings.Contains(joined, "2818"))                          // the tracking issue
-		is.True(strings.Contains(joined, "GOOS=wasip1 GOARCH=wasm"))       // the real, working fallback
+		is.True(strings.Contains(joined, "minConduitVersion"))             // the real, still-enforced requirement
+		is.True(strings.Contains(joined, "0.20.0"))                        // its actual value
+		is.True(strings.Contains(joined, "registry.incompatible_version")) // the code for a too-old Conduit
+		is.True(strings.Contains(joined, "2818"))                          // the tracking issue, now fixed
+		is.True(strings.Contains(joined, "fixed"))                         // must say so, not just cite the issue number
+		is.True(strings.Contains(joined, "GOOS=wasip1 GOARCH=wasm"))       // the fallback for pre-0.20.0 builds
 		is.True(strings.Contains(joined, "./cmd/chunking"))
 		is.True(strings.Contains(joined, "./cmd/embedding"))
 		// --bundle hits the identical version algebra offline (bundle.go), so

--- a/cmd/conduit/root/pipelines/templates/postgres-pgvector-rag/README.md
+++ b/cmd/conduit/root/pipelines/templates/postgres-pgvector-rag/README.md
@@ -30,19 +30,22 @@ is):
 | Plugin | Kind | Install |
 | --- | --- | --- |
 | `standalone:pgvector` (destination) | Standalone Go connector (`conduit-connector-pgvector`) | **Not yet in the registry** — the repo has no tagged release, so there is no version to pass to `conduit connectors install`. Build it: clone the repo, `go build -o conduit-connector-pgvector ./cmd/connector`, and place the binary under `--connectors.path`. Switch to the registry install once a tagged release ships. |
-| `standalone:ai.chunk` (processor) | Standalone WASM processor (`conduit-processor-ai`) | Published to the signed registry at **0.1.0** — but `conduit processor-plugins install ai.chunk` currently refuses it on every build with `registry.incompatible_version` ([#2818](https://github.com/ConduitIO/conduit/issues/2818)). Build it: clone `conduit-processor-ai`, `GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-chunk.wasm ./cmd/chunking`, and place the `.wasm` under `--processors.path`. |
-| `standalone:ai.embed` (processor) | Standalone WASM processor (`conduit-processor-ai`) | Published to the signed registry at **0.1.0** — same `registry.incompatible_version` failure ([#2818](https://github.com/ConduitIO/conduit/issues/2818)). Build it the same way (`./cmd/embedding`). |
+| `standalone:ai.chunk` (processor) | Standalone WASM processor (`conduit-processor-ai`) | Published to the signed registry at **0.1.0** — install with `conduit processor-plugins install ai.chunk` (the `registry.incompatible_version` refusal tracked as [#2818](https://github.com/ConduitIO/conduit/issues/2818) is fixed). Requires a running Conduit that satisfies `minConduitVersion` **0.20.0** (a v0.20.0 nightly or later; v0.19.0 stable is correctly refused as too old). On an older Conduit, build it yourself: clone `conduit-processor-ai`, `GOOS=wasip1 GOARCH=wasm go build -tags wasm -o ai-chunk.wasm ./cmd/chunking`, and place the `.wasm` under `--processors.path`. |
+| `standalone:ai.embed` (processor) | Standalone WASM processor (`conduit-processor-ai`) | Published to the signed registry at **0.1.0** — install with `conduit processor-plugins install ai.embed`, same `minConduitVersion` 0.20.0 requirement as `ai.chunk`. On an older Conduit, build it the same way (`./cmd/embedding`). |
 
-`ai.chunk` and `ai.embed` ARE published to the signed registry (0.1.0), but installing either
-currently fails on **every** build with a `registry.incompatible_version` error: the compatibility
-gate compares this build's `conduit-connector-protocol` module version (a connector protocol
-version) against each processor's `minProtocolVersion`, rather than an actual processor-protocol
-version — tracked as [issue #2818](https://github.com/ConduitIO/conduit/issues/2818).
-`--bundle` is not a workaround: it applies the identical version algebra offline. A registry install
-for the pgvector destination is separately impossible today for an unrelated
-reason — `conduit-connector-pgvector` has not cut a tagged release, so there is no version for
-`conduit connectors install` to resolve. Until both are fixed, all three non-built-in plugins this
-template needs must be built from source (see the table above). `conduit pipelines init --template
+`ai.chunk` and `ai.embed` ARE published to the signed registry (0.1.0) and ARE installable via
+`conduit processor-plugins install`: the compatibility gate used to compare this build's
+`conduit-connector-protocol` module version (a connector protocol version) against each
+processor's `minProtocolVersion`, refusing every install regardless of build — tracked as
+[issue #2818](https://github.com/ConduitIO/conduit/issues/2818), now fixed. What remains is the
+processors' genuine `minConduitVersion: 0.20.0` requirement: a v0.19.0 stable Conduit is still
+correctly refused with `registry.incompatible_version` (it really predates the release these
+processors target), while any v0.20.0 nightly or the eventual v0.20.0 stable release installs
+them successfully. `--bundle` applies the identical version algebra offline, so it is not a
+workaround for that version requirement. A registry install for the pgvector destination is
+separately impossible today for an unrelated reason — `conduit-connector-pgvector` has not cut a
+tagged release, so there is no version for `conduit connectors install` to resolve; that plugin
+still needs to be built from source (see the table above). `conduit pipelines init --template
 postgres-pgvector-rag` names all three realities in its prerequisite note every time this template
 is scaffolded.
 

--- a/cmd/conduit/root/processorplugins/common.go
+++ b/cmd/conduit/root/processorplugins/common.go
@@ -34,8 +34,18 @@ const envPrefix = "CONDUIT"
 // runningProtocolVersion reports the conduit-connector-protocol module version
 // this binary was built against, via Go's embedded build info (avoiding a
 // hand-maintained constant that could drift from go.mod). Falls back to
-// "development" (which resolve.go's compatibility check treats as satisfying
-// every minProtocolVersion) when build info isn't available, e.g. `go run`.
+// "development" when build info isn't available, e.g. `go run`.
+//
+// Its result is still plumbed into InstallOptions/ResolveOptions.
+// RunningProtocolVersion for structural parity with the connector package
+// (they share the same options types), but registry.checkProcessorCompatible
+// no longer reads it: a processor has no meaningful protocol version to
+// compare against connector-protocol at all (issue #2818 — see
+// resolveprocessor.go's doc). Keeping this call, rather than passing a
+// hand-picked sentinel, avoids adding a second, divergent notion of "no
+// protocol value" to the shared options type for no behavioral benefit — the
+// value is simply inert on this path now.
+//
 // Duplicated deliberately from the connectors package rather than exported: it
 // is a trivial, self-contained helper, and coupling the two command packages on
 // it would buy nothing.

--- a/docs/design-documents/20260713-connector-registry-mvp.md
+++ b/docs/design-documents/20260713-connector-registry-mvp.md
@@ -161,7 +161,11 @@ of the integrity-checked bundle, not a bolt-on unsigned field. `kind` reserves r
 2. Resolve `<name>[@version]` **exact-match only** (no fuzzy/nearest-match — a typo'd name is a hard
    `ERR_NOT_FOUND`, never an auto-installed lookalike); if `@version` omitted, pick the newest
    version whose `minConduitVersion`/`minProtocolVersion` the running Conduit satisfies, so "latest"
-   never means "latest-incompatible". Refuse a yanked/revoked selection with its reason.
+   never means "latest-incompatible". Refuse a yanked/revoked selection with its reason. (This
+   section predates processor support and describes the **connector** install pipeline specifically:
+   both fields are compared for connectors, unchanged since this doc was written. Processors, added
+   later, diverge — `minProtocolVersion` is never compared for them; see
+   `20260727-registry-processor-artifacts.md` §D3 and issue #2818.)
 3. Select the host-OS/arch artifact; **none → refuse**, listing available platforms.
 4. Download (following any Scarf redirect) into a **per-install, `0700`, uniquely-named staging dir
    owned by the invoking user** — never a shared/predictable path.

--- a/docs/design-documents/20260727-registry-processor-artifacts.md
+++ b/docs/design-documents/20260727-registry-processor-artifacts.md
@@ -127,10 +127,17 @@ os/arch, is a schema/validation error, not a silent skip.
 
 ### D3 — Resolution and the install pipeline
 
-`Resolve` gains a processor path that iterates `payload.Processors` by exact name (anti-typosquat, no
-fuzzy match), newest-non-yanked-compatible when `@version` is omitted, refusing revoked publisher /
-yanked pinned version / incompatible min-versions — the _same_ logic as connectors, over the
-processor collection. The install pipeline is parameterized (target dir `--processors.path`, filename
+`Resolve` gains a processor path (`ResolveProcessor`) that iterates `payload.Processors` by exact name
+(anti-typosquat, no fuzzy match), newest-non-yanked-compatible when `@version` is omitted, refusing
+revoked publisher / yanked pinned version / incompatible min-versions — over the processor collection,
+using the same building blocks as connectors, with one deliberate divergence: `minProtocolVersion`
+stays present in a processor entry's schema but is never compared for compatibility
+(`checkProcessorCompatible` in `resolveprocessor.go` drops the comparison entirely — there is no
+`conduit-processor-protocol` module for a processor's copied
+`minProtocolVersion` value to mean anything against; see issue #2818). `minConduitVersion` is compared
+identically for both artifact kinds, including a shared prerelease carve-out
+(`checkMinConduitVersion`, `resolve.go`) so a nightly build can install something gated to the release
+it is building toward. The install pipeline is parameterized (target dir `--processors.path`, filename
 prefix `conduit-processor-`, artifact kind, audit label `processor_install`) per the ADR; the
 download → verify → atomic-rename → manifest core is shared. See the `processor-plugins install` plan
 for the pipeline generalization and install-time WASM validation.

--- a/pkg/registry/bundle.go
+++ b/pkg/registry/bundle.go
@@ -408,16 +408,20 @@ type InstallBundleOptions struct {
 	LockTimeout time.Duration
 
 	// RunningConduitVersion/RunningProtocolVersion are this build's own
-	// versions, compared against the bundled version's minConduitVersion/
-	// minProtocolVersion exactly as an online install would (resolve.go) —
-	// an offline install must refuse an incompatible pinned version just as
-	// readily as an online one; being offline is not a compatibility
-	// exemption. This runs through the SAME Resolve/ResolveProcessor
-	// entry points as the online path (resolveBundleArtifact/
-	// resolveProcessorBundleArtifact below), so both the prerelease-tolerant
-	// minConduitVersion comparison and the processor path's
-	// no-minProtocolVersion-comparison (issue #2818, resolveprocessor.go)
-	// apply here identically — no separate algebra to keep in sync.
+	// versions, compared against the bundled version's minConduitVersion
+	// (and, for connectors only, minProtocolVersion) exactly as an online
+	// install would (resolve.go) — an offline install must refuse an
+	// incompatible pinned version just as readily as an online one; being
+	// offline is not a compatibility exemption. This runs through the SAME
+	// Resolve/ResolveProcessor entry points as the online path
+	// (resolveBundleArtifact/resolveProcessorBundleArtifact below), so both
+	// the minConduitVersion prerelease carve-out (checkMinConduitVersion,
+	// resolve.go) and the processor path's no-minProtocolVersion-comparison
+	// (issue #2818, resolveprocessor.go) apply here identically — no
+	// separate algebra to keep in sync. Processors specifically do NOT
+	// compare minProtocolVersion, online or offline (see
+	// checkProcessorCompatible's doc for why); the field stays on this
+	// struct only because it is shared with the connector path.
 	RunningConduitVersion  string
 	RunningProtocolVersion string
 

--- a/pkg/registry/bundle.go
+++ b/pkg/registry/bundle.go
@@ -412,7 +412,12 @@ type InstallBundleOptions struct {
 	// minProtocolVersion exactly as an online install would (resolve.go) —
 	// an offline install must refuse an incompatible pinned version just as
 	// readily as an online one; being offline is not a compatibility
-	// exemption.
+	// exemption. This runs through the SAME Resolve/ResolveProcessor
+	// entry points as the online path (resolveBundleArtifact/
+	// resolveProcessorBundleArtifact below), so both the prerelease-tolerant
+	// minConduitVersion comparison and the processor path's
+	// no-minProtocolVersion-comparison (issue #2818, resolveprocessor.go)
+	// apply here identically — no separate algebra to keep in sync.
 	RunningConduitVersion  string
 	RunningProtocolVersion string
 

--- a/pkg/registry/checkminversion_test.go
+++ b/pkg/registry/checkminversion_test.go
@@ -1,0 +1,197 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/registry"
+	"github.com/conduitio/conduit/pkg/registry/index"
+)
+
+// TestCheckMinConduitVersion_MutationBoundaries exercises
+// checkMinConduitVersion (resolve.go) directly, row by row, against every
+// guard condition its doc comment promises. This test exists because PR
+// #2822's review found the prior suite — Resolve/ResolveProcessor
+// happy-path tests only — left all three of the carve-out's guard
+// conditions (same patch, same minor, minV has no prerelease of its own)
+// and the top-level Prerelease()!="" gate structurally unenforced: mutating
+// any one of the four (dropping any single guard, or replacing the whole
+// condition with "anything goes") left `go test ./pkg/registry/` green.
+//
+// Each row's name states which mutation it kills. Verified by hand during
+// the #2822 review response: each of the four mutations from the review
+// (drop the patch guard, drop the minor guard, drop minV's
+// no-prerelease guard, and collapse the whole condition to
+// "if runV.Prerelease() != \"\"") was applied to checkMinConduitVersion in
+// turn and this test re-run; each left exactly the row(s) named after it
+// failing (the anything-goes mutation additionally fails the two
+// same-core-prerelease-ordering rows below, since it also disables
+// ordinary rc.N-vs-rc.M precedence — expected, not a gap), then the guard
+// was restored and a diff confirmed byte-identical to the pre-mutation
+// file before moving on to the next row.
+func TestCheckMinConduitVersion_MutationBoundaries(t *testing.T) {
+	tests := []struct {
+		name    string
+		minVer  string
+		running string
+		wantErr bool
+	}{
+		{
+			// Kills: dropping `runV.Patch() == minV.Patch()`. Without that
+			// guard, a same-(major,minor) prerelease with a LOWER patch
+			// would satisfy a higher-patch minimum it genuinely doesn't
+			// meet — running truly lacks 0.20.1's code.
+			name:    "drop-patch-guard: 0.20.0-pre must not satisfy >=0.20.1",
+			minVer:  "0.20.1",
+			running: "0.20.0-pre",
+			wantErr: true,
+		},
+		{
+			// Kills: dropping `runV.Minor() == minV.Minor()`. Same idea one
+			// level up — a same-major, lower-minor prerelease must not
+			// satisfy a higher-minor minimum.
+			name:    "drop-minor-guard: 0.20.0-pre must not satisfy >=0.21.0",
+			minVer:  "0.21.0",
+			running: "0.20.0-pre",
+			wantErr: true,
+		},
+		{
+			// Kills: dropping `minV.Prerelease() == ""`. The carve-out is
+			// defined as "a prerelease of the exact RELEASE minimum
+			// satisfies it" — it must not also let a lower prerelease
+			// satisfy a HIGHER prerelease minimum at the same core.
+			name:    "drop-minV-prerelease-empty-guard: 0.20.0-rc.0 must not satisfy >=0.20.0-rc.1",
+			minVer:  "0.20.0-rc.1",
+			running: "0.20.0-rc.0",
+			wantErr: true,
+		},
+		{
+			// Kills: replacing the whole `if runV.Prerelease() != "" && ...`
+			// condition with just `if runV.Prerelease() != ""` (anything
+			// goes for any prerelease running version, against any
+			// minimum). Per the review, this mutation IS already caught by
+			// TestResolve_PrereleaseDoesNotSatisfyHigherMinimum via
+			// Resolve() — kept here too so the direct-function suite is a
+			// complete mutation-kill set on its own, without relying on an
+			// indirect caller's fixture to cover it.
+			name:    "reject-anything-goes: a low-core prerelease must not satisfy a much higher minimum",
+			minVer:  "99.0.0",
+			running: "0.1.0-pre",
+			wantErr: true,
+		},
+		// Positive controls: prove the guard rows above aren't just
+		// vacuously true by also checking the carve-out still WORKS at its
+		// intended boundary, and that ordinary same-core prerelease
+		// precedence (untouched by the carve-out) behaves correctly in
+		// both directions.
+		{
+			name:    "positive control: 0.20.0-pre satisfies its own exact release minimum",
+			minVer:  "0.20.0",
+			running: "0.20.0-pre",
+			wantErr: false,
+		},
+		{
+			name:    "ordinary same-core prerelease precedence: 0.20.0-rc.1 satisfies >=0.20.0-rc.0",
+			minVer:  "0.20.0-rc.0",
+			running: "0.20.0-rc.1",
+			wantErr: false,
+		},
+		{
+			name:    "ordinary same-core prerelease precedence: 0.20.0-rc.1 does not satisfy >=0.20.0-rc.2",
+			minVer:  "0.20.0-rc.2",
+			running: "0.20.0-rc.1",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := registry.CheckMinConduitVersionForTest(tt.minVer, tt.running)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestCheckMinVersion_NeverAppliesPrereleaseCarveOut proves checkMinVersion
+// (the strict comparison, used directly for minProtocolVersion) has NO
+// carve-out at all — the same exact-minimum prerelease case that
+// checkMinConduitVersion accepts must be refused here.
+func TestCheckMinVersion_NeverAppliesPrereleaseCarveOut(t *testing.T) {
+	err := registry.CheckMinVersionForTest("minProtocolVersion", "0.20.0", "0.20.0-pre")
+	require.Error(t, err)
+}
+
+// TestResolve_MinProtocolVersionNeverGetsPrereleaseCarveOut is PR #2822's
+// review Finding 2, reproduced at the Resolve() level with the reviewer's
+// own empirically-probed values: before the scope fix, checkMinVersion was
+// SHARED between the minConduitVersion and minProtocolVersion call sites in
+// checkCompatible, so the nightly-train prerelease carve-out silently
+// widened the protocol gate too —
+//
+//	minProtocolVersion=0.10.0  runningProtocol=v0.10.0-rc.1  -> was ALLOWED (bug)
+//	minProtocolVersion=0.10.1  runningProtocol=v0.10.0-rc.1  -> refused (unaffected boundary)
+//
+// even though the "nightly train" rationale for the carve-out — a build
+// can install something gated to the release it is building toward — has
+// no analogue for a wire protocol version. After the fix, the first case
+// above must also refuse: minProtocolVersion goes through checkMinVersion
+// (resolve.go), which never carries the carve-out.
+func TestResolve_MinProtocolVersionNeverGetsPrereleaseCarveOut(t *testing.T) {
+	payload := index.Payload{
+		SchemaVersion: 1,
+		Index:         index.IndexMeta{Version: 1, Timestamp: time.Now()},
+		Connectors: []index.Connector{
+			{
+				Name: "probe",
+				Publisher: index.Publisher{
+					ExpectedOIDCIssuer:      "https://token.actions.githubusercontent.com",
+					ExpectedIdentityPattern: "^https://github\\.com/example/probe/.*$",
+				},
+				Versions: []index.ConnectorVersion{
+					{
+						Version: "1.0.0", MinConduitVersion: "0.1.0", MinProtocolVersion: "0.10.0",
+						Artifacts: []index.Artifact{{OS: "linux", Arch: "amd64", Kind: "standalone", URL: "http://example/probe.tar.gz", SHA256: "aa"}},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("exact-minimum prerelease protocol is refused, not silently widened", func(t *testing.T) {
+		_, err := registry.Resolve(payload, registry.ResolveOptions{
+			Name: "probe", RunningConduitVersion: "1.0.0", RunningProtocolVersion: "v0.10.0-rc.1",
+		})
+		requireCode(t, err, registry.CodeIncompatibleVersion)
+	})
+
+	t.Run("higher-minimum prerelease protocol is refused (unaffected boundary, sanity check)", func(t *testing.T) {
+		higherMin := payload
+		higherMin.Connectors = []index.Connector{payload.Connectors[0]}
+		higherMin.Connectors[0].Versions = []index.ConnectorVersion{payload.Connectors[0].Versions[0]}
+		higherMin.Connectors[0].Versions[0].MinProtocolVersion = "0.10.1"
+
+		_, err := registry.Resolve(higherMin, registry.ResolveOptions{
+			Name: "probe", RunningConduitVersion: "1.0.0", RunningProtocolVersion: "v0.10.0-rc.1",
+		})
+		requireCode(t, err, registry.CodeIncompatibleVersion)
+	})
+}

--- a/pkg/registry/export_test.go
+++ b/pkg/registry/export_test.go
@@ -41,3 +41,22 @@ const (
 func CacheMetaForTest(connectorsPath, digestHex string) (CacheMeta, error) {
 	return cacheMetaFor(connectorsPath, digestHex)
 }
+
+// CheckMinConduitVersionForTest exposes checkMinConduitVersion (resolve.go)
+// — the minConduitVersion-specific comparison that carries the nightly-train
+// prerelease carve-out — to the external registry_test package. Added for
+// PR #2822's review Finding 1: the prior test suite only exercised this
+// logic indirectly through Resolve/ResolveProcessor happy paths, which
+// mutation testing showed left the carve-out's guard conditions
+// unenforced (checkminversion_test.go tests this function directly against
+// each of those mutations).
+func CheckMinConduitVersionForTest(minVer, running string) error {
+	return checkMinConduitVersion(minVer, running)
+}
+
+// CheckMinVersionForTest exposes the strict, no-carve-out checkMinVersion
+// (resolve.go) — used to prove minProtocolVersion never receives the
+// prerelease carve-out after PR #2822's review Finding 2 scope fix.
+func CheckMinVersionForTest(label, minVer, running string) error {
+	return checkMinVersion(label, minVer, running)
+}

--- a/pkg/registry/index/schema_v1.go
+++ b/pkg/registry/index/schema_v1.go
@@ -146,10 +146,20 @@ type Processor struct {
 // asserts Kind == "wasm-processor" and (OS, Arch) == ("wasip1", "wasm") and
 // never consults runtime.GOOS/GOARCH.
 type ProcessorVersion struct {
-	Version            string     `json:"version"`
-	ReleasedAt         *time.Time `json:"releasedAt,omitempty"`
-	MinConduitVersion  string     `json:"minConduitVersion"`
-	MinProtocolVersion string     `json:"minProtocolVersion"`
+	Version           string     `json:"version"`
+	ReleasedAt        *time.Time `json:"releasedAt,omitempty"`
+	MinConduitVersion string     `json:"minConduitVersion"`
+	// MinProtocolVersion is part of the frozen schema and every published
+	// entry carries it, but it is NOT consulted by processor resolution
+	// (registry.checkProcessorCompatible): there is no
+	// conduit-processor-protocol module for a processor build to report a
+	// version of, so there is nothing honest to compare it against (issue
+	// #2818). It is present-but-ignored deliberately, rather than removed
+	// from the type, so this stays a pure additive/client-side fix: dropping
+	// the field would require re-signing every already-published entry
+	// (a role:root-gated, maintainer-approved operation), where ignoring it
+	// on read does not.
+	MinProtocolVersion string `json:"minProtocolVersion"`
 	// Artifact is the single arch-neutral (wasip1/wasm) build for this version,
 	// with Kind == "wasm-processor". Not a list: see the type doc.
 	Artifact       Artifact       `json:"artifact"`

--- a/pkg/registry/resolve.go
+++ b/pkg/registry/resolve.go
@@ -43,7 +43,22 @@ type ResolveOptions struct {
 	// own "development" build-info fallback for a locally built binary) is
 	// treated as satisfying every compatibility check — a local dev build
 	// must not hard-refuse every install just because it has no embedded
-	// version.
+	// version. checkMinVersion additionally treats a PRERELEASE of the
+	// exact minimum version as satisfying it (see that function's doc) —
+	// so a nightly build can install something gated to the release it is
+	// building toward.
+	//
+	// RunningProtocolVersion is the conduit-connector-protocol module
+	// version, and is meaningful ONLY for connector resolution
+	// (checkCompatible, below) — connectors genuinely speak that protocol.
+	// Processor resolution (checkProcessorCompatible,
+	// resolveprocessor.go) does NOT compare it: there is no
+	// conduit-processor-protocol module for it to represent, and a
+	// processor entry's minProtocolVersion is a copied connector-SDK
+	// version that corresponds to nothing real (issue #2818). The field
+	// stays on this shared struct because InstallOptions/ResolveOptions is
+	// shared between the two entry points; it is simply never read on the
+	// processor path.
 	RunningConduitVersion  string
 	RunningProtocolVersion string
 }
@@ -182,6 +197,38 @@ func checkCompatible(name string, v index.ConnectorVersion, opts ResolveOptions)
 // checkMinVersion reports whether running satisfies >= minVer. An
 // unparsable running version (e.g. "development") is treated as satisfying
 // every check — see ResolveOptions's doc for why.
+//
+// Deliberate semver deviation: a PRERELEASE of the exact minimum version
+// satisfies it. Plain semver precedence ranks any prerelease below its
+// associated release for the same (major, minor, patch) — e.g.
+// "0.20.0-nightly.20260805" < "0.20.0" — so a strict comparison here would
+// mean no nightly build could ever install a connector/processor gated on
+// the release currently in flight. That makes the nightly train
+// permanently untestable for anything version-gated to the release it is
+// building toward, which is exactly the bug in
+// https://github.com/ConduitIO/conduit/issues/2818: the published
+// postgres-pgvector-rag processors pin minConduitVersion 0.20.0, so
+// v0.20.0-nightly.* builds — the only builds that exist before v0.20.0
+// ships — were refused by every one of them. Nobody caught it earlier
+// because the failure only reproduces against a real build's version
+// string, not the synthetic ones prior unit tests used.
+//
+// Scope is intentionally narrow: this widens compatibility only within the
+// SAME (major, minor, patch) core. "0.20.0-pre" satisfies ">= 0.20.0" but
+// must NOT satisfy ">= 0.20.1" or ">= 0.21.0" — running genuinely lacks
+// that unreleased code, and ordinary numeric precedence (which already
+// ranks a higher-core prerelease above a lower-core release, e.g.
+// "0.21.0-pre" > "0.20.0") is left untouched. A minVer that itself carries
+// a prerelease (an index entry pinned to a prerelease minimum) is also
+// left on ordinary precedence between same-core prereleases, so
+// "0.20.0-rc.0" still fails to satisfy ">= 0.20.0-rc.1".
+//
+// This is shared by both checkCompatible (connectors) and
+// checkProcessorCompatible (processors) — deliberately: the nightly-train
+// testability problem is identical for both artifact kinds (a connector
+// pinned to the in-flight release's minConduitVersion is exactly as
+// unresolvable on a nightly as a processor is), so the fix lives once,
+// here, rather than being special-cased per artifact kind.
 func checkMinVersion(label, minVer, running string) error {
 	minV, err := NormalizeVersion(minVer)
 	if err != nil {
@@ -191,6 +238,12 @@ func checkMinVersion(label, minVer, running string) error {
 	if err != nil {
 		return nil // unparsable running version (dev build): treat as compatible
 	}
+
+	if runV.Prerelease() != "" && minV.Prerelease() == "" &&
+		runV.Major() == minV.Major() && runV.Minor() == minV.Minor() && runV.Patch() == minV.Patch() {
+		return nil // prerelease of the exact minimum version: see doc above
+	}
+
 	if runV.LessThan(minV) {
 		return fmt.Errorf("%s %s not satisfied by running %s", label, minVer, running)
 	}

--- a/pkg/registry/resolve.go
+++ b/pkg/registry/resolve.go
@@ -43,10 +43,13 @@ type ResolveOptions struct {
 	// own "development" build-info fallback for a locally built binary) is
 	// treated as satisfying every compatibility check — a local dev build
 	// must not hard-refuse every install just because it has no embedded
-	// version. checkMinVersion additionally treats a PRERELEASE of the
-	// exact minimum version as satisfying it (see that function's doc) —
-	// so a nightly build can install something gated to the release it is
-	// building toward.
+	// version. RunningConduitVersion additionally goes through
+	// checkMinConduitVersion, which treats a PRERELEASE of the exact
+	// minimum version as satisfying it (see that function's doc) — so a
+	// nightly build can install something gated to the release it is
+	// building toward. RunningProtocolVersion does NOT get that treatment
+	// — see checkMinConduitVersion's doc for why the deviation must stay
+	// scoped to the Conduit-core gate and not the protocol gate.
 	//
 	// RunningProtocolVersion is the conduit-connector-protocol module
 	// version, and is meaningful ONLY for connector resolution
@@ -184,8 +187,22 @@ func resolveNewestCompatible(conn *index.Connector, opts ResolveOptions) (*Resol
 
 // checkCompatible refuses a candidate version whose MinConduitVersion or
 // MinProtocolVersion exceeds the running build's own versions.
+//
+// The two comparisons deliberately use DIFFERENT functions:
+// checkMinConduitVersion (nightly-train prerelease carve-out; see its doc)
+// for MinConduitVersion, and plain checkMinVersion (no carve-out) for
+// MinProtocolVersion. They were briefly a single shared function during
+// the #2818 fix, which — undetected until #2822's review — silently
+// widened the protocol gate too: an rc build of conduit-connector-protocol
+// would have satisfied a stable minProtocolVersion pin it doesn't actually
+// implement. The nightly-train rationale (a build can install something
+// gated to the release IT is building toward) has no analogue for a wire
+// protocol: conduit-connector-protocol does not track the Conduit core
+// version or its nightly cadence, so there is no "protocol prerelease this
+// build is building toward" for the carve-out to legitimately mean. Keep
+// these two calls on separate functions — do not re-merge them.
 func checkCompatible(name string, v index.ConnectorVersion, opts ResolveOptions) error {
-	if err := checkMinVersion("minConduitVersion", v.MinConduitVersion, opts.RunningConduitVersion); err != nil {
+	if err := checkMinConduitVersion(v.MinConduitVersion, opts.RunningConduitVersion); err != nil {
 		return newIncompatibleError(name, v, opts)
 	}
 	if err := checkMinVersion("minProtocolVersion", v.MinProtocolVersion, opts.RunningProtocolVersion); err != nil {
@@ -194,9 +211,42 @@ func checkCompatible(name string, v index.ConnectorVersion, opts ResolveOptions)
 	return nil
 }
 
-// checkMinVersion reports whether running satisfies >= minVer. An
-// unparsable running version (e.g. "development") is treated as satisfying
-// every check — see ResolveOptions's doc for why.
+// checkMinVersion reports whether running satisfies >= minVer under
+// ORDINARY semver precedence — no deviation, no carve-out. An unparsable
+// running version (e.g. "development") is treated as satisfying every
+// check — see ResolveOptions's doc for why.
+//
+// This is the strict comparison. It is used directly for minProtocolVersion
+// (checkCompatible, above — processors never compare minProtocolVersion at
+// all, see checkProcessorCompatible in resolveprocessor.go) and internally
+// by checkMinConduitVersion once its prerelease carve-out doesn't apply.
+// Do NOT add the nightly-train prerelease carve-out here — that would
+// silently widen the protocol gate again exactly as #2822's review found.
+// The carve-out belongs only in checkMinConduitVersion.
+func checkMinVersion(label, minVer, running string) error {
+	minV, err := NormalizeVersion(minVer)
+	if err != nil {
+		return fmt.Errorf("index entry has an invalid %s %q: %w", label, minVer, err)
+	}
+	runV, err := NormalizeVersion(running)
+	if err != nil {
+		return nil // unparsable running version (dev build): treat as compatible
+	}
+	if runV.LessThan(minV) {
+		return fmt.Errorf("%s %s not satisfied by running %s", label, minVer, running)
+	}
+	return nil
+}
+
+// checkMinConduitVersion is checkMinVersion specialized for
+// minConduitVersion — and ONLY minConduitVersion; see checkMinVersion's doc
+// and checkCompatible's doc for why minProtocolVersion must stay on the
+// strict comparison. It is shared, as-is, by checkCompatible (connectors,
+// above) and checkProcessorCompatible (processors, resolveprocessor.go):
+// the nightly-train testability problem this exists to fix is identical
+// for both artifact kinds (a connector pinned to the in-flight release's
+// minConduitVersion is exactly as unresolvable on a nightly as a processor
+// is), so that half of the fix legitimately lives once, here.
 //
 // Deliberate semver deviation: a PRERELEASE of the exact minimum version
 // satisfies it. Plain semver precedence ranks any prerelease below its
@@ -221,33 +271,49 @@ func checkCompatible(name string, v index.ConnectorVersion, opts ResolveOptions)
 // "0.21.0-pre" > "0.20.0") is left untouched. A minVer that itself carries
 // a prerelease (an index entry pinned to a prerelease minimum) is also
 // left on ordinary precedence between same-core prereleases, so
-// "0.20.0-rc.0" still fails to satisfy ">= 0.20.0-rc.1".
+// "0.20.0-rc.0" still fails to satisfy ">= 0.20.0-rc.1". See
+// checkminversion_test.go for a table exercising each of these boundaries
+// directly against this function (added after #2822's review found the
+// prior test suite — Resolve/ResolveProcessor happy-path tests only —
+// stayed green under four separate mutations of the guard below).
 //
-// This is shared by both checkCompatible (connectors) and
-// checkProcessorCompatible (processors) — deliberately: the nightly-train
-// testability problem is identical for both artifact kinds (a connector
-// pinned to the in-flight release's minConduitVersion is exactly as
-// unresolvable on a nightly as a processor is), so the fix lives once,
-// here, rather than being special-cased per artifact kind.
-func checkMinVersion(label, minVer, running string) error {
-	minV, err := NormalizeVersion(minVer)
-	if err != nil {
-		return fmt.Errorf("index entry has an invalid %s %q: %w", label, minVer, err)
-	}
-	runV, err := NormalizeVersion(running)
-	if err != nil {
-		return nil // unparsable running version (dev build): treat as compatible
-	}
-
-	if runV.Prerelease() != "" && minV.Prerelease() == "" &&
+// Accepted risk (documented, not fixed — inherent to comparing against
+// only (major, minor, patch)): within the prerelease window for a given
+// core version, minConduitVersion cannot discriminate BY DATE. A binary
+// stamped v0.20.0-nightly.20260101 satisfies minConduitVersion 0.20.0 just
+// as readily as one stamped v0.20.0-nightly.20260801 — including
+// installing a processor that was published seven months after the older
+// nightly was built. There is no core-version-only fix for this; it is the
+// necessary cost of the carve-out existing at all.
+//
+// The one available discriminator an index publisher can reach for is
+// pinning a PRERELEASE minimum instead of a release one: e.g.
+// minConduitVersion "0.20.0-nightly.20260701" correctly refuses
+// "0.20.0-nightly.20260601" (ordinary same-core prerelease precedence,
+// untouched by the carve-out above; the running date is genuinely lower).
+// But it is reliable only for TAG-EXACT nightlies. `git describe`'s
+// commits-ahead-of-tag suffix (e.g.
+// "v0.20.0-nightly.20260822-2-g974fda9") defeats it: per the semver spec,
+// a purely-numeric prerelease identifier always sorts BELOW an
+// alphanumeric one at the same dot-separated position, so a build with any
+// non-numeric suffix segment outranks a same-dated numeric-only one —
+//
+//	min=0.20.0-nightly.20260901  running=v0.20.0-nightly.20260822-2-g974fda9  -> SATISFIED (wrong)
+//
+// even though the running build predates the minimum by ten days. This is
+// plain upstream semver precedence, not something this function adds or
+// could reasonably special-case away — but anyone reaching for a
+// prerelease minConduitVersion as a stronger nightly gate should know it
+// only holds for tag-exact (no commits-ahead) nightly builds.
+func checkMinConduitVersion(minVer, running string) error {
+	minV, minErr := NormalizeVersion(minVer)
+	runV, runErr := NormalizeVersion(running)
+	if minErr == nil && runErr == nil &&
+		runV.Prerelease() != "" && minV.Prerelease() == "" &&
 		runV.Major() == minV.Major() && runV.Minor() == minV.Minor() && runV.Patch() == minV.Patch() {
 		return nil // prerelease of the exact minimum version: see doc above
 	}
-
-	if runV.LessThan(minV) {
-		return fmt.Errorf("%s %s not satisfied by running %s", label, minVer, running)
-	}
-	return nil
+	return checkMinVersion("minConduitVersion", minVer, running)
 }
 
 // newIncompatibleError builds the actionable CodeIncompatibleVersion error:

--- a/pkg/registry/resolve_realindex_test.go
+++ b/pkg/registry/resolve_realindex_test.go
@@ -34,17 +34,31 @@ import (
 // synthetic, mutually-consistent version fixtures that never exercised the
 // real mismatch).
 //
-// The entries below are copied verbatim (fields relevant to resolution only)
-// from https://github.com/ConduitIO/conduit-connector-registry's
+// The entries below reproduce the resolution-relevant fields from
+// https://github.com/ConduitIO/conduit-connector-registry's
 // index/index.json on main, index.version 10, timestamp
 // 2026-08-21T19:26:17Z — the same snapshot
 // TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality
-// (template_gallery_test.go) verified its prose against. If the registry
-// re-publishes ai.chunk/ai.embed/postgres with different min-versions this
-// will drift from "real" and should be re-synced, but it will not go
-// silently stale: a mismatch here would only make these tests pass or fail
-// on stale data, not corrupt anything, and the fixtures are annotated with
-// their source so re-syncing is a copy-paste.
+// (template_gallery_test.go) verified its prose against. Not quite
+// verbatim: the live index stores postgres's version as "v0.14.2" (leading
+// "v", matching its own git tag); the fixture below uses "0.14.2". That
+// difference is harmless — every comparison in this codebase goes through
+// NormalizeVersion (semver.go), which is leading-v tolerant by design — but
+// it means "copied verbatim" would overstate it, so this fixture is
+// reproduced-with-normalization-in-mind, not byte-for-byte.
+//
+// If the registry re-publishes ai.chunk/ai.embed/postgres with different
+// min-versions, this WILL go silently stale: nothing here detects that the
+// live index has drifted from what's hardcoded below, and a stale fixture
+// still runs and still passes. That is deliberately accepted, not an
+// oversight: a hardcoded fixture is definitionally unable to notice its
+// source moved without re-fetching it, and staleness here is low-stakes —
+// the fixtures only feed pure, no-I/O resolution logic, so a drifted
+// fixture makes this file's assertions describe an outdated snapshot, not a
+// production behavior change. The failure mode is "this test suite proves
+// less than its comment implies," not "this test suite lies about
+// something that matters" — and the source/timestamp annotation above
+// means re-syncing is a deliberate, easy copy-paste when someone notices.
 
 // realAIChunkProcessor is ConduitIO/conduit-processor-ai's published
 // ai.chunk@0.1.0 entry: minConduitVersion 0.20.0, minProtocolVersion 0.14.0
@@ -183,9 +197,24 @@ func TestResolve_RealPublishedEntry_ConnectorPathUnaffected(t *testing.T) {
 // TestResolve_MinProtocolVersionStillEnforcedForConnectors is the negative
 // counterpart to the above: a connector version whose minProtocolVersion
 // genuinely exceeds the running protocol must still be refused — proving
-// the connector protocol comparison itself (correct before #2818, and
-// untouched by its fix) still refuses on a real mismatch, not just that it
-// happens to pass against postgres's low bar.
+// the connector protocol comparison itself still refuses on a real
+// mismatch, not just that it happens to pass against postgres's low bar.
+//
+// This is checking more than it looks like: PR #2822's review found that
+// checkMinVersion originally being SHARED between the minConduitVersion and
+// minProtocolVersion call sites silently widened the protocol gate too —
+// the exact-minimum prerelease carve-out (see checkMinConduitVersion's doc,
+// resolve.go) does not belong on a wire-protocol comparison, but nothing
+// here would have caught it leaking there, because tooNew below is a
+// plain-release minimum against a plain-release-adjacent running value.
+// TestResolve_MinProtocolVersionNeverGetsPrereleaseCarveOut (resolve_test.go)
+// is the test that actually exercises the leak scenario (a PRERELEASE
+// running protocol against its exact-minimum release) and would have
+// failed against the pre-#2822-review code. This test's job is narrower:
+// confirm the protocol gate — whichever function backs it — still refuses
+// an ordinary, non-prerelease mismatch, i.e. that checking WHETHER
+// minProtocolVersion is compared for connectors was untouched by either
+// #2818 fix (only processors dropped that comparison).
 func TestResolve_MinProtocolVersionStillEnforcedForConnectors(t *testing.T) {
 	payload := realIndexPayload()
 	tooNew := realPostgresConnector()

--- a/pkg/registry/resolve_realindex_test.go
+++ b/pkg/registry/resolve_realindex_test.go
@@ -1,0 +1,201 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/conduitio/conduit/pkg/registry"
+	"github.com/conduitio/conduit/pkg/registry/index"
+)
+
+// This file is the regression test issue #2818 asked for: resolving a REAL
+// published registry entry against a REAL running build's version strings,
+// so the "processor compat gate reads the wrong protocol" and "a nightly
+// prerelease never satisfies a stable minConduitVersion" bugs fail in CI
+// instead of only reproducing in a user's terminal (which is how both
+// shipped undetected — every existing Resolve/ResolveProcessor test used
+// synthetic, mutually-consistent version fixtures that never exercised the
+// real mismatch).
+//
+// The entries below are copied verbatim (fields relevant to resolution only)
+// from https://github.com/ConduitIO/conduit-connector-registry's
+// index/index.json on main, index.version 10, timestamp
+// 2026-08-21T19:26:17Z — the same snapshot
+// TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality
+// (template_gallery_test.go) verified its prose against. If the registry
+// re-publishes ai.chunk/ai.embed/postgres with different min-versions this
+// will drift from "real" and should be re-synced, but it will not go
+// silently stale: a mismatch here would only make these tests pass or fail
+// on stale data, not corrupt anything, and the fixtures are annotated with
+// their source so re-syncing is a copy-paste.
+
+// realAIChunkProcessor is ConduitIO/conduit-processor-ai's published
+// ai.chunk@0.1.0 entry: minConduitVersion 0.20.0, minProtocolVersion 0.14.0
+// (the value at the center of issue #2818 — a copied conduit-connector-sdk
+// version that corresponds to no real conduit-processor-protocol module).
+func realAIChunkProcessor() index.Processor {
+	return index.Processor{
+		Name: "ai.chunk",
+		Publisher: index.Publisher{
+			ExpectedOIDCIssuer:      "https://token.actions.githubusercontent.com",
+			ExpectedIdentityPattern: `^https://github\.com/ConduitIO/conduit-processor-ai/\.github/workflows/publish\.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$`,
+		},
+		Repository: "https://github.com/ConduitIO/conduit-processor-ai",
+		Versions: []index.ProcessorVersion{
+			{
+				Version:            "0.1.0",
+				MinConduitVersion:  "0.20.0",
+				MinProtocolVersion: "0.14.0",
+				Artifact: index.Artifact{
+					OS: "wasip1", Arch: "wasm", Kind: registry.WASMProcessorArtifactKind,
+					URL:    "https://github.com/ConduitIO/conduit-processor-ai/releases/download/v0.1.0/conduit-processor-ai-chunk_0.1.0_wasip1_wasm.tar.gz",
+					SHA256: "c7da3607342e8699314eb434595ea914d714e0d5752fe3e190640736924892b9",
+				},
+			},
+		},
+	}
+}
+
+// realPostgresConnector is ConduitIO/conduit-connector-postgres's published
+// v0.14.2 entry: minConduitVersion 0.15.0, minProtocolVersion 0.9.0 — used
+// to prove the connector path's real-world resolution is unaffected by
+// either #2818 fix.
+func realPostgresConnector() index.Connector {
+	return index.Connector{
+		Name: "postgres",
+		Publisher: index.Publisher{
+			ExpectedOIDCIssuer:      "https://token.actions.githubusercontent.com",
+			ExpectedIdentityPattern: `^https://github\.com/ConduitIO/conduit-connector-postgres/\.github/workflows/publish\.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$`,
+		},
+		Repository: "https://github.com/ConduitIO/conduit-connector-postgres",
+		Versions: []index.ConnectorVersion{
+			{
+				Version:            "0.14.2",
+				MinConduitVersion:  "0.15.0",
+				MinProtocolVersion: "0.9.0",
+				Artifacts: []index.Artifact{
+					{
+						OS: "linux", Arch: "amd64", Kind: "standalone",
+						URL:    "https://github.com/ConduitIO/conduit-connector-postgres/releases/download/v0.14.2/postgres_v0.14.2_linux_amd64",
+						SHA256: "aa",
+					},
+				},
+			},
+		},
+	}
+}
+
+func realIndexPayload() index.Payload {
+	return index.Payload{
+		SchemaVersion: 1,
+		Index:         index.IndexMeta{Version: 10, Timestamp: time.Now()},
+		Connectors:    []index.Connector{realPostgresConnector()},
+		Processors:    []index.Processor{realAIChunkProcessor()},
+	}
+}
+
+// realRunningConnectorProtocolVersion is go.mod's real pinned
+// conduit-connector-protocol version (see this repo's go.mod) — what
+// runningProtocolVersion() (cmd/conduit/root/{connectors,processorplugins})
+// actually reports on any build, real or nightly.
+const realRunningConnectorProtocolVersion = "v0.9.5"
+
+// realNightlyConduitVersion is an ACTUAL `git describe --tags --dirty`
+// output from this repo's nightly train (captured verbatim, not
+// hand-simplified), and matches the exact string the issue's reproduction
+// quoted ("conduit v0.20.0-nightly.20260805, protocol v0.9.5").
+const realNightlyConduitVersion = "v0.20.0-nightly.20260805"
+
+// TestResolveProcessor_RealPublishedEntry_NightlyBuildCanInstall reproduces
+// issue #2818's exact failure and proves the fix: resolving the real
+// ai.chunk@0.1.0 entry (minConduitVersion 0.20.0, minProtocolVersion 0.14.0)
+// against a real nightly build's real versions (conduit
+// v0.20.0-nightly.20260805, conduit-connector-protocol v0.9.5 — the
+// running values `conduit processor-plugins install ai.chunk` actually
+// sees) must now SUCCEED. Before the fix this failed with
+// registry.incompatible_version because 0.9.5 (connector protocol) was
+// compared against 0.14.0 (a processor's copied, meaningless
+// minProtocolVersion) — an always-false comparison on every build, not
+// just this one.
+func TestResolveProcessor_RealPublishedEntry_NightlyBuildCanInstall(t *testing.T) {
+	res, err := registry.ResolveProcessor(realIndexPayload(), registry.ResolveOptions{
+		Name:                   "ai.chunk",
+		RunningConduitVersion:  realNightlyConduitVersion,
+		RunningProtocolVersion: realRunningConnectorProtocolVersion,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ai.chunk", res.Processor.Name)
+	assert.Equal(t, "0.1.0", res.Version.Version)
+}
+
+// TestResolveProcessor_RealPublishedEntry_StableV0_19Refused proves the fix
+// did not disable compatibility checking outright: the real v0.19.0 stable
+// release (the latest stable at the time of #2818, which does not carry the
+// postgres-pgvector-rag template) genuinely does not satisfy
+// minConduitVersion 0.20.0 — 0.19.0's core version really is lower, not
+// merely differently-tagged — so resolution must still refuse it.
+func TestResolveProcessor_RealPublishedEntry_StableV0_19Refused(t *testing.T) {
+	_, err := registry.ResolveProcessor(realIndexPayload(), registry.ResolveOptions{
+		Name:                   "ai.chunk",
+		RunningConduitVersion:  "v0.19.0",
+		RunningProtocolVersion: realRunningConnectorProtocolVersion,
+	})
+	requireCode(t, err, registry.CodeIncompatibleVersion)
+}
+
+// TestResolve_RealPublishedEntry_ConnectorPathUnaffected proves the
+// connector resolution path — which was already correct — still resolves
+// the real, live postgres@0.14.2 entry the same way after both #2818
+// fixes: a real nightly build's real conduit-connector-protocol version
+// (0.9.5) genuinely satisfies postgres's real minProtocolVersion (0.9.0),
+// so this must succeed for the ordinary reason, not because protocol
+// checking was silently dropped (it is dropped only for PROCESSORS, see
+// TestResolveProcessor_RealPublishedEntry_NightlyBuildCanInstall's sibling
+// coverage and checkProcessorCompatible's doc).
+func TestResolve_RealPublishedEntry_ConnectorPathUnaffected(t *testing.T) {
+	res, err := registry.Resolve(realIndexPayload(), registry.ResolveOptions{
+		Name:                   "postgres",
+		RunningConduitVersion:  realNightlyConduitVersion,
+		RunningProtocolVersion: realRunningConnectorProtocolVersion,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "postgres", res.Connector.Name)
+	assert.Equal(t, "0.14.2", res.Version.Version)
+}
+
+// TestResolve_MinProtocolVersionStillEnforcedForConnectors is the negative
+// counterpart to the above: a connector version whose minProtocolVersion
+// genuinely exceeds the running protocol must still be refused — proving
+// the connector protocol comparison itself (correct before #2818, and
+// untouched by its fix) still refuses on a real mismatch, not just that it
+// happens to pass against postgres's low bar.
+func TestResolve_MinProtocolVersionStillEnforcedForConnectors(t *testing.T) {
+	payload := realIndexPayload()
+	tooNew := realPostgresConnector()
+	tooNew.Versions[0].MinProtocolVersion = "9.9.9"
+	payload.Connectors = []index.Connector{tooNew}
+
+	_, err := registry.Resolve(payload, registry.ResolveOptions{
+		Name:                   "postgres",
+		RunningConduitVersion:  realNightlyConduitVersion,
+		RunningProtocolVersion: realRunningConnectorProtocolVersion,
+	})
+	requireCode(t, err, registry.CodeIncompatibleVersion)
+}

--- a/pkg/registry/resolve_test.go
+++ b/pkg/registry/resolve_test.go
@@ -172,6 +172,52 @@ func TestResolve_DevBuildSkipsCompatibilityCheck(t *testing.T) {
 	assert.Equal(t, "0.15.0", rv.Version.Version)
 }
 
+// TestResolve_PrereleaseOfExactMinimumSatisfies is the nightly-train
+// scenario from issue #2818: a running version that is a PRERELEASE of the
+// exact minimum required version must satisfy it, even though plain semver
+// precedence ranks any prerelease below its associated release.
+func TestResolve_PrereleaseOfExactMinimumSatisfies(t *testing.T) {
+	rv, err := registry.Resolve(testPayload(), registry.ResolveOptions{
+		Name: "postgres", Version: "0.14.1", // MinConduitVersion 0.14.0
+		RunningConduitVersion: "0.14.0-nightly.1", RunningProtocolVersion: "0.14.0-nightly.1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "0.14.1", rv.Version.Version)
+}
+
+// TestResolve_PrereleaseDoesNotSatisfyHigherMinimum bounds the deviation:
+// a prerelease only widens compatibility within the SAME (major, minor,
+// patch) core as the minimum. A prerelease of a version whose core is still
+// BELOW the requirement must not be let through — running truly lacks that
+// unreleased code.
+func TestResolve_PrereleaseDoesNotSatisfyHigherMinimum(t *testing.T) {
+	// 0.15.0 requires MinConduitVersion 99.0.0; a 0.15.0 prerelease's core
+	// (0.15.0) is nowhere near that, so this must still refuse exactly as a
+	// non-prerelease 0.15.0 would.
+	_, err := registry.Resolve(testPayload(), registry.ResolveOptions{
+		Name: "postgres", Version: "0.15.0",
+		RunningConduitVersion: "0.15.0-rc.1", RunningProtocolVersion: "0.15.0-rc.1",
+	})
+	require.Error(t, err)
+	ce, ok := conduiterr.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, registry.CodeIncompatibleVersion, ce.Code)
+}
+
+// TestResolve_HigherCorePrereleaseAlreadySatisfiesOrdinarily is a sanity
+// check that ordinary semver precedence (untouched by the deviation) already
+// does the right thing when the running prerelease's core EXCEEDS the
+// minimum: "0.14.1-rc.1" > "0.14.0" under plain semver (core compared
+// first), with no special-casing required.
+func TestResolve_HigherCorePrereleaseAlreadySatisfiesOrdinarily(t *testing.T) {
+	rv, err := registry.Resolve(testPayload(), registry.ResolveOptions{
+		Name: "postgres", Version: "0.14.1", // MinConduitVersion 0.14.0
+		RunningConduitVersion: "0.14.1-rc.1", RunningProtocolVersion: "0.14.1-rc.1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "0.14.1", rv.Version.Version)
+}
+
 func TestResolve_DeprecatedIsNotRefused(t *testing.T) {
 	// Deprecated is a soft, informational flag (plan-v2 §7) — never a
 	// refusal reason, and no error code exists for it in the canonical

--- a/pkg/registry/resolve_test.go
+++ b/pkg/registry/resolve_test.go
@@ -173,13 +173,34 @@ func TestResolve_DevBuildSkipsCompatibilityCheck(t *testing.T) {
 }
 
 // TestResolve_PrereleaseOfExactMinimumSatisfies is the nightly-train
-// scenario from issue #2818: a running version that is a PRERELEASE of the
-// exact minimum required version must satisfy it, even though plain semver
-// precedence ranks any prerelease below its associated release.
+// scenario from issue #2818: a running CONDUIT version that is a
+// PRERELEASE of the exact minConduitVersion must satisfy it, even though
+// plain semver precedence ranks any prerelease below its associated
+// release.
+//
+// RunningProtocolVersion is deliberately "0.14.0" (an ordinary, exact,
+// non-prerelease match) rather than mirroring RunningConduitVersion's
+// prerelease — before PR #2822's review (Finding 2), this test used
+// "0.14.0-nightly.1" for BOTH, which meant it was — unnoticed — also
+// asserting that a PRERELEASE protocol version satisfies its exact
+// minProtocolVersion. That was true only because checkMinVersion was, at
+// the time, shared between the minConduitVersion and minProtocolVersion
+// call sites: the carve-out this test exists to check leaked onto the
+// protocol gate too, and this test's use of an identical prerelease string
+// for both fields masked exactly that leak. Now that minProtocolVersion
+// goes through checkMinVersion directly (no carve-out — see
+// checkMinConduitVersion's doc, resolve.go), reusing the prerelease string
+// here would fail for the correct reason: this test is about the
+// CONDUIT-version carve-out specifically, so RunningProtocolVersion is
+// pinned to a value that satisfies MinProtocolVersion ordinarily, with no
+// carve-out required to make the point.
+// TestResolve_MinProtocolVersionNeverGetsPrereleaseCarveOut
+// (checkminversion_test.go) is the test that positively exercises the
+// leak scenario this one used to mask.
 func TestResolve_PrereleaseOfExactMinimumSatisfies(t *testing.T) {
 	rv, err := registry.Resolve(testPayload(), registry.ResolveOptions{
-		Name: "postgres", Version: "0.14.1", // MinConduitVersion 0.14.0
-		RunningConduitVersion: "0.14.0-nightly.1", RunningProtocolVersion: "0.14.0-nightly.1",
+		Name: "postgres", Version: "0.14.1", // MinConduitVersion 0.14.0, MinProtocolVersion 0.14.0
+		RunningConduitVersion: "0.14.0-nightly.1", RunningProtocolVersion: "0.14.0",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "0.14.1", rv.Version.Version)

--- a/pkg/registry/resolveprocessor.go
+++ b/pkg/registry/resolveprocessor.go
@@ -32,12 +32,15 @@ type ResolvedProcessorVersion struct {
 }
 
 // ResolveProcessor is the processor analogue of Resolve, over
-// payload.Processors. It applies IDENTICAL rules — exact-match name
+// payload.Processors. It applies the SAME rules — exact-match name
 // (anti-typosquat, no fuzzy suggestion), revoked publisher refused, a pinned
 // yanked version refused, newest-non-yanked-compatible when @version is
-// omitted, and incompatible min-versions refused — differing only in the
-// collection it searches and the (processor-worded, processor-coded) errors it
-// returns. Like Resolve it never mutates payload and performs no I/O.
+// omitted, and an incompatible min-version refused — differing in the
+// collection it searches, the (processor-worded, processor-coded) errors it
+// returns, and ONE deliberate divergence: minConduitVersion is checked but
+// minProtocolVersion is NOT (see checkProcessorCompatible's doc — there is no
+// meaningful processor-side protocol version to compare against). Like
+// Resolve it never mutates payload and performs no I/O.
 //
 // It deliberately does NOT refuse a deprecated version: deprecated is a soft,
 // informational flag surfaced by the caller, not a trust or safety state —
@@ -132,21 +135,39 @@ func resolveProcessorNewestCompatible(proc *index.Processor, opts ResolveOptions
 	}
 
 	e := conduiterr.New(CodeIncompatibleVersion, fmt.Sprintf(
-		"no version of %q is compatible with the running Conduit (conduit %s, protocol %s)",
-		proc.Name, opts.RunningConduitVersion, opts.RunningProtocolVersion))
+		"no version of %q is compatible with the running Conduit (conduit %s)",
+		proc.Name, opts.RunningConduitVersion))
 	e.Suggestion = "upgrade Conduit, or pin an older @version explicitly if you know one is compatible"
 	return nil, e
 }
 
 // checkProcessorCompatible refuses a candidate version whose MinConduitVersion
-// or MinProtocolVersion exceeds the running build's own versions. It reuses
-// checkMinVersion (resolve.go) verbatim — the compatibility algebra is
-// identical to connectors; only the error wording/type differs.
+// exceeds the running build's own version.
+//
+// Unlike checkCompatible (connectors, resolve.go), it deliberately does NOT
+// check MinProtocolVersion. A processor entry's minProtocolVersion has no
+// real meaning to compare against: there is no conduit-processor-protocol
+// module (verified against the module proxy — it does not exist), and
+// processors are built against conduit-processor-sdk, not
+// conduit-connector-protocol. The published entries' minProtocolVersion
+// values (e.g. "0.14.0" for ai.chunk/ai.embed) are a copy of an unrelated
+// connector-SDK version and correspond to nothing this binary can honestly
+// report. Comparing them against opts.RunningProtocolVersion — which IS a
+// real version, just the wrong module's (conduit-connector-protocol) — is
+// how issue #2818 happened: `conduit processor-plugins install ai.chunk`
+// refused on every build because 0.9.5 (the connector protocol pin) will
+// never satisfy an unrelated 0.14.0 minimum.
+//
+// This does not require re-signing the published index: index entries keep
+// their minProtocolVersion field (the frozen schema still declares it, and
+// changing published, already-hashed/signed entries would need a
+// role:root-gated re-sign and maintainer approval — see R-1's identity
+// pinning, which treats an already-registered entry's fields the same
+// way). Dropping the comparison here is a client-side, additive fix: the
+// field stays present in every entry (see index.ProcessorVersion's doc)
+// and is simply never consulted for a compatibility decision.
 func checkProcessorCompatible(name string, v index.ProcessorVersion, opts ResolveOptions) error {
 	if err := checkMinVersion("minConduitVersion", v.MinConduitVersion, opts.RunningConduitVersion); err != nil {
-		return newProcessorIncompatibleError(name, v, opts)
-	}
-	if err := checkMinVersion("minProtocolVersion", v.MinProtocolVersion, opts.RunningProtocolVersion); err != nil {
 		return newProcessorIncompatibleError(name, v, opts)
 	}
 	return nil
@@ -154,11 +175,13 @@ func checkProcessorCompatible(name string, v index.ProcessorVersion, opts Resolv
 
 // newProcessorIncompatibleError is newIncompatibleError's processor twin:
 // CodeIncompatibleVersion with the required-vs-running facts and a concrete fix
-// suggestion ("errors are API").
+// suggestion ("errors are API"). It reports only Conduit versions — see
+// checkProcessorCompatible's doc for why protocol is not part of this
+// decision for processors.
 func newProcessorIncompatibleError(name string, v index.ProcessorVersion, opts ResolveOptions) error {
 	e := conduiterr.New(CodeIncompatibleVersion, fmt.Sprintf(
-		"processor %q version %s requires Conduit >= %s and protocol >= %s; running Conduit %s, protocol %s",
-		name, v.Version, v.MinConduitVersion, v.MinProtocolVersion, opts.RunningConduitVersion, opts.RunningProtocolVersion))
+		"processor %q version %s requires Conduit >= %s; running Conduit %s",
+		name, v.Version, v.MinConduitVersion, opts.RunningConduitVersion))
 	e.Suggestion = fmt.Sprintf(
 		"upgrade Conduit to >= %s, or install an older %s version compatible with your running Conduit (omit @version to auto-select one)",
 		v.MinConduitVersion, name)

--- a/pkg/registry/resolveprocessor.go
+++ b/pkg/registry/resolveprocessor.go
@@ -167,7 +167,7 @@ func resolveProcessorNewestCompatible(proc *index.Processor, opts ResolveOptions
 // field stays present in every entry (see index.ProcessorVersion's doc)
 // and is simply never consulted for a compatibility decision.
 func checkProcessorCompatible(name string, v index.ProcessorVersion, opts ResolveOptions) error {
-	if err := checkMinVersion("minConduitVersion", v.MinConduitVersion, opts.RunningConduitVersion); err != nil {
+	if err := checkMinConduitVersion(v.MinConduitVersion, opts.RunningConduitVersion); err != nil {
 		return newProcessorIncompatibleError(name, v, opts)
 	}
 	return nil

--- a/pkg/registry/resolveprocessor_test.go
+++ b/pkg/registry/resolveprocessor_test.go
@@ -171,6 +171,43 @@ func TestResolveProcessor_NoCompatibleVersion(t *testing.T) {
 	requireCode(t, err, registry.CodeIncompatibleVersion)
 }
 
+// TestResolveProcessor_IgnoresMinProtocolVersion is issue #2818's Gate 1,
+// unit-tested directly: a version whose MinProtocolVersion is impossibly
+// high (99.9.9 — no running value could ever satisfy it under a real
+// comparison) must still resolve successfully, because processor
+// compatibility never compares it at all. See checkProcessorCompatible's
+// doc for why: there is no meaningful processor-protocol version to compare
+// against.
+func TestResolveProcessor_IgnoresMinProtocolVersion(t *testing.T) {
+	v := procVersion("1.0.0")
+	v.MinProtocolVersion = "99.9.9"
+	payload := procIndex("ai.embed", okPublisher(), v)
+
+	res, err := registry.ResolveProcessor(payload, registry.ResolveOptions{
+		Name: "ai.embed", Version: "1.0.0",
+		RunningConduitVersion: "1.0.0", RunningProtocolVersion: "0.0.1", // wildly below MinProtocolVersion
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.0", res.Version.Version)
+}
+
+// TestResolveProcessor_PrereleaseOfExactMinimumSatisfies mirrors
+// TestResolve_PrereleaseOfExactMinimumSatisfies for the processor path: a
+// nightly build (a prerelease of the exact minConduitVersion) must be able
+// to install a processor gated to the release it is building toward.
+func TestResolveProcessor_PrereleaseOfExactMinimumSatisfies(t *testing.T) {
+	v := procVersion("0.1.0")
+	v.MinConduitVersion = "0.20.0"
+	payload := procIndex("ai.chunk", okPublisher(), v)
+
+	res, err := registry.ResolveProcessor(payload, registry.ResolveOptions{
+		Name: "ai.chunk", Version: "0.1.0",
+		RunningConduitVersion: "0.20.0-nightly.20260805", RunningProtocolVersion: "0.9.5",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "0.1.0", res.Version.Version)
+}
+
 // TestResolveProcessor_SearchesProcessorsNotConnectors proves the two
 // collections are independent: a name present only in connectors[] is NOT
 // found by ResolveProcessor, and vice versa (design doc failure mode 4).


### PR DESCRIPTION
## Summary

`conduit processor-plugins install ai.chunk`/`ai.embed` refused unconditionally, on every build, via two independent gates. Closes #2818.

**Gate 1 — wrong protocol compared.** `checkProcessorCompatible` (`pkg/registry/resolveprocessor.go`) compared a processor entry's `minProtocolVersion` against this build's `conduit-connector-protocol` module version. There is no `conduit-processor-protocol` module (checked the module proxy — it does not exist); the published `0.14.0` value is a copy of an unrelated `conduit-connector-sdk` version and corresponds to nothing this binary can honestly report. **Fix:** dropped the comparison from processor resolution entirely. `index.ProcessorVersion.MinProtocolVersion` stays in the type and every already-published entry still carries it (present-but-ignored) — this is a deliberate, additive, client-side-only fix. Re-signing published entries would need a `role: root`-gated re-sign and maintainer sign-off per `docs/design-documents/20260714-connector-registry-index-schema.md` (§ append-only enforcement, root-key-gated content changes); ignoring an already-present field on read needs none of that.

**Gate 2 — prerelease loses to its own minimum.** `checkMinVersion` (`pkg/registry/resolve.go`) used plain semver ordering, so `v0.20.0-nightly.20260805 < v0.20.0` — meaning a build gated to the release it's *building toward* could never install it, for the whole nightly window. **Fix:** the `minConduitVersion` comparison now treats a prerelease of the exact `(major, minor, patch)` minimum as satisfying it. Scope is deliberately narrow — `0.20.0-pre` satisfies `>= 0.20.0` but not `>= 0.20.1` or `>= 0.21.0`; ordinary semver precedence (a higher-core prerelease already beats a lower release) is untouched; a minimum that itself carries a prerelease keeps ordinary same-core prerelease ordering.

**minConduitVersion only — connectors and processors share it, minProtocolVersion never gets it.** The carve-out lives in a dedicated `checkMinConduitVersion`, called by both `checkCompatible` (connectors) and `checkProcessorCompatible` (processors) — the nightly-testability problem is identical for both artifact kinds, so that half of the fix legitimately lives once. `minProtocolVersion` (connectors only; processors never compare it, per Gate 1) goes through a separate, strict `checkMinVersion` that never receives the carve-out. **This split is itself a fix landed in response to review** — see "Review response" below; the first version of this PR shared one function between both comparisons, which silently widened the protocol gate too.

## What I verified by running

- Built the binary (`git describe --tags --dirty` version stamp, exactly as `make build` does).
- **Before the fix** (stashed working tree, built from `main`): `conduit processor-plugins install ai.chunk --dry-run --json` reproduces the issue's exact error byte-for-byte: `registry.incompatible_version`, `"conduit v0.20.0-nightly.20260805, protocol v0.9.5"`.
- **After the fix**: same command against the **live** registry index (`https://raw.githubusercontent.com/ConduitIO/conduit-connector-registry/main/index/index.json`) now succeeds for both `ai.chunk` and `ai.embed` (`--dry-run --json`, `ok: true`, resolves `0.1.0`).
- `conduit connectors install postgres --dry-run --json` against the live registry: unaffected, resolves `v0.14.2` as before — the connector path (already correct) is untouched.
- `--bundle`: shares the exact same `Resolve`/`ResolveProcessor` entry points (`pkg/registry/bundle.go`'s `resolveBundleArtifact`/`resolveProcessorBundleArtifact`), so both fixes apply there automatically — no separate algebra to keep in sync.
- `go build ./...`, `go test ./pkg/registry/... ./cmd/conduit/...` (`-race`, `-count=1`, including all new tests), `golangci-lint run` (run from inside a clean worktree, not the shared checkout — that resolved cleanly to `0 issues` too), `go vet ./...` — all clean.
- `make generate-llms`: no diff.
- Re-ran the live dry-run checks after the review-response changes: both `ai.chunk` and `postgres` still resolve correctly against the live index.

## Tests added

`pkg/registry/resolve_realindex_test.go` is the regression test the issue asked for: it resolves the **real** published `ai.chunk`/`postgres` entries (fields reproducing the resolution-relevant values from the live index, annotated with source/timestamp — see the file's header comment for one place they're *not* byte-identical: the live index's postgres version string carries a leading `v` the fixture doesn't, which `NormalizeVersion` makes harmless) against **real** build version strings (`v0.20.0-nightly.20260805`, `conduit-connector-protocol v0.9.5` from `go.mod`), so this class of bug fails in CI instead of only reproducing in a user's terminal. Plus:
- `TestResolveProcessor_IgnoresMinProtocolVersion` / `TestResolveProcessor_RealPublishedEntry_StableV0_19Refused` — protocol is ignored, but `minConduitVersion` is still genuinely enforced (a v0.19.0 stable build is correctly refused).
- `TestResolve_PrereleaseOfExactMinimumSatisfies` / `TestResolve_PrereleaseDoesNotSatisfyHigherMinimum` / `TestResolve_HigherCorePrereleaseAlreadySatisfiesOrdinarily` — the semver-deviation scope boundaries, on the connector path.
- `TestResolveProcessor_PrereleaseOfExactMinimumSatisfies` — same, processor path.
- `TestResolve_MinProtocolVersionStillEnforcedForConnectors` — proves the connector protocol gate still refuses an ordinary (non-prerelease) mismatch; it does **not** by itself prove the gate never receives the carve-out (see next bullet — that gap is exactly what review Finding 2 found).
- **New, added in response to review:** `TestCheckMinConduitVersion_MutationBoundaries` (`pkg/registry/checkminversion_test.go`) — a table-driven test against `checkMinConduitVersion` directly, covering each of the four boundary mutations found by mutation testing (see "Review response"). `TestCheckMinVersion_NeverAppliesPrereleaseCarveOut` and `TestResolve_MinProtocolVersionNeverGetsPrereleaseCarveOut` — positively prove the protocol gate never receives the carve-out, using the reviewer's own probed values (`minProtocolVersion=0.10.0` vs `running=v0.10.0-rc.1`).

## Docs updated

`postgres-pgvector-rag` template's `Prerequisites` (`cmd/conduit/root/pipelines/template_gallery.go`) and its `README.md` no longer describe the processor install as unconditionally refused — they now state the real remaining constraint (`minConduitVersion: 0.20.0`, satisfied by any v0.20.0 nightly or later, not by v0.19.0 stable). `TestGalleryCatalog_PgvectorRAG_PrerequisitesMatchPublishedReality`'s drift guard was updated in step, per its own doc comment's instruction to revisit "the moment #2818 is fixed."

**Added in response to review:** `docs/design-documents/20260727-registry-processor-artifacts.md` (§D3) and `20260713-connector-registry-mvp.md` (§3 step 2) both described processor resolution as using "the same logic as connectors" / a single generic `minConduitVersion`/`minProtocolVersion` check — both now false given Gate 1. Both updated to state the actual divergence (processors never compare `minProtocolVersion`) and to scope the older doc's install-pipeline description to connectors specifically. `pkg/registry/bundle.go`'s `RunningConduitVersion`/`RunningProtocolVersion` doc comment had the same stale claim ("compared... exactly as an online install would") sitting one paragraph above text correctly describing the processor divergence — fixed to stop contradicting itself.

## Risk tier

**Tier 2** (CLI/registry resolution) per CLAUDE.md — not the data path — but it changes install-path semantics, so a failure-mode analysis:

- **What could this let through that shouldn't be installed?** Nothing beyond what the index already vouches for. Neither fix touches signature verification, SLSA provenance, publisher-identity pinning, revocation, or yank handling — `checkProcessorCompatible` still enforces `minConduitVersion`, and the semver-deviation is scoped to same-core prereleases only (can't widen into a version whose code genuinely isn't present) *and*, after the review's Finding 2 fix, scoped to `minConduitVersion` only (never `minProtocolVersion`). The worst case is a processor with a stated `minProtocolVersion` compatibility claim that's simply never checked — but that claim was already meaningless (compared against the wrong module), so removing a comparison that was never testing anything real doesn't lower the bar; it removes a check that always failed for the wrong reason.
- **Accepted, documented risk (Finding 3):** `minConduitVersion` cannot discriminate *by date* within a prerelease window — a binary stamped `v0.20.0-nightly.20260101` satisfies `minConduitVersion: 0.20.0` exactly as readily as one stamped seven months later, including installing something published in between. There is no core-version-only fix for this; it's the necessary cost of the carve-out existing at all, and it's now documented at `checkMinConduitVersion` (`resolve.go`). The available mitigation — an index publisher pinning a *prerelease* `minConduitVersion` (e.g. `0.20.0-nightly.20260701`) instead of a release one — genuinely discriminates by date, but only for tag-exact nightlies: `git describe`'s commits-ahead suffix (e.g. `v0.20.0-nightly.20260822-2-g974fda9`) defeats it, because plain semver ranks a purely-numeric prerelease identifier below an alphanumeric one at the same position. Verified empirically: `min=0.20.0-nightly.20260901` is satisfied by `running=v0.20.0-nightly.20260822-2-g974fda9` even though running predates the minimum by ten days. This is upstream semver precedence, not something this PR could reasonably special-case away, but it's now called out at the doc site so nobody reaches for a prerelease minimum expecting a stronger guarantee than it gives.
- **How would we know?** The new real-index regression test pins today's live published values; if the registry starts publishing entries where `minConduitVersion` is wrong in the other direction (too permissive), that's an index-content problem the append-only/root-key-gated review process (not this comparison) is responsible for catching — out of scope for this PR.

## Review response

PR review verdict was approve-with-nits, two items required before merge:

- **Finding 2 (scope error, fixed first).** `checkMinVersion` was shared by both the `minConduitVersion` and `minProtocolVersion` comparisons in `checkCompatible`, so the prerelease carve-out silently widened the *connector protocol gate* too — reviewer confirmed empirically (`minProtocolVersion=0.10.0` vs `runningProtocol=v0.10.0-rc.1` was wrongly allowed). Not exploitable today (`go.mod` pins a stable protocol version and every published `minProtocolVersion` is stable), but an unstated widening of a gate CLAUDE.md flags as "breaking-change territory." **Fixed:** split into `checkMinConduitVersion` (carries the carve-out) and a strict `checkMinVersion` (no carve-out, used for `minProtocolVersion` and internally by `checkMinConduitVersion`'s fallback path). One existing test (`TestResolve_PrereleaseOfExactMinimumSatisfies`) turned out to have been asserting the leaked behavior without anyone noticing — it used the same prerelease string for both `RunningConduitVersion` and `RunningProtocolVersion`, which only passed *because* of the leak. Fixed to use a value that satisfies `minProtocolVersion` ordinarily, and its doc comment now explains why. `resolve_realindex_test.go`'s comment claiming the connector protocol comparison was "untouched by [the #2818] fix" was also false — *whether* it's checked was untouched, *how* it compares was not (until this fix restored that) — corrected.
- **Finding 1 (HIGH, tests didn't defend the scope claims).** Mutation testing showed four separate mutations to the carve-out's guard conditions left `go test ./pkg/registry/` green: dropping the patch-equality guard, the minor-equality guard, or the "minimum has no prerelease of its own" guard, and replacing the whole condition with "any prerelease satisfies anything." Added `TestCheckMinConduitVersion_MutationBoundaries`, a table-driven test against `checkMinConduitVersion` directly (via a new `export_test.go` seam), covering all four rows plus `0.20.0-rc.1` vs `0.20.0-rc.0`/`rc.2`. Verified by hand: applied each of the four mutations in turn, confirmed the corresponding row(s) failed (nothing else did, except the "anything goes" mutation, which — expectedly — also breaks the two ordinary same-core-precedence rows, since it disables ordinary `rc.N` ordering too), then restored and diffed byte-identical before moving to the next.
- **Finding 5 (fixture comment).** `resolve_realindex_test.go`'s header claimed the real-index fixture "will not go silently stale" — false on its face for a hardcoded fixture — and that its fields were "copied verbatim," which slightly overstates it (the live index's postgres version is `"v0.14.2"`, the fixture uses `"0.14.2"`; harmless via `NormalizeVersion`, but not verbatim). Rewrote to state plainly that it *will* go silently stale if the registry republishes different values, and why that's an accepted, low-stakes tradeoff rather than a hidden risk.
- **Finding 6 (`bundle.go` self-contradiction).** Its `RunningConduitVersion`/`RunningProtocolVersion` doc said the offline path compares "minConduitVersion/minProtocolVersion exactly as an online install would," then immediately explained processors don't compare `minProtocolVersion` at all — fixed the first sentence to scope the claim correctly.
- **Finding 4 (stale design docs).** Both `20260727-registry-processor-artifacts.md` and `20260713-connector-registry-mvp.md` described processor resolution in terms that are now false given Gate 1 — fixed, see "Docs updated" above.

Self-review (this round): re-verified `checkCompatible`/`checkProcessorCompatible` call the correct function each (no accidental cross-wiring after the split); re-ran the full `-race` suite after the split and caught the one test (`TestResolve_PrereleaseOfExactMinimumSatisfies`) that had been depending on the leaked behavior; re-confirmed `make generate-llms` still produces no diff after all doc edits; re-ran the live dry-run checks against both `ai.chunk` and `postgres` after all changes.

## Roadmap

v0.20 / RAG template (`postgres-pgvector-rag`) — this was the last blocker on its processor install path (pgvector destination remains a from-source build until `conduit-connector-pgvector` cuts a tagged release; unrelated to this issue).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
https://claude.ai/code/session_016xE861dwb3MLgqEdWRECLY
