### PR TITLE
docs: fix broken OpenAPI definition link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ using the CLI flag `-api.http.address`. It is generated
 using [gRPC gateway](https://github.com/grpc-ecosystem/grpc-gateway) and is thus
 providing the same functionality as the gRPC API. To learn more about the HTTP
 API please have a look at the [API documentation](https://www.conduit.io/api),
-[OpenAPI definition](https://github.com/ConduitIO/conduit/blob/main/pkg/web/openapi/swagger-ui/api/v1/api.swagger.json)
+[OpenAPI definition](https://github.com/ConduitIO/conduit/blob/main/pkg/http/openapi/swagger-ui/api/v1/api.swagger.json)
 or run Conduit and navigate to `http://localhost:8080/openapi` to open
 a [Swagger UI](https://github.com/swagger-api/swagger-ui) which makes it easy to
 try it out.


### PR DESCRIPTION
The README links to the OpenAPI definition at `pkg/web/openapi/swagger-ui/api/v1/api.swagger.json`, which 404s — the package was moved to `pkg/http/openapi/`, so the file now lives at `pkg/http/openapi/swagger-ui/api/v1/api.swagger.json`.

Verified against the current tree on `main`: `pkg/web/` no longer exists, and `pkg/http/openapi/swagger-ui/api/v1/api.swagger.json` does.

One-line link fix. The other in-tree reference to the old path is in `docs/design-documents/20260713-ci-relevance-and-prepush-guard.md`, which I left alone since design documents are a historical record of what was true when written.
