### PR TITLE
test(lifecycle-poc): wait for the live status on the recovery path, don't instant-read it

### DIFF
--- a/pkg/lifecycle-poc/service_nxm_test.go
+++ b/pkg/lifecycle-poc/service_nxm_test.go
@@ -514,7 +514,7 @@ func TestServiceLifecycle_NxM_TransientErrorOneSource_RecoversAllSourcesAndDesti
 	is.NoErr(err)
 
 	// Must have passed through Recovering and be Running again.
-	waitForRecovered(t, rec)
+	waitForRecovered(t, rec, pl)
 
 	// Post-recovery records flow cleanly through the REBUILT shared
 	// destinations - proof the poison flag (which never clears in place) is

--- a/pkg/lifecycle-poc/service_test.go
+++ b/pkg/lifecycle-poc/service_test.go
@@ -770,7 +770,7 @@ func TestServiceLifecycle_Recovery_TransientErrorRecovers(t *testing.T) {
 	// Wait until the pipeline has recovered: it must have passed through
 	// Recovering and be Running again. (The initial run also briefly reports
 	// Running, so "Running after a Recovering" is what distinguishes recovery.)
-	waitForRecovered(t, rec)
+	waitForRecovered(t, rec, pl)
 
 	// The recovered run delivers its records end-to-end; wait for the source to
 	// ack them so the graceful stop below has a deterministic last position.
@@ -905,7 +905,12 @@ func TestServiceLifecycle_Recovery_LiveEntryPublishedBeforeRunningStatus(t *test
 	// pre-recovery error resurfacing from a dead tomb, and no orphaned run
 	// left behind (which is what stopAndWaitPersister above would hang on).
 	waitForRecordsAcked(t, source, healthyRecords)
-	is.Equal(pipeline.StatusRunning, pl.GetStatus())
+	// Poll rather than read instantly: close(release) only lets the post-recovery
+	// UpdateStatus(StatusRunning) call PROCEED, it does not wait for it to land on
+	// the instance, and the records this test just waited on were already acked
+	// while the window was frozen — so an instant read here races the status write
+	// with no intervening delay at all. See waitForRecovered for the full ordering.
+	waitForStatus(t, pl, pipeline.StatusRunning)
 
 	is.NoErr(ls.Stop(ctx, pl.ID, false))
 	is.NoErr(ls.WaitPipeline(pl.ID))
@@ -1754,7 +1759,7 @@ func TestServiceLifecycle_NSource_TransientErrorOneSource_Recovers(t *testing.T)
 
 	// Wait until the pipeline has recovered: it must have passed through
 	// Recovering and be Running again.
-	waitForRecovered(t, rec)
+	waitForRecovered(t, rec, pl)
 
 	waitForRecordsAcked(t, sourceA, healthyRecords)
 	is.Equal(pipeline.StatusRunning, pl.GetStatus())
@@ -1925,24 +1930,56 @@ func (r *statusRecorder) snapshot() []pipeline.Status {
 	return out
 }
 
-// waitForRecovered blocks until the recorded status sequence shows a recovery:
-// a Recovering entry followed by a later Running. Fails the test on timeout.
-func waitForRecovered(t *testing.T, rec *statusRecorder) {
+// waitForRecovered blocks until the pipeline has recovered: the recorded status
+// sequence shows a Recovering entry followed by a later Running, AND the live
+// instance actually reports StatusRunning. Fails the test on timeout.
+//
+// Both halves are load-bearing, and the second one is why this takes pl.
+//
+// The recorder is only a LEADING indicator. statusRecorder.UpdateStatus appends
+// the status and runs its hook BEFORE delegating to the wrapped
+// pipeline.Service, which is what actually calls Instance.SetStatus. So the
+// recorded post-recovery Running appears strictly before pl.GetStatus() returns
+// Running, and the gap is a full pipeline.Service.UpdateStatus call (a Get, two
+// metrics updates, and a store write).
+//
+// Record flow is not a substitute watermark either: runPipeline releases every
+// worker goroutine (close(registered)) BEFORE it calls
+// UpdateStatus(StatusRunning), so the recovered run can read, write and ack its
+// entire record set while that status write is still in flight. That is exactly
+// how TestServiceLifecycle_Recovery_TransientErrorRecovers used to flake in CI
+// — waitForRecovered followed by waitForRecordsAcked followed by an INSTANT
+// is.Equal(StatusRunning, pl.GetStatus()) that read Recovering, because neither
+// wait is ordered after the status write. Unlike the initial start (ls.Start
+// returns only after runPipeline's status write completes), a recovery restart
+// runs on the tomb's cleanup goroutine, so nothing in the test goroutine is
+// synchronized with it. Polling the live value here is the ordering the test
+// actually needs; it is a watermark, not a widened timeout.
+func waitForRecovered(t *testing.T, rec *statusRecorder, pl *pipeline.Instance) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)
+	recovered := false
 	for {
 		statuses := rec.snapshot()
-		seenRecovering := false
-		for _, s := range statuses {
-			switch {
-			case s == pipeline.StatusRecovering:
-				seenRecovering = true
-			case s == pipeline.StatusRunning && seenRecovering:
-				return // Running after a Recovering == recovered
+		if !recovered {
+			seenRecovering := false
+			for _, s := range statuses {
+				switch {
+				case s == pipeline.StatusRecovering:
+					seenRecovering = true
+				case s == pipeline.StatusRunning && seenRecovering:
+					recovered = true // Running after a Recovering == recovered
+				}
 			}
 		}
+		if recovered && pl.GetStatus() == pipeline.StatusRunning {
+			return
+		}
 		if time.Now().After(deadline) {
-			t.Fatalf("timed out waiting for pipeline to recover (statuses: %v)", statuses)
+			t.Fatalf(
+				"timed out waiting for pipeline to recover (recorded: %v, live status: %s)",
+				statuses, pl.GetStatus(),
+			)
 		}
 		time.Sleep(time.Millisecond)
 	}


### PR DESCRIPTION
**Tier 3** (test files only — no production code touched).

Fixes the `TestServiceLifecycle_Recovery_TransientErrorRecovers` failure seen on `main` at
[run 32785888309](https://github.com/ConduitIO/conduit/actions/runs/32785888309)
(`service_test.go:778: Running != Recovering`). The commit that failed was docs-only and the next
commit passed, so this is a flake, not a regression.

## Root cause

Neither watermark the test waits on is ordered after the status write it then asserts.

`statusRecorder.UpdateStatus` appends the status and runs its hook **before** delegating to
`pipeline.Service`, which is what actually calls `Instance.SetStatus`. So `waitForRecovered`'s
"Running after a Recovering" fires strictly before `pl.GetStatus()` can return `Running`, with a
whole `UpdateStatus` (a `Get`, two metrics updates, a store write) still in flight.

`waitForRecordsAcked` adds no delay either: `runPipeline` does `close(registered)` — releasing every
worker goroutine — *before* it calls `UpdateStatus(StatusRunning)`, so the recovered run can read,
write and ack its whole record set while the status write is still pending.

The identical instant assertion is sound on the initial start (and in `pkg/lifecycle`) because
`ls.Start` returns only after `runPipeline`'s status write completes. A **recovery** restart runs on
the tomb's cleanup goroutine, and nothing in the test goroutine is synchronized with it. The
assertion was passing on a ~microsecond margin that a 4-core CI runner under `-race -shuffle=on`
loses to a single goroutine preemption.

Ruled out: this is **not** a second recovery. Both dispensers are `.Times(2)` with no over-call
reported (a second recovery needs a third dispense), and the three missing `Teardown`s are the
*recovered* run's own plugins — run 2 was alive and healthy when `is.Equal` called `FailNow`.
Everything after line 778 is cascade.

## Fix

`waitForRecovered` now also polls the live `pl.GetStatus()` until it reports `Running`, so the helper
means what its name says. A genuine second recovery is still caught: the helper does not latch past
it, and the AC-7 exact-sequence assertion would fail on `[Running Recovering Running Recovering …]`.

Four sites carried the same unsound pattern; all are fixed. The fourth
(`TestServiceLifecycle_Recovery_LiveEntryPublishedBeforeRunningStatus`) has no `waitForRecovered`
call and was the most exposed, because `close(release)` only lets the status write proceed while the
records it then waits on were already acked during the freeze.

## Perturbation proof

Could not reproduce naturally on a 16-core M-series box: 3840 runs of the race binary
(24x40 at `-cpu=1,4`; 64x30 at GOMAXPROCS=1) all green. So the preemption was injected directly — a
sleep in `statusRecorder` between recording the status and delegating (injection **not** committed):

| injection | before | after |
| --- | --- | --- |
| 200ms, 4 tests, `-race -count=10` | **40/40 FAIL** (byte-identical to CI) | **40/40 PASS** |
| 20ms, same 80-run matrix | **46/80 FAIL** | **0/80 PASS** |

Package green at `-race -count=3 -shuffle=on`; `golangci-lint` reports 0 issues.

## Relationship to prior fixes

Not a recurrence of the #2746/#2806 *production* bugs — those were about `runningPipelines` holding
a dead run, and 4ec2b5f is intact. It is the same *class* as the async assertion fixed in 34bf97d,
and that commit is where the fourth site was introduced: the PR that fixed one async assertion
shipped a new one of the same kind. `waitForRecovered` itself dates to a61d4bc (#2718).

## Not fixed here

A Tier-1 production ordering finding surfaced during this work and is filed separately rather than
folded in — see the linked issue. It needs its own PR with a deterministic regression test.

Roadmap: v0.20 WS9-B (flaky tests fixed at cause, never masked).
