### PR TITLE
fix(chaos): bound the recovery kill point by construction, not by a race

### DIFF
--- a/tests/chaos/recovery_child.go
+++ b/tests/chaos/recovery_child.go
@@ -84,6 +84,7 @@ const (
 	envLCTotal      = "CONDUIT_CHAOS_LC_TOTAL"
 	envLCPaceMS     = "CONDUIT_CHAOS_LC_PACE_MS"
 	envLCFailAt     = "CONDUIT_CHAOS_LC_FAIL_AT"
+	envLCHoldAt     = "CONDUIT_CHAOS_LC_HOLD_AT"
 	envLCMinDelayMS = "CONDUIT_CHAOS_LC_MIN_DELAY_MS"
 	envLCMaxDelayMS = "CONDUIT_CHAOS_LC_MAX_DELAY_MS"
 	envLCGraceful   = "CONDUIT_CHAOS_LC_GRACEFUL"
@@ -110,6 +111,15 @@ const (
 	// pipeline cleanly and confirmed every record through cfg.total was
 	// acked - the counterpart to child.go's markerDone for this scenario.
 	markerLCDone = "LC_DONE"
+	// markerLCHeld ("LC_HELD <pos>") is printed once by
+	// recoverySourcePlugin.produceLoop when a nonzero holdAt cap has stopped
+	// production - see holdAt's field doc for why this cap exists. Purely a
+	// diagnostic/observability line for the parent (and for
+	// TestRecoveryChild_HoldAt_CapsProductionBelowTotal, which asserts the
+	// cap directly); no scenario gates its SIGKILL on it, because the cap's
+	// whole point is to bound the child's progress REGARDLESS of when the
+	// parent gets scheduled to look.
+	markerLCHeld = "LC_HELD"
 )
 
 // lcChildConfig is the parent-side (harness) counterpart to lcChildEnv,
@@ -123,6 +133,27 @@ type lcChildConfig struct {
 	total  uint64
 	paceMS int
 	failAt uint64 // 0 = this dispense never fails
+
+	// holdAt caps how far this process's source may ever produce, making a
+	// mid-run SIGKILL's landing point bounded BY CONSTRUCTION instead of by
+	// the parent winning a race. Once position holdAt has been sent, the
+	// producer prints markerLCHeld and stops for good (it never reaches
+	// total), so no matter how long the parent is descheduled between
+	// deciding to kill and the signal actually landing, the durable
+	// committed watermark this process can leave behind is <= holdAt.
+	// TestSIGKILL_RecoveryLoop_CrashDuringRecoveredRun's
+	// "committedAtKill < total" precondition is exactly that bound; before
+	// this cap existed the child was free-running to total and that
+	// precondition was merely probable, which is what made that test flaky
+	// (#2836).
+	//
+	// 0 (the default, and the value every other scenario in this package
+	// leaves it at) disables the cap entirely - the producer behaves exactly
+	// as it did before this seam existed. It is only ever meaningful for the
+	// crashable variant; graceful children must leave it 0 (enforced in
+	// parseLCChildEnv), since a capped producer could never reach total and
+	// the graceful path waits for exactly that.
+	holdAt uint64
 
 	minDelayMS int
 	maxDelayMS int
@@ -147,6 +178,7 @@ func (c lcChildConfig) env() []string {
 		envLCTotal + "=" + strconv.FormatUint(c.total, 10),
 		envLCPaceMS + "=" + strconv.Itoa(c.paceMS),
 		envLCFailAt + "=" + strconv.FormatUint(c.failAt, 10),
+		envLCHoldAt + "=" + strconv.FormatUint(c.holdAt, 10),
 		envLCMinDelayMS + "=" + strconv.Itoa(c.minDelayMS),
 		envLCMaxDelayMS + "=" + strconv.Itoa(c.maxDelayMS),
 		envLCGraceful + "=" + strconv.FormatBool(c.graceful),
@@ -165,6 +197,7 @@ type lcChildEnv struct {
 	total  uint64
 	paceMS int
 	failAt uint64
+	holdAt uint64
 
 	minDelayMS int
 	maxDelayMS int
@@ -203,6 +236,13 @@ func parseLCChildEnv() lcChildEnv {
 	}
 	cfg.failAt = failAt
 
+	holdAt, err := strconv.ParseUint(os.Getenv(envLCHoldAt), 10, 64)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: invalid %s: %v\n", markerFatal, envLCHoldAt, err)
+		os.Exit(exitBadArgs)
+	}
+	cfg.holdAt = holdAt
+
 	minDelayMS, err := strconv.Atoi(os.Getenv(envLCMinDelayMS))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s: invalid %s: %v\n", markerFatal, envLCMinDelayMS, err)
@@ -221,6 +261,18 @@ func parseLCChildEnv() lcChildEnv {
 
 	if cfg.dbDir == "" || cfg.upstreamDir == "" || cfg.mainDir == "" || cfg.dlqDir == "" {
 		fmt.Fprintf(os.Stderr, "%s: %s, %s, %s and %s are required\n", markerFatal, envLCDBDir, envLCUpstream, envLCMainDir, envLCDLQDir)
+		os.Exit(exitBadArgs)
+	}
+	// A capped producer can never reach total, and the graceful variant's
+	// whole exit path (waitForLCTotalAcked) waits for exactly that - so this
+	// combination could only ever manifest as an opaque 30s timeout. Fail
+	// loudly and immediately instead, like every other misconfiguration here.
+	if cfg.graceful && cfg.holdAt > 0 {
+		fmt.Fprintf(os.Stderr, "%s: %s is only valid for the crashable (non-graceful) variant\n", markerFatal, envLCHoldAt)
+		os.Exit(exitBadArgs)
+	}
+	if cfg.holdAt > 0 && cfg.total > 0 && cfg.holdAt >= cfg.total {
+		fmt.Fprintf(os.Stderr, "%s: %s (%d) must be below %s (%d) to bound anything\n", markerFatal, envLCHoldAt, cfg.holdAt, envLCTotal, cfg.total)
 		os.Exit(exitBadArgs)
 	}
 	return cfg
@@ -385,6 +437,7 @@ type recoverySourcePlugin struct {
 	total  uint64 // 0 means unbounded
 	paceMS int
 	failAt uint64 // 0 = never fail; otherwise inject a transient error just before producing this position
+	holdAt uint64 // 0 = no cap; otherwise stop producing for good once this position has been sent (see lcChildConfig.holdAt)
 
 	mu         sync.Mutex
 	nextToRead uint64
@@ -425,7 +478,8 @@ func (p *recoverySourcePlugin) Run(ctx context.Context, stream pconnector.Source
 }
 
 // produceLoop delivers records start+1, start+2, ... up to p.total
-// (inclusive), exactly like chaosPlugin.produceLoop's single-phase mode. If
+// (inclusive), exactly like chaosPlugin.produceLoop's single-phase mode -
+// unless a nonzero p.holdAt cuts production short first (see below). If
 // failAt is nonzero, the instant production would reach that position it
 // instead closes the stream with a synthetic transient error - surfacing as a
 // plain (non-fatal) error from pkg/connector.Source.Read (via
@@ -435,6 +489,13 @@ func (p *recoverySourcePlugin) Run(ctx context.Context, stream pconnector.Source
 // service.go - the same mechanism pkg/lifecycle-poc/service_test.go's
 // sourceRecoversAfterTransientError uses via a mock, just over the real
 // in-memory stream transport instead.
+//
+// If p.holdAt is nonzero, production stops for good once position holdAt has
+// been sent: the loop prints markerLCHeld and returns, exactly as it does on
+// reaching p.total, leaving the stream open and the ack path running but no
+// further records ever produced by this process. That is a hard ceiling on
+// how far this process can get, which is what lets a parent test SIGKILL it
+// mid-run without racing it - see lcChildConfig.holdAt.
 func (p *recoverySourcePlugin) produceLoop(inmemStream *builtin.InMemorySourceRunStream, server pconnector.SourceRunStreamServer, start uint64) {
 	pos := start
 	for {
@@ -452,6 +513,13 @@ func (p *recoverySourcePlugin) produceLoop(inmemStream *builtin.InMemorySourceRu
 		printProgress("READ", pos)
 
 		if p.total > 0 && pos >= p.total {
+			return
+		}
+		// The production ceiling. Checked after the send (so holdAt is the
+		// last position actually produced, inclusive) and before the pace
+		// sleep, so the marker is printed the instant the ceiling is hit.
+		if p.holdAt > 0 && pos >= p.holdAt {
+			printProgress(markerLCHeld, pos)
 			return
 		}
 		if p.paceMS > 0 {
@@ -613,6 +681,7 @@ type lcSourceDispenser struct {
 	total  uint64
 	paceMS int
 	failAt uint64
+	holdAt uint64
 
 	dispensed atomic.Int64
 }
@@ -628,7 +697,9 @@ func (d *lcSourceDispenser) DispenseSource() (connectorPlugin.SourcePlugin, erro
 	if d.dispensed.Add(1) == 1 {
 		failAt = d.failAt
 	}
-	return &recoverySourcePlugin{store: d.store, total: d.total, paceMS: d.paceMS, failAt: failAt}, nil
+	// holdAt, unlike failAt, applies to EVERY dispense: it is a ceiling on
+	// this process's total production, not a one-shot injected fault.
+	return &recoverySourcePlugin{store: d.store, total: d.total, paceMS: d.paceMS, failAt: failAt, holdAt: d.holdAt}, nil
 }
 
 func (d *lcSourceDispenser) DispenseDestination() (connectorPlugin.DestinationPlugin, error) {
@@ -851,7 +922,7 @@ func buildLifecycleChild(ctx context.Context, cfg lcChildEnv) (*childLifecycleBu
 	pl.SetStatus(pipeline.StatusUserStopped) // Init's own required starting status, per pkg/lifecycle-poc.Service.Start
 
 	plugins := staticFetcher{
-		sourceInstance.Plugin: &lcSourceDispenser{store: upstream, total: cfg.total, paceMS: cfg.paceMS, failAt: cfg.failAt},
+		sourceInstance.Plugin: &lcSourceDispenser{store: upstream, total: cfg.total, paceMS: cfg.paceMS, failAt: cfg.failAt, holdAt: cfg.holdAt},
 		destInstance.Plugin:   &lcDestDispenser{log: mainLog},
 		dlqInstance.Plugin:    &lcDestDispenser{log: dlqLog},
 	}

--- a/tests/chaos/recovery_test.go
+++ b/tests/chaos/recovery_test.go
@@ -15,6 +15,7 @@
 package chaos
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -149,6 +150,68 @@ func assertNoGapThrough(t *testing.T, positions []uint64, upTo uint64, label str
 	}
 }
 
+// waitForUpstreamCommittedAtLeast blocks (polling the child's durable
+// upstream commit marker on disk, not sleeping a fixed duration) until that
+// watermark has reached at least want, then returns it.
+//
+// This reads the very same file assertRecoveryInvariantsAtKill reads back
+// after the kill, while the child is still running. That is safe and
+// race-free by construction: upstreamStore.Commit writes to a temp file,
+// fsyncs, and atomically renames it into place (upstream.go), so a concurrent
+// reader in another process only ever observes a complete previous or
+// complete new value - never a torn one.
+//
+// Why gate a kill on THIS rather than on childProcess.waitForReadCount: read
+// progress is a LAGGING, parent-side observation of a child that keeps
+// running while the parent is descheduled, so "the child had produced n
+// records when I last looked" says nothing about where the child is now. The
+// committed watermark is a durable fact, and - crucially - it is paired with
+// lcChildConfig.holdAt, which caps how far the child can ever get. Lower
+// bound observed, upper bound structural: neither depends on the parent being
+// scheduled promptly.
+func waitForUpstreamCommittedAtLeast(t *testing.T, cp *childProcess, upstreamDir string, want uint64, timeout time.Duration) uint64 {
+	t.Helper()
+	upstream, err := openUpstreamStore(upstreamDir, false)
+	if err != nil {
+		t.Fatalf("open upstream store %s: %v", upstreamDir, err)
+	}
+	deadline := time.Now().Add(timeout)
+	var last uint64
+	for time.Now().Before(deadline) {
+		got, err := upstream.Committed()
+		if err != nil {
+			t.Fatalf("read upstream commit marker: %v\n%s", err, cp.diagnostics())
+		}
+		if got >= want {
+			return got
+		}
+		last = got
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for the upstream commit watermark to reach %d (saw %d)\n%s", want, last, cp.diagnostics())
+	return 0
+}
+
+// maxProgressPosition returns the highest position across every observed
+// progress line with the given tag ("READ", markerLCHeld, ...). Positions,
+// not line counts: a restart within one process re-produces positions it
+// already produced once (see waitForLCRecovered), so counting lines and
+// reading a position off the count are not the same thing - which is
+// precisely the confusion the old read-count kill gate encoded.
+func maxProgressPosition(cp *childProcess, tag string) uint64 {
+	var highest uint64
+	for _, l := range cp.linesWithPrefix(tag + " ") {
+		n, err := strconv.ParseUint(strings.TrimSpace(strings.TrimPrefix(l, tag+" ")), 10, 64)
+		if err != nil {
+			continue
+		}
+		if n > highest {
+			highest = n
+		}
+	}
+	return highest
+}
+
 // assertRecoveryInvariantsAtKill reads the upstream commit ledger and the
 // main destination's delivery ledger fresh from disk immediately after a
 // SIGKILL, and asserts invariant 1: every position already committed
@@ -257,11 +320,56 @@ func TestSIGKILL_RecoveryLoop_CrashDuringBackoff(t *testing.T) {
 // the pipeline actually completes the restart (Recovering -> Running again)
 // and resumes producing records - and the child is SIGKILLed WHILE that
 // second, recovered run is mid-flight, not while parked in the backoff wait.
-// waitForLCRecovered gates on the observed Recovering->Running transition
-// (not a guess), and waitForReadCount then gates the kill on genuine
-// production progress past the point the first run ever reached (see the
-// comment at its call site) - both are polling waits on the child's own
-// progress, never a blind wall-clock sleep.
+//
+// # Why the kill point is bounded on both sides, and neither bound is a race
+//
+// The two sanity assertions below are the test's own vacuity guards: they
+// refuse to let it pass unless the kill genuinely landed after the recovery
+// and before the run's natural end. Both of those preconditions are
+// established by construction here, not won by out-running the child:
+//
+//   - Lower bound (committedAtKill > failAt-1): the kill is gated on the
+//     child's DURABLE upstream commit watermark reaching killAfterCommitted,
+//     read off disk (waitForUpstreamCommittedAtLeast). Every position at or
+//     past failAt is one the first run provably never produced - produceLoop
+//     closes the stream instead of sending failAt - so a committed watermark
+//     that has passed it is positive proof the recovered run is the one
+//     making progress. It is a durable fact at the instant it is read, not an
+//     inference from a parent-side observation that may already be stale.
+//
+//   - Upper bound (committedAtKill < total): cfg.holdAt caps this child's
+//     producer at position 20, well below cfg.total (60). Nothing past 20 is
+//     ever produced by this process, so nothing past 20 can ever be acked or
+//     committed by it, no matter how long the parent is descheduled between
+//     deciding to kill and SIGKILL actually landing.
+//
+// That second bound is the fix for #2836. This test used to gate its kill on
+// childProcess.waitForReadCount(30) against an uncapped child free-running to
+// total: the child kept producing during the (unbounded) window between the
+// parent observing the 30th READ line and the signal landing, so on a loaded
+// runner it could reach total before it died and the "committedAtKill <
+// total" guard would - correctly - refuse to pass a test that had not
+// actually crashed anything mid-run. A ~400ms stall in that window is enough
+// to reproduce it; see TestRecoveryChild_HoldAt_CapsProductionBelowTotal,
+// which pins the cap against exactly that stall. Enlarging total would only
+// have widened the window that has to be lost, not closed it.
+//
+// Records really are in flight at the kill: the cap is a ceiling, not the
+// trigger. The kill fires the moment the watermark reaches
+// killAfterCommitted (10) while the producer is still on its way to holdAt
+// (20), so records are typically produced-but-not-yet-committed at the
+// instant of the SIGKILL - which is what gives
+// assertRecoveryInvariantsAtKill's invariant-1 check something to bite on,
+// over a committed range (1..10+) deep enough to be worth checking.
+//
+// Note what killAfterCommitted does and does not control. Any value strictly
+// inside (failAt-1, holdAt] gives the identical verdict: the gate cannot
+// return before it, and the child cannot pass holdAt, so both guards hold for
+// every one of them. It tunes how deep the in-flight window is, never whether
+// the test passes - which is exactly the difference between bounding a test
+// and tuning one. (If a badly-starved runner drains all 20 before the parent
+// gets to the kill, the assertions still hold: 40 records were still never
+// produced, so the crash is still mid-run.)
 func TestSIGKILL_RecoveryLoop_CrashDuringRecoveredRun(t *testing.T) {
 	is := is.New(t)
 	dir := t.TempDir()
@@ -272,32 +380,44 @@ func TestSIGKILL_RecoveryLoop_CrashDuringRecoveredRun(t *testing.T) {
 		dlqDir:      dir + "/dlq-delivered",
 		total:       60,
 		paceMS:      3,
-		failAt:      5, // fail fast so the recovered run gets most of the budget
+		failAt:      5,  // fail fast so the recovered run gets most of the budget
+		holdAt:      20, // hard ceiling on this process's production; see the doc comment above
 		minDelayMS:  20,
 		maxDelayMS:  20,
 		graceful:    false,
 	}
 
+	// killAfterCommitted brackets the kill point together with cfg.holdAt:
+	// the watermark at the kill is always in [10, 20], strictly inside
+	// (failAt-1, total). See the doc comment above for why every value in
+	// that interval yields the same verdict.
+	const killAfterCommitted = 10
+
 	first := spawnLCChild(t, cfg)
 	waitForLCRecovered(t, first, 10*time.Second)
-	// The first run could only ever have produced positions 1..failAt-1 (4)
-	// before its induced failure - waiting for 30 total READ lines (READ
-	// progress is cumulative across both dispenses within this one process,
-	// see recoverySourcePlugin.produceLoop) proves we are deep into the
-	// SECOND (recovered) run's production, comfortably past both the failure
-	// point and the restart itself, and well short of cfg.total (60) so the
-	// kill still lands mid-run rather than at the natural end.
-	const killAfterReads = 30
-	first.waitForReadCount(t, killAfterReads, 10*time.Second)
+	// Gate the kill on durable, recovered-run progress: once the watermark is
+	// past failAt, the recovered run has provably produced, delivered and
+	// acked records the first run never even sent. See
+	// waitForUpstreamCommittedAtLeast for why this signal, and not a
+	// parent-side read count, is the sound one to kill on. This wait can
+	// never overshoot, because cfg.holdAt caps the child at 20.
+	waitForUpstreamCommittedAtLeast(t, first, cfg.upstreamDir, killAfterCommitted, 10*time.Second)
 	first.sigkill(t)
 
 	committedAtKill := assertRecoveryInvariantsAtKill(t, cfg)
 	// Sanity: the kill landed after the recovery actually happened (more
 	// progress committed than the first run alone could ever have reached)
 	// and before the natural end (otherwise this wouldn't be testing a
-	// mid-recovered-run crash at all).
+	// mid-recovered-run crash at all). Both hold by construction - see the
+	// doc comment above.
 	is.True(committedAtKill > cfg.failAt-1)
 	is.True(committedAtKill < cfg.total)
+	is.True(committedAtKill >= killAfterCommitted) // the gate's own guarantee, restated against the ledger
+	// The stronger, structural form of the guard above: the producer ceiling,
+	// not the margin to total, is what makes it impossible to reach total.
+	// Asserted separately so that if someone removes holdAt, this fails
+	// immediately and deterministically rather than flaking back to life.
+	is.True(committedAtKill <= cfg.holdAt)
 
 	restart := lcChildConfig{
 		dbDir: cfg.dbDir, upstreamDir: cfg.upstreamDir, mainDir: cfg.mainDir, dlqDir: cfg.dlqDir,
@@ -310,4 +430,80 @@ func TestSIGKILL_RecoveryLoop_CrashDuringRecoveredRun(t *testing.T) {
 	is.True(done)
 
 	assertRecoveryInvariantsAfterRestart(t, cfg)
+}
+
+// recoveryHoldStall is how long TestRecoveryChild_HoldAt_CapsProductionBelowTotal
+// deliberately does nothing after the producer reports it has hit its ceiling.
+//
+// This is not a "wait long enough and hope" sleep - it is the opposite, and
+// the distinction matters because this package forbids the former. An
+// unsound kill gate is one whose precondition decays as the parent is
+// descheduled for longer; this sleep IS that descheduling, injected on
+// purpose, and the assertions after it must hold no matter how large it
+// gets. Making it larger can only make an unsound cap fail harder. It is
+// sized at 400ms because that is empirically enough for the uncapped
+// producer this test guards against (60 records at paceMS 3, plus a 10ms
+// persister debounce) to run all the way to total - i.e. enough to reproduce
+// #2836's original failure, and the value the flake was diagnosed with.
+const recoveryHoldStall = 400 * time.Millisecond
+
+// TestRecoveryChild_HoldAt_CapsProductionBelowTotal is #2836's regression
+// test: it pins the production ceiling that
+// TestSIGKILL_RecoveryLoop_CrashDuringRecoveredRun's "committedAtKill <
+// total" guard now rests on.
+//
+// Before the ceiling existed, that test raced its own child: it observed a
+// read count and then SIGKILLed, and the child kept producing throughout the
+// window in between. This test reproduces that window directly and
+// adversarially - it waits for the producer to report its ceiling, then
+// stalls for recoveryHoldStall (long enough that a ceiling-less child would
+// have finished all 60 records several times over, which is exactly how the
+// original flake was reproduced) - and asserts the child has not moved.
+//
+// Run against a child without the holdAt cap, the maxRead assertion below
+// fails outright: production would be at total (60), not the ceiling (20).
+func TestRecoveryChild_HoldAt_CapsProductionBelowTotal(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	cfg := lcChildConfig{
+		dbDir:       dir + "/db",
+		upstreamDir: dir + "/upstream",
+		mainDir:     dir + "/main-delivered",
+		dlqDir:      dir + "/dlq-delivered",
+		total:       60,
+		paceMS:      3,
+		failAt:      5,
+		holdAt:      20,
+		minDelayMS:  20,
+		maxDelayMS:  20,
+		graceful:    false,
+	}
+	// The ceiling only bounds anything if it is genuinely below total; the
+	// child enforces this too (parseLCChildEnv), but state it here so the
+	// scenario's own numbers can't drift into vacuity unnoticed.
+	is.True(cfg.holdAt > cfg.failAt)
+	is.True(cfg.holdAt < cfg.total)
+
+	child := spawnLCChild(t, cfg)
+	child.waitForMarker(t, markerLCHeld+" ", 10*time.Second)
+	is.Equal(maxProgressPosition(child, markerLCHeld), cfg.holdAt) // the marker reports the ceiling itself
+
+	time.Sleep(recoveryHoldStall) // see recoveryHoldStall: adversarial, not load-bearing
+
+	// Nothing beyond the ceiling was ever produced, however long we looked
+	// away...
+	is.True(maxProgressPosition(child, "READ") <= cfg.holdAt)
+
+	// ...so nothing beyond it can ever have been acked and committed either,
+	// which is the property the SIGKILL scenario's upper-bound guard needs.
+	// Read while the child is still alive, exactly as the kill gate does.
+	upstream, err := openUpstreamStore(cfg.upstreamDir, false)
+	is.NoErr(err)
+	committed, err := upstream.Committed()
+	is.NoErr(err)
+	is.True(committed >= cfg.failAt) // the recovered run really did make durable progress
+	is.True(committed <= cfg.holdAt)
+	is.True(committed < cfg.total)
+
+	child.sigkill(t) // crashable variant: it would otherwise block forever
 }


### PR DESCRIPTION
**Tier 3** — test harness only. Confined to `tests/chaos`; no engine or data-path code touched, and
the `holdAt` seam is inert unless a test sets it. Unblocks #2832 and #2834, since
`tests/chaos (race, x3)` is a required context on `main`.

## The failure

`TestSIGKILL_RecoveryLoop_CrashDuringRecoveredRun` failed on #2832's CI
([run 32792092690](https://github.com/ConduitIO/conduit/actions/runs/32792092690)):

```
recovery_test.go:300: not true: committedAtKill < cfg.total
```

That is a **vacuity guard firing correctly**. The test asserts the SIGKILL landed mid-run; it hadn't,
because the child committed all 60 records before dying, so the test refused to pass while exercising
nothing. The guard is the good part — this PR fixes what made its precondition false, and does not
touch the guard.

## Root cause

`waitForReadCount` is a **lagging, parent-side observation of a free-running child**. The parent's
stdout reader goroutine and its 1ms poll loop are both subject to descheduling, so "I last saw 30
READ lines" says nothing about where the child is *now*.

The margin is ~0.3s, not the "orders of magnitude" a sibling scenario's comment claims: at 30 READs
the child is at position 30, and 30 records x 3ms + the 10ms `lcPersistDelay` debounce is ~150ms to
finish the whole run. Injecting a stall between `waitForReadCount` and `sigkill` reproduces CI's
assertion verbatim at 400ms; 200ms and 120ms both pass.

## The fix

1. **`holdAt` production ceiling** on `recoverySourcePlugin.produceLoop`. Once position `holdAt` (20)
   is sent the child prints `LC_HELD` and stops for good, so it can never reach `total` (60). Inert
   at 0, which every other scenario leaves it at. `parseLCChildEnv` rejects `graceful && holdAt>0`
   and `holdAt >= total` — both would otherwise surface only as opaque timeouts.
2. **Kill gated on the durable committed watermark**, read from the same on-disk marker the
   assertion reads. `upstreamStore.Commit` is write -> fsync -> atomic rename, so a cross-process
   reader never sees a torn value.

**Why this is deterministic rather than tuned: lower bound observed, upper bound structural.** The
first run provably never sends `failAt` (`produceLoop` closes the stream instead), so a watermark
past it is positive proof the recovered run is producing. The ceiling means nothing past 20 is ever
produced, so nothing past 20 can ever be committed — however long the parent is descheduled. The
kill point is bracketed in `[10, 20]` and **every value in that interval yields the identical
verdict**, so `killAfterCommitted` tunes in-flight depth, not pass/fail.

Rejected: enlarging `total` (tuning, not a bound). Rejected: gating only on committed count — fixes
the lower bound but leaves the upper bound racing, since a stalled parent can observe `committed >= 5`
while the child is at 60.

This is the same shape as #2534's fix already in this package: `sigkill_test.go`'s `mid-snapshot`
case had its precondition made structurally true via a 600s persister debounce rather than a wider
margin. Applied here to the production side.

The test still tests what it says: the kill fires at watermark 10 while the producer is still on its
way to 20, so records are genuinely in flight. `committedAtKill > cfg.failAt-1` remains meaningful
and is now guaranteed. Added `committedAtKill <= cfg.holdAt` so removing the cap fails
deterministically instead of flaking back to life.

## Proof

| | result |
| --- | --- |
| injected 400ms stall, pre-fix | **FAIL**, assertion identical to CI |
| injected 3s stall (7.5x), post-fix | **10/10 pass** |
| soak, 24 CPU spinners, load avg 61 | **100/100** |
| same soak, **pre-fix** | **20/20 green** |
| full `tests/chaos` `-race` | green, run 3x |

That pre-fix 20/20 is the honest number: **brute-force repetition cannot measure this flake locally**
— it is rare on CI and nightly has been green 8 days. Repetition counts are not the evidence; the
bound is. Hence the deterministic reproduction.

Regression test `TestRecoveryChild_HoldAt_CapsProductionBelowTotal` waits for the ceiling, stalls
400ms (the exact window that reproduced the flake), and asserts the child has not moved. Verified to
fail without the fix — the `LC_HELD` wait times out and diagnostics print `READ 1 … READ 60`. That
sleep is adversarial, not load-bearing: enlarging it can only make an unsound cap fail harder, the
inverse of a masking sleep. Documented at the constant.

Independently verified before merge: target test and regression test 5/5 each under `-race`, full
`tests/chaos` green under `-race`.

## Known-unfixed sibling

`tests/chaos/property2_test.go` carries the same unsound pattern across all three cases and both
prune classes (6 subtests) — kill-point vacuity guards racing a free-running child, and unlike
`sigkill_test.go` it never got `persistDelayMS`. With a 1.5s stall injected, `mid-handoff` and
`mid-position-write` fail, and `mid-snapshot` **hangs for 41.6s** rather than failing fast — the
starvation hang `sigkillCase`'s own doc comment describes. On a required check that is a 40s stall
per subtest.

Filed separately rather than folded in, per the small-PR rule. `fanout_sigkill_test.go:65` and
`nsource_sigkill_test.go:102` also gate on `waitForReadCount`, but their post-kill assertions do not
depend on the child being mid-run — they degrade to silently weaker coverage, not to red.

## Caveats

- The flake was never observed **naturally** on the dev machine, under contention or otherwise. Every
  reproduction used an injected stall. The assertion, the margin arithmetic and the `READ 1…60`
  diagnostics all line up with what CI hit, but it was not caught in the wild.
- In-flight depth at the kill is typical, not guaranteed: a badly starved runner could drain all 20
  before the signal lands. The assertions still hold (40 records were never produced, so it is still
  a mid-run crash) — only the depth of the invariant-1 window degrades, never the verdict.
- Developed on darwin; CI runs Linux.

Roadmap: v0.20 WS9-B (flaky tests fixed at cause, never masked).
