### PR TITLE
fix(cli): conduit init must generate a config conduit run accepts

### DIFF
--- a/cmd/conduit/internal/yaml.go
+++ b/cmd/conduit/internal/yaml.go
@@ -34,8 +34,39 @@ func NewYAMLTree() *YAMLTree {
 	}
 }
 
-// Insert adds a path with a value to the tree
+// Insert adds a path with a scalar value to the tree.
 func (t *YAMLTree) Insert(path, value, comment string) {
+	t.insertNode(path, &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Value: value,
+	}, comment)
+}
+
+// InsertSeq adds a path holding a YAML sequence of scalars.
+//
+// A sequence must be inserted as a real SequenceNode, never as a scalar: a
+// Go slice formatted through fmt (%v) yields "[]" or "[a b]", which the
+// encoder then emits as the *quoted string* '[]' — a value the config loader
+// rejects. That produced a conduit.yaml `conduit run` refused to start with,
+// so slices go through this method and never through Insert.
+func (t *YAMLTree) InsertSeq(path string, values []string, comment string) {
+	seq := &yaml.Node{Kind: yaml.SequenceNode}
+	if len(values) == 0 {
+		// Flow style so an empty sequence renders as `key: []` rather than a
+		// dangling key with a nil value.
+		seq.Style = yaml.FlowStyle
+	}
+	for _, v := range values {
+		seq.Content = append(seq.Content, &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Value: v,
+		})
+	}
+	t.insertNode(path, seq, comment)
+}
+
+// insertNode walks/creates the mapping path and attaches valueNode at the leaf.
+func (t *YAMLTree) insertNode(path string, valueNode *yaml.Node, comment string) {
 	parts := strings.Split(path, ".")
 	current := t.Root
 
@@ -50,13 +81,13 @@ func (t *YAMLTree) Insert(path, value, comment string) {
 			keyNode.HeadComment = "# " + comment
 		}
 
-		var valueNode *yaml.Node
+		var node *yaml.Node
 		found := false
 
 		// Search for existing key
 		for j := 0; j < len(current.Content); j += 2 {
 			if current.Content[j].Value == part {
-				valueNode = current.Content[j+1]
+				node = current.Content[j+1]
 				found = true
 				break
 			}
@@ -64,18 +95,15 @@ func (t *YAMLTree) Insert(path, value, comment string) {
 
 		if !found {
 			if isLast {
-				valueNode = &yaml.Node{
-					Kind:  yaml.ScalarNode,
-					Value: value,
-				}
+				node = valueNode
 			} else {
-				valueNode = &yaml.Node{
+				node = &yaml.Node{
 					Kind: yaml.MappingNode,
 				}
 			}
-			current.Content = append(current.Content, keyNode, valueNode)
+			current.Content = append(current.Content, keyNode, node)
 		}
 
-		current = valueNode
+		current = node
 	}
 }

--- a/cmd/conduit/internal/yaml.go
+++ b/cmd/conduit/internal/yaml.go
@@ -58,7 +58,13 @@ func (t *YAMLTree) InsertSeq(path string, values []string, comment string) {
 	}
 	for _, v := range values {
 		seq.Content = append(seq.Content, &yaml.Node{
-			Kind:  yaml.ScalarNode,
+			Kind: yaml.ScalarNode,
+			// !!str is load-bearing: an untagged scalar is emitted bare
+			// wherever YAML syntax does not force quoting, so elements like
+			// "null", "~", "true" or "0755" resolve back as null/bool/int on
+			// decode — silently changing, and for "null" dropping outright,
+			// elements of a []string. The tag pins them as strings.
+			Tag:   "!!str",
 			Value: v,
 		})
 	}

--- a/cmd/conduit/internal/yaml_test.go
+++ b/cmd/conduit/internal/yaml_test.go
@@ -61,10 +61,21 @@ func TestInsertSeq_EmptyRendersAsSequenceNotQuotedString(t *testing.T) {
 
 // TestInsertSeq_NonEmptyRoundTrips covers the branch no config default
 // exercises today: a populated list must survive encode/decode in order.
+//
+// The values are chosen to be hostile on purpose. An untagged scalar node is
+// emitted bare wherever YAML syntax does not force quoting, so "null" and "~"
+// resolve to null and vanish from a []string on decode, "true" resolves to a
+// bool, and "0755" resolves to octal 493. A benign allowlist like
+// {"api.openai.com"} cannot detect any of that, which is exactly how the
+// defect survived the first pass at this test.
 func TestInsertSeq_NonEmptyRoundTrips(t *testing.T) {
 	is := is.New(t)
 	tree := internal.NewYAMLTree()
-	tree.InsertSeq("processors.egress.allow", []string{"api.openai.com", "https://api.voyageai.com:443"}, "allowlist")
+	tree.InsertSeq("processors.egress.allow", []string{
+		"api.openai.com",
+		"https://api.voyageai.com:443",
+		"true", "null", "~", "0755", "123", "no",
+	}, "allowlist")
 
 	out := encode(t, tree)
 
@@ -76,7 +87,11 @@ func TestInsertSeq_NonEmptyRoundTrips(t *testing.T) {
 		} `yaml:"processors"`
 	}
 	is.NoErr(yaml.Unmarshal([]byte(out), &decoded))
-	is.Equal(decoded.Processors.Egress.Allow, []string{"api.openai.com", "https://api.voyageai.com:443"})
+	is.Equal(decoded.Processors.Egress.Allow, []string{
+		"api.openai.com",
+		"https://api.voyageai.com:443",
+		"true", "null", "~", "0755", "123", "no",
+	})
 }
 
 // TestInsert_ScalarUnchanged guards the pre-existing scalar path through the

--- a/cmd/conduit/internal/yaml_test.go
+++ b/cmd/conduit/internal/yaml_test.go
@@ -1,0 +1,101 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/conduitio/conduit/cmd/conduit/internal"
+	"github.com/conduitio/yaml/v3"
+	"github.com/matryer/is"
+)
+
+func encode(t *testing.T, tree *internal.YAMLTree) string {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(tree.Root); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	return buf.String()
+}
+
+// TestInsertSeq_EmptyRendersAsSequenceNotQuotedString pins the contract that
+// `conduit init`'s generated conduit.yaml depends on: an empty list must
+// round-trip as an empty sequence. Rendering it through fmt produced the
+// quoted scalar '[]', which decodes back as a one-element []string{"[]"} and
+// makes the generated config unstartable.
+func TestInsertSeq_EmptyRendersAsSequenceNotQuotedString(t *testing.T) {
+	is := is.New(t)
+	tree := internal.NewYAMLTree()
+	tree.InsertSeq("api.http.cors.allowed-origins", nil, "allowed origins")
+
+	out := encode(t, tree)
+
+	var decoded struct {
+		API struct {
+			HTTP struct {
+				CORS struct {
+					AllowedOrigins []string `yaml:"allowed-origins"`
+				} `yaml:"cors"`
+			} `yaml:"http"`
+		} `yaml:"api"`
+	}
+	is.NoErr(yaml.Unmarshal([]byte(out), &decoded))
+	is.Equal(len(decoded.API.HTTP.CORS.AllowedOrigins), 0)
+}
+
+// TestInsertSeq_NonEmptyRoundTrips covers the branch no config default
+// exercises today: a populated list must survive encode/decode in order.
+func TestInsertSeq_NonEmptyRoundTrips(t *testing.T) {
+	is := is.New(t)
+	tree := internal.NewYAMLTree()
+	tree.InsertSeq("processors.egress.allow", []string{"api.openai.com", "https://api.voyageai.com:443"}, "allowlist")
+
+	out := encode(t, tree)
+
+	var decoded struct {
+		Processors struct {
+			Egress struct {
+				Allow []string `yaml:"allow"`
+			} `yaml:"egress"`
+		} `yaml:"processors"`
+	}
+	is.NoErr(yaml.Unmarshal([]byte(out), &decoded))
+	is.Equal(decoded.Processors.Egress.Allow, []string{"api.openai.com", "https://api.voyageai.com:443"})
+}
+
+// TestInsert_ScalarUnchanged guards the pre-existing scalar path through the
+// shared insertNode refactor.
+func TestInsert_ScalarUnchanged(t *testing.T) {
+	is := is.New(t)
+	tree := internal.NewYAMLTree()
+	tree.Insert("db.type", "badger", "database type")
+	tree.Insert("db.badger.path", "/var/lib/conduit", "")
+
+	var decoded struct {
+		DB struct {
+			Type   string `yaml:"type"`
+			Badger struct {
+				Path string `yaml:"path"`
+			} `yaml:"badger"`
+		} `yaml:"db"`
+	}
+	is.NoErr(yaml.Unmarshal([]byte(encode(t, tree)), &decoded))
+	is.Equal(decoded.DB.Type, "badger")
+	is.Equal(decoded.DB.Badger.Path, "/var/lib/conduit")
+}

--- a/cmd/conduit/root/initialize/init.go
+++ b/cmd/conduit/root/initialize/init.go
@@ -152,13 +152,39 @@ func processConfigStruct(v reflect.Value, parentPath string, cfgYAML *internal.Y
 
 		// Process non-struct fields with a long tag
 		if longName != "" {
-			value := fmt.Sprintf("%v", fieldValue.Interface())
 			usage := field.Tag.Get("usage")
+
+			// Slices must be written as a YAML sequence. Rendering one with
+			// fmt (%v) produces "[]" or "[a b]", which the encoder emits as a
+			// quoted string ('[]') that the config loader then rejects — the
+			// generated conduit.yaml would not start (api.http.cors.allowed-origins).
+			if fieldValue.Kind() == reflect.Slice {
+				cfgYAML.InsertSeq(fullPath, sliceToStrings(fieldValue), usage)
+				continue
+			}
+
+			value := fmt.Sprintf("%v", fieldValue.Interface())
 			if value != "" { // Only insert non-empty values
 				cfgYAML.Insert(fullPath, value, usage)
 			}
 		}
 	}
+}
+
+// sliceToStrings renders each element of a slice as the scalar it will be
+// written as. Config slices are []string today; the fmt fallback keeps any
+// future element type from silently producing a malformed document.
+func sliceToStrings(v reflect.Value) []string {
+	out := make([]string, 0, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		e := v.Index(i)
+		if e.Kind() == reflect.String {
+			out = append(out, e.String())
+			continue
+		}
+		out = append(out, fmt.Sprintf("%v", e.Interface()))
+	}
+	return out
 }
 
 // ResultCommand returns the --json envelope's stable dotted discriminator.

--- a/cmd/conduit/root/initialize/init_test.go
+++ b/cmd/conduit/root/initialize/init_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/conduitio/conduit/cmd/conduit/cecdysis"
 	"github.com/conduitio/conduit/cmd/conduit/internal/testutils"
 	"github.com/conduitio/conduit/cmd/conduit/root/initialize"
+	"github.com/conduitio/conduit/cmd/conduit/root/run"
 	"github.com/conduitio/conduit/pkg/conduit"
 	"github.com/conduitio/ecdysis"
 	json "github.com/goccy/go-json"
@@ -147,6 +148,18 @@ func TestInit_RerunSkipsExistingDirs(t *testing.T) {
 // documented getting-started walkthrough — refused to start.
 func TestInit_GeneratedConfigIsAcceptedByRun(t *testing.T) {
 	is := is.New(t)
+
+	// ecdysis binds viper with AutomaticEnv under the CONDUIT_ prefix, and
+	// CONDUIT_CONFIG_PATH overrides the file path outright. A developer shell
+	// carrying either would make this test validate something other than the
+	// file init just wrote, so clear them for the duration.
+	for _, e := range os.Environ() {
+		if k, _, ok := strings.Cut(e, "="); ok && strings.HasPrefix(k, "CONDUIT_") {
+			t.Setenv(k, "")
+			os.Unsetenv(k)
+		}
+	}
+
 	dir := t.TempDir()
 	cfg := conduit.DefaultConfigWithBasePath(dir)
 
@@ -157,22 +170,21 @@ func TestInit_GeneratedConfigIsAcceptedByRun(t *testing.T) {
 	_, statErr := os.Stat(generated)
 	is.NoErr(statErr)
 
-	// Same shape as RunCommand.Config(): viper layers the generated file over
-	// the defaults, exactly as `conduit run` does.
-	var parsed conduit.Config
-	err = ecdysis.ParseConfig(ecdysis.Config{
-		EnvPrefix:     "CONDUIT",
-		Parsed:        &parsed,
-		Path:          generated,
-		DefaultValues: conduit.DefaultConfigWithBasePath(dir),
-	}, &cobra.Command{})
-	is.NoErr(err)
+	// Drive the REAL run command: its own Config() and its own fully-bound
+	// cobra flag set, not a restatement of them. A hand-copied ecdysis.Config
+	// drifts silently the moment RunCommand.Config() changes (EnvPrefix,
+	// ExcludedFlags, a flag's type), leaving this test green while
+	// `conduit run` breaks — the exact failure it exists to catch.
+	runCmd := &run.RunCommand{}
+	cobraRun := ecdysis.New().MustBuildCobraCommand(runCmd)
+	is.NoErr(cobraRun.ParseFlags([]string{"--config.path=" + generated}))
+	is.NoErr(ecdysis.ParseConfig(runCmd.Config(), cobraRun))
 
 	// Assert the slice shape directly so a regression names its own cause
 	// rather than surfacing as an opaque validation failure.
-	is.Equal(len(parsed.API.HTTP.CORS.AllowedOrigins), 0)
-	is.Equal(len(parsed.Processors.Egress.Allow), 0)
-	is.Equal(len(parsed.Processors.Egress.SecretRefs), 0)
+	is.Equal(len(runCmd.Cfg.API.HTTP.CORS.AllowedOrigins), 0)
+	is.Equal(len(runCmd.Cfg.Processors.Egress.Allow), 0)
+	is.Equal(len(runCmd.Cfg.Processors.Egress.SecretRefs), 0)
 
-	is.NoErr(parsed.Validate())
+	is.NoErr(runCmd.Cfg.Validate())
 }

--- a/cmd/conduit/root/initialize/init_test.go
+++ b/cmd/conduit/root/initialize/init_test.go
@@ -133,3 +133,46 @@ func TestInit_RerunSkipsExistingDirs(t *testing.T) {
 		is.Equal(entry["created"], false)
 	}
 }
+
+// TestInit_GeneratedConfigIsAcceptedByRun closes the loop the tests above
+// leave open: they assert conduit.yaml *exists*, never that it *works*. This
+// feeds the file `conduit init` just wrote back through the exact viper path
+// RunCommand.Config() uses and validates the result, so a config Conduit
+// cannot start with fails here instead of in a user's terminal.
+//
+// Regression test for the defect where every []string field was rendered
+// through fmt ("%v") and written as the quoted scalar '[]'. viper decoded
+// that as []string{"[]"}, Validate rejected api.http.cors.allowed-origins,
+// and `conduit init && conduit pipelines init && conduit run` — the
+// documented getting-started walkthrough — refused to start.
+func TestInit_GeneratedConfigIsAcceptedByRun(t *testing.T) {
+	is := is.New(t)
+	dir := t.TempDir()
+	cfg := conduit.DefaultConfigWithBasePath(dir)
+
+	_, err := runInit(t, &cfg, "--path="+dir)
+	is.NoErr(err)
+
+	generated := filepath.Join(dir, "conduit.yaml")
+	_, statErr := os.Stat(generated)
+	is.NoErr(statErr)
+
+	// Same shape as RunCommand.Config(): viper layers the generated file over
+	// the defaults, exactly as `conduit run` does.
+	var parsed conduit.Config
+	err = ecdysis.ParseConfig(ecdysis.Config{
+		EnvPrefix:     "CONDUIT",
+		Parsed:        &parsed,
+		Path:          generated,
+		DefaultValues: conduit.DefaultConfigWithBasePath(dir),
+	}, &cobra.Command{})
+	is.NoErr(err)
+
+	// Assert the slice shape directly so a regression names its own cause
+	// rather than surfacing as an opaque validation failure.
+	is.Equal(len(parsed.API.HTTP.CORS.AllowedOrigins), 0)
+	is.Equal(len(parsed.Processors.Egress.Allow), 0)
+	is.Equal(len(parsed.Processors.Egress.SecretRefs), 0)
+
+	is.NoErr(parsed.Validate())
+}


### PR DESCRIPTION
## What

`conduit init` wrote a `conduit.yaml` that `conduit run` then refused to start with. The documented getting-started walkthrough — `conduit init` → `conduit pipelines init` → `conduit run` — failed on **v0.19.0 and on today's main**, from a clean directory:

```
$ conduit init && conduit pipelines init && conduit run
error: failed to set up conduit runtime:
    github.com/conduitio/conduit/pkg/conduit.(*Entrypoint).Serve
        .../pkg/conduit/entrypoint.go:48
  - invalid config:
  - "api.http.cors.allowed-origins" config value is invalid:
    github.com/conduitio/conduit/pkg/conduit.invalidConfigFieldErr
```

Found by an end-to-end developer-experience audit, not by CI — no test walks the path a first-time user walks.

## Root cause

`processConfigStruct` (`init.go`) rendered every field with `fmt.Sprintf("%v", …)`. On an empty `[]string` that produces `[]`, which the YAML encoder writes as the **quoted scalar** `'[]'`. viper decodes that back as `[]string{"[]"}` — a one-element allowlist — and `Validate()` rejects it.

Three fields are affected, all `[]string`:

| Field | Effect |
|---|---|
| `api.http.cors.allowed-origins` | hard startup failure — the only one validated |
| `processors.egress.allow` | engine-level egress allowlist, malformed baseline |
| `processors.egress.secret-refs` | engine-level egress secret grants, malformed baseline |

The egress pair is not currently exploitable — the ceiling is gated by `processors.egress.enabled: false` — but an operator who starts from the generated file starts from a malformed allowlist.

## Fix

`YAMLTree` gains `InsertSeq`, which writes a real `SequenceNode`: `[]` in flow style when empty, a block list when populated. `Insert`'s path-walking is extracted into a shared `insertNode`; the scalar path is byte-for-byte unchanged. `processConfigStruct` routes `reflect.Slice` fields through `InsertSeq`.

Generated output, before and after:

```yaml
# before                          # after
allowed-origins: '[]'             allowed-origins: []
allow: '[]'                       allow: []
secret-refs: '[]'                 secret-refs: []
```

Per-key usage comments are retained, so the generated file keeps its documentation role. A populated list renders as a block sequence (verified).

## The test that would have caught it

`TestInit_GeneratedConfigIsAcceptedByRun` runs `init`, then feeds the generated `conduit.yaml` back through `ecdysis.ParseConfig` — the exact viper path `RunCommand.Config()` uses — and calls `Validate()`.

The three existing `init` tests assert the file **exists**; none asserted it **works**. That was the gap.

**Verified to fail without the fix:**
```
init_test.go:173: 1 != 0
--- FAIL: TestInit_GeneratedConfigIsAcceptedByRun
```
(`AllowedOrigins` decoded as one element containing `"[]"` — the diagnosis, stated by the test.)

`cmd/conduit/internal/yaml_test.go` is new: direct coverage for the empty-sequence, non-empty-sequence, and scalar paths.

## Verification

- `go test -race ./cmd/conduit/internal/... ./cmd/conduit/root/initialize/... ./cmd/conduit/root/pipelines/...` — green
- `golangci-lint run` (pinned v2.12.2 via `make install-tools`) on touched packages — 0 issues
- Manual, from a clean temp dir with a binary built off this branch: `init` → `pipelines init` → `run` → **12 records flowed**, no config error

## Adversarial self-review

- **Nil vs empty slice** — `reflect.Value.Len()` is 0 for both; both take the empty-sequence path. Covered.
- **`[]byte` config fields** — would render as a sequence of numbers. Considered and declined: no `[]byte` field exists, all three slices are `[]string` and enumerated in the test. Adding speculative handling would be a YAGNI violation.
- **Pre-existing, not fixed here** — `insertNode` walking into an existing `ScalarNode` on a path collision (`a.b` inserted, then `a.b.c`) would append to a scalar and corrupt the node. Unreachable with the current config struct (no colliding `long` tags) and unchanged by this PR. Flagging, not fixing.
- **Blast radius** — `YAMLTree` has exactly one non-test consumer, `init.go`. Confirmed by grep.
- **Unrelated** — `gofumpt` flags `cmd/conduit/internal/deploy/{deploy,service}.go` on `main` already; untouched here.

## Risk tier

**Tier 2** — CLI surface. No data-path change, no config-schema change (this fixes a malformed *value*, not the schema), no serialized-format change.

## Roadmap

v0.20 ship blocker: the documented first-run path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xE861dwb3MLgqEdWRECLY