### PR TITLE
build(release): macOS Developer ID signing + notarization (inert until secrets exist)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,27 @@ jobs:
           prev_tag=$(git tag | grep -v "nightly" | sort -r --version-sort | head -n 2 | tail -n 1)
           echo "GORELEASER_PREVIOUS_TAG=$prev_tag" >> $GITHUB_ENV
 
+      # quill signs and notarizes Mach-O binaries from a Linux runner, so the
+      # release job needs no macOS runner. Installed from a pinned release and
+      # checksum-verified rather than through anchore's `curl | sh` installer:
+      # this is the one job that produces the artifacts users execute, so an
+      # unverified download here is a supply-chain hole.
+      - name: Install quill
+        if: ${{ !contains(github.ref, '-nightly') }}
+        env:
+          QUILL_VERSION: 0.7.1
+          QUILL_SHA256: e58c6f86378a22507c1123e24412afd4ee2d3bb32ebd94d6059827dc0c1b3fbf
+        run: |
+          set -euo pipefail
+          tarball="quill_${QUILL_VERSION}_linux_amd64.tar.gz"
+          curl -sSfL -o "$tarball" \
+            "https://github.com/anchore/quill/releases/download/v${QUILL_VERSION}/${tarball}"
+          echo "${QUILL_SHA256}  ${tarball}" | sha256sum -c -
+          tar xzf "$tarball" quill
+          install -m 0755 quill /usr/local/bin/quill
+          rm -f "$tarball" quill
+          quill version
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -40,6 +61,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
+          # macOS signing + notarization. All five are optional: when
+          # QUILL_SIGN_P12 is empty, scripts/sign-darwin.sh leaves the binaries
+          # ad-hoc signed and the release proceeds exactly as it does today.
+          QUILL_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
+          QUILL_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_P12_PASSWORD }}
+          QUILL_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+          QUILL_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          QUILL_NOTARY_ISSUER: ${{ secrets.MACOS_NOTARY_ISSUER }}
 
   build-push-docker-image:
     name: Build and push Docker image

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,8 +16,15 @@ builds:
       - ui
     ldflags:
       - "-s -w -X 'github.com/conduitio/conduit/pkg/conduit.version={{ .Tag }}'"
+    hooks:
+      post:
+        # Developer ID-sign and notarize darwin binaries so a browser-downloaded
+        # release is not killed by Gatekeeper. No-op for non-darwin targets, for
+        # nightly tags, and whenever QUILL_SIGN_P12 is unset — see the script.
+        - cmd: ./scripts/sign-darwin.sh "{{ .Path }}" "{{ .Target }}"
+          output: true
 archives:
-  - builds:
+  - ids:
       - conduit
     name_template: >-
       {{ .ProjectName }}_
@@ -28,7 +35,8 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -39,3 +39,60 @@ In order to create a new Conduit release, you'll need to create a new issue usin
 The issue will guide you through the process of creating a new release.
 
 It will also provide you with a checklist to make sure you don't forget anything.
+
+## macOS signing and notarization
+
+Through v0.19.0 the darwin binaries were **ad-hoc signed only**: `codesign -dv`
+reports `Signature=adhoc` and `spctl -a -vv` reports `rejected`. A binary
+downloaded through a browser carries `com.apple.quarantine`, so Gatekeeper
+kills it with no output at all — exit 137, an empty terminal, no dialog. It is
+invisible to CI and to `curl`-based testing because neither sets the quarantine
+attribute, which is why it went unnoticed. Homebrew and `install.sh` are
+unaffected for the same reason.
+
+The release pipeline can now Developer ID-sign and notarize those binaries.
+[quill](https://github.com/anchore/quill) does the work from the Linux release
+runner, so no macOS runner is needed, and it is driven by
+`scripts/sign-darwin.sh` as a GoReleaser post-build hook.
+
+**Signing is off until the secrets below exist.** With `MACOS_SIGN_P12` unset
+the hook logs why and exits 0, so the release behaves exactly as it does today.
+Nightly tags always skip notarization: it costs an Apple round-trip of several
+minutes, the nightly train runs daily, and nobody browser-downloads a nightly.
+
+### Required repository secrets
+
+These come from an **Apple Developer Program** membership (99 USD/year). There
+is no way to notarize without one.
+
+| Secret | What it is | Where it comes from |
+| --- | --- | --- |
+| `MACOS_SIGN_P12` | base64 of the **Developer ID Application** certificate + private key, exported as `.p12` | Apple Developer → Certificates → create a Developer ID Application cert, then export from Keychain Access |
+| `MACOS_SIGN_P12_PASSWORD` | the password set on that `.p12` export | chosen at export time |
+| `MACOS_NOTARY_KEY` | base64 of the App Store Connect API key (`.p8`) | App Store Connect → Users and Access → Integrations → Keys, role **Developer** |
+| `MACOS_NOTARY_KEY_ID` | that key's Key ID | shown beside the key |
+| `MACOS_NOTARY_ISSUER` | the Issuer ID (a UUID) | shown above the key list |
+
+A **Developer ID Application** certificate is the specific type required.
+"Apple Development" and "Apple Distribution" certificates cannot notarize
+software distributed outside the App Store.
+
+### Verifying a signed release
+
+A bare Mach-O executable cannot be stapled — stapling needs a container
+(`.app`, `.dmg`, `.pkg`). Apple publishes the notarization ticket and Gatekeeper
+fetches it on first run, so a notarized CLI shipped in a tarball is accepted
+given network access. That is the standard shape for a notarized command-line
+tool, not a gap.
+
+After a signed release, download the darwin tarball **through a browser** (a
+`curl` download sets no quarantine attribute and will pass either way) and:
+
+```sh
+codesign -dv ./conduit          # expect: Authority=Developer ID Application: ...
+spctl -a -vv ./conduit          # expect: accepted
+xattr ./conduit                 # expect: com.apple.quarantine present
+./conduit version               # expect: it runs
+```
+
+Before this change the last command produced no output and exit 137.

--- a/scripts/sign-darwin.sh
+++ b/scripts/sign-darwin.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Developer ID-sign and notarize a darwin build artifact.
+#
+# Runs as a GoReleaser post-build hook, once per build target. It is a no-op
+# unless all of the following hold, so the release pipeline behaves exactly as
+# it does today whenever signing is not configured:
+#
+#   * the target is darwin (nothing else can be notarized)
+#   * the tag is not a nightly — notarization costs an Apple round-trip of
+#     several minutes, the nightly train runs daily, and nobody
+#     browser-downloads a nightly
+#   * QUILL_SIGN_P12 is set (the Developer ID Application certificate)
+#
+# Why this exists: through v0.19.0 the darwin binaries were ad-hoc signed only
+# (`codesign -dv` reports `Signature=adhoc`, `spctl -a` reports `rejected`). A
+# browser download carries com.apple.quarantine, and Gatekeeper then kills the
+# binary with no output whatsoever — exit 137, empty terminal, no dialog, no
+# reason to search for. Homebrew and install.sh are unaffected because neither
+# sets the quarantine attribute, which is exactly why this stayed invisible to
+# CI and to curl-based testing.
+#
+# Note on stapling: a bare Mach-O executable cannot be stapled — stapling
+# requires a container (.app/.dmg/.pkg). The notarization ticket is published
+# by Apple and Gatekeeper fetches it on first run, so a notarized CLI in a
+# tarball is accepted with network access. That is the standard shape for a
+# notarized command-line tool and is not a gap in this script.
+set -euo pipefail
+
+binary="${1:?usage: sign-darwin.sh <binary> <target>}"
+target="${2:?usage: sign-darwin.sh <binary> <target>}"
+
+case "$target" in
+  darwin_*) ;;
+  *) exit 0 ;;
+esac
+
+if [[ "${GORELEASER_CURRENT_TAG:-}" == *nightly* ]]; then
+  echo "sign-darwin: ${GORELEASER_CURRENT_TAG} is a nightly tag, skipping notarization"
+  exit 0
+fi
+
+if [[ -z "${QUILL_SIGN_P12:-}" ]]; then
+  echo "sign-darwin: QUILL_SIGN_P12 is unset — leaving ${binary} ad-hoc signed." >&2
+  echo "sign-darwin: browser-downloaded macOS binaries will be quarantined." >&2
+  exit 0
+fi
+
+echo "sign-darwin: signing and notarizing ${binary} (${target})"
+quill sign-and-notarize "${binary}" --dry-run=false --ad-hoc=false -vv


### PR DESCRIPTION
**Draft on purpose.** The signing path cannot be executed until an Apple Developer Program membership exists, so I will not claim it verified. Everything that *can* be verified without credentials has been, and is evidenced below. See "What I need from you".

## Defect

Through v0.19.0 the darwin release binaries are **ad-hoc signed only**. A browser download carries `com.apple.quarantine` and Gatekeeper kills the binary with **no output at all**:

```
$ ./conduit version          # quarantined, as a browser leaves it
(no output)
$ echo $?
137                          # SIGKILL

$ codesign -dv ./conduit
Signature=adhoc
$ spctl -a -vv ./conduit
./conduit: rejected
```

This is the README's **first** documented install route ("Download a pre-built binary ... and simply run it!"). Exit 137 and an empty terminal — no dialog, no reason, nothing to search for.

It stayed invisible because neither CI nor `curl` sets the quarantine attribute; only a human with a browser hits it. Homebrew and `install.sh` are unaffected for the same reason. Found by an end-to-end DX audit.

## Approach

`scripts/sign-darwin.sh` runs as a GoReleaser post-build hook and signs + notarizes with [quill](https://github.com/anchore/quill), which works from the **Linux** release runner — no macOS runner needed, no change to the job topology.

**It is inert by construction.** The hook exits 0 without doing anything unless *all* of:
- the target is darwin,
- the tag is not a nightly,
- `MACOS_SIGN_P12` is set.

So this is safe to merge before the credentials exist: the release behaves exactly as it does today and logs why it skipped. Nightlies never notarize — it costs an Apple round-trip of several minutes, the train runs daily, and nobody browser-downloads a nightly.

quill is installed from a **pinned release with its checksum verified** rather than anchore's `curl | sh` installer. This is the one job that produces the artifacts users execute; an unverified download here is a supply-chain hole. Checksum `e58c6f86...3fbf` was taken from quill's published `checksums.txt` and the download+verify was executed locally.

## Bonus fix: a latent release-pipeline break

`.goreleaser.yml` used two properties GoReleaser has **deprecated** (`archives.builds`, `archives.format_overrides.format`) while `release.yml` pins goreleaser `version: latest`. When those are removed upstream, **releases break at tag time** — the worst possible moment to discover it. Pre-existing on `main`; confirmed by A/B, not introduced here.

Migrated to `archives.ids` and `formats`. `goreleaser check` now reports **no deprecations** (previously two).

## Verification — what I actually ran

| Check | Result |
|---|---|
| `goreleaser check` | clean; **no deprecations**, config valid |
| A/B snapshot build, `main` vs this branch | **13 artifacts, byte-identical names** (`diff` empty) |
| Post-build hook execution | ran on **all 7 targets**; silent no-op on the 5 non-darwin, explanatory message on both darwin |
| Built darwin binary still works | `dist/conduit_darwin_arm64_v8.0/conduit version` → `v0.20.0-nightly.20260905 darwin/arm64` |
| quill pinned download + checksum | executed: `quill_0.7.1_linux_amd64.tar.gz: OK`, extracts to a 27MB binary |
| `bash -n` + `shellcheck` on the hook | clean |
| Hook no-op paths | all three exercised by hand (non-darwin / nightly / no-p12), all exit 0 |
| markdownlint | **not run** — local `node` is broken (`syntax error: unexpected end of file`). Checked MD013 (tables exempt per `.markdownlint.yml`), MD040, tabs and emphasis style by hand. CI is authoritative. |

Note on the goreleaser target string: it is `darwin_arm64_v8.0`, not `darwin_arm64`. The hook matches `darwin_*`, verified against real hook output.

## What I could NOT verify

The signing and notarization path itself. It requires an Apple Developer ID certificate that does not exist. **No claim is made that signing works.** The first real signed release is the test, and `docs/releases.md` documents exactly how to verify it (download through a browser, then `codesign -dv` / `spctl -a` / `./conduit version`).

## What I need from you

An **Apple Developer Program** membership (99 USD/year). There is no way to notarize without one — it is not a technical choice. Then five repo secrets, documented in `docs/releases.md`:

`MACOS_SIGN_P12`, `MACOS_SIGN_P12_PASSWORD`, `MACOS_NOTARY_KEY`, `MACOS_NOTARY_KEY_ID`, `MACOS_NOTARY_ISSUER`

The certificate type must be **Developer ID Application** specifically. "Apple Development" and "Apple Distribution" certs cannot notarize software distributed outside the App Store.

## Interim mitigation

The README fix — stop telling macOS users to do the thing that silently dies, and document `xattr -d com.apple.quarantine` — is landing separately in the stale-references PR, which is already editing that install section.

## Adversarial self-review

- **Invented an action.** My first draft used `anchore/quill-action@v0`. I checked and it **404s** — it does not exist. Replaced with the pinned checksum-verified install. Flagging because it is exactly the kind of thing that looks plausible and would have failed only at tag time.
- **Nightly guard tested against a real nightly tag string** (`v0.20.0-nightly.20260905`), not a guess at the format.
- **Stapling** — a bare Mach-O cannot be stapled; that needs a container (`.app`/`.dmg`/`.pkg`). Apple publishes the ticket and Gatekeeper fetches it on first run, so a notarized CLI in a tarball is accepted with network access. Standard shape for a notarized CLI, documented in `docs/releases.md`, not a gap.
- **Blast radius of the deprecation migration** — proven by artifact-name diff rather than by reading the config, because the archive-name template is the thing users' scripts depend on.
- **`skip=sign`** in my snapshot runs skips goreleaser's own `signs` block (unused here), not build hooks — confirmed by seeing the hook actually run.

## Risk tier

**Tier 3** — release tooling. No engine, data-path or config-schema change. The one real risk is breaking the release job, which is why the artifact-name A/B and the inert-by-default design are the core of the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xE861dwb3MLgqEdWRECLY