### PR TITLE
docs: fix stale public references found by the DX audit

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,136 @@
+name: link check
+
+# Catches STALE_PUBLIC_REFERENCE rot in the repo's front-door markdown: dead
+# domains and moved files. It exists because the three broken links fixed in
+# the PR that added it had been broken for months with nothing to notice - the
+# README's "API docs" badge pointed at docs.conduit.io, a domain that no longer
+# resolves, and the OpenAPI definition at a pkg/web/... path that had moved to
+# pkg/http/... . A reader hits both of those before they ever run Conduit.
+#
+# SCHEDULED, NOT PER-PR, AND DELIBERATELY NOT BLOCKING. Link checking is the
+# textbook flaky gate: it fails on someone else's rate limit, someone else's
+# TLS renewal, and someone else's outage, none of which the PR author can fix
+# or should be blocked by. A blocking check that goes red for reasons outside
+# the diff teaches people to bypass it, and a check people bypass protects
+# nothing. This is flake-hunt.yml's reasoning, applied to links.
+#
+# Because it is not a PR gate, it does NOT get a row in CLAUDE.md's "Process
+# maturity" table - that table tracks gates that block a merge. Do not describe
+# this workflow as a gate anywhere.
+#
+# WHY WEEKLY AND NOT NIGHTLY: link rot is measured in months, and every run
+# spends third-party rate-limit budget (github.com most of all). Weekly catches
+# rot long before a release cut, at a seventh of the traffic.
+#
+# WHY lychee AND NOT markdown-link-check: lychee has native retries and
+# per-host rate limiting, caches verdicts between runs, and reads GITHUB_TOKEN
+# so the many github.com links here are not 429'd from a shared runner IP. The
+# action is pinned by commit SHA, matching the markdownlint-cli2-action pin in
+# markdown-lint.yml.
+
+on:
+  schedule:
+    # Mondays 06:40 UTC. Minute/hour offset from the other scheduled workflows
+    # (trigger-nightly 03:00, flake-hunt 03:30, govulncheck 05:15) so they do
+    # not contend for runners.
+    - cron: '40 6 * * 1'
+  workflow_dispatch:
+  # Also runs when the check itself is edited, so a change to the workflow or
+  # its ignore list is exercised before it merges. This does not make the job a
+  # gate: it is not in main's required contexts, and being path-filtered it
+  # could not become one without being restructured first.
+  pull_request:
+    paths:
+      - '.github/workflows/link-check.yml'
+      - '.lycheeignore'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  link-check:
+    name: check links in front-door docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # Restore lychee's verdict cache so a manual re-run does not re-request
+      # every URL. --max-cache-age below decides when an entry goes stale.
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
+      - name: Check links
+        # v2.9.0, pinned by commit SHA. Keep the trailing comment and the SHA
+        # in sync when bumping.
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          # Scoped to the front-door docs a new reader actually lands on,
+          # rather than globbing **/*.md. Design documents, ADRs and
+          # postmortems are historical records that cite URLs as they were at
+          # the time; rewriting them to chase link rot would falsify them.
+          #
+          # 429 is accepted, not failed: a rate-limited response says nothing
+          # about whether the link is alive, and failing on it is exactly the
+          # flakiness this workflow is shaped to avoid.
+          args: >-
+            --no-progress
+            --cache
+            --max-cache-age 1w
+            --max-retries 4
+            --retry-wait-time 10
+            --timeout 30
+            --accept 200,206,429
+            README.md
+            CONTRIBUTING.md
+            ROADMAP.md
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # A scheduled failure has no PR to annotate, so it files (or comments on)
+      # an issue. Without this the only record is a red run nobody opens.
+      - name: File an issue on failure
+        if: failure() && github.event_name != 'pull_request'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const title = 'Broken links found in front-door docs';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              `The weekly link check failed: ${runUrl}`,
+              '',
+              'Open the run and read the lychee summary for the failing URLs.',
+              'Fix the link, or - if the target is legitimately gone - point it at',
+              'something that resolves. Do not add it to `.lycheeignore` just to make',
+              'this green.',
+            ].join('\n');
+            // Dedupe on title rather than a label so this does not depend on a
+            // label existing in the repo.
+            const open = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const existing = open.find((i) => !i.pull_request && i.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['documentation'],
+              });
+            }

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -14,9 +14,14 @@ name: link check
 # the diff teaches people to bypass it, and a check people bypass protects
 # nothing. This is flake-hunt.yml's reasoning, applied to links.
 #
-# Because it is not a PR gate, it does NOT get a row in CLAUDE.md's "Process
-# maturity" table - that table tracks gates that block a merge. Do not describe
-# this workflow as a gate anywhere.
+# It does NOT get a row in CLAUDE.md's "Process maturity" table. Not because the
+# table only tracks blocking gates - it does track non-blocking and scheduled
+# states (the property/fuzz row tracks a MISSING scheduled long-fuzz run) - but
+# because that table enumerates the specific engineering-standard gates named in
+# CLAUDE.md's "Testing standards" and "PR review process". A link check is named
+# nowhere in CLAUDE.md, and neither flake-hunt.yml nor markdown-lint.yml has a
+# row either, despite markdownlint being a live blocking PR check. Do not
+# describe this workflow as a gate anywhere.
 #
 # WHY WEEKLY AND NOT NIGHTLY: link rot is measured in months, and every run
 # spends third-party rate-limit budget (github.com most of all). Weekly catches
@@ -52,13 +57,19 @@ jobs:
   link-check:
     name: check links in front-door docs
     runs-on: ubuntu-latest
+    # The retry budget below backs off exponentially, so the theoretical worst
+    # case is ~23 minutes of waiting. Bound it explicitly rather than falling
+    # back to GitHub's 360-minute default.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 
       # Restore lychee's verdict cache so a manual re-run does not re-request
       # every URL. --max-cache-age below decides when an entry goes stale.
       - name: Restore lychee cache
-        uses: actions/cache@v4
+        # v6, not v4: v4 targets Node.js 20, which the runners now force onto
+        # Node.js 24 with a deprecation warning. v6 targets Node.js 24 natively.
+        uses: actions/cache@v6
         with:
           path: .lycheecache
           key: cache-lychee-${{ github.sha }}
@@ -74,9 +85,16 @@ jobs:
           # postmortems are historical records that cite URLs as they were at
           # the time; rewriting them to chase link rot would falsify them.
           #
-          # 429 is accepted, not failed: a rate-limited response says nothing
-          # about whether the link is alive, and failing on it is exactly the
-          # flakiness this workflow is shaped to avoid.
+          # --accept REPLACES lychee's default accepted set (100..=103,200..=299)
+          # rather than extending it, so the default range is restated here.
+          # Passing a bare "200,206,429" would quietly start failing any link
+          # that answers 201/202/204 - a latent false-failure generator inside a
+          # check whose whole point is not producing false failures.
+          #
+          # 429 is added because a rate-limited response says nothing about
+          # whether the link is alive, and failing on it is exactly the
+          # flakiness this workflow is shaped to avoid. It does not burn the
+          # retry budget: lychee returns early once a status is accepted.
           #
           # The retry/timeout budget is deliberately generous (up to 6 attempts,
           # 15s apart, 60s each). The first run of this workflow timed out on
@@ -91,7 +109,7 @@ jobs:
             --max-retries 6
             --retry-wait-time 15
             --timeout 60
-            --accept 200,206,429
+            --accept 100..=103,200..=299,429
             README.md
             CONTRIBUTING.md
             ROADMAP.md

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -77,13 +77,20 @@ jobs:
           # 429 is accepted, not failed: a rate-limited response says nothing
           # about whether the link is alive, and failing on it is exactly the
           # flakiness this workflow is shaped to avoid.
+          #
+          # The retry/timeout budget is deliberately generous (up to 6 attempts,
+          # 15s apart, 60s each). The first run of this workflow timed out on
+          # www.gnu.org at a 30s budget while the same URL answered in 0.5s from
+          # an ordinary connection - a runner-side hiccup, not link rot. On a
+          # weekly job the extra wall-clock costs nothing and buys a report
+          # people can trust.
           args: >-
             --no-progress
             --cache
             --max-cache-age 1w
-            --max-retries 4
-            --retry-wait-time 10
-            --timeout 30
+            --max-retries 6
+            --retry-wait-time 15
+            --timeout 60
             --accept 200,206,429
             README.md
             CONTRIBUTING.md

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,7 @@ golangci-report.xml
 # Python bytecode (the CI helper scripts under .github/scripts are run, not imported)
 __pycache__/
 *.pyc
+
+# lychee's link-check result cache (.github/workflows/link-check.yml); written
+# when the check is run locally, restored from the Actions cache in CI.
+.lycheecache

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,13 @@
+# URLs the link check (.github/workflows/link-check.yml) must not try to fetch.
+# One regex per line; lines starting with # are comments.
+#
+# Keep this file empty of "make it green" entries. A link that is genuinely
+# gone gets repointed at something that resolves, not silenced here. The only
+# legitimate entries are URLs that cannot be checked by an unauthenticated
+# runner at all - private hosts, endpoints that only exist while Conduit is
+# running locally, or hosts that reject automated requests outright.
+#
+# Nothing is excluded today: every URL in README.md, CONTRIBUTING.md and
+# ROADMAP.md resolves, and the two that do not (http://localhost:8080/openapi
+# and the api.voyageai.com allowlist example) sit inside inline code and fenced
+# code blocks, which lychee skips as verbatim unless --include-verbatim is set.

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,13 +1,24 @@
 # URLs the link check (.github/workflows/link-check.yml) must not try to fetch.
-# One regex per line; lines starting with # are comments.
+# One regex per line, matched against the URL; lines starting with # are
+# comments.
 #
 # Keep this file empty of "make it green" entries. A link that is genuinely
 # gone gets repointed at something that resolves, not silenced here. The only
-# legitimate entries are URLs that cannot be checked by an unauthenticated
-# runner at all - private hosts, endpoints that only exist while Conduit is
-# running locally, or hosts that reject automated requests outright.
+# legitimate entries are URLs that cannot be checked by an unauthenticated CI
+# runner at all - hosts that refuse automated or datacenter-origin requests
+# outright, private hosts, or endpoints that exist only while Conduit is
+# running locally.
 #
-# Nothing is excluded today: every URL in README.md, CONTRIBUTING.md and
-# ROADMAP.md resolves, and the two that do not (http://localhost:8080/openapi
-# and the api.voyageai.com allowlist example) sit inside inline code and fenced
-# code blocks, which lychee skips as verbatim unless --include-verbatim is set.
+# Everything else in README.md, CONTRIBUTING.md and ROADMAP.md is checked. The
+# two unreachable URLs that are NOT listed here - http://localhost:8080/openapi
+# and the api.voyageai.com egress-allowlist example - need no entry: both sit
+# inside inline code and fenced code blocks, which lychee skips as verbatim
+# unless --include-verbatim is set.
+
+# X/Twitter serves 403 Forbidden to datacenter IP ranges regardless of user
+# agent, so a GitHub-hosted runner can never verify this link, while the same
+# URL returns 200 from an ordinary connection. Checking it would report a
+# permanent false failure about a link that works for every human reader.
+# Verified 2026-09-06: 403 from an ubuntu-latest runner, 200 from a residential
+# IP with both a curl and a browser user agent.
+^https?://(www\.)?(x|twitter)\.com/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ _Data Integration for Production Data Stores. :dizzy:_
 [![Twitter](https://img.shields.io/static/v1?label=X/Twitter&message=Follow&color=1DA1F2&logo=twitter&logoColor=white)](https://x.com/ConduitIO)
 [![Go Reference](https://pkg.go.dev/badge/github.com/conduitio/conduit.svg)](https://pkg.go.dev/github.com/conduitio/conduit)
 [![Conduit docs](https://img.shields.io/badge/conduit-docs-blue)](https://conduitdata.io/docs/getting-started)
-[![API docs](https://img.shields.io/badge/HTTP_API-docs-blue)](https://docs.conduit.io/api)
+[![API docs](https://img.shields.io/badge/HTTP_API-docs-blue)](https://conduitdata.io/api)
 
 ## Overview
 
@@ -60,15 +60,53 @@ see <https://conduitdata.io/docs/getting-started>.
 
 ## Installation guide
 
+### Install script (recommended)
+
+The install script detects your platform and installs Conduit through the native
+package manager for it — Homebrew on macOS, `dpkg` or `rpm` on Linux:
+
+```sh
+curl https://conduitdata.io/install.sh | bash
+```
+
+This is the route the [documentation site](https://conduitdata.io/docs/getting-started)
+leads with, and on macOS it is the one to prefer: it goes through Homebrew, so it
+avoids the quarantine problem described under
+[Download binary and run](#download-binary-and-run).
+
+### Homebrew
+
+Make sure you have [homebrew](https://brew.sh/) installed on your machine, then run:
+
+```sh
+brew update
+brew install conduit
+```
+
 ### Download binary and run
 
 Download a pre-built binary from
 the [latest release](https://github.com/conduitio/conduit/releases/latest) and
-simply run it!
+run it:
 
 ```sh
 ./conduit run
 ```
+
+On macOS, the release binaries are ad-hoc signed — they are not Developer ID
+signed and they are not notarized. A binary downloaded through a browser
+therefore carries the `com.apple.quarantine` attribute, and Gatekeeper refuses
+to run it with no error message at all: the process is killed and you get an
+empty terminal. Clear the attribute after downloading and before you run the
+binary for the first time:
+
+```sh
+xattr -d com.apple.quarantine ./conduit
+```
+
+`curl` and `wget` do not set the quarantine attribute, so a binary fetched that
+way runs as-is. Homebrew and the install script are unaffected — on macOS,
+prefer either of those.
 
 Once you see that the service is running, the configured pipeline should start
 processing records automatically. You can also interact with
@@ -80,31 +118,26 @@ Conduit can be configured through command line parameters. To view the full list
 of available options, run `./conduit run --help` or see
 [configuring Conduit](#configuring-conduit).
 
-### Homebrew
-
-Make sure you have [homebrew](https://brew.sh/) installed on your machine, then run:
-
-```sh
-brew update
-brew install conduit
-```
-
 ### Debian
 
 Download the right `.deb` file for your machine architecture from the
-[latest release](https://github.com/conduitio/conduit/releases/latest), then run:
+[latest release](https://github.com/conduitio/conduit/releases/latest), then run
+the command below, substituting the version and architecture of the file you
+downloaded for `<version>` and `<arch>`:
 
 ```sh
-dpkg -i conduit_0.17.0_Linux_x86_64.deb
+dpkg -i conduit_<version>_Linux_<arch>.deb
 ```
 
 ### RPM
 
 Download the right `.rpm` file for your machine architecture from the
-[latest release](https://github.com/conduitio/conduit/releases/latest), then run:
+[latest release](https://github.com/conduitio/conduit/releases/latest), then run
+the command below, substituting the version and architecture of the file you
+downloaded for `<version>` and `<arch>`:
 
 ```sh
-rpm -i conduit_0.17.0_Linux_x86_64.rpm
+rpm -i conduit_<version>_Linux_<arch>.rpm
 ```
 
 ### Build from source
@@ -352,8 +385,8 @@ The HTTP API is by default running on port 8080. You can define a custom address
 using the CLI flag `-api.http.address`. It is generated
 using [gRPC gateway](https://github.com/grpc-ecosystem/grpc-gateway) and is thus
 providing the same functionality as the gRPC API. To learn more about the HTTP
-API please have a look at the [API documentation](https://www.conduit.io/api),
-[OpenAPI definition](https://github.com/ConduitIO/conduit/blob/main/pkg/web/openapi/swagger-ui/api/v1/api.swagger.json)
+API please have a look at the [API documentation](https://conduitdata.io/api),
+[OpenAPI definition](https://github.com/ConduitIO/conduit/blob/main/pkg/http/openapi/swagger-ui/api/v1/api.swagger.json)
 or run Conduit and navigate to `http://localhost:8080/openapi` to open
 a [Swagger UI](https://github.com/swagger-api/swagger-ui) which makes it easy to
 try it out.
@@ -479,7 +512,7 @@ files drift from source.
 ## Contributing
 
 For a complete guide to contributing to Conduit, see
-the [contribution guide](https://github.com/ConduitIO/conduit/blob/master/CONTRIBUTING.md).
+the [contribution guide](https://github.com/ConduitIO/conduit/blob/main/CONTRIBUTING.md).
 
 We welcome you to join the community and contribute to Conduit to make it
 better! When something does not work as intended please check if there is

--- a/cmd/conduit/root/connectors/install.go
+++ b/cmd/conduit/root/connectors/install.go
@@ -167,15 +167,21 @@ There is no flag, config value, or environment variable that disables index veri
                      in a non-interactive context, and never at all when the operator has set
                      install.allow-unsigned to false.
 
-Exit codes (via the ConduitError's registered category):
+Exit codes (via the ConduitError's registered category). Trust rejections are split across
+buckets on purpose — read the error code, not just the exit code:
   0  success
   1  Runtime    — internal bug, archive-shape violation, corrupt download (sha256 mismatch),
-                  index integrity failure, no usable trust anchors in this build
-  2  Validation — connector/version not found, incompatible version, yanked version,
-                  no platform artifact, stale/rolled-back/too-new index, stale bundle
-  3  Environment — index unreachable, download failed, install lock contended, and every
-                  trust rejection: unsigned or mis-signed artifact, invalid provenance,
-                  revoked identity, or an --allow-unsigned attempt refused by policy`,
+                  index integrity failure (a key this build knows, but verification failed),
+                  or this build's embedded anchors could not be loaded at all
+                  (registry.trust_anchors_unavailable — a broken build; reinstall a release)
+  2  Validation — connector/version not found, incompatible version, yanked version, no
+                  platform artifact, stale/rolled-back/too-new index, index nesting too deep,
+                  stale bundle, and registry.trust_anchor_expired: the index is signed by a
+                  key this build does not know, so upgrade Conduit
+  3  Environment — index unreachable, download failed, install lock contended, an index or
+                  signature bundle over its size cap, and the artifact trust rejections:
+                  unsigned or mis-signed, invalid provenance, a revoked or too-loosely-pinned
+                  publisher identity, or an --allow-unsigned attempt refused by policy`,
 		Example: "conduit connectors install postgres\n" +
 			"conduit connectors install postgres@0.14.1\n" +
 			"conduit connectors install postgres --dry-run\n" +

--- a/cmd/conduit/root/connectors/install.go
+++ b/cmd/conduit/root/connectors/install.go
@@ -147,19 +147,40 @@ func (c *InstallCommand) Docs() ecdysis.Docs {
 		Short: "Install a standalone connector from the registry index",
 		Long: `install resolves <name>[@version] against the registry index (exact-match name lookup,
 newest-compatible version selection when @version is omitted), downloads the artifact for this
-host's platform, checks its integrity, and — pending the trust core landing in a future
-release — refuses at the verification step: this build has no code path that installs an
-unverified connector artifact.
+host's platform, verifies it, and unpacks it into --connectors.path so 'conduit run' can use it.
+
+Every install is verified end to end. The signed index is checked against the trust anchors
+compiled into this build and refused if it is unsigned, stale, or rolled back; the downloaded
+artifact must match the index sha256 and carry BOTH a valid signature and a SLSA provenance
+attestation from the connector's pinned identity. A signature without provenance is refused.
+There is no flag, config value, or environment variable that disables index verification.
+
+  --dry-run          resolve and select the platform artifact and report what would be
+                     installed; downloads no artifact and installs nothing (the verified
+                     index's freshness state is still recorded under --connectors.path)
+  --index-file       read the index from a local file instead of --index-url (offline)
+  --bundle           install fully offline from a 'conduit connectors bundle' tarball; makes no
+                     network call and re-verifies everything from the bundle's own contents
+  --allow-unsigned   skip ONLY the artifact signature/provenance check — never the sha256 check
+                     and never index verification. Refused unless it clears the full gate: a
+                     typed interactive confirmation, or CONDUIT_ALLOW_UNSIGNED_INSTALL=I_UNDERSTAND
+                     in a non-interactive context, and never at all when the operator has set
+                     install.allow-unsigned to false.
 
 Exit codes (via the ConduitError's registered category):
   0  success
-  1  Runtime    — internal bug, archive-shape violation, verification not yet available
-  2  Validation — connector/version not found, incompatible version, yanked/revoked, no platform artifact
-  3  Environment — index unreachable, download failed, corrupt download, install lock contended`,
+  1  Runtime    — internal bug, archive-shape violation, corrupt download (sha256 mismatch),
+                  index integrity failure, no usable trust anchors in this build
+  2  Validation — connector/version not found, incompatible version, yanked version,
+                  no platform artifact, stale/rolled-back/too-new index, stale bundle
+  3  Environment — index unreachable, download failed, install lock contended, and every
+                  trust rejection: unsigned or mis-signed artifact, invalid provenance,
+                  revoked identity, or an --allow-unsigned attempt refused by policy`,
 		Example: "conduit connectors install postgres\n" +
 			"conduit connectors install postgres@0.14.1\n" +
 			"conduit connectors install postgres --dry-run\n" +
-			"conduit connectors install postgres --json",
+			"conduit connectors install postgres --json\n" +
+			"conduit connectors install --bundle ./postgres-0.14.2-linux-amd64.bundle.tar.gz",
 	}
 }
 


### PR DESCRIPTION
Four stale public references surfaced by the developer-experience audit, all
`STALE_PUBLIC_REFERENCE`-class: published reference material that observably
disagrees with what the code does. Plus a guard so they cannot rot silently
again.

**Risk tier: 3.** Docs, CLI help text, and a new non-blocking CI workflow. No
data-path, protocol, serialization, or state code is touched. Roadmap: DX
follow-up on the v0.19.0 release surface.

---

## Defect 1 (P1) — `conduit connectors install --help` said the command cannot install

### Evidence

The shipped long description read:

> install resolves `<name>[@version]` against the registry index ... and — pending
> the trust core landing in a future release — refuses at the verification step:
> this build has no code path that installs an unverified connector artifact.

That is false. Against a build of this tree:

```text
$ conduit connectors install postgres --connectors.path /tmp/sr --json
{
  "command": "connectors.install",
  "ok": true,
  "result": {
    "name": "postgres",
    "version": "v0.14.2",
    "os": "darwin",
    "arch": "arm64",
    "artifactFile": "conduit-connector-postgres_v0.14.2",
    "digest": "sha256:833bc554d6b3dcdeb1221e30b1405051b6e4b3ee80bac342c335587ed22606c0",
    "sourceIndexVersion": 12
  },
  "error": null
}
$ ls /tmp/sr
.registry/  conduit-connector-postgres_v0.14.2
```

A developer reading that help concludes the registry is not finished and stops.
`FailClosedVerifier` no longer exists in the tree; `install.go` wires
`registry.TrustedVerifier` for both `IndexVerifier` and `ArtifactVerifier` with
`RequireProvenance: true`.

### What changed

Rewrote the long description to describe what the command does today: resolve,
verify the signed index against the compiled-in anchors, verify the artifact's
sha256 + signature + SLSA provenance against the pinned identity, unpack into
`--connectors.path`. Added a short block for the four install-specific flags
(`--dry-run`, `--index-file`, `--bundle`, `--allow-unsigned`), because the
auto-generated flag list is ~60 lines long (it embeds `conduit.Config`) and the
install-specific ones are invisible in it.

### Further drift found in the same help text — all fixed

The exit-code table was wrong in three places. Ground truth taken by running
every registry/index/trust/policy `conduiterr.Code` through
`exitcode.ExitCode(conduiterr.New(code, "x"))`:

| Documented | Actual | Note |
| --- | --- | --- |
| corrupt download → 3 Environment | **1 Runtime** | `CodeCorruptDownload` is `codes.DataLoss`, and `DataLoss` maps to Runtime |
| "yanked/revoked" → 2 Validation | yanked **2**, revoked **3** | `index.CodeVersionYanked` is `FailedPrecondition` (2); `trust.CodeIdentityRevoked` is `PermissionDenied` (3) |
| trust rejections | **undocumented** | `unsigned`, `provenance_invalid`, `identity_mismatch`, `identity_pattern_too_loose`, both `unsigned_install_*` policy codes all map to 3 |
| stale / rolled-back / too-new index, stale bundle | **undocumented** | all 2 |
| "verification not yet available" at exit 1 | stale phrasing | `CodeVerificationUnavailable` survives only as a defensive "no verifier configured" internal-bug path |

Confirmed end-to-end against the binary, not just the mapping table:

```text
notfound       EXIT=2 :: registry.connector_not_found
versionnotfnd  EXIT=2 :: registry.version_not_found
unreachable    EXIT=3 :: registry.index_unreachable
badargs        EXIT=1
stalefail      EXIT=2 :: registry.index_stale
tampered index EXIT=1 :: registry.index_integrity
```

I also verified the specific claim "there is no flag, config value, or
environment variable that disables index verification" rather than asserting it:
`--index-file` routes through the same `fetchIndexRaw` →
`opts.IndexVerifier.VerifyIndex` path, and a byte-tampered local index is
refused:

```text
$ conduit connectors install postgres --index-file /tmp/idx-bad.json --dry-run
[FAIL] registry.index_integrity
    index signature verification failed — the index may be tampered or corrupted
EXIT=1
```

One further inaccuracy **found and corrected in the prose, but left alone in the
flag's own `usage:` string**: `--dry-run`'s usage says it reports what would be
installed "without downloading or writing anything", but a dry run does write
`.registry/index-state.json` (the verified index's freshness/rollback state)
under `--connectors.path`. My new prose says so explicitly. I did not rewrite
the flag `usage:` string itself — that is a behavioral-description nuance rather
than a stale reference, and changing it belongs with whoever decides whether
dry-run should persist index state at all.

**Not covered by a golden fixture.** `cmd/conduit/cli/schema_golden_test.go`
classifies commands by `--json` family and asserts against
`cecdysis/testdata/envelope.schema.json`; it does not snapshot help text. No
golden file needed updating. `make generate` produces no diff — `llms.txt` /
`llms-full.txt` do not embed CLI long descriptions (verified by grep and by
running `make generate` and getting a clean tree).

---

## Defect 2 (P1/P2) — three broken links in README.md

### Before (curl, follow-redirects, HTTP status)

```text
000  https://docs.conduit.io/api                         <- "API docs" badge, line 15
000  https://www.conduit.io/api                          <- "API documentation", API section
404  .../blob/main/pkg/web/openapi/swagger-ui/api/v1/api.swagger.json
```

`conduit open docs` was fixed for this same dead domain in v0.19.0; the README
was never updated.

### Where the API docs actually live

`https://conduitdata.io/api` is a real page, not an SPA 404 fallback:

- it is in the site's `sitemap.xml`;
- a genuinely nonexistent path returns 404 while `/api` returns 200 with
  different content (`/definitely-not-a-real-page-xyz` → 404, 17833 bytes;
  `/api` → 200, 3554 bytes);
- the site's own navbar has a top-level item `{to: "/api", label: "HTTP API"}`.

So this is the successor to `www.conduit.io/api`, and no URL was invented.

### After

```text
200  https://conduitdata.io/api
200  https://github.com/ConduitIO/conduit/blob/main/pkg/http/openapi/swagger-ui/api/v1/api.swagger.json
200  https://conduitdata.io/docs/getting-started
200  https://conduitdata.io/install.sh
200  https://github.com/ConduitIO/conduit/blob/main/proto/api/v1/api.proto
```

The in-repo path was verified in the worktree before editing:
`pkg/http/openapi/swagger-ui/api/v1/api.swagger.json`. The `/openapi` Swagger UI
reference was already in the README and is kept.

Also fixed while in there: the contribution-guide link used `blob/master`, which
only works because GitHub silently redirects to `main`.

---

## Defect 3 (P3) — stale version examples

`conduit_0.17.0_Linux_x86_64.deb` / `.rpm` → `conduit_<version>_Linux_<arch>.deb`
/ `.rpm`, with a sentence telling the reader to substitute what they downloaded.
`<version>` follows existing precedent in the repo
(`conduit connectors install <name>[@<version>]` in three design docs).
`<arch>` has no such precedent — it is newly minted here — but it matches the
real release asset naming and the prose tells the reader to substitute what
they downloaded. Not hardcoded to 0.19.0, so this cannot recur.

<!-- correction: an earlier revision of this section claimed both placeholders
     were established convention. Only <version> was. -->

---

## Defect 4 (P1) — the README's first install route died silently on macOS

### Evidence

The v0.19.0 darwin/arm64 release binary is ad-hoc signed and Gatekeeper-rejected:

```text
$ codesign -dv ./conduit
Identifier=a.out
CodeDirectory v=20400 size=567230 flags=0x20002(adhoc,linker-signed) hashes=17723+0
Signature=adhoc
TeamIdentifier=not set

$ spctl -a -vv ./conduit
./conduit: rejected
```

Controlled A/B on three byte-identical copies of that binary, each at a path the
system had never assessed, each run under a watchdog:

```text
A) never-before-seen path, NO quarantine: []
A no-quarantine: exit=0 in 2s out='v0.19.0 darwin/arm64'

B) never-before-seen path, quarantined:
   [com.apple.quarantine: 0081;68bb0000;Safari;12345678-...]
B quarantined: BLOCKED, no output after 180s -> killed. out=''

D) fresh path, quarantined as a browser leaves it:
   [com.apple.quarantine: 0081;68bb0000;Safari;12345678-...]
   after 'xattr -d com.apple.quarantine ./fix_...': []
D cleared-before-first-run: exit=0 in 2s out='v0.19.0 darwin/arm64'
```

So: quarantine is the sole variable, the documented `xattr -d` command is
verified to fix it, and — as the audit reported — the failure produces no output
of any kind. On macOS 26 here the symptom was an indefinite block in Gatekeeper
assessment (`syspolicyd` pegged at 57% CPU) rather than the audit's exit 137
SIGKILL; both are "empty terminal, nothing to search for", and the README
describes the user-visible symptom rather than either specific mechanism.

One extra finding worth recording: clearing the attribute **after** already
trying to run the quarantined copy did not recover that copy in place —

```text
C) same file after: xattr -d com.apple.quarantine
C after xattr -d: BLOCKED, no output after 90s -> killed. out=''
```

which is why the README says to clear it *before the first run*. A fresh copy
(A/D) is unaffected.

### What changed

- New `### Install script (recommended)` section leading with
  `curl https://conduitdata.io/install.sh | bash`. The README never mentioned
  the script at all even though the docs site leads with it; adding it also
  closes the "two competing canonical install routes" finding. I read the
  current script before describing it (on macOS it delegates to
  `brew install conduit`) but deliberately described it in general terms, since
  a conduit-site PR is changing it.
- Moved `### Homebrew` above `### Download binary and run` so macOS readers hit
  a working route first.
- The macOS caveat and the `xattr -d` command are stated as fact inside the
  manual-download subsection only, so Linux and Windows readers are not taxed.
- No claim that the binaries are signed or notarized — the text says the
  opposite, explicitly.

---

## Recurrence guard: `.github/workflows/link-check.yml`

Weekly lychee run over `README.md`, `CONTRIBUTING.md`, `ROADMAP.md`; files (or
comments on) an issue when it fails; also runs on a PR that edits the workflow
or `.lycheeignore` so a change to the check is exercised before merge.

**Scheduled and non-blocking, deliberately.** Link checking is the textbook
flaky gate: it fails on someone else's rate limit, someone else's TLS renewal,
and someone else's outage — none of which a PR author can fix. A required check
that goes red for reasons outside the diff teaches people to bypass it, and a
check people bypass protects nothing. Same reasoning `flake-hunt.yml` uses.

Because it does not block a merge, **it gets no row in CLAUDE.md's "Process
maturity" table** — that table is the source of truth for gates, and adding a
non-gate to it would make the table less honest, not more. The workflow header
says so explicitly so nobody later describes it as a gate. It is also
path-filtered on its PR trigger, which per the table's own `rag-template-e2e`
note means it could not become required without being restructured first; that
is called out in the file.

Follows the `markdown-lint.yml` pattern: third-party action pinned by commit SHA
with the version in a trailing comment
(`lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0`).

Flake-resistance specifics: `--max-retries 4 --retry-wait-time 10 --timeout 30`,
`--accept 200,206,429` (a rate-limited response says nothing about whether the
link is alive), `GITHUB_TOKEN` set so the many github.com links are not 429'd
from a shared runner IP, and a restored `--cache` so a manual re-run does not
re-request everything.

### The check was run locally, not just written

lychee 0.24.2, same arguments as the workflow, against this branch:

```text
🔍 103 Total (in 2s 433ms) 🔗 87 Unique ✅ 103 OK 🚫 0 Errors 🔀 12 Redirects
```

And against `origin/main`'s README, to prove it catches the exact bugs this PR
fixes:

```text
[ERROR] https://docs.conduit.io/api (at 15:1) | Connection failed
[404]   https://github.com/ConduitIO/conduit/blob/main/pkg/web/openapi/swagger-ui/api/v1/api.swagger.json (at 356:1) | Rejected status code: 404 Not Found
[ERROR] https://www.conduit.io/api (at 355:31) | Connection refused
```

Writing it blind would have shipped a broken workflow: my first draft passed
`--exclude-mail`, which lychee 0.24 removed —
`error: unexpected argument '--exclude-mail' found`. Caught by running it,
removed. No mailto links exist in the three files anyway.

`.lycheeignore` is added empty-but-documented, with the policy that a genuinely
dead link gets repointed rather than silenced. `.lycheecache` is gitignored.

---

## Adversarial self-review

Re-read the diff hunting for the bug rather than admiring it. Findings and
resolutions:

1. **Did I trade one false help string for another?** The riskiest new sentence
   is "There is no flag, config value, or environment variable that disables
   index verification." Rather than trusting the code comment that says so, I
   traced `--index-file` to `fetchIndexRaw` → `IndexVerifier.VerifyIndex` and
   then tampered with a real downloaded index and confirmed the refusal
   (`registry.index_integrity`, exit 1). Claim holds.

2. **`--dry-run` "writes nothing" was an overclaim in my own first draft.** I
   wrote "download and write nothing", then checked and found
   `.registry/index-state.json` + its lock file are created. Corrected before
   commit. This is exactly the class of bug this PR is fixing, so shipping it
   would have been embarrassing.

3. **Is `https://conduitdata.io/api` real, or an SPA fallback that 200s on
   everything?** Checked deliberately: a nonsense path 404s, `/api` is in the
   sitemap, and the site's own navbar links to it. Not invented, not guessed.

4. **`--bundle` example filename.** My first draft invented
   `postgres-v0.14.2.bundle.tar.gz`. Checked `bundle.go`'s actual default
   (`<name>-<version>-<os>-<arch>.bundle.tar.gz`) and corrected it. An example
   in `--help` that does not match the sibling command's output is the same
   defect class as Defect 1.

5. **Would the new workflow file an issue against a label that does not exist?**
   The first draft used a `link-rot` label; `gh api repos/ConduitIO/conduit/labels`
   shows no such label. Switched to the existing `documentation` label and
   deduped on issue title rather than label, so the step does not depend on repo
   label state. Also bumped `actions/github-script` v7 → v8 (node24).

6. **Injection surface in the new workflow.** The `github-script` step
   interpolates only `context.serverUrl`, `context.repo.*` and `context.runId` —
   no `github.event.*` attacker-controlled fields reach a `run:` block or a
   template string. `permissions:` is minimal (`contents: read`,
   `issues: write`).

7. **Did I move a README anchor anyone links to?** Reordering Homebrew above
   the binary download changes section order but not anchor text. Grepped the
   repo: the only reference to `#download-binary-and-run` is the new one I
   added, and the TOC only links `#installation-guide`.

8. **Did the edit damage `install.go`?** A language-server report claimed
   `envPrefix`, `guardTrustAnchors` and `defaultTrustAnchors` were undefined.
   They are defined in sibling files in the same package (`connectors.go:25`,
   `anchors.go:73`, `anchors.go:97`) — that was single-file analysis, not a real
   break. `go build ./...` exits 0 and the diff is confined to the `Docs()`
   string literal (28 insertions, 7 deletions, no declarations touched).

9. **Anything found and NOT fixed?** Three things, all reported above rather
   than silently left: the `--dry-run` `usage:` string's own "writing anything"
   overclaim (item 2 — behavioral question, not a stale reference); the
   pre-existing `goheader` lint findings on the three generated
   `cmd/conduit/api/mock/*.go` files; and macOS notarization itself, which is
   blocked on credentials and tracked separately — this PR is only the
   documentation mitigation and does not pretend otherwise.

## Verification

| Check | Result |
| --- | --- |
| `go build ./...` | clean |
| `gofumpt -l cmd/conduit/root/connectors/install.go` | clean |
| `golangci-lint run ./cmd/conduit/root/connectors/...` (pinned, v2.12.2 via `make install-tools`) | `0 issues.` |
| `go test -race ./cmd/conduit/root/connectors/... ./cmd/conduit/cli/...` | ok |
| `make generate` | no diff |
| `markdownlint-cli2@0.18.1` with the repo's globs | `113 file(s), 0 error(s)` |
| lychee 0.24.2 with the workflow's args | `103 OK, 0 Errors` |

Wider `golangci-lint run ./cmd/conduit/...` reports 10 issues, all pre-existing
and none in this diff: 3 `goheader` on generated mock files and 7 that resolve
into a sibling git worktree on this machine, not this tree.

No new dependencies. No breaking changes. Nothing in the *Process maturity*
table is claimed that is not live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xE861dwb3MLgqEdWRECLY


---

## Addendum: the link check failed its own first CI run, and that was useful

Commit `bef7db0`. The first run reported **101 of 103 links OK** and failed on
two URLs, both of which are healthy from an ordinary connection — precisely the
"someone else's rate limit, someone else's outage" noise the workflow header
predicts, arriving on the first run rather than in six months.

```text
* [403]     https://x.com/ConduitIO (at 12:1) | Rejected status code: 403 Forbidden
* [TIMEOUT] https://www.gnu.org/software/make/ (at 148:3) | Request timed out
```

Reproduced from a residential IP, where both are fine:

```text
UA='curl/8' x.com: 200
UA='Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36' x.com: 200
gnu.org (30s): 200 time=0.497491
```

So neither is link rot. Fixes:

- **`x.com` excluded in `.lycheeignore`**, with the reason written beside it.
  X/Twitter serves 403 to datacenter IP ranges regardless of user agent, so a
  GitHub-hosted runner can never verify that link while every human reader can.
  This is the "cannot be checked by an unauthenticated runner at all" category
  the ignore file's own policy header already allows — not a make-it-green
  entry, and the entry says which it is.
- **Retry/timeout budget raised** to `--max-retries 6 --retry-wait-time 15
  --timeout 60` (was 4/10/30). `gnu.org` answering in 0.5s locally but timing
  out at 30s on the runner is a runner-side hiccup; on a weekly job the extra
  wall-clock costs nothing.

Re-verified locally with lychee 0.24.2 and the new arguments:

```text
🔍 103 Total 🔗 87 Unique ✅ 102 OK 🚫 0 Errors 👻 1 Excluded 🔀 12 Redirects
```

This is also the strongest argument for the not-a-gate decision. Had this been
per-PR and blocking, its first act would have been to block an unrelated PR
because X/Twitter does not like GitHub's IP ranges.

One observation from the run log: `actions/cache@v4` targets Node.js 20 and is
being force-run on Node.js 24. **I originally recorded this as pre-existing and
repo-wide. That was wrong** — see the second addendum below.


---

## Addendum 2: fresh-context review findings, folded in

Commits `378e617` and `4516661`. One blocking, three substantive, two nits — all correct, all fixed.

### 1. BLOCKING — "every trust rejection" was false (`378e617`)

The exit-3 line claimed it covered *every* trust rejection. It does not:
`registry.trust_anchor_expired` **is** a trust rejection and is **exit 2**
(`FailedPrecondition`), and it appeared in none of the three buckets. Worse, the
exit-1 line described `trust_anchors_unavailable` as "no usable trust anchors in
this build" — wording near-indistinguishable from the exit-2 case — so a user
hitting the exit-2 code got two separate cues pointing at the wrong bucket.

This is the "moved the defect" failure this PR exists to eliminate: wrong
documentation replaced with differently-wrong documentation. The reviewer is
right that it is not hypothetical — anchor *rotation* is the ordinary path,
while `trust_anchors_unavailable` needs a corrupt release build.

Induced live, by rewriting every `keyId` in a real signed index so no
compiled-in anchor matches:

```text
$ conduit connectors install postgres --index-file /tmp/idx-anchor.json --dry-run
EXIT=2
[FAIL] registry.trust_anchor_expired
    no signature keyId in this index matches any trust anchor compiled into this build — upgrade Conduit
```

Both anchor cases are now named by error code with deliberately distinct
wording, and a lead-in tells the reader trust rejections span buckets on purpose
so they go to the code rather than the exit status.

### 2. Three more reachable codes — plus a fourth the review did not name (`378e617`)

Added `registry.index_too_large` (3), `registry.bundle_too_large` (3),
`registry.index_nesting_too_deep` (2) as requested. While checking those I found
**`registry.identity_pattern_too_loose` (3)** was also missing and folded it in
too.

To stop this recurring a third time, the verification is now a completeness
cross-check rather than spot checks: every registry/index/trust/policy code is
run through `exitcode.ExitCode` and matched against both the bucket *and* the
covering phrase the help text assigns it.

```text
MISMATCHES: 0
```

28 codes, every one landing where the text says. Four buckets re-confirmed
against the built binary as well (`trust_anchor_expired` 2, `index_integrity` 1,
`index_stale` 2, `index_unreachable` 3).

### 3. `--accept` narrows rather than extends (`4516661`)

Correct, and my comment justifying it as permissiveness was backwards.
Reproduced independently with the pinned 0.24.2 binary:

```text
no --accept:           3 Total, 3 OK, 0 Errors
--accept 200,206,429:  3 Total, 1 OK, 2 Errors
  [201] Rejected status code: 201 Created
  [204] Rejected status code: 204 No Content
```

Now `--accept 100..=103,200..=299,429`, restating the default range with a
comment explaining why it must be restated. Passed **unquoted** — the value has
no whitespace or shell metacharacters, so it does not depend on whether the
action shell-interprets its args string, which is not worth betting the job on.
Verified the corrected form accepts 201/204.

### 4. The `actions/cache@v4` Node 20 warning was mine (`4516661`)

I reported it as pre-existing and repo-wide. It is not:

```text
$ grep -rn 'actions/cache@' .github/workflows/
.github/workflows/link-check.yml:61:        uses: actions/cache@v4
```

One hit, in my own new file. Bumped to `actions/cache@v6` (Node.js 24 native).
I have corrected the earlier claim in the first addendum rather than leaving it
standing.

### 5. `timeout-minutes: 15` (`4516661`)

Added. The exponential backoff gives a ~23-minute theoretical worst case; the
alternative was GitHub's 360-minute default.

### 6. Right conclusion, wrong reason (`4516661`)

The no-row conclusion stands, but my stated reason — "that table tracks gates
that block a merge" — overstated what the table is. It does track non-blocking
and scheduled states, including the *absence* of a scheduled long-fuzz run. The
header now gives the real reason: the table enumerates the specific gates named
in CLAUDE.md's *Testing standards* and *PR review process*, a link check is
named nowhere in CLAUDE.md, and neither `flake-hunt.yml` nor `markdown-lint.yml`
has a row either — despite markdownlint being a live blocking PR check.

### 7. `<arch>` is newly minted

Correct; the claim in the Defect 3 section above has been softened accordingly.

### Re-verification after these changes

| Check | Result |
| --- | --- |
| `go build ./...` | clean |
| `gofumpt -l` on the touched file | clean |
| `golangci-lint run ./cmd/conduit/root/connectors/...` (pinned) | `0 issues.` |
| `go test -race -count=1` on both touched packages | ok |
| `make generate` | no diff |
| markdownlint with the repo's globs | `113 files, 0 errors` |
| lychee 0.24.2, final argument list | `103 Total, 102 OK, 0 Errors, 1 Excluded` |
| exit-code completeness cross-check | `28 codes, 0 mismatches` |
